### PR TITLE
GPU shakedown: AZ pin, PATH fix, torchvision dep

### DIFF
--- a/deploy/terraform/.gitignore
+++ b/deploy/terraform/.gitignore
@@ -5,3 +5,4 @@ terraform.tfstate.*
 terraform.tfvars
 *.auto.tfvars
 crash.log
+*.tfstate.*

--- a/deploy/terraform/gpu.tf
+++ b/deploy/terraform/gpu.tf
@@ -26,6 +26,15 @@ data "aws_ami" "dlami_gpu" {
   }
 }
 
+# g6 instances are not offered in every AZ (ap-south-1c lacks them), so the
+# GPU box pins its subnet to an AZ that has them instead of taking the
+# default-subnet list's first entry like the CPU box does.
+data "aws_subnet" "gpu" {
+  vpc_id            = data.aws_vpc.default.id
+  availability_zone = var.gpu_availability_zone
+  default_for_az    = true
+}
+
 resource "aws_security_group" "gpu_box" {
   name        = "janasunani-gpu-box"
   description = "Janasunani GPU box: SSH from the maintainer only, no inbound services"
@@ -62,7 +71,7 @@ resource "aws_instance" "gpu_box" {
 
   ami                    = data.aws_ami.dlami_gpu.id
   instance_type          = var.gpu_instance_type
-  subnet_id              = data.aws_subnets.default.ids[0]
+  subnet_id              = data.aws_subnet.gpu.id
   vpc_security_group_ids = [aws_security_group.gpu_box.id]
   key_name               = aws_key_pair.maintainer.key_name
   iam_instance_profile   = aws_iam_instance_profile.gpu_box.name

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -51,6 +51,12 @@ variable "gpu_instance_type" {
   default     = "g6.xlarge"
 }
 
+variable "gpu_availability_zone" {
+  description = "AZ for the GPU box. g6 is offered in ap-south-1a/1b but NOT 1c (verified 2026-07-04)."
+  type        = string
+  default     = "ap-south-1a"
+}
+
 variable "gpu_root_volume_gb" {
   description = "GPU box root EBS (gp3). DLAMI snapshot is 75 GB; extra covers model weights, uv envs, HF cache, document sample."
   type        = number

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -127,15 +127,19 @@ ingestion smoke — blocked on the Janasunani API credentials.
    (Odia extraction verified after adding the `ori` traineddata).
 5. ✅ **PII stage rebuilt** on Presidio (see Phase 5) — the default full-stage run
    works again; the pipeline-sample DVC stage now includes redaction.
-6. 🔶 GPU box: infra + tooling done on `feat/gpu-box` — count-toggled g6.xlarge in
-   `deploy/terraform/gpu.tf` from the Deep Learning **Base** AMI (driver + docker +
-   nvidia-container-toolkit preinstalled; `terraform plan` verified 2-add/0-change),
-   `scripts/gpu_smoke.sh` (format via `pipeline-core` env, OCR via `ocr-deepseek` env,
-   same SQLite), and the DSI repetition-collapse guard wired into the DeepSeek path
-   (generalized to the repeated-trigram share > 0.5 ⇒ page recorded unreadable —
-   DSI's raw top-trigram rule only catches single-word loops). *Pending:* first real
-   apply + on-box smoke run. Watch for `trust_remote_code` importing `flash_attn`
-   unconditionally — attn is forced eager, but the import itself may still fire.
+6. ✅ GPU box, built and shaken down (first real run 2026-07-04): count-toggled
+   g6.xlarge in `deploy/terraform/gpu.tf` (Deep Learning **Base** AMI; AZ pinned to
+   ap-south-1a — g6 not offered in 1c), `scripts/gpu_smoke.sh` (format via
+   `pipeline-core` env, DeepSeek OCR via `ocr-deepseek` env, same SQLite), and the
+   repetition-collapse guard (repeated-trigram share > 0.5 — generalizes DSI's
+   top-trigram rule, which only catches single-word loops). On-box smoke: model
+   loads on the L4, 3/5 sample pages extract; the guard fired on a looping Odia
+   handwritten page and was **verified a true positive** (repeated share 0.55 where
+   DSI's metric read 0.04). The predicted `trust_remote_code` surprise was
+   **torchvision**, not flash_attn — now in the `ocr-deepseek` extra. Learned:
+   DeepSeek is English-only in practice (Odia comes out script-confused) — the
+   backfill routes DeepSeek at `--filter-language English`, pytesseract+`ori` at
+   Odia, matching DSI. Box destroyed after the run (create/destroy per use).
 7. ⬜ **PII eval before sample backfill**: label ~100-200 real pages and beat the
    legacy 80.56% any-overlap baseline before exporting real-page outputs.
 8. ⬜ **Sample backfill only** (~200 curated docs; pick STANDARD storage class — parts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,9 @@ ocr-deepseek = [
     "pillow",
     "torch",
     "tokenizers==0.20.3",
+    # DeepSeek-OCR's trust_remote_code model code imports torchvision
+    # unconditionally (found by the first GPU smoke run).
+    "torchvision",
     "transformers==4.46.3",
 ]
 # MuRIL grievance categorizer

--- a/scripts/gpu_smoke.sh
+++ b/scripts/gpu_smoke.sh
@@ -11,6 +11,10 @@
 # ocr_model='deepseek' and no repetition collapse.
 set -euo pipefail
 
+# uv installs to ~/.local/bin, which non-login shells (nohup, ssh <cmd>)
+# don't put on PATH.
+export PATH="$HOME/.local/bin:$PATH"
+
 DB=data/processed/gpu-smoke.sqlite
 
 echo "== GPU check =="

--- a/uv.lock
+++ b/uv.lock
@@ -2151,6 +2151,7 @@ ocr-deepseek = [
     { name = "pillow" },
     { name = "tokenizers", version = "0.20.3", source = { registry = "https://pypi.org/simple" } },
     { name = "torch" },
+    { name = "torchvision" },
     { name = "transformers", version = "4.46.3", source = { registry = "https://pypi.org/simple" } },
 ]
 pipeline-core = [
@@ -2237,6 +2238,7 @@ requires-dist = [
     { name = "torch", marker = "extra == 'categorizer'" },
     { name = "torch", marker = "extra == 'ocr-deepseek'" },
     { name = "torch", marker = "extra == 'pipeline-core'" },
+    { name = "torchvision", marker = "extra == 'ocr-deepseek'" },
     { name = "tqdm", specifier = ">=4.66" },
     { name = "transformers", marker = "extra == 'categorizer'", specifier = ">=4.57,<5" },
     { name = "transformers", marker = "extra == 'ocr-deepseek'", specifier = "==4.46.3" },
@@ -5814,6 +5816,30 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/07/fe09d1699fbed2afa10ebc692ff2b99d113f2605b6748cea633989e2789a/torch-2.12.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:97eba061fcb042fed191400b15568990073d67eaacaa6ee9b7ca01dd8b790fe9", size = 426404009, upload-time = "2026-06-17T21:04:57.557Z" },
     { url = "https://files.pythonhosted.org/packages/2e/f7/0ce4f6c1962c60ded7270e0a9eb560fb615c92b89d332cf9e3dff36d5ecc/torch-2.12.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:3867b861391701012adb2df93360efb88494dca245a185e3bb7624495cfe3f33", size = 532184292, upload-time = "2026-06-17T21:05:17.526Z" },
     { url = "https://files.pythonhosted.org/packages/70/db/e384c12aba30320ca92aaaf557456cbcb26f04b4df307728bb8f019f5000/torch-2.12.1-cp314-cp314t-win_amd64.whl", hash = "sha256:dd15595f8fc764cffde8c6361a3beb6ef69a028c851b1b3e70e077f615980d4e", size = 123231142, upload-time = "2026-06-17T21:05:27.061Z" },
+]
+
+[[package]]
+name = "torchvision"
+version = "0.27.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "pillow" },
+    { name = "torch" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/bb/b21e0f598ca191bb2a9e9fda2fee37c06ad113313b43c6769dbefa0e921d/torchvision-0.27.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:d60311a6d08df905f9656a3a312f0a8f55f0d46321bc737bad30a8dec9644309", size = 1852110, upload-time = "2026-06-17T21:09:22.577Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/90/d61171daa5d6cd5f9315f84f9ef947b047a9fdf283d53241327045a8dd6d/torchvision-0.27.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:08aa33bc8e062cca32aefa90ac714916c5a855cbe1ab4c6148fc0453eb40ca5a", size = 7789476, upload-time = "2026-06-17T21:09:13.105Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/dc/b21d7801562c23a770e7037989814582f22ca4db479204293561de4b62e8/torchvision-0.27.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:916448be4b19676677b0dbf47d08f68b7955ea0abec7fc79340c31e217a824ba", size = 7664256, upload-time = "2026-06-17T21:09:07.549Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/b3/4386976ff77eda55f0aed504a288564f3ff8d170b6db49ee22e172eddfac/torchvision-0.27.1-cp313-cp313-win_amd64.whl", hash = "sha256:18bc906235bfa901c135acd239f05b8c8ab90d502830cf1ef2cba3301e1f8a23", size = 4150710, upload-time = "2026-06-17T21:09:14.457Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/74/1d237c61f665bf46d02e15f67c9d40be42b1b634f87164b9cefd257450e7/torchvision-0.27.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:9f5ef59ad60e695796eca6b64e97cb9b21b9d5463cac5ac0ef86cfb72b6e5db9", size = 1852112, upload-time = "2026-06-17T21:09:21.445Z" },
+    { url = "https://files.pythonhosted.org/packages/24/84/f0d772e7ed85891f084755bd5d7f6f7fd279992a02652c653c1c8429dd84/torchvision-0.27.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:ab2f8047c2da5bf6742fec6da86840e5feaeb0cea76930d0536f3520df31e166", size = 7789751, upload-time = "2026-06-17T21:09:11.51Z" },
+    { url = "https://files.pythonhosted.org/packages/76/68/3febd41b6eef453a83fb7a0178446334fbb0405eb4b0c40b00efaf99a2dc/torchvision-0.27.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:b44ef28ad1963f8cba5bf82f3564c454c74be300df9f79efa43f773312d17d6c", size = 7664350, upload-time = "2026-06-17T21:09:04.486Z" },
+    { url = "https://files.pythonhosted.org/packages/52/49/a23e199faf29e42a90f7d6b76437ade5d17e3185da3c64d368973ba8243e/torchvision-0.27.1-cp314-cp314-win_amd64.whl", hash = "sha256:b3e9bc71854fddbf94ddb69ed8d88983945f3f28f78ee104214b0088669af66a", size = 4177297, upload-time = "2026-06-17T21:09:10.273Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/48/b3240eaf0fe3676dcf677ce8930ef477fe77d7f69ebe58ca8d0941384952/torchvision-0.27.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:c2fd9902f23b56b6ac667213171672fb6c89287ff011918b04af053852a2c4eb", size = 1852118, upload-time = "2026-06-17T21:09:20.223Z" },
+    { url = "https://files.pythonhosted.org/packages/73/01/6c8f3158994a9e5bb0c7b1bacc361d60e015ad79487af88fa4d7ce72c2b6/torchvision-0.27.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:8abb6d5cacd56486ca2240e5580750e53ac559412e472ea6a3cee83231a77ca7", size = 7791242, upload-time = "2026-06-17T21:09:02.062Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/e6/f66733fc411a9ce070c0d899c1ae562ff11654a0bc708511e23efe9d6872/torchvision-0.27.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:d11da1ce8a5cc7fc527f2d5e0fe25efba93687897fe9339382b593910b1d1c6e", size = 7664934, upload-time = "2026-06-17T21:09:06.221Z" },
+    { url = "https://files.pythonhosted.org/packages/90/aa/d6179812ec52b70a7a8f5e99fe7937895d28c535106df1ca0d03f5f51425/torchvision-0.27.1-cp314-cp314t-win_amd64.whl", hash = "sha256:12deaee20d0d9dec6302025d3f93354266befeb692f5c50bca0137b395598b9e", size = 4284412, upload-time = "2026-06-17T21:09:08.989Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Fixes from the first real GPU box run (apply + `scripts/gpu_smoke.sh` on g6.xlarge):

- **Terraform**: g6 isn't offered in ap-south-1c, which is where the default-subnet list put the instance. New `gpu_availability_zone` variable (default ap-south-1a, verified via `describe-instance-type-offerings`) pins the GPU box's subnet.
- **gpu_smoke.sh**: export `~/.local/bin` — non-login shells (nohup, `ssh <cmd>`) don't have uv on PATH.
- **pyproject/uv.lock**: DeepSeek-OCR's `trust_remote_code` model code unconditionally imports **torchvision** (the flash_attn-class risk the ROADMAP flagged, different package). Added to the `ocr-deepseek` extra.

## Smoke findings (box verified, then torn down)
- Full stack works: DLAMI drivers, both conflicting uv envs, CUDA torch, model load, inference.
- 3/5 sample pages extracted; 1 page legitimately blank-ish (0 chars); 1 page **killed by the repetition-collapse guard — verified true positive** (model loops on Odia handwriting; repeated-trigram share 0.55 while DSI's raw top-trigram metric read 0.04, i.e. their rule would have missed it).
- Odia pages come out script-confused/degraded — consistent with DSI running DeepSeek **English-only**. Backfill should route DeepSeek at English pages (`--filter-language English`) and pytesseract+ori at Odia.

## Test plan
- [x] All three fixes exercised on the real box (smoke progressed past each failure)
- [x] `uv lock` resolves (torchvision 0.27.1 added to the ocr-deepseek fork)
- [x] `terraform fmt`/`validate`; box created in ap-south-1a and destroyed cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)