### PR TITLE
Week 1: cloud foundation — Terraform CPU box, verified Postgres migration, cloud fixes

### DIFF
--- a/data/raw/Dump20250730.sql.dvc
+++ b/data/raw/Dump20250730.sql.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 5d1aced3adccecdf3f4cdfb072643928
+  size: 3474630354
+  hash: md5
+  path: Dump20250730.sql

--- a/deploy/terraform.tfstate
+++ b/deploy/terraform.tfstate
@@ -1,0 +1,9 @@
+{
+  "version": 4,
+  "terraform_version": "1.12.1",
+  "serial": 1,
+  "lineage": "ed88e041-461a-65e6-98d4-a3a90eeb8688",
+  "outputs": {},
+  "resources": [],
+  "check_results": null
+}

--- a/deploy/terraform/.gitignore
+++ b/deploy/terraform/.gitignore
@@ -1,0 +1,7 @@
+# Local state + secrets — never commit.
+.terraform/
+terraform.tfstate
+terraform.tfstate.*
+terraform.tfvars
+*.auto.tfvars
+crash.log

--- a/deploy/terraform/.terraform.lock.hcl
+++ b/deploy/terraform/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.53.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:UFEhEEFJcR/pAOZcwdR11gN9W3X8VwvSl1IS0vbj2G0=",
+    "zh:0757ce9d5a30e8225521857924f5d6c49e5885fd9e309e56193c9c9920b3f8f0",
+    "zh:10ddb3a20e0779788e8002bc67d184eb166dec70f9d07220bfc55e15c3e5e206",
+    "zh:1e943f59a8c3f3b04f09fd5d967fef2518e0ce3ec4959e31f5d7f820660e8524",
+    "zh:21d55ad3b28f48c6dd34faceeb1fd1fe2ec3b1aaecfc5eb0e0841884f6520d69",
+    "zh:2e551bc0ff29ea608a99f63d899afbdf2f23c14035f27dc0c0bdca60209d9575",
+    "zh:581db963564364200426f2a4be866470a975cde6a4bd6fd09362ec2bab119cbb",
+    "zh:71a7abc88e16ccbe4410fc4966bd35fae9e0161c1385a9b3c19800e3db626b01",
+    "zh:8767767776c45590d4cc74b4c37f6377e05ce75039a9c2e834de0bbcc29f7a1a",
+    "zh:99c8e37beb9b1017f67c41e402031559b745fa797848f1a4ef8b40421dee3f05",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ba1477eda2f3ee51846492449338146f80806088d2952c08c2f8af874550a75d",
+    "zh:c389f68ba4d39fa2bf8a54d4af7f7b2132da2a964c260892c1dd1a89b67e61f8",
+    "zh:d7381490a637a1fa45769d0ee6b3e0578cce488d078077ec63d9090113784f2a",
+    "zh:df3b82fb1a675fc6548fac2fff10a8741efa5bcb5a53d01d8f0659179a2f717f",
+    "zh:e5d78b2ac3dc5477cf21d7cd4c8b9e3d944ff091e90b62c1b2ea9cc7c7eef57c",
+    "zh:fd224078287c6d82de2ec30ea03d3d550c2c554e372b234f7a6ac2b07c23dba0",
+  ]
+}

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -1,0 +1,31 @@
+# Janasunani demo infrastructure (Terraform)
+
+The **always-on CPU box** for the demo stack (Week 1 of the roadmap): one Ubuntu 24.04
+EC2 instance + Elastic IP + security group + an IAM instance role scoped to the three
+existing S3 buckets (documents, DVC cache, DB backups). The buckets themselves are
+**not** managed here. The on-demand GPU box arrives in Week 2 as a separate instance.
+
+## Usage
+
+```bash
+cd deploy/terraform
+cp terraform.tfvars.example terraform.tfvars   # set admin_cidr to your IP/32
+terraform init
+terraform plan
+terraform apply
+```
+
+Then, following `docs/ROADMAP.md` (Week 1):
+
+```bash
+ssh ubuntu@$(terraform output -raw public_ip)
+# on the box (bootstrap installs docker, aws cli, uv — check /var/log/cloud-init-output.log):
+git clone git@github.com:Data-Policy-and-Innovation-Centre/janasunani.git && cd janasunani
+uv sync
+uv run dvc pull data/raw/Dump20250730.sql.dvc   # the 3.2 GB dump, via the instance role
+# postgres up -> alembic upgrade head -> bash scripts/migrate.sh (OLTP_DB_URL=postgres)
+```
+
+Cost control: `aws ec2 stop-instances --instance-ids $(terraform output -raw instance_id)`
+— the EIP keeps the address; EBS keeps the data. State is local (`terraform.tfstate`,
+gitignored) — single maintainer; move to an S3 backend if that changes.

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -15,10 +15,14 @@ terraform plan
 terraform apply
 ```
 
-Then, following `docs/ROADMAP.md` (Week 1):
+Then, following `docs/ROADMAP.md` (Week 1). The repo **and** its `dpic` dependency
+(pyproject.toml) are private, and the box holds no GitHub credential by design —
+connect with **SSH agent forwarding** (`-A`) so the clone and `uv sync` authenticate
+through your local key:
 
 ```bash
-ssh ubuntu@$(terraform output -raw public_ip)
+ssh-add --apple-use-keychain ~/.ssh/id_ed25519   # the local agent often starts empty
+ssh -A ubuntu@$(terraform output -raw public_ip)
 # on the box (bootstrap installs docker, aws cli, uv — check /var/log/cloud-init-output.log):
 git clone git@github.com:Data-Policy-and-Innovation-Centre/janasunani.git && cd janasunani
 uv sync

--- a/deploy/terraform/iam.tf
+++ b/deploy/terraform/iam.tf
@@ -30,18 +30,39 @@ resource "aws_iam_role_policy" "s3_access" {
         Action = ["s3:ListBucket", "s3:GetBucketLocation"]
         Resource = [
           "arn:aws:s3:::${var.documents_bucket}",
-          "arn:aws:s3:::${var.dvc_cache_bucket}",
           "arn:aws:s3:::${var.backups_bucket}",
         ]
       },
       {
-        Sid    = "ReadWriteDocumentsAndDvc"
+        # The DVC cache bucket is shared across DPIC projects — this role only
+        # sees the repo's own prefix (matches the remote in .dvc/config).
+        Sid      = "ListDvcCacheRepoPrefixOnly"
+        Effect   = "Allow"
+        Action   = ["s3:ListBucket"]
+        Resource = ["arn:aws:s3:::${var.dvc_cache_bucket}"]
+        Condition = {
+          StringLike = { "s3:prefix" = ["${var.dvc_cache_prefix}/*", var.dvc_cache_prefix] }
+        }
+      },
+      {
+        Sid      = "GetDvcCacheBucketLocation"
+        Effect   = "Allow"
+        Action   = ["s3:GetBucketLocation"]
+        Resource = ["arn:aws:s3:::${var.dvc_cache_bucket}"]
+      },
+      {
+        Sid    = "ReadWriteDocuments"
         Effect = "Allow"
         Action = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
         Resource = [
           "arn:aws:s3:::${var.documents_bucket}/*",
-          "arn:aws:s3:::${var.dvc_cache_bucket}/*",
         ]
+      },
+      {
+        Sid      = "ReadWriteDvcCacheRepoPrefixOnly"
+        Effect   = "Allow"
+        Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+        Resource = ["arn:aws:s3:::${var.dvc_cache_bucket}/${var.dvc_cache_prefix}/*"]
       },
       {
         Sid      = "WriteBackups"

--- a/deploy/terraform/iam.tf
+++ b/deploy/terraform/iam.tf
@@ -1,0 +1,59 @@
+# IAM instance role — the box's only credentials. Scoped to the three existing
+# buckets (created outside Terraform; referenced by name, not managed here):
+#   - janasunani-documents-main      ingested documents (s3service)
+#   - dpic-dvc-cache                 DVC remote (raw dump, Parquet lake, models)
+#   - grievance-database-backups-main  nightly pg_dump target (write-mostly)
+
+resource "aws_iam_role" "cpu_box" {
+  name = "janasunani-cpu-box"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Action    = "sts:AssumeRole"
+      Principal = { Service = "ec2.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "s3_access" {
+  name = "janasunani-s3-access"
+  role = aws_iam_role.cpu_box.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "ListProjectBuckets"
+        Effect = "Allow"
+        Action = ["s3:ListBucket", "s3:GetBucketLocation"]
+        Resource = [
+          "arn:aws:s3:::${var.documents_bucket}",
+          "arn:aws:s3:::${var.dvc_cache_bucket}",
+          "arn:aws:s3:::${var.backups_bucket}",
+        ]
+      },
+      {
+        Sid    = "ReadWriteDocumentsAndDvc"
+        Effect = "Allow"
+        Action = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+        Resource = [
+          "arn:aws:s3:::${var.documents_bucket}/*",
+          "arn:aws:s3:::${var.dvc_cache_bucket}/*",
+        ]
+      },
+      {
+        Sid      = "WriteBackups"
+        Effect   = "Allow"
+        Action   = ["s3:PutObject"]
+        Resource = ["arn:aws:s3:::${var.backups_bucket}/*"]
+      },
+    ]
+  })
+}
+
+resource "aws_iam_instance_profile" "cpu_box" {
+  name = "janasunani-cpu-box"
+  role = aws_iam_role.cpu_box.name
+}

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -1,0 +1,137 @@
+# Janasunani demo infrastructure — the always-on CPU box.
+#
+# Minimal by design (see docs/ROADMAP.md "Cross-cutting — Infrastructure"):
+# one EC2 instance running docker-compose (api + frontend + mlflow +
+# oltp-postgres + proxy) plus the migration/materialization one-offs. S3 access
+# via an IAM instance role — no static keys on the box. The on-demand GPU box
+# (week 2) will be added as a separate, count-toggled instance.
+#
+# State is local (terraform.tfstate, gitignored) — fine for a single
+# maintainer; move to an S3 backend if a second operator ever appears.
+
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project   = "janasunani"
+      ManagedBy = "terraform"
+    }
+  }
+}
+
+# --- Networking: default VPC, public subnet ---------------------------------
+
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+}
+
+resource "aws_security_group" "cpu_box" {
+  name        = "janasunani-cpu-box"
+  description = "Janasunani demo CPU box: SSH from the maintainer, HTTP/S from the world"
+  vpc_id      = data.aws_vpc.default.id
+
+  ingress {
+    description = "SSH from the maintainer IP only"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [var.admin_cidr]
+  }
+
+  ingress {
+    description = "HTTP (proxy)"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "HTTPS (proxy)"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "All outbound (apt, pip, HF hub, S3, ...)"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# --- Instance ----------------------------------------------------------------
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"] # Canonical
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+resource "aws_key_pair" "maintainer" {
+  key_name   = "janasunani-maintainer"
+  public_key = file(pathexpand(var.ssh_public_key_path))
+}
+
+resource "aws_instance" "cpu_box" {
+  ami                    = data.aws_ami.ubuntu.id
+  instance_type          = var.instance_type
+  subnet_id              = data.aws_subnets.default.ids[0]
+  vpc_security_group_ids = [aws_security_group.cpu_box.id]
+  key_name               = aws_key_pair.maintainer.key_name
+  iam_instance_profile   = aws_iam_instance_profile.cpu_box.name
+  user_data              = file("${path.module}/user_data.sh")
+
+  root_block_device {
+    volume_type = "gp3"
+    volume_size = var.root_volume_gb
+    # Everything stateful lives here: the Postgres named volume, the restored
+    # MySQL scratch DB during migration, the dump, and the Parquet lake.
+    delete_on_termination = true
+  }
+
+  tags = {
+    Name = "janasunani-cpu-box"
+  }
+}
+
+# Stable public address so the demo URL survives instance stop/start.
+resource "aws_eip" "cpu_box" {
+  instance = aws_instance.cpu_box.id
+  domain   = "vpc"
+
+  tags = {
+    Name = "janasunani-cpu-box"
+  }
+}

--- a/deploy/terraform/outputs.tf
+++ b/deploy/terraform/outputs.tf
@@ -1,0 +1,14 @@
+output "public_ip" {
+  description = "Stable public IP of the CPU box (Elastic IP)."
+  value       = aws_eip.cpu_box.public_ip
+}
+
+output "instance_id" {
+  description = "EC2 instance ID (for aws ec2 stop-instances / start-instances)."
+  value       = aws_instance.cpu_box.id
+}
+
+output "ssh_command" {
+  description = "SSH into the box."
+  value       = "ssh ubuntu@${aws_eip.cpu_box.public_ip}"
+}

--- a/deploy/terraform/terraform.tfvars.example
+++ b/deploy/terraform/terraform.tfvars.example
@@ -1,0 +1,10 @@
+# Copy to terraform.tfvars (gitignored) and fill in.
+
+# Your current public IPv4, /32:  echo "$(curl -4 -s ifconfig.me)/32"
+# (plain curl may return IPv6 on this network — the SG rule is IPv4)
+admin_cidr = "203.0.113.7/32"
+
+# Defaults below usually fine — uncomment to override.
+# instance_type       = "t3.large"   # downsize after the one-time migration
+# root_volume_gb      = 150
+# ssh_public_key_path = "~/.ssh/id_ed25519.pub"

--- a/deploy/terraform/user_data.sh
+++ b/deploy/terraform/user_data.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Cloud-init bootstrap for the Janasunani CPU box (Ubuntu 24.04).
+# Installs: Docker (+ compose plugin), AWS CLI v2, uv. Idempotent-ish; runs
+# once at first boot. Log: /var/log/cloud-init-output.log
+set -euxo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y ca-certificates curl git unzip
+
+# --- Docker (official repo, includes the compose plugin) ---
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+chmod a+r /etc/apt/keyrings/docker.asc
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] \
+  https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+  > /etc/apt/sources.list.d/docker.list
+apt-get update
+apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+usermod -aG docker ubuntu
+
+# --- AWS CLI v2 (instance role supplies credentials) ---
+curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+unzip -q /tmp/awscliv2.zip -d /tmp
+/tmp/aws/install
+rm -rf /tmp/aws /tmp/awscliv2.zip
+
+# --- uv, for the ubuntu user (runs the project CLIs: migrate, materialize, dvc) ---
+sudo -u ubuntu bash -c 'curl -LsSf https://astral.sh/uv/install.sh | sh'
+
+echo "janasunani bootstrap complete"

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -1,0 +1,55 @@
+variable "aws_region" {
+  description = "AWS region (matches config.py AWS_REGION and the DVC remote)."
+  type        = string
+  default     = "ap-south-1"
+}
+
+variable "admin_cidr" {
+  description = "IPv4 CIDR allowed to SSH (your IP /32 — \"$(curl -4 -s ifconfig.me)/32\"). No default on purpose."
+  type        = string
+
+  validation {
+    condition     = can(cidrnetmask(var.admin_cidr)) && var.admin_cidr != "0.0.0.0/0"
+    error_message = "admin_cidr must be a valid IPv4 CIDR (use `curl -4 -s ifconfig.me`) and not 0.0.0.0/0 — SSH stays maintainer-only."
+  }
+}
+
+variable "instance_type" {
+  description = <<-EOT
+    CPU box size. Default t3.xlarge (4 vCPU / 16 GB) for week 1, where the
+    one-time migration runs MySQL + Postgres side by side; downsize to
+    t3.large afterwards (stop instance -> change type -> start).
+  EOT
+  type        = string
+  default     = "t3.xlarge"
+}
+
+variable "root_volume_gb" {
+  description = "Root EBS (gp3) size. Holds the 3.2 GB dump, a ~15 GB restored MySQL scratch DB, the Postgres volume, and the Parquet lake."
+  type        = number
+  default     = 150
+}
+
+variable "ssh_public_key_path" {
+  description = "Local path to the SSH public key installed on the box."
+  type        = string
+  default     = "~/.ssh/id_ed25519.pub"
+}
+
+variable "documents_bucket" {
+  description = "Existing S3 bucket for ingested documents (config.py AWS_S3_DOCUMENTS)."
+  type        = string
+  default     = "janasunani-documents-main"
+}
+
+variable "dvc_cache_bucket" {
+  description = "Existing S3 bucket backing the DVC remote (.dvc/config)."
+  type        = string
+  default     = "dpic-dvc-cache"
+}
+
+variable "backups_bucket" {
+  description = "Existing S3 bucket for nightly pg_dump snapshots."
+  type        = string
+  default     = "grievance-database-backups-main"
+}

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -48,6 +48,12 @@ variable "dvc_cache_bucket" {
   default     = "dpic-dvc-cache"
 }
 
+variable "dvc_cache_prefix" {
+  description = "This repo's prefix inside the shared DVC cache bucket (.dvc/config remote url path). IAM object access is scoped to it."
+  type        = string
+  default     = "janasunani"
+}
+
 variable "backups_bucket" {
   description = "Existing S3 bucket for nightly pg_dump snapshots."
   type        = string

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -350,8 +350,11 @@ container for the demo (no RDS needed), repointable to RDS via `OLTP_DB_URL`.
 - Routing consumes the `janasunani-mappings` tables + OLAP history.
 
 ## Open items to confirm during implementation (non-blocking)
-- ~~Exact S3 bucket name~~ → resolved: the `config.py` defaults are authoritative
-  (`janasunani-data-main` / `janasunani-documents-main`).
+- ~~Exact S3 bucket name~~ → resolved: `janasunani-documents-main` (exists; the one `s3service` uses).
+  `AWS_S3_BUCKET_NAME`/`janasunani-data-main` was vestigial — defined in config since the grievance
+  backend but read by no code, and the bucket never existed — dropped from `config.py`. Nightly
+  `pg_dump`s go to the existing `grievance-database-backups-main`; DVC artifacts (incl. the raw dump)
+  to `dpic-dvc-cache`.
 - AGENTS.md read access to `data/raw/janasunani-mappings/*` for routing rules.
 - Whether live demo grievances reuse the `complaints` table (+ AI/routing columns) or a sibling table.
 - Whether to DVC-track an OLTP "seed" snapshot for reproducible demos (vs regenerate from dump).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -84,35 +84,50 @@ uv run pytest && uv run ruff check .   # gate
   (NULL-keyed duplicate rows now collapse). This rebuild is why the count is
   **6,556,171** (down from a pre-dedup 6,565,323 seen in earlier notes).
 
-**Immediate real-world plan (reviewed 2026-07-02; single maintainer, week-by-week)**
+**Immediate real-world plan (single maintainer, week-by-week; re-sequenced 2026-07-02
+after the Week-1 cloud run — see "Reviewer input" below for the original rationale)**
 
-*Week 1 — cloud foundation (CPU only; no GPU needed — only DeepSeek OCR requires CUDA).*
-1. Pre-flight fixes: `config.py` AWS settings → `Optional[str] = None`; document the
-   Postgres materialize workaround (see DVC note below). `pytest` + `ruff` green.
-2. Terraform (`deploy/terraform/`): t3.large-class CPU box + ~150 GB gp3 EBS, IAM
-   instance role (documents/data buckets + `dpic-dvc-cache`), SG (22 from own IP, 80/443).
-3. Bootstrap the box (Docker, uv, clone); `aws s3 cp` the 3.2 GB dump up.
-4. Postgres container (volume on EBS) → `alembic upgrade head` → run
-   `scripts/migrate.sh` **on the box** (never across the internet) → verify
-   **1,371,288 / 6,556,171**. The full-scale load over asyncpg is the least-tested
-   path — watch batch sizes + total time.
-5. Materialize on-box → verify Parquet counts → `dvc commit` + push.
-6. Ingestion smoke against real S3 (small batch); nightly `pg_dump` → S3 cron.
+*Week 1 — cloud foundation. ✅ DONE 2026-07-02.* Terraform CPU box (t3.xlarge for the
+migration, downsized to t3.large after) + IAM instance role; dump via `dvc pull`; full
+migration → cloud Postgres with **exact counts 1,371,288 / 6,556,171**; materialize via
+the DuckDB postgres scanner (same counts, ~24 s on-box); nightly `pg_dump` → S3 cron
+(first 623 MB backup verified); pytest gate green on the box. Three cloud-only kinks
+found + fixed with regression tests: the MySQL first-boot auth race in `migrate.sh`,
+NUL bytes in dump text (Postgres rejects; now stripped in the schema layer), and the
+dedup index exceeding Postgres's ~2.7 KB btree entry cap (remark now md5-digested on
+Postgres via a dialect-compiled expression + Alembic revision). *Still pending:*
+ingestion smoke — blocked on the Janasunani API credentials.
 
-*Week 2 — Phase 5 pipeline + GPU.*
-7. Refold `document_pipeline` → `janasunani/pipeline/` (decisions in Phase 5 below);
-   per-stage tests + 2-file pytesseract smoke locally.
-8. GPU box: g6.xlarge from a Deep Learning AMI (skips driver pain) +
+*Week 2 — Phase 5 pipeline + GPU, plus the pulled-forward plumbing.*
+1. **Unblock the two external dependencies first** (wait-time, not work-time): the
+   Janasunani API credentials (ingestion smoke) and read access to
+   `janasunani-mappings` (Phase 9's only data source — if this is a problem we must
+   know now, not in Week 3).
+2. **Minimal `deploy/docker-compose.yml` now**: declare the existing `oltp` Postgres
+   (today it exists only as an ad-hoc `docker run`); grow the file service-by-service
+   as they're born. Phase 12 becomes integration, not "first time compose exists".
+3. **Minimal CI now** (Phase 7 split): a GitHub Actions job running `pytest` + `ruff`
+   with a throwaway Postgres service, so fixes stop shipping on locally-run tests only.
+4. Refold `document_pipeline` → `janasunani/pipeline/` (decisions in Phase 5 below);
+   per-stage tests + 2-file pytesseract smoke locally (CPU — before the GPU box exists).
+5. GPU box: g6.xlarge from a Deep Learning AMI (skips driver pain) +
    nvidia-container-toolkit; build the `ocr-deepseek` image; DeepSeek smoke on the
    2-file sample. Watch for `trust_remote_code` importing `flash_attn` unconditionally.
-9. **Sample backfill only** (~200 curated docs), not the full corpus → OLTP → lake.
-10. MLflow slim (Phase 6 folded in): local backend on the CPU box, artifacts to S3.
+6. **Sample backfill only** (~200 curated docs), not the full corpus → OLTP → lake.
+7. MLflow slim (Phase 6 folded in): local backend on the CPU box, artifacts to S3.
 
-*Week 3 — inference, routing, serving (Phases 8–10).* Rules router **before** the
-learned router so the demo never blocks on training.
+*Week 3 — API-contract-first (re-ordered: the frontend must not sit at the tail of a
+serial chain with zero float).*
+1. **Phase 10 skeleton first** (~a day): the three endpoints + `/health` with a
+   **mocked processor** returning the real response shapes.
+2. **Phase 11 scaffold immediately after**, built against the mocked contract — the
+   demo's visible deliverable gets Weeks 3–4 of iteration instead of a cramped tail.
+3. Phases 8 + 9 fill in behind the stable contract: single-item inference, then the
+   rules router (learned router only after the E2E path works).
+4. Phase 10 wire-up = swap the mock for the real processor + persist to OLTP.
 
-*Week 4 — frontend + deploy + demo (Phases 11–12).* Demo runbook: start GPU box →
-health check → demo → stop GPU box.
+*Week 4 — integrate + demo (Phase 12).* Full compose on the CPU box; demo runbook:
+start GPU box → health check → demo → stop GPU box; latency pass; stakeholder dry run.
 
 ## Storage architecture — OLTP front, Parquet/OLAP downstream
 
@@ -167,8 +182,10 @@ health check → demo → stop GPU box.
   `JanasunaniAPIClient`), and `DocumentService` (download → S3/local, status into OLTP). Console script
   `janasunani-ingest-documents`. 30 tests (moto + respx).
 - 🔄 **Phase 5 (next)** — document processing pipeline (refold `document_pipeline`, DVC-track models).
-- ⬜ **Phases 6–7** — MLflow+DVC tracking, CI/docs.
+- ⬜ **Phases 6–7** — MLflow+DVC tracking, CI/docs. *(MLflow slim + minimal CI pulled forward to
+  Week 2; docs stay late.)*
 - ⬜ **Phases 8–12** (Part II) — inference, routing, serving (live → OLTP), frontend, deploy.
+  *(Built API-contract-first — see the Part II build-order note.)*
 
 ## Package structure
 
@@ -253,6 +270,10 @@ Parquet. Cover counts, idempotency, malformed inputs, the source→field mapping
   preserving that layout.
 - GPU note: only DeepSeek OCR hard-requires CUDA (fails fast); summarizer/categorizer/PII fall back to
   CPU. DeepSeek's `trust_remote_code` may import `flash_attn` unconditionally — pin or force eager attn.
+- **Index rule (Week-1 lesson, generalized):** the `pages`/`documents` tables carry unbounded text
+  (`extracted_text`, summaries). On Postgres, btree entries cap at ~2.7 KB — **never put an unbounded
+  text column in a btree key or unique index**; hash it (see `dedup_remark` in `db/models.py`) or key on
+  ids. Applies to the OLTP exporter's Alembic revisions.
 - **Tests**: per-stage unit tests on fixtures; format+pytesseract smoke run on the 2-file sample.
 
 ## Phase 6 — MLflow + DVC dual tracking  ⬜
@@ -260,8 +281,11 @@ Parquet. Cover counts, idempotency, malformed inputs, the source→field mapping
   path + content hash. `dvc.yaml` stages mirror the flow.
 - **Tests**: a logged run + registered version resolves to a real DVC artifact; `dvc dag` renders.
 
-## Phase 7 — CI + docs  ⬜
-- Wire `uv run pytest` + `uv run ruff` into the GitHub workflows; expand coverage; update `README`/`AGENTS`.
+## Phase 7 — CI + docs  ⬜ *(split 2026-07-02)*
+- **CI — pulled forward to Week 2**: a GitHub Actions job running `uv run pytest` + `uv run ruff` with a
+  throwaway Postgres service container (so the Postgres-path tests run, not skip). Cheap, and fixes stop
+  shipping gated only by locally-run tests.
+- **Docs — stays late**: expand coverage; update `README`/`AGENTS`.
 
 ---
 
@@ -270,6 +294,12 @@ Parquet. Cover counts, idempotency, malformed inputs, the source→field mapping
 **Goal:** live single-grievance path — *raw input → extract → redact → classify → summarize → route →
 persist to OLTP → view* — behind FastAPI + a Next.js UI. The live app writes into the **same** OLTP DB
 (seeded with fake data for the demo); analytics/history read the Parquet lake.
+
+**Build order (re-sequenced 2026-07-02): API-contract-first, not 8→9→10→11.** The phases below are
+numbered by component, but they are *built* around the API contract so the frontend — the demo's visible
+deliverable — never sits at the tail of a serial chain: Phase 10 **skeleton** (endpoints + mocked
+processor, ~a day) → Phase 11 scaffold against it → Phases 8 + 9 fill in behind the contract → Phase 10
+wire-up (swap mock for real).
 
 ```
 janasunani/inference/service.py   # warm GrievanceProcessor (load models once; extract→redact→classify→summarize)
@@ -295,25 +325,31 @@ deploy/                           # docker-compose (api, frontend, mlflow, oltp-
   the learned router lands only after the E2E demo path works, so the demo never blocks on training.
 - **Tests**: rule lookups; learned-router top-k on held-out; combiner fallback.
 
-## Phase 10 — Serving API + live wiring  ⬜
-- `serving/api.py`: `POST /grievance` (text or file) → inference + routing → **persist a new grievance into
-  OLTP** (via `crud.py`) → return result; `GET /grievance/{id}` + status update; `GET /history` browse/
-  search via `olap/lake.py`. Models warm from MLflow; `/health`; CORS. **Seed fake live grievances**.
+## Phase 10 — Serving API + live wiring  ⬜ *(two steps: skeleton early, wire-up late)*
+- **Skeleton (start of Week 3, before Phases 8–9):** all endpoints + `/health` + CORS with a **mocked
+  processor** returning the real response shapes — the stable contract Phases 8/9/11 build against.
+- **Wire-up (after 8–9):** `POST /grievance` (text or file) → inference + routing → **persist a new
+  grievance into OLTP** (via `crud.py`) → return result; `GET /grievance/{id}` + status update;
+  `GET /history` browse/search via `olap/lake.py`. Models warm from MLflow. **Seed fake live grievances**.
 - **Tests**: API tests (TestClient) with mocked processor against a temp OLTP DB — submit→persist→fetch;
   history endpoint returns lake rows.
 
-## Phase 11 — Demo frontend (Next.js)  ⬜
-- Submit (text + upload) → staged view (extracted/redacted text, category/subcategory/dept, summary,
-  routing + escalation + confidence) + a history browse/search view. Env-configurable API URL
-  (`NEXT_PUBLIC_API_URL`); client-side fetch only — no auth, no SSR data plumbing.
+## Phase 11 — Demo frontend (Next.js)  ⬜ *(starts against the Phase 10 mock, not after Phase 10)*
+- Scaffolded right after the Phase 10 skeleton and built against the mocked contract, so it gets
+  Weeks 3–4 of iteration instead of a cramped tail. Submit (text + upload) → staged view
+  (extracted/redacted text, category/subcategory/dept, summary, routing + escalation + confidence) +
+  a history browse/search view. Env-configurable API URL (`NEXT_PUBLIC_API_URL`); client-side fetch
+  only — no auth, no SSR data plumbing.
 - **Tests**: manual verification against the demo checklist (Playwright deferred post-demo; the
   pytest policy for the Python side is unchanged).
 
-## Phase 12 — Demo integration & deployment  ⬜
-- `deploy/docker-compose.yml` on the **CPU box**: `api` + `frontend` + `mlflow` + **`oltp` (Postgres)** +
-  `proxy`; seed data; `make demo`. The GPU box runs the OCR container separately during demo windows
-  (runbook: start GPU box → health check → demo → stop). Materialize Parquet on a schedule/one-off.
-  Latency pass.
+## Phase 12 — Demo integration & deployment  ⬜ *(integration only — compose grows incrementally)*
+- `deploy/docker-compose.yml` starts in **Week 2** with just `oltp` (replacing the ad-hoc `docker run`)
+  and gains each service as it's born (`mlflow` → `api` → `frontend` → `proxy`), so this phase is
+  integration + runbook + latency — not the first time the runtime composition exists in the repo.
+- On the **CPU box**: full stack + seed data; `make demo`. The GPU box runs the OCR container separately
+  during demo windows (runbook: start GPU box → health check → demo → stop). Materialize Parquet on a
+  schedule/one-off. Latency pass.
 - **Verify**: fresh bring-up → submit a grievance in the browser → pipeline + routing renders and persists
   to OLTP; history view shows historical tickets.
 

--- a/janasunani/config.py
+++ b/janasunani/config.py
@@ -110,7 +110,6 @@ class Settings(BaseSettings):
     AWS_ACCESS_KEY_ID: Optional[str] = os.getenv("AWS_ACCESS_KEY_ID")
     AWS_SECRET_ACCESS_KEY: Optional[str] = os.getenv("AWS_SECRET_ACCESS_KEY")
     AWS_REGION: str = os.getenv("AWS_REGION", "ap-south-1")
-    AWS_S3_BUCKET_NAME: str = os.getenv("AWS_S3_BUCKET_NAME", "janasunani-data-main")
     AWS_S3_DOCUMENTS: str = os.getenv("AWS_S3_DOCUMENTS", "janasunani-documents-main")
 
     model_config = SettingsConfigDict(env_file=ROOT_DIR / ".env", extra="ignore")

--- a/janasunani/db/alembic/versions/09f36c201e97_md5_remark_in_action_history_uniq_on_.py
+++ b/janasunani/db/alembic/versions/09f36c201e97_md5_remark_in_action_history_uniq_on_.py
@@ -1,0 +1,54 @@
+"""md5 remark in action_history_uniq on postgres
+
+PostgreSQL caps btree index entries at ~2.7 KB; real ``action_taken_remark``
+values run to multiple KB, so the raw functional dedup index from the baseline
+cannot hold the data (``ProgramLimitExceededError`` on the first cloud
+migration). Recreate it with the remark md5-digested — same dedup semantics
+(the paired ``IS NULL`` flag still distinguishes NULL from ``''``).
+
+SQLite has no such limit (and no ``md5()``): no-op there. The model-side
+definition compiles per-dialect via ``dedup_remark`` in ``db/models.py``.
+
+Revision ID: 09f36c201e97
+Revises: daa6c55ad888
+Create Date: 2026-07-02 16:08:03.223909
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = '09f36c201e97'
+down_revision: Union[str, None] = 'daa6c55ad888'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_INDEX_COLUMNS = """
+    (ticket_no IS NULL), coalesce(ticket_no, ''),
+    (action_taken_by IS NULL), coalesce(action_taken_by, ''),
+    (action_status IS NULL), coalesce(action_status, ''),
+    (action_taken_remark IS NULL), {remark_expr},
+    (complaint_status_with_authority IS NULL),
+    coalesce(complaint_status_with_authority, '')
+"""
+
+
+def _recreate_index(remark_expr: str) -> None:
+    op.drop_index("action_history_uniq", table_name="action_history")
+    op.execute(
+        "CREATE UNIQUE INDEX action_history_uniq ON action_history ("
+        + _INDEX_COLUMNS.format(remark_expr=remark_expr)
+        + ")"
+    )
+
+
+def upgrade() -> None:
+    if op.get_bind().dialect.name != "postgresql":
+        return
+    _recreate_index("md5(coalesce(action_taken_remark, ''))")
+
+
+def downgrade() -> None:
+    if op.get_bind().dialect.name != "postgresql":
+        return
+    _recreate_index("coalesce(action_taken_remark, '')")

--- a/janasunani/db/models.py
+++ b/janasunani/db/models.py
@@ -29,9 +29,36 @@ from sqlalchemy import (
     UniqueConstraint,
     func,
 )
+from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import declarative_base, relationship
+from sqlalchemy.sql.functions import GenericFunction
 
 Base = declarative_base()
+
+
+class dedup_remark(GenericFunction):  # noqa: N801 - compiles to SQL, named like SQL
+    """The remark's contribution to the ``action_history_uniq`` dedup key.
+
+    SQLite indexes the coalesced text directly. PostgreSQL indexes its md5
+    digest instead: real remarks run to multiple KB and Postgres btree entries
+    cap at ~2.7 KB (raw text broke the first cloud migration with
+    ``ProgramLimitExceededError``). Same dedup semantics either way — the
+    paired ``IS NULL`` flag keeps NULL distinct from ``''``.
+    """
+
+    inherit_cache = True
+
+
+@compiles(dedup_remark)
+def _dedup_remark_sqlite(element, compiler, **kw):
+    (col,) = list(element.clauses)
+    return f"coalesce({compiler.process(col, **kw)}, '')"
+
+
+@compiles(dedup_remark, "postgresql")
+def _dedup_remark_postgres(element, compiler, **kw):
+    (col,) = list(element.clauses)
+    return f"md5(coalesce({compiler.process(col, **kw)}, ''))"
 
 
 class District(Base):
@@ -176,7 +203,7 @@ class ActionHistory(Base):
             action_status.is_(None),
             func.coalesce(action_status, ""),
             action_taken_remark.is_(None),
-            func.coalesce(action_taken_remark, ""),
+            func.dedup_remark(action_taken_remark),
             complaint_status_with_authority.is_(None),
             func.coalesce(complaint_status_with_authority, ""),
             unique=True,

--- a/janasunani/ingestion/schemas.py
+++ b/janasunani/ingestion/schemas.py
@@ -22,6 +22,15 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from . import OFFICE
 
 
+def _strip_nul(v):
+    """Drop NUL bytes from strings. PostgreSQL text columns cannot contain
+    ``0x00`` (asyncpg raises ``CharacterNotInRepertoireError``); MySQL and
+    SQLite pass it through silently, so real dump rows do carry them."""
+    if isinstance(v, str) and "\x00" in v:
+        return v.replace("\x00", "")
+    return v
+
+
 def _coerce_datetime(v):
     """Best-effort parse of a datetime from the source (already a ``datetime``
     via DB reflection, or an ISO / Janasunani-formatted string). Returns ``None``
@@ -54,6 +63,8 @@ class Complaint(BaseModel):
     ``t_janasunani_etl_pre_data`` mapped to snake_case ORM fields."""
 
     model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    _sanitize_strings = field_validator("*", mode="before")(_strip_nul)
 
     # Identity / linkage
     ticket_no: str = Field(..., alias="ticketNumber")
@@ -172,6 +183,8 @@ class ActionHistory(BaseModel):
     tracking map) and set before/at validation."""
 
     model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    _sanitize_strings = field_validator("*", mode="before")(_strip_nul)
 
     ticket_no: Optional[str] = Field(default=None, alias="ticketNumber")
     tracking_id: Optional[str] = Field(default=None, alias="trackingId")

--- a/janasunani/migration/from_mysql.py
+++ b/janasunani/migration/from_mysql.py
@@ -34,6 +34,7 @@ from janasunani.db.models import Base
 from janasunani.db.models import Complaint as ComplaintModel
 from janasunani.ingestion.schemas import ActionHistory as ActionHistorySchema
 from janasunani.ingestion.schemas import Complaint as ComplaintSchema
+from janasunani.ingestion.schemas import _strip_nul
 
 COMPLAINT_TABLE = "t_janasunani_etl_pre_data"
 ACTION_HISTORY_TABLE = "t_janasunani_etl_history_pre_data"
@@ -189,7 +190,10 @@ async def migrate_action_history(
                 break
             recs = []
             for r in rows:
-                ticket_no = tracking_map.get(r["trackingId"])
+                # Sanitize the raw key BEFORE the lookup: the map keys come from
+                # complaints already NUL-stripped by the schema layer, so a raw
+                # NUL-carrying trackingId would silently miss its complaint.
+                ticket_no = tracking_map.get(_strip_nul(r["trackingId"]))
                 if ticket_no is None:
                     continue
                 d = dict(r)

--- a/janasunani/migration/from_mysql.py
+++ b/janasunani/migration/from_mysql.py
@@ -24,6 +24,7 @@ from sqlalchemy import insert as core_insert
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.exc import IntegrityError, OperationalError
+from sqlalchemy.engine import make_url
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -226,7 +227,10 @@ async def run_migration(
             "No MySQL URL given. Set MYSQL_URL in the environment/.env or pass mysql_url."
         )
 
-    logger.info(f"Starting migration from {mysql_url} -> {target_db_url}")
+    # Log URLs with credentials masked (they land in shipped log files).
+    safe_src = make_url(mysql_url).render_as_string(hide_password=True)
+    safe_dst = make_url(target_db_url).render_as_string(hide_password=True)
+    logger.info(f"Starting migration from {safe_src} -> {safe_dst}")
     mysql_engine, target_engine = setup_engines(mysql_url, target_db_url)
     dialect_name = target_engine.dialect.name  # 'sqlite' | 'postgresql' | …
     try:
@@ -241,7 +245,7 @@ async def run_migration(
             await migrate_action_history(
                 mysql_engine, target_sess, tracking_map, dialect_name, chunk_size
             )
-        logger.success(f"Migration completed into {target_db_url}")
+        logger.success(f"Migration completed into {safe_dst}")
     finally:
         mysql_engine.dispose()
         await target_engine.dispose()

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -40,10 +40,14 @@ if ! docker ps --format '{{.Names}}' | grep -qx "$CONTAINER"; then
     mysql:8.0 --default-authentication-plugin=mysql_native_password --sql-mode="" >/dev/null
 fi
 
-# 2) Wait for readiness.
-log "waiting for MySQL to accept connections"
+# 2) Wait for readiness. An authenticated query, NOT `mysqladmin ping`: on a
+# true first boot the entrypoint runs a temporary init server that answers
+# ping before the real server (with the root password) is up, so ping lets us
+# proceed straight into "Access denied" (bit us on EC2, where first boot is
+# slow; locally a reused container hides it).
+log "waiting for MySQL to accept authenticated connections"
 for _ in $(seq 1 90); do
-  if docker exec "$CONTAINER" mysqladmin ping -uroot -p"$PASSWORD" --silent >/dev/null 2>&1; then
+  if docker exec "$CONTAINER" mysql -uroot -p"$PASSWORD" -N -e "SELECT 1" >/dev/null 2>&1; then
     break
   fi
   sleep 2

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -95,6 +95,45 @@ async def test_migration_counts_skip_dedup_and_join(urls):
     assert orphans == 0
 
 
+async def test_nul_tracking_id_still_joins_history(tmp_path):
+    """A NUL-carrying trackingId on both sides must still join.
+
+    Complaints are NUL-stripped by the schema layer, so the tracking map's
+    keys are clean — the history pass must sanitize the RAW key before its
+    lookup or the row is silently skipped (Codex review catch on PR #2)."""
+    source = tmp_path / "source.db"
+    con = sqlite3.connect(source)
+    con.execute(
+        "CREATE TABLE t_janasunani_etl_pre_data ("
+        "ticketNumber TEXT, trackingId TEXT, grievanceSubject TEXT)"
+    )
+    con.execute(
+        "INSERT INTO t_janasunani_etl_pre_data VALUES (?, ?, ?)",
+        ("T9", "TR\x009", "nul in tracking id"),
+    )
+    con.execute(
+        "CREATE TABLE t_janasunani_etl_history_pre_data ("
+        "trackingId TEXT, action_taken_by TEXT, action_taken_date TEXT, action_status TEXT, "
+        "action_taken_remark TEXT, complaint_status_with_authority TEXT)"
+    )
+    con.execute(
+        "INSERT INTO t_janasunani_etl_history_pre_data VALUES (?, ?, ?, ?, ?, ?)",
+        ("TR\x009", "Officer N", "2021-05-01 10:00:00", "Noted", "r", "open"),
+    )
+    con.commit()
+    con.close()
+
+    target = tmp_path / "grievance.db"
+    await run_migration(f"sqlite:///{source}", f"sqlite+aiosqlite:///{target}")
+
+    out = sqlite3.connect(target)
+    row = out.execute(
+        "SELECT tracking_id, ticket_no FROM action_history"
+    ).fetchone()
+    out.close()
+    assert row == ("TR9", "T9")  # joined, and stored sanitized
+
+
 async def test_migration_is_idempotent(urls):
     source_url, target_url, target = urls
     await run_migration(source_url, target_url)

--- a/tests/test_oltp_swap.py
+++ b/tests/test_oltp_swap.py
@@ -105,6 +105,37 @@ async def test_migration_into_postgres(tmp_path, clean_pg):
     assert (nc, nh, orphans) == (3, 2, 0)
 
 
+async def test_long_remark_dedup_postgres(tmp_path, clean_pg):
+    """Multi-KB remarks must insert and dedup on Postgres.
+
+    Regression: the raw functional index exceeded Postgres's ~2.7 KB btree
+    entry cap (ProgramLimitExceededError) on real Odia remarks; the dedup key
+    now indexes md5(remark) there (see dedup_remark in db/models.py)."""
+    long_remark = "ଅଭିଯୋଗ ବିବରଣୀ " * 400  # ~14 KB utf-8, far past the btree cap
+    source = tmp_path / "source.db"
+    _build_sqlite_source(source)
+    con = sqlite3.connect(source)
+    con.executemany(
+        "INSERT INTO t_janasunani_etl_history_pre_data VALUES (?,?,?,?,?,?)",
+        [
+            ("TR2", "Officer B", "2021-02-05 09:00:00", "Noted", long_remark, "open"),
+            ("TR2", "Officer B", "2021-02-05 09:00:00", "Noted", long_remark, "open"),  # dup
+        ],
+    )
+    con.commit()
+    con.close()
+
+    await run_migration(f"sqlite:///{source}", PG_URL)
+
+    engine = create_engine(_sync_pg_url())
+    with engine.connect() as conn:
+        n = conn.execute(
+            text("SELECT count(*) FROM action_history WHERE length(action_taken_remark) > 2704")
+        ).scalar_one()
+    engine.dispose()
+    assert n == 1  # inserted once, duplicate collapsed
+
+
 async def test_crud_roundtrip_postgres(clean_pg):
     engine = create_async_engine(PG_URL)
     async with engine.begin() as conn:

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -79,6 +79,21 @@ def test_datetime_coercion_handles_strings_and_garbage():
     assert c.last_updated_on is None  # unparseable -> None, not an error
 
 
+def test_nul_bytes_stripped_from_all_string_fields():
+    # PostgreSQL text can't hold 0x00; MySQL/SQLite pass it through, and real
+    # dump rows carry it (broke the first cloud migration at ~600k rows).
+    c = ComplaintSchema(
+        **_raw_complaint(grievanceSubject="need\x00 help", petitionerName="\x00A B")
+    )
+    assert c.grievance == "need help"
+    assert c.petitioner_name == "A B"
+
+    out = validate_action_history(
+        [{"trackingId": "TR1", "action_taken_remark": "ok\x00"}], ticket_no="T1"
+    )
+    assert out[0]["action_taken_remark"] == "ok"
+
+
 def test_office_validator_is_lenient():
     # Unknown office (outside the 7-value API map) must pass through, not raise.
     c = ComplaintSchema(**_raw_complaint(officeNAme="Tahasildar, Some Block"))


### PR DESCRIPTION
## Summary

Week 1 of the roadmap: the migration + materialization stack is live on AWS and fully verified.

**Infrastructure (`deploy/terraform/`)**
- One Ubuntu 24.04 CPU box (t3.xlarge for the migration, since downsized to t3.large) + Elastic IP + SG (SSH from maintainer IPv4 only, 80/443 open) + IAM instance role scoped to the three existing S3 buckets — no static keys anywhere. First-boot user_data installs Docker/AWS CLI/uv. Applied 2026-07-02.
- The 3.2 GB raw dump is now DVC-tracked; deploy boxes fetch it with `dvc pull` via the instance role.

**Verified on the box**
- Full dump → cloud Postgres migration: **exact counts 1,371,288 complaints / 6,556,171 action-history** (identical to the local SQLite ground truth).
- OLTP → Parquet materialization via DuckDB's postgres scanner: same counts, ~24 s.
- Nightly `pg_dump` → S3 cron installed; first 623 MB backup verified.
- pytest gate green on the box (throwaway Postgres for the pg-path tests).

**Cloud-only kinks found + fixed (each with a regression test where applicable)**
- `migrate.sh`: MySQL first-boot race — `mysqladmin ping` answers during the entrypoint's temporary init server; readiness probe is now an authenticated `SELECT 1`.
- NUL bytes (`0x00`) in real dump text broke asyncpg ~600k rows in (Postgres text can't hold NUL; MySQL/SQLite pass it silently). Stripped by a before-validator in the single source→field map.
- The `action_history_uniq` dedup index exceeded Postgres's ~2.7 KB btree entry cap on multi-KB Odia remarks. The remark's key expression now compiles per-dialect (`coalesce` on SQLite, `md5(coalesce(...))` on Postgres) + Alembic revision `09f36c201e97` for existing DBs. Dedup semantics proven identical by the exact row counts.
- Migration logs no longer print DB credentials.

**Housekeeping**
- Dropped vestigial `AWS_S3_BUCKET_NAME` (read by no code; bucket never existed).
- ROADMAP re-sequenced after the week-1 lessons: API-contract-first Part II, compose grows incrementally from Week 2, minimal CI pulled forward, no-unbounded-text-in-btree-keys rule for Phase 5.

## Test plan
- [x] `uv run pytest` — 34 passed locally (incl. Postgres-path + 2 new regression tests) and 32 on the box
- [x] `uv run ruff check .` clean
- [x] Alembic upgrade/downgrade cycle verified on SQLite + Postgres
- [x] End-to-end on AWS: migration counts, materialize counts, S3 backup object, instance-role S3 access

🤖 Generated with [Claude Code](https://claude.com/claude-code)