### PR TITLE
docs: architecture overview + per-package READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,21 @@
 
 Odisha's new unified AI powered grievance redressal portal Janasunani 2.0 
 
+## Documentation
+
+- [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — system overview: data flow,
+  storage layers, environments, infrastructure, invariants. **Start here.**
+- [docs/ROADMAP.md](docs/ROADMAP.md) — the plan and current status (source of
+  truth for sequencing).
+- Per-package detail: [db](janasunani/db/README.md) ·
+  [migration](janasunani/migration/README.md) ·
+  [ingestion](janasunani/ingestion/README.md) ·
+  [olap](janasunani/olap/README.md) ·
+  [pipeline](janasunani/pipeline/README.md) ·
+  [deploy](deploy/README.md) ·
+  [terraform](deploy/terraform/README.md) ·
+  [tests](tests/README.md)
+
 ## Setup
 
 Run:

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,38 @@
+# deploy/ — runtime composition and infrastructure
+
+Two halves: [`terraform/`](terraform/README.md) creates the EC2 boxes;
+`docker-compose.yml` is what runs **on** the CPU box.
+
+## docker-compose.yml (CPU box)
+
+Grows service-by-service as Part II lands (`oltp` today; `mlflow` → `api` →
+`frontend` → `proxy` to come). Config from `deploy/.env` (gitignored — holds
+`POSTGRES_PASSWORD`; the box's copy is chmod 600).
+
+The `oltp` service (postgres:17, container `janasunani-oltp`) **adopts the
+already-running production volume by name** (`janasunani-oltp`, declared
+`external`). It binds to `127.0.0.1:5432` only — nothing on the public
+interface; future app services reach it over the compose network.
+
+Rules that protect the data:
+
+- **NEVER `docker compose down -v`** — the external volume holds the migrated
+  1.37M/6.56M-row production data.
+- Nightly `pg_dump | aws s3 cp` cron on the box is the backup path (bucket
+  `grievance-database-backups-main`); the re-runnable migration is the deeper
+  backstop.
+- Never point pytest at this container (fixtures drop tables — see
+  [tests/README](../tests/README.md)).
+
+## Terraform (summary — details in [terraform/README.md](terraform/README.md))
+
+- **CPU box**: always-on t3.large, Elastic IP, IAM instance role scoped to the
+  three project buckets (documents / DVC-cache prefix / backups). SSH is locked
+  to `admin_cidr` — when your IP rotates (VPN on/off), update
+  `terraform.tfvars` and re-apply; use `curl -4 -s ifconfig.me` (plain curl may
+  return IPv6).
+- **GPU box**: `gpu_box_count = 0/1` toggle, g6.xlarge from the Deep Learning
+  Base AMI, create/destroy per use. Push outputs (`dvc push` / `aws s3 cp`)
+  **before** toggling to 0 — the root volume dies with the instance.
+- State/tfvars are local and gitignored (CI + pre-commit guards enforce).
+- Both boxes hold no GitHub credential: clone via `ssh -A` agent forwarding.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,144 @@
+# Janasunani 2.0 — Architecture
+
+> The **what and why** of the codebase, for someone landing here cold.
+> The **plan and status** live in [ROADMAP.md](ROADMAP.md) (source of truth for
+> sequencing); per-package detail lives in the READMEs linked throughout.
+
+## What this is
+
+An AI-powered grievance redressal prototype for Odisha. A raw grievance — typed
+text or a scanned document — is **extracted** (OCR), **redacted** (PII),
+**classified** (category), **summarized**, and **routed** to the responsible
+office, ending in a Next.js demo UI.
+
+The repo consolidates two earlier projects (a grievance backend and the DSI
+document-processing pipeline) into one `janasunani/` package, in two parts:
+
+- **Part I — Foundation** *(built)*: data migration into an OLTP store, Parquet
+  materialization, document ingestion → S3, the document pipeline, cloud infra.
+- **Part II — Automation prototype** *(next)*: single-grievance inference,
+  routing, FastAPI serving, Next.js UI.
+
+## The data flow, end to end
+
+```
+                     COLD START (one-off)                LIVE (per grievance)
+                     ────────────────────                ────────────────────
+mysqldump (3.2 GB)                                       Janasunani API / demo UI
+      │  scripts/migrate.sh                                     │
+      ▼                                                         ▼
+throwaway MySQL ──▶ janasunani/migration ──▶ ┌──────────────────────────┐
+                    (validate via schemas)   │   OLTP store             │◀── janasunani/ingestion
+                                             │   SQLite (dev) or       │    (documents → S3,
+                                             │   Postgres (deploy),    │     status → OLTP)
+                                             │   via OLTP_DB_URL       │
+   scanned documents (S3)                    └──────────┬───────────────┘
+      │                                                 │
+      ▼                                                 │ janasunani/olap
+janasunani/pipeline ──▶ artifact SQLite ──▶ exporter ───┤ (materialize)
+ format → OCR → PII →   (pages/documents)   (upsert     ▼
+ page-type → summarize →                     into OLTP) Parquet lake (data/interim/)
+ categorize                                             = analytics / ML / demo history
+```
+
+Three storage layers, deliberately distinct
+([db/README](../janasunani/db/README.md), [olap/README](../janasunani/olap/README.md),
+[pipeline/README](../janasunani/pipeline/README.md)):
+
+| Layer | Engine | Role |
+|---|---|---|
+| **OLTP store** | SQLite / Postgres via `OLTP_DB_URL` (async SQLAlchemy, Alembic) | System of record: 1.37M complaints, 6.56M action-history rows, plus exported pipeline outputs. Live writes land here. |
+| **Parquet lake** | Files in `data/interim/`, DuckDB/Polars readers | Read-optimized downstream copy, produced by `janasunani-materialize`. The demo's history browse and all ML/analytics read this, never OLTP. |
+| **Pipeline artifact DB** | Standalone SQLite per run | The document pipeline's own working state (`pages`/`documents`/`unreadable_pages`), resumable by design. Reaches OLTP only through the exporter. |
+
+Verified full-scale counts (local **and** cloud Postgres, must match after any
+migration change): **1,371,288 complaints / 6,556,171 action-history rows**.
+
+## Package map
+
+| Path | What lives there |
+|---|---|
+| [`janasunani/config.py`](../janasunani/config.py) | Paths (`directories`), settings (`settings`, pydantic-settings from env/`.env`), loguru helpers. The two things everything else imports. |
+| [`janasunani/db/`](../janasunani/db/README.md) | ORM models, async session, CRUD, Alembic migrations. Engine-portable (SQLite + Postgres). |
+| [`janasunani/migration/`](../janasunani/migration/README.md) | Cold-start dump loader + live-MySQL sync, converging on one validated insert routine. |
+| [`janasunani/ingestion/`](../janasunani/ingestion/README.md) | Janasunani API client, S3 service, document downloader, and the Pydantic schemas that are the **single raw→ORM column map**. |
+| [`janasunani/olap/`](../janasunani/olap/README.md) | `materialize` (OLTP → Parquet via DuckDB scanners) and `lake` (read helpers). |
+| [`janasunani/pipeline/`](../janasunani/pipeline/README.md) | The six-stage document pipeline (DSI refold), its artifact DB, the OLTP exporter, OCR quality guards, PII evaluator. |
+| [`janasunani/tracking/`](../janasunani/tracking/__init__.py) | MLflow + DVC dual tracking (slim; being built). |
+| [`deploy/`](../deploy/README.md) | docker-compose for the CPU box; [Terraform](../deploy/terraform/README.md) for both EC2 boxes. |
+| [`scripts/`](../scripts) | Operational one-offs: `migrate.sh` (cold-start), `gpu_smoke.sh` (DeepSeek smoke), `setup.sh`. |
+| [`tests/`](../tests/README.md) | Real-code-path pytest suite. Read the README before running tests anywhere near production. |
+
+## Environments and the dependency split
+
+Python ≥ 3.13, managed by **uv**. Base deps are light; heavy ML stacks live in
+three **optional extras** (`pyproject.toml`):
+
+- `pipeline-core` — format classifier, pytesseract OCR, Presidio PII, page-type
+  ViT, summarizer (`transformers>=4.57,<5`)
+- `ocr-deepseek` — DeepSeek OCR only (`transformers==4.46.3` — **conflicts** with
+  the others; declared in `[tool.uv].conflicts`)
+- `categorizer` — MuRIL categorizer
+
+The conflict is load-bearing: one environment can never hold both transformers
+pins, so **stages import their deps lazily** and deploy runs one env per extra
+(`uv run --extra X`) against the same artifact DB. `scripts/gpu_smoke.sh` is the
+canonical demonstration. `scikit-learn>=1.8,<1.9` is pinned to the pickle era of
+the inherited estimators.
+
+## Infrastructure (two boxes)
+
+Managed by [Terraform](../deploy/terraform/README.md), state local, region
+ap-south-1, IAM instance roles only (no static keys):
+
+- **CPU box** (always on, t3.large, Elastic IP 52.66.116.80): Postgres OLTP in
+  Docker ([compose](../deploy/README.md)), migration/materialization one-offs,
+  nightly `pg_dump` → S3; will grow api/frontend/mlflow/proxy services.
+- **GPU box** (on demand, g6.xlarge/L4, `gpu_box_count = 0/1` toggle, ~$1/hr
+  while up): DeepSeek OCR batch runs and demo windows. Built from the Deep
+  Learning Base AMI; created and destroyed per use — nothing stateful on it.
+
+## DVC: what it tracks and what it doesn't
+
+DVC (S3 remote `dpic-dvc-cache/janasunani`) versions **file artifacts** — the raw
+dump, the Parquet lake, mirrored models under `models/`, the document sample —
+and **file-in/file-out transforms** (`dvc.yaml`: `pipeline-sample`,
+`materialize`). Operational jobs whose effects live in external systems
+(migration → OLTP, ingestion → S3, backfills) are **not** DVC stages; they run
+as CLIs/cron and reach the lake via `materialize`. With Postgres OLTP, run
+`janasunani-materialize` directly then `dvc commit` (the `materialize` stage
+deps on the SQLite path).
+
+## Model provenance (hard rule)
+
+The DSI team disbanded (2026-07-03) and their Box data is gone. Runtime loads
+models **only** from our DVC mirrors under `models/` or from large public repos
+(`facebook/bart-large-cnn`, `deepseek-ai/DeepSeek-OCR`) — never from
+DSI-controlled accounts. The PII model was the one unrecoverable artifact; its
+replacement is the Presidio-based stage (see
+[pipeline/README](../janasunani/pipeline/README.md)). The DSI technical report's
+measured baselines (the only surviving eval record) are recorded in
+[ROADMAP.md](ROADMAP.md) — headline: legacy PII coverage **80.56%** any-overlap,
+the number the rebuilt stage must beat.
+
+## Security invariants
+
+- **Citizen text never leaves the box**: PII detection/redaction is fully
+  in-process (Presidio + local spaCy). No external redaction APIs, ever.
+- Postgres password only in the box's chmod-600 `.env` / gitignored
+  `deploy/.env`. Terraform state/tfvars, SSH keys: local only (CI + pre-commit
+  guards enforce; `no-raw-data-in-git` blocks data files).
+- **Never `docker compose down -v`** on the CPU box — the OLTP volume holds the
+  migrated production data.
+- **Never run pytest on the CPU box against the prod container** — fixtures drop
+  tables. See [tests/README](../tests/README.md).
+- The boxes hold no GitHub credential; clone/`uv sync` via SSH agent forwarding.
+
+## Gates
+
+Every feature ships with real-code-path pytest tests, run before "done":
+`uv run --extra pipeline-core pytest && uv run ruff check .`. CI
+(`.github/workflows/`) runs ruff, the test suite against a service-container
+Postgres plus `dvc status` validation, and the raw-data-in-git guard. CI installs
+**no heavy extras** — anything imported by tests must live in a light module
+(see [pipeline/README](../janasunani/pipeline/README.md) for the pattern).

--- a/janasunani/db/README.md
+++ b/janasunani/db/README.md
@@ -1,0 +1,48 @@
+# janasunani.db — the OLTP store
+
+System of record for complaints, action history, and exported pipeline outputs.
+Engine-swappable via `OLTP_DB_URL` (SQLite locally, Postgres on the CPU box) —
+every feature here must work on **both** engines.
+
+## Modules
+
+- `models.py` — SQLAlchemy ORM. `Complaint` / `ActionHistory` model the full
+  column set of the source dump in clean snake_case; `PipelinePage` /
+  `PipelineDocument` receive the document pipeline's exported outputs. Columns
+  are intentionally nullable (except `ticket_no`): historical data is patchy and
+  dropping rows on a missing field would lose records.
+- `session.py` — async engine + session factory (`create_async_engine` on
+  `OLTP_DB_URL`).
+- `crud.py` — async CRUD used by ingestion (and later the API): conflict-safe
+  inserts, document-status updates, API request tracking.
+- `alembic/` — schema migrations. `alembic upgrade head` is part of every
+  deploy; upgrade **and** downgrade are verified on both engines.
+
+## The raw→ORM column map lives elsewhere
+
+Source column names (mixed-case, Hungarian-prefixed, occasionally misspelled)
+are mapped to ORM fields in exactly one place: the Pydantic `Field` aliases in
+[`janasunani/ingestion/schemas.py`](../ingestion/schemas.py). Migration and API
+ingestion both validate through those schemas. Don't add a second mapping.
+
+## Engine-portability lessons (learned the hard way, all regression-tested)
+
+- **NUL bytes**: Postgres rejects `0x00` in text (SQLite doesn't). All string
+  fields are NUL-stripped by a `mode="before"` validator in the ingestion
+  schemas — strip **before** any key lookup, not just before insert.
+- **btree entry cap**: Postgres rejects index entries > ~2.7 KB. The
+  `action_history` dedup index digests `remark` with `md5(...)` on Postgres
+  only, via the `dedup_remark` compiled function in `models.py`
+  (`@compiles` dialect branching: `coalesce` on SQLite, `md5(coalesce(...))` on
+  Postgres). Alembic revision `09f36c201e97`.
+- **Conflict inserts** are dialect-portable through `_dialect_insert`
+  (ON CONFLICT DO NOTHING / DO UPDATE per engine).
+- **asyncpg is strict** where aiosqlite is lenient (tz-awareness, type
+  coercion). If a migration change works on SQLite, run the Postgres-path tests
+  (`tests/test_oltp_swap.py`) before calling it done — CI does.
+
+## Dedup semantics
+
+`action_history` rows deduplicate on a **functional unique index** that
+coalesces NULL keys, so NULL-keyed duplicates collapse. This is why the
+canonical row count is 6,556,171 (not the raw 6,565,323).

--- a/janasunani/ingestion/README.md
+++ b/janasunani/ingestion/README.md
@@ -1,0 +1,34 @@
+# janasunani.ingestion — API client, S3, document download
+
+Everything that brings data *into* the system from outside: the Janasunani API,
+complaint documents, and the schemas that gatekeep both paths.
+
+## Modules
+
+- `schemas.py` — **the single raw-source → ORM column map.** Every `Field`
+  alias is a raw source column name (dump or API); the field name is the clean
+  ORM column. Both migration and API ingestion validate through these, so messy
+  source names live in exactly one place. Deliberately lenient (everything but
+  `ticket_no` optional; validators normalize but never raise) — a single odd
+  value must not drop a historical record. Also the home of the NUL-stripping
+  `mode="before"` validator (Postgres rejects `0x00` in text).
+- `client.py` — Janasunani API client (`httpx`, `with_retry` backoff).
+  **Status:** API credentials currently unavailable; the live-pull path is
+  parked and untested against the real API.
+- `s3service.py` — `S3Service` over boto3's **default credential chain**: env
+  vars or `~/.aws` locally, the **instance role** on EC2. Leave the `AWS_*`
+  settings unset unless a static key is genuinely needed. Reused for documents
+  and (planned) MLflow artifacts.
+- `document_ingestion.py` (`janasunani-ingest-documents`) — for each complaint
+  with a `document_url`: download, write to S3 (or `LOCAL_STORAGE_PATH` in
+  dev), and record status back onto the complaint's document-status columns in
+  OLTP in bulk. Failed uploads are recorded, not silently skipped.
+
+## Gotchas
+
+- The documents bucket (`janasunani-documents-main`) is partly
+  **GLACIER-archived** — sample/backfill selection must filter to
+  STANDARD-class objects or downloads fail.
+- Document keys preserve the source directory structure; the pipeline's ticket
+  parsing (`janasunani/pipeline/ticket.py`) depends on paths starting at the
+  `documents/` root. Don't flatten.

--- a/janasunani/migration/README.md
+++ b/janasunani/migration/README.md
@@ -1,0 +1,36 @@
+# janasunani.migration — cold-start and live sync
+
+Loads the grievance history into the OLTP store. Two entry points, **one
+validated insert routine** (`from_mysql.run_migration`):
+
+- `janasunani-migrate-dump` (`from_sql_dump.py`) — cold start: restore the raw
+  `mysqldump` (`data/raw/Dump20250730.sql`, 3.2 GB, DVC-tracked) into a
+  throwaway MySQL container, then hand off to `run_migration`. Wrapped end to
+  end by [`scripts/migrate.sh`](../../scripts/migrate.sh).
+- `janasunani-migrate-mysql` (`from_mysql.py`) — live sync against a running
+  MySQL, same routine.
+
+## How the load works
+
+Each source table is read **once** through a server-side streaming cursor; rows
+validate through the Pydantic schemas (the single raw→ORM map in
+`janasunani/ingestion/schemas.py`) and bulk-insert with driver `executemany` +
+on-conflict-do-nothing. Action-history rows resolve `ticket_no` from an
+in-memory `{tracking_id: ticket_no}` map — no giant `IN (...)`, no `OFFSET`
+re-scans. The load is deterministic and idempotent: re-running produces the
+same OLTP content.
+
+**Ground truth after a full run: 1,371,288 complaints / 6,556,171
+action-history rows.** Any change here must reproduce those exact counts (the
+dedup story behind the second number is in [`../db/README.md`](../db/README.md)).
+
+## Operational notes
+
+- Run the full-scale migration **on the box next to the database** (dump pulled
+  via `dvc pull`), never across the internet.
+- `scripts/migrate.sh` probes MySQL readiness with an **authenticated**
+  `SELECT 1` — a bare ping answers during MySQL's first-boot temp server and
+  then hits "Access denied" (bit us on EC2).
+- The dump text contains NUL bytes (~600k rows); they're stripped in the schema
+  layer *before* the tracking-map lookup. Postgres would reject them at insert.
+- URLs in logs are rendered with `hide_password=True`.

--- a/janasunani/olap/README.md
+++ b/janasunani/olap/README.md
@@ -1,0 +1,33 @@
+# janasunani.olap — the Parquet lake
+
+The read-optimized downstream copy of the OLTP store: one Parquet file per
+table in `data/interim/`, DVC-tracked. Analytics, ML training, and the demo's
+history browse read **this**, never OLTP.
+
+## Modules
+
+- `materialize.py` (`janasunani-materialize`) — DuckDB attaches the OLTP DB
+  directly via its `sqlite`/`postgres` scanner and `COPY`s each table to
+  Parquet. No ORM, no hand-rolled export, engine-agnostic off `OLTP_DB_URL`.
+  Full scale runs in ~25 s. Currently materializes `complaints`,
+  `action_history`, `pages`, `documents`.
+- `lake.py` — read helpers: `query(sql)` (DuckDB over the Parquet files) and
+  `read(table)` (whole table as a Polars DataFrame).
+
+## Why "lake"
+
+It's the cheap, schema-on-read, file-based analytical layer — the OLTP store
+stays small and transactional up front, and everything downstream (dataframes,
+training sets, history endpoints) reads columnar files. Refreshing it is a
+one-command re-materialization, which is also the freshness model: **live
+grievances appear in OLTP immediately but reach the lake only on the next
+materialize** (nightly/one-off). The demo reads `GET /grievance/{id}` from OLTP
+and `GET /history` from the lake by design.
+
+## DVC interaction
+
+`materialize` is a `dvc.yaml` stage whose dep is the **SQLite** OLTP path, so
+`dvc repro` only works in the local-SQLite setup. Against Postgres (the CPU
+box), run `janasunani-materialize` directly, then `dvc commit` + `dvc push` the
+Parquet outs. DuckDB's `postgres` extension `INSTALL`s at runtime — needs
+egress on first use.

--- a/janasunani/pipeline/README.md
+++ b/janasunani/pipeline/README.md
@@ -1,0 +1,81 @@
+# janasunani.pipeline — the document-processing pipeline
+
+The DSI document pipeline, refolded. Takes scanned complaint documents and
+produces per-page extracted/redacted text and per-document summaries and
+categories, in its **own SQLite artifact DB** — deliberately separate from the
+OLTP store (see "Artifact DB", below).
+
+## Running it
+
+```bash
+uv run --extra pipeline-core janasunani-pipeline run \
+  --input data/raw/documents-sample \
+  --db data/processed/pipeline.sqlite \
+  --models models \
+  --stages format_classifier ocr_extraction   # omit --stages to run all six
+```
+
+`--stages` exists because of the dependency split (below). Other key flags:
+`--ocr-engine {pytesseract,deepseek}`, `--filter-language`,
+`--worker-id/--num-workers` (cross-machine sharding), `--file-list` (curated
+subsets/resume).
+
+## The six stages (`STAGE_ORDER` in `pipeline.py`)
+
+| Stage | Writes | Notes |
+|---|---|---|
+| `format_classifier` | `pages` rows (discovery + page split + format label) | XGBoost/OpenCV; pickle at `models/format_classifier/`. Must run first — it populates `pages`. |
+| `ocr_extraction` | `pages.extracted_text` | Backends: `pytesseract` (CPU; needs the `tesseract` binary + `tesseract-lang` for Odia `ori`) or `deepseek` (GPU-only, fails fast without CUDA). Resumable: only NULL-text pages, known-bad pages skipped. |
+| `pii_tagger` | `pages.redacted_text` | **Presidio-based rebuild** (the legacy CRF weights died with the DSI Box). Custom Indian recognizers (mobile/Aadhaar/PAN), typed tokens `[NAME]`/`[PHONE]`/…, whole-page analysis (no 512-token window), covers mixed `English, Odia` pages, Indic-digit normalization. Fully in-process — citizen text never leaves the box. |
+| `page_type_classifier` | `pages.page_type` | ViT from the DVC mirror (`models/page_type_classifier/`), HF fallback. The **signal/noise gate**: letters/forms are substance, IDs/bills are noise. |
+| `summarizer` | document summaries | BART (`facebook/bart-large-cnn`, public). Only summarizes target page types — gated on the page-type stage. |
+| `categorizer` | `documents.grievance_category` | MuRIL from the DVC mirror (`models/categorizer/`). Feature = grievance text + joined **redacted** page text, mirroring training. English-only. |
+
+Stages run in canonical order regardless of the order given to `--stages`.
+
+## The dependency split (why `--stages` and lazy imports exist)
+
+DeepSeek OCR pins `transformers==4.46.3`; everything else needs `>=4.57`. The
+extras (`pipeline-core` / `ocr-deepseek` / `categorizer`) are declared
+**mutually conflicting** in `[tool.uv].conflicts`, so an environment holds one
+side only. Stages import their heavy deps **inside** their run functions, and a
+`--stages` subset imports only what it runs. Deploy pattern: one
+`uv run --extra X` env per extra, sequential invocations against the same
+artifact DB (`scripts/gpu_smoke.sh` is the working example).
+
+**CI corollary:** CI installs no extras. Any module a test imports at collection
+time must be import-light. That's why `ticket.py`, `ocr_quality.py`, and
+`pii_eval.py`'s dependencies sit at the light `janasunani.pipeline` level —
+and why nothing test-imported may route through `stages/<x>/__init__.py`
+(those pull the heavy stacks). We've been bitten (cv2, PIL); keep the pattern.
+
+## Artifact DB → OLTP → lake
+
+`db.py` owns the pipeline SQLite schema (`pages`, `documents`,
+`unreadable_pages`). It is per-run working state: resumable (stages select
+their own pending work), cheap to throw away, safe to run anywhere. Outputs
+reach the OLTP store via `janasunani-export-pipeline` (`export.py`): streaming
+batched upserts (ON CONFLICT DO UPDATE), idempotent, re-export refreshes rows.
+`janasunani-materialize` then carries them into the Parquet lake. Do **not**
+rewrite the pipeline onto the ORM — the split is a decision, not an accident.
+
+## Quality guards and evaluation
+
+- `ocr_quality.py` — repetition-collapse guard for DeepSeek output (its
+  signature failure: generation loops and one phrase fills the page). Detector:
+  **repeated-trigram share > 0.5** (generalizes the DSI report's top-trigram
+  rule, which only catches single-word loops), 20-word floor. Collapsed pages
+  store nothing and land in `unreadable_pages`.
+- `pii_eval.py` (`janasunani-evaluate-pii`) — scores gold-labeled JSONL
+  (external to the repo — never commit citizen text) against the **production
+  analyzer**. The pass/fail gate is untyped **COVERAGE** overlap recall vs the
+  legacy baseline **0.8056**; typed per-entity metrics are diagnostics.
+- `ticket.py` — ticket-number parsing from document paths. Only correct when
+  the format classifier's `--input` points exactly at the `documents/` root —
+  read its docstring before touching backfill inputs.
+
+## Regression anchor
+
+The `pipeline-sample` DVC stage runs format + pytesseract OCR + PII over the
+2-file DVC-tracked sample into a versioned SQLite — a cheap end-to-end check
+that the CPU path still works (`dvc repro pipeline-sample`).

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,36 @@
+# tests/ — policy and footguns
+
+**Policy: every feature ships with tests that exercise the real code path**
+(real async engine, moto for S3, respx for HTTP, real Presidio analyzer, real
+SQLite artifact DBs) — not mocks of our own code. Gate before "done":
+
+```bash
+uv run --extra pipeline-core pytest && uv run ruff check .
+```
+
+## Where tests run
+
+- **Locally / CI: yes.** CI (`pipeline.yml`) provides a throwaway Postgres
+  service on `127.0.0.1:5433` so the Postgres-path tests (`test_oltp_swap.py`)
+  run instead of skipping; it installs **no heavy extras**, so tests needing
+  presidio/torch skip there and MUST be run locally before merging.
+- **On the CPU box: NEVER against the prod container.** Fixtures create and
+  **drop tables**. If tests must run on the box, point them at a throwaway
+  `postgres:16` on `127.0.0.1:5433`, never the production `janasunani-oltp`
+  container on 5432.
+
+## Footguns encoded here
+
+- `conftest.py` pins `OMP_NUM_THREADS=1` **on macOS only**: importing spaCy
+  (blis) before xgboost initializes OpenMP in a way that segfaults arm64 Macs.
+  Production stage order loads xgboost first and is unaffected — don't "fix"
+  this by reordering production imports.
+- CI has no ML extras, so anything a test imports at collection time must be
+  import-light. Helpers for tests live in light modules
+  (`janasunani/pipeline/ticket.py`, `ocr_quality.py`) — never import through
+  `janasunani/pipeline/stages/<x>/__init__.py` in a test.
+- Postgres-path tests read `TEST_OLTP_PG_URL` (default
+  `postgres:pass@127.0.0.1:5433/janasunani`) and skip when unreachable —
+  "green locally" without a local Postgres means those paths ran nowhere.
+  Check CI.
+- `tests/` is not a package — no relative imports between test files.


### PR DESCRIPTION
## Summary
- **docs/ARCHITECTURE.md** — the cold-start entry point: end-to-end data flow (cold start vs live), the three storage layers and why they're distinct, package map, the uv extras/conflicts story, two-box infra, DVC boundary, model-provenance rule, security invariants, gates.
- **Per-package READMEs** (`janasunani/{db,migration,ingestion,olap,pipeline}/`, `deploy/`, `tests/`) — each covers its contracts plus the operational lessons already paid for: Postgres portability (NUL bytes, btree cap, asyncpg strictness), the authenticated MySQL probe, GLACIER filtering, the ticket-parsing input-root rule, the CI no-extras import pattern, the macOS OMP pin, and the never-list (compose down -v, pytest vs prod container).
- Root README gains a Documentation section linking the set.

No code changes — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)