### PR TITLE
Week 2: CI Postgres service, mappings in DVC, compose oltp

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -11,6 +11,22 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DPIC_GITHUB_SSH_KEY: ${{ secrets.DPIC_GITHUB_SSH_KEY }}
+    services:
+      # Throwaway Postgres so the Postgres-path tests (test_oltp_swap.py) run
+      # instead of skipping. Port/credentials match the tests' default
+      # TEST_OLTP_PG_URL (postgres:pass @ 127.0.0.1:5433/janasunani).
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: pass
+          POSTGRES_DB: janasunani
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -39,10 +55,10 @@ jobs:
         run: uv run pytest
 
       # Validate the pipeline DEFINITION only — do not execute data stages in CI.
-      # The `migrate` stage needs the 3.2 GB raw dump (not in git / not DVC-tracked)
-      # plus Docker + MySQL, and `materialize` needs the operational OLTP DB
-      # (out is cache:false, so it can't be `dvc pull`ed). These produce data and
-      # run on the operational box / a scheduled job, never on a clean CI runner.
+      # `materialize` needs the operational OLTP DB (SQLite dev file or the box's
+      # Postgres), and the cold-start migration needs the 3.2 GB DVC-tracked dump
+      # plus Docker + MySQL. These produce data and run on the operational box /
+      # a scheduled job, never on a clean CI runner.
       - name: Validate DVC pipeline definition
         run: |
           uv run dvc dag

--- a/data/raw/janasunani-mappings.dvc
+++ b/data/raw/janasunani-mappings.dvc
@@ -1,0 +1,6 @@
+outs:
+- md5: fb61ea36cc030726cb0e540124159e6a.dir
+  size: 6882119
+  nfiles: 11
+  hash: md5
+  path: janasunani-mappings

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,5 @@
+# Copy to deploy/.env (gitignored) on the box and fill in.
+
+# Postgres superuser password — same one embedded in the project .env's
+# OLTP_DB_URL. Compose refuses to start oltp without it.
+POSTGRES_PASSWORD=change-me

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,38 @@
+# Janasunani demo stack — runtime composition on the CPU box.
+#
+# Grows service-by-service as Part II lands (mlflow -> api -> frontend ->
+# proxy); Phase 12 is integration, not a big-bang compose. Config comes from
+# deploy/.env (gitignored; see .env.example).
+#
+# `oltp` adopts the ALREADY-RUNNING production volume by name — the container
+# name and volume match what scripts (backup cron) and the Week-1 setup use.
+# NEVER `docker compose down -v`: the OLTP volume holds the migrated data.
+
+name: janasunani
+
+services:
+  oltp:
+    image: postgres:17
+    container_name: janasunani-oltp
+    restart: unless-stopped
+    environment:
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in deploy/.env}
+      POSTGRES_DB: janasunani
+    ports:
+      # Localhost only — nothing on the public interface; app services reach it
+      # via the compose network, host-side tools via 127.0.0.1:5432.
+      - "127.0.0.1:5432:5432"
+    volumes:
+      - oltp-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d janasunani"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  oltp-data:
+    # Pre-existing named volume from the Week-1 bring-up; compose must attach
+    # to it, not create its own.
+    external: true
+    name: janasunani-oltp


### PR DESCRIPTION
## Summary
Week-2 plumbing (draft — will retarget to main after #2 merges):
- CI: postgres:16 service on 5433 so the Postgres-path tests run instead of skipping
- janasunani-mappings master tables DVC-tracked (Phase 9 gate cleared)
- deploy/docker-compose.yml with the oltp service — adopted live on the box with zero data movement (external volume), backup path verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)