### PR TITLE
Script: sample English-subject complaints + documents into a zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,13 +95,15 @@ uv run --extra pipeline-core janasunani-evaluate-pii --gold <gold.jsonl> # gate:
 ### 5 · Sample English complaints + documents (evaluation bundles)
 
 ```bash
-uv run --with langdetect python scripts/sample_english_complaints.py   # --n/--seed/--out
+uv run --extra pipeline-core python scripts/sample_english_complaints.py   # --n/--seed/--out
 ```
 
-Picks N complaints whose grievance subject is English (not Odia, not romanized
-Odia), downloads their S3 documents (STANDARD storage class only), and writes
-one zip: the documents + a `complaints.parquet` of their metadata. Selection
-logic and gates: [scripts/README.md](scripts/README.md).
+Picks N complaints that are English on both sides — the grievance subject (not
+Odia, not romanized Odia) *and* the scanned document (judged by the pipeline's
+format classifier + page-type ViT; documents that are pure PII like an Aadhaar
+are dropped) — downloads the S3 documents (STANDARD storage class only), and
+writes one zip: the documents + a `complaints.parquet` of their metadata and
+gate evidence. Selection logic: [scripts/README.md](scripts/README.md).
 
 ### 6 · Document ingestion (complaint files → S3)
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,18 @@ uv run janasunani-export-pipeline --db data/processed/pipeline.sqlite  # → OLT
 uv run --extra pipeline-core janasunani-evaluate-pii --gold <gold.jsonl> # gate: coverage ≥ 0.8056
 ```
 
-### 5 · Document ingestion (complaint files → S3)
+### 5 · Sample English complaints + documents (evaluation bundles)
+
+```bash
+uv run --with langdetect python scripts/sample_english_complaints.py   # --n/--seed/--out
+```
+
+Picks N complaints whose grievance subject is English (not Odia, not romanized
+Odia), downloads their S3 documents (STANDARD storage class only), and writes
+one zip: the documents + a `complaints.parquet` of their metadata. Selection
+logic and gates: [scripts/README.md](scripts/README.md).
+
+### 6 · Document ingestion (complaint files → S3)
 
 ```bash
 uv run janasunani-ingest-documents
@@ -130,6 +141,7 @@ The GPU box is a `gpu_box_count = 0/1` toggle (~$1/hr while up).
   [pipeline](janasunani/pipeline/README.md) ·
   [deploy](deploy/README.md) ·
   [terraform](deploy/terraform/README.md) ·
+  [scripts](scripts/README.md) ·
   [tests](tests/README.md)
 
 ## Contributor reference

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -66,7 +66,7 @@ migration change): **1,371,288 complaints / 6,556,171 action-history rows**.
 | [`janasunani/pipeline/`](../janasunani/pipeline/README.md) | The six-stage document pipeline (DSI refold), its artifact DB, the OLTP exporter, OCR quality guards, PII evaluator. |
 | [`janasunani/tracking/`](../janasunani/tracking/__init__.py) | MLflow + DVC dual tracking (slim; being built). |
 | [`deploy/`](../deploy/README.md) | docker-compose for the CPU box; [Terraform](../deploy/terraform/README.md) for both EC2 boxes. |
-| [`scripts/`](../scripts) | Operational one-offs: `migrate.sh` (cold-start), `gpu_smoke.sh` (DeepSeek smoke), `setup.sh`. |
+| [`scripts/`](../scripts/README.md) | Operational one-offs: `migrate.sh` (cold-start), `gpu_smoke.sh` (DeepSeek smoke), `sample_english_complaints.py` (evaluation bundles), `setup.sh`. |
 | [`tests/`](../tests/README.md) | Real-code-path pytest suite. Read the README before running tests anywhere near production. |
 
 ## Environments and the dependency split

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -72,3 +72,16 @@ english_complaints_sample.zip
 Exits non-zero if fewer than N complaints qualify, telling you how many
 candidates were checked. Both the subject gate and the document verdict logic
 have tests (`tests/test_sample_english_complaints.py`).
+
+### Debugging a run
+
+Every decision is logged: model load times, a progress heartbeat every 100
+candidates (checked/picked/reject counters), per-ticket S3 keys, per-page
+`language`/`page_type` verdicts with timings (DEBUG), drop reasons per
+document, and an end-of-run breakdown (subject rejects / no-STANDARD-doc
+skips / documents dropped by gates). Per-candidate subject rejections are
+high-volume, so they sit at TRACE:
+
+```bash
+LOGURU_LEVEL=TRACE uv run --extra pipeline-core python scripts/sample_english_complaints.py
+```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,61 @@
+# scripts/ — operational one-offs
+
+Jobs whose effects live in external systems (OLTP, S3, a GPU box), so they run
+as scripts rather than DVC stages. Each is safe to re-run.
+
+| Script | What it does |
+|---|---|
+| `migrate.sh` | Cold-start migration: ephemeral MySQL → restore dump → load OLTP ([migration/README](../janasunani/migration/README.md)). |
+| `gpu_smoke.sh` | DeepSeek OCR smoke on the GPU box ([terraform/README](../deploy/terraform/README.md), "GPU box"). |
+| `sample_english_complaints.py` | Sample English-subject complaints + their documents into a zip (below). |
+| `evaluate_pii_redaction.py` | Thin wrapper over `janasunani-evaluate-pii` (the PII gold-JSONL gate). |
+| `setup.sh` | Workspace setup backing `make setup` (uv, rclone, AWS CLI, hooks). |
+
+## sample_english_complaints.py
+
+Builds a small, clean evaluation bundle: **N complaints (default 10) whose
+grievance subject is written in English**, with their scanned documents and
+their full metadata rows, in a single zip.
+
+### Run it
+
+```bash
+# needs: the lake locally (dvc pull / janasunani-materialize) + AWS credentials
+uv run --with langdetect python scripts/sample_english_complaints.py \
+    --n 10 --seed 7 --out data/output/english_complaints_sample.zip
+```
+
+All flags optional (defaults shown). langdetect isn't a base dependency —
+`--with langdetect` supplies it ad hoc. Same seed ⇒ same sample.
+
+### What lands in the zip
+
+```
+english_complaints_sample.zip
+├── complaints.parquet          # the N sampled rows, all lake columns
+└── documents/
+    ├── CMO2022142102_complaint_20250919_012958.pdf
+    └── ...                     # S3 key paths preserved — nested tickets keep
+                                # the directory structure the pipeline's
+                                # ticket parsing requires
+```
+
+### How it selects
+
+1. Load `data/interim/complaints.parquet`; keep rows with a subject
+   (≥ 30 chars) and a `document_url`.
+2. Shuffle deterministically (`--seed`), then walk candidates lazily until N
+   qualify — the expensive checks only run on rows actually considered:
+   - **English gate** (three tests, in order):
+     no Odia codepoints → **≥ 2 common English stopwords** (this is what
+     rejects *romanized* Odia, which langdetect often mislabels) →
+     langdetect says `en` (seeded, so deterministic).
+   - **Document gate**: the ticket has ≥ 1 object in the S3 documents bucket
+     under `{ticket_no}_complaint_` with storage class **STANDARD** — parts of
+     the bucket are GLACIER-archived and can't be downloaded directly, so
+     those tickets are skipped rather than failed on.
+3. Download the qualifying documents and write the zip (parquet + documents).
+
+Exits non-zero if fewer than N complaints qualify, telling you how many
+candidates were checked. The language gate has its own tests
+(`tests/test_sample_english_complaints.py`).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -59,13 +59,17 @@ english_complaints_sample.zip
      bucket under `{ticket_no}_complaint_` with storage class **STANDARD** —
      parts of the bucket are GLACIER-archived and can't be downloaded
      directly, so those tickets are skipped rather than failed on.
-   - **Document gates** (the pipeline's own models, on the first 5 pages):
-     the format classifier's language prediction must be exactly `English`
-     on **a majority of pages** ("largely English"), and the page-type ViT
-     must find **≥ 1 signal-class page** (Letter / Form/Application /
-     Text Only). A document whose pages are all Identification / Bills /
-     Misc — i.e. pure PII like an Aadhaar — has no signal page and is
-     dropped, with the reason logged.
+   - **Document gates** (the pipeline's own components, on the first 5
+     pages). Language: per-page **tesseract dominance** — eng vs ori
+     confidence-weighted word counts via the pipeline's `perform_ocr` (the
+     raw signal, deliberately not the ~76%-accuracy format-classifier label,
+     which let Odia pages through). **Any Odia-dominant page rejects the
+     document**; pages with too little confident text either way count as
+     `Sparse` and are tolerated, but ≥ 1 confidently-English page is
+     required. Substance: the page-type ViT must find **≥ 1 signal-class
+     page** (Letter / Form/Application / Text Only). A document whose pages
+     are all Identification / Bills / Misc — i.e. pure PII like an Aadhaar —
+     has no signal page and is dropped, with the reason logged.
 3. Write the zip: the qualifying documents + the metadata parquet, which
    carries the per-document gate evidence for auditability.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,26 +13,30 @@ as scripts rather than DVC stages. Each is safe to re-run.
 
 ## sample_english_complaints.py
 
-Builds a small, clean evaluation bundle: **N complaints (default 10) whose
-grievance subject is written in English**, with their scanned documents and
-their full metadata rows, in a single zip.
+Builds a small, clean evaluation bundle: **N complaints (default 10) that are
+English on both sides** — the grievance subject *and* the scanned document —
+with the documents and full metadata rows in a single zip. Documents that are
+nothing but PII (an Aadhaar or voter ID, a bill) are dropped.
 
 ### Run it
 
 ```bash
-# needs: the lake locally (dvc pull / janasunani-materialize) + AWS credentials
-uv run --with langdetect python scripts/sample_english_complaints.py \
+# needs: the lake locally (dvc pull / janasunani-materialize), the model
+# mirrors under models/, tesseract (+ ori traineddata), AWS credentials
+uv run --extra pipeline-core python scripts/sample_english_complaints.py \
     --n 10 --seed 7 --out data/output/english_complaints_sample.zip
 ```
 
-All flags optional (defaults shown). langdetect isn't a base dependency —
-`--with langdetect` supplies it ad hoc. Same seed ⇒ same sample.
+All flags optional (defaults shown). The document gates run pipeline models,
+hence the `pipeline-core` env. Same seed ⇒ same sample.
 
 ### What lands in the zip
 
 ```
 english_complaints_sample.zip
-├── complaints.parquet          # the N sampled rows, all lake columns
+├── complaints.parquet          # the N sampled rows, all lake columns, plus
+│                               # gate evidence: doc_languages, doc_page_types,
+│                               # doc_english_share
 └── documents/
     ├── CMO2022142102_complaint_20250919_012958.pdf
     └── ...                     # S3 key paths preserved — nested tickets keep
@@ -45,17 +49,26 @@ english_complaints_sample.zip
 1. Load `data/interim/complaints.parquet`; keep rows with a subject
    (≥ 30 chars) and a `document_url`.
 2. Shuffle deterministically (`--seed`), then walk candidates lazily until N
-   qualify — the expensive checks only run on rows actually considered:
-   - **English gate** (three tests, in order):
-     no Odia codepoints → **≥ 2 common English stopwords** (this is what
-     rejects *romanized* Odia, which langdetect often mislabels) →
-     langdetect says `en` (seeded, so deterministic).
-   - **Document gate**: the ticket has ≥ 1 object in the S3 documents bucket
-     under `{ticket_no}_complaint_` with storage class **STANDARD** — parts of
-     the bucket are GLACIER-archived and can't be downloaded directly, so
-     those tickets are skipped rather than failed on.
-3. Download the qualifying documents and write the zip (parquet + documents).
+   qualify — cheapest gate first, so the model work only runs on plausible
+   rows:
+   - **Subject gate** (three tests, in order): no Odia codepoints →
+     **≥ 2 common English stopwords** (this is what rejects *romanized* Odia,
+     which langdetect often mislabels) → langdetect says `en` (seeded, so
+     deterministic).
+   - **Availability gate**: the ticket has ≥ 1 object in the S3 documents
+     bucket under `{ticket_no}_complaint_` with storage class **STANDARD** —
+     parts of the bucket are GLACIER-archived and can't be downloaded
+     directly, so those tickets are skipped rather than failed on.
+   - **Document gates** (the pipeline's own models, on the first 5 pages):
+     the format classifier's language prediction must be exactly `English`
+     on **a majority of pages** ("largely English"), and the page-type ViT
+     must find **≥ 1 signal-class page** (Letter / Form/Application /
+     Text Only). A document whose pages are all Identification / Bills /
+     Misc — i.e. pure PII like an Aadhaar — has no signal page and is
+     dropped, with the reason logged.
+3. Write the zip: the qualifying documents + the metadata parquet, which
+   carries the per-document gate evidence for auditability.
 
 Exits non-zero if fewer than N complaints qualify, telling you how many
-candidates were checked. The language gate has its own tests
-(`tests/test_sample_english_complaints.py`).
+candidates were checked. Both the subject gate and the document verdict logic
+have tests (`tests/test_sample_english_complaints.py`).

--- a/scripts/sample_english_complaints.py
+++ b/scripts/sample_english_complaints.py
@@ -4,12 +4,14 @@ Selects complaints from the Parquet lake where BOTH sides are English:
 
 - the **grievance subject** is written in English — not Odia script and not
   romanized Odia;
-- the **document** is largely English and substantive — judged by the
-  pipeline's own models: the format classifier's language prediction (majority
-  of pages exactly "English") and the page-type ViT (at least one
-  signal-class page: Letter / Form/Application / Text Only). Documents that
-  are nothing but PII — an Aadhaar or voter ID, a bill — have only
-  noise-class pages and are dropped.
+- the **document** is English and substantive — judged per page by the
+  pipeline's own components: tesseract language dominance (eng vs ori
+  confidence, via ``perform_ocr``) and the page-type ViT. ANY Odia-dominant
+  page rejects the document; sparse pages (stamps, signatures) are tolerated
+  but ≥1 confidently-English page and ≥1 signal-class page (Letter /
+  Form/Application / Text Only) are required. Documents that are nothing but
+  PII — an Aadhaar or voter ID, a bill — have only noise-class pages and are
+  dropped.
 
 Only complaints with ≥1 STANDARD-storage-class document in S3 qualify (parts
 of the bucket are GLACIER-archived). The output zip contains:
@@ -39,11 +41,10 @@ from __future__ import annotations
 import os
 import sys
 
-# macOS: xgboost (format classifier) and torch (page-type ViT) each load their
-# own OpenMP runtime; interleaving them makes the first ViT conv2d after an
-# xgboost predict spin forever (same family as the segfault noted in
-# tests/conftest.py). One OMP thread sidesteps it — must be set before either
-# library loads libomp.
+# macOS: mixing OpenMP-linked libraries (xgboost, torch) in one process makes
+# kernels hang or segfault (see tests/conftest.py). This script now only loads
+# torch, but the guard stays as insurance against reintroducing the mix — it
+# must be set before any such library loads libomp.
 if sys.platform == "darwin":
     os.environ.setdefault("OMP_NUM_THREADS", "1")
 
@@ -76,7 +77,10 @@ _MIN_SUBJECT_CHARS = 30
 # Document gates: cap per-document work (letters are 1-3 pages; a 40-page
 # annexure doesn't need every page judged to know its character).
 _MAX_PAGES_CHECKED = 5
-_MIN_ENGLISH_PAGE_SHARE = 0.5
+# A page needs this many confident tesseract words (in either language) to be
+# judged at all; below it the page is "Sparse" (stamps, signatures, photos)
+# and is ignored rather than counted for or against.
+_MIN_CONFIDENT_WORDS = 10
 
 _ODIA_RANGE = re.compile(r"[଀-୿]")
 _WORD = re.compile(r"[a-z']+")
@@ -123,8 +127,15 @@ class DocVerdict:
 
 
 def assess_document(languages: list[str], page_types: list[str]) -> DocVerdict:
-    """Pure verdict logic over per-page predictions (kept import-light so the
-    tests can exercise it without models)."""
+    """Pure verdict logic over per-page judgements (kept import-light so the
+    tests can exercise it without models).
+
+    ``languages`` values are "English" / "Odia" / "Sparse" (too little
+    confident text to judge). The rule is strict on purpose — an earlier,
+    share-based version shipped bundles with Odia-dominant pages inside:
+    ANY Odia-dominant page rejects the document; sparse pages are tolerated
+    but at least one confidently-English page is required.
+    """
     from janasunani.pipeline.stages.page_type_classifier import (
         PAGE_TYPE_CLASS_BY_LABEL,
     )
@@ -133,11 +144,13 @@ def assess_document(languages: list[str], page_types: list[str]) -> DocVerdict:
     types = tuple(page_types)
     if not langs:
         return DocVerdict(False, "no readable pages", langs, types)
-    english_share = sum(1 for lang in langs if lang == "English") / len(langs)
-    if english_share < _MIN_ENGLISH_PAGE_SHARE:
+    n_odia = sum(1 for lang in langs if lang == "Odia")
+    if n_odia:
         return DocVerdict(
-            False, f"not largely English (share {english_share:.2f})", langs, types
+            False, f"{n_odia} Odia-dominant page(s) of {len(langs)}", langs, types
         )
+    if "English" not in langs:
+        return DocVerdict(False, "no confidently-English page", langs, types)
     if not any(PAGE_TYPE_CLASS_BY_LABEL.get(t) == 1 for t in types):
         return DocVerdict(
             False, f"no substantive page — only {sorted(set(types))}", langs, types
@@ -145,26 +158,34 @@ def assess_document(languages: list[str], page_types: list[str]) -> DocVerdict:
     return DocVerdict(True, "ok", langs, types)
 
 
-class DocumentGates:
-    """Judge a downloaded document with the pipeline's own models.
+def classify_page_language(image) -> str:
+    """"English" / "Odia" / "Sparse" for one page, from the pipeline's raw
+    tesseract signal (``perform_ocr``: eng + ori passes, confidence-weighted).
 
-    Loads the format classifier (language) and the page-type ViT once; the
-    XGBoost pickle loads before torch, matching the pipeline's stage order
-    (relevant on macOS — see tests/conftest.py's OMP note).
+    Deliberately NOT the format classifier's language label — that model
+    (~76% accuracy) let Odia-dominant pages through as "English"; the direct
+    confidence comparison is the harder signal for script dominance.
     """
+    from janasunani.pipeline.stages.format_classifier.features import perform_ocr
+
+    ocr = perform_ocr(image)
+    if max(ocr["word_count_eng"], ocr["word_count_ori"]) < _MIN_CONFIDENT_WORDS:
+        return "Sparse"
+    return "Odia" if ocr["predominant_lang"] == "ori" else "English"
+
+
+class DocumentGates:
+    """Judge a downloaded document with the pipeline's own components:
+    tesseract language dominance per page + the page-type ViT."""
 
     def __init__(self, models_dir: Path = MODELS_DIR) -> None:
         import time
 
-        from janasunani.pipeline.stages.format_classifier.model import FormatClassifier
         from janasunani.pipeline.stages.page_type_classifier import (
             _PageTypeClassifier,
         )
 
-        format_path = models_dir / "format_classifier" / "page_split_v3.0_doc_split.pkl"
         t0 = time.time()
-        self._format = FormatClassifier(format_path)
-        t1 = time.time()
         vit_local = models_dir / "page_type_classifier" / "vit_type_classifier"
         model_id = (
             str(vit_local)
@@ -173,14 +194,12 @@ class DocumentGates:
         )
         self._page_type = _PageTypeClassifier(model_id)
         logger.info(
-            f"document gates ready: format classifier {format_path.name} "
-            f"({t1 - t0:.1f}s), page-type ViT {model_id} ({time.time() - t1:.1f}s)"
+            f"document gates ready: page-type ViT {model_id} "
+            f"({time.time() - t0:.1f}s); language via tesseract eng+ori"
         )
 
     def assess(self, doc_path: Path) -> DocVerdict:
         import time
-
-        import numpy as np
 
         t0 = time.time()
         languages: list[str] = []
@@ -188,16 +207,8 @@ class DocumentGates:
         for page_number, image in enumerate(
             _page_images(doc_path, _MAX_PAGES_CHECKED), start=1
         ):
-            bgr = np.array(image.convert("RGB"))[:, :, ::-1]
             t_page = time.time()
-            prediction = self._format.predict(bgr)
-            if prediction is None or not prediction.get("language"):
-                logger.debug(
-                    f"{doc_path.name} p{page_number}: format classifier "
-                    "returned nothing — page skipped"
-                )
-                continue
-            language = prediction["language"]
+            language = classify_page_language(image)
             page_type = self._page_type.predict(image)
             logger.debug(
                 f"{doc_path.name} p{page_number}: language={language!r} "

--- a/scripts/sample_english_complaints.py
+++ b/scripts/sample_english_complaints.py
@@ -1,36 +1,60 @@
-"""Sample N English-subject complaints and pack their documents into a zip.
+"""Sample N English complaints (subject AND document) + documents into a zip.
 
-Selects complaints from the Parquet lake whose grievance subject is written in
-English — not Odia script and not romanized Odia — and which have at least one
-STANDARD-storage-class document in the S3 documents bucket (parts of the bucket
-are GLACIER-archived and can't be downloaded directly). Downloads those
-documents and writes one zip containing:
+Selects complaints from the Parquet lake where BOTH sides are English:
 
-    documents/<s3-key>...     the complaint documents (key paths preserved,
+- the **grievance subject** is written in English — not Odia script and not
+  romanized Odia;
+- the **document** is largely English and substantive — judged by the
+  pipeline's own models: the format classifier's language prediction (majority
+  of pages exactly "English") and the page-type ViT (at least one
+  signal-class page: Letter / Form/Application / Text Only). Documents that
+  are nothing but PII — an Aadhaar or voter ID, a bill — have only
+  noise-class pages and are dropped.
+
+Only complaints with ≥1 STANDARD-storage-class document in S3 qualify (parts
+of the bucket are GLACIER-archived). The output zip contains:
+
+    documents/<s3-key>...     the qualifying documents (key paths preserved,
                               so nested tickets keep their directory structure
                               for the pipeline's ticket parsing)
-    complaints.parquet        the sampled complaints' full metadata rows
+    complaints.parquet        the sampled complaints' metadata rows, plus the
+                              per-document gate evidence (doc_languages,
+                              doc_page_types, doc_english_share)
 
-Needs the lake locally (`dvc pull` / `janasunani-materialize`) and AWS
-credentials (default chain). langdetect is not a base dependency — run with:
+Needs the lake locally (`dvc pull` / `janasunani-materialize`), the DVC model
+mirrors under models/, the `tesseract` binary (+ `ori` traineddata), and AWS
+credentials. The document gates use pipeline models, so run in the
+pipeline-core env:
 
-    uv run --with langdetect python scripts/sample_english_complaints.py \
+    uv run --extra pipeline-core python scripts/sample_english_complaints.py \
         [--n 10] [--seed 7] [--out data/output/english_complaints_sample.zip]
 """
 
 from __future__ import annotations
+
+import os
+import sys
+
+# macOS: xgboost (format classifier) and torch (page-type ViT) each load their
+# own OpenMP runtime; interleaving them makes the first ViT conv2d after an
+# xgboost predict spin forever (same family as the segfault noted in
+# tests/conftest.py). One OMP thread sidesteps it — must be set before either
+# library loads libomp.
+if sys.platform == "darwin":
+    os.environ.setdefault("OMP_NUM_THREADS", "1")
 
 import argparse
 import random
 import re
 import tempfile
 import zipfile
+from dataclasses import dataclass
 from pathlib import Path
 
 import polars as pl
 from loguru import logger
 
-from janasunani.config import INTERIM_DATA_DIR, OUTPUT_DATA_DIR
+from janasunani.config import INTERIM_DATA_DIR, MODELS_DIR, OUTPUT_DATA_DIR
 from janasunani.ingestion.s3service import S3Service
 
 # Words that appear in essentially any English sentence but not in romanized
@@ -44,6 +68,11 @@ _ENGLISH_STOPWORDS = frozenset(
 )
 _MIN_STOPWORD_HITS = 2
 _MIN_SUBJECT_CHARS = 30
+
+# Document gates: cap per-document work (letters are 1-3 pages; a 40-page
+# annexure doesn't need every page judged to know its character).
+_MAX_PAGES_CHECKED = 5
+_MIN_ENGLISH_PAGE_SHARE = 0.5
 
 _ODIA_RANGE = re.compile(r"[଀-୿]")
 _WORD = re.compile(r"[a-z']+")
@@ -73,6 +102,102 @@ def is_english(text: str) -> bool:
         return False
 
 
+@dataclass(frozen=True)
+class DocVerdict:
+    ok: bool
+    reason: str
+    languages: tuple[str, ...]
+    page_types: tuple[str, ...]
+
+    @property
+    def english_share(self) -> float:
+        if not self.languages:
+            return 0.0
+        return sum(1 for lang in self.languages if lang == "English") / len(
+            self.languages
+        )
+
+
+def assess_document(languages: list[str], page_types: list[str]) -> DocVerdict:
+    """Pure verdict logic over per-page predictions (kept import-light so the
+    tests can exercise it without models)."""
+    from janasunani.pipeline.stages.page_type_classifier import (
+        PAGE_TYPE_CLASS_BY_LABEL,
+    )
+
+    langs = tuple(languages)
+    types = tuple(page_types)
+    if not langs:
+        return DocVerdict(False, "no readable pages", langs, types)
+    english_share = sum(1 for lang in langs if lang == "English") / len(langs)
+    if english_share < _MIN_ENGLISH_PAGE_SHARE:
+        return DocVerdict(
+            False, f"not largely English (share {english_share:.2f})", langs, types
+        )
+    if not any(PAGE_TYPE_CLASS_BY_LABEL.get(t) == 1 for t in types):
+        return DocVerdict(
+            False, f"no substantive page — only {sorted(set(types))}", langs, types
+        )
+    return DocVerdict(True, "ok", langs, types)
+
+
+class DocumentGates:
+    """Judge a downloaded document with the pipeline's own models.
+
+    Loads the format classifier (language) and the page-type ViT once; the
+    XGBoost pickle loads before torch, matching the pipeline's stage order
+    (relevant on macOS — see tests/conftest.py's OMP note).
+    """
+
+    def __init__(self, models_dir: Path = MODELS_DIR) -> None:
+        from janasunani.pipeline.stages.format_classifier.model import FormatClassifier
+        from janasunani.pipeline.stages.page_type_classifier import (
+            _PageTypeClassifier,
+        )
+
+        self._format = FormatClassifier(
+            models_dir / "format_classifier" / "page_split_v3.0_doc_split.pkl"
+        )
+        vit_local = models_dir / "page_type_classifier" / "vit_type_classifier"
+        model_id = (
+            str(vit_local)
+            if (vit_local / "config.json").exists()
+            else "DPIC-Pipeline/vit_type_classifier"
+        )
+        self._page_type = _PageTypeClassifier(model_id)
+
+    def assess(self, doc_path: Path) -> DocVerdict:
+        import numpy as np
+
+        languages: list[str] = []
+        page_types: list[str] = []
+        for image in _page_images(doc_path, _MAX_PAGES_CHECKED):
+            bgr = np.array(image.convert("RGB"))[:, :, ::-1]
+            prediction = self._format.predict(bgr)
+            if prediction is None or not prediction.get("language"):
+                continue
+            languages.append(prediction["language"])
+            page_types.append(self._page_type.predict(image))
+        return assess_document(languages, page_types)
+
+
+def _page_images(doc_path: Path, max_pages: int):
+    """First ``max_pages`` pages of a PDF/image as PIL images."""
+    if doc_path.suffix.lower() == ".pdf":
+        from pdf2image import pdfinfo_from_path
+
+        from janasunani.pipeline.stages.page_type_classifier import _render_pdf_page
+
+        n_pages = int(pdfinfo_from_path(str(doc_path))["Pages"])
+        for page_number in range(1, min(n_pages, max_pages) + 1):
+            yield _render_pdf_page(doc_path, page_number)
+    else:
+        from PIL import Image
+
+        with Image.open(doc_path) as image:
+            yield image.convert("RGB")
+
+
 def _standard_class_documents(s3: S3Service, ticket_no: str) -> list[str]:
     """S3 keys of the ticket's documents that are directly downloadable."""
     objects = s3.list_objects(prefix=f"{ticket_no}_complaint_")
@@ -83,12 +208,14 @@ def _standard_class_documents(s3: S3Service, ticket_no: str) -> list[str]:
     ]
 
 
-def sample_complaints(n: int, seed: int) -> tuple[pl.DataFrame, dict[str, list[str]]]:
-    """Pick ``n`` English-subject complaints with downloadable documents.
+def sample_complaints(
+    n: int, seed: int, workdir: Path
+) -> tuple[pl.DataFrame, dict[str, list[Path]]]:
+    """Pick ``n`` complaints passing every gate; download their documents.
 
-    Returns (metadata rows, {ticket_no: [s3 keys]}). Candidates are shuffled
-    deterministically and language-checked lazily, so the expensive work only
-    runs on rows actually considered.
+    Returns (metadata rows + gate evidence, {ticket_no: [downloaded paths]}).
+    Candidates are shuffled deterministically and checked lazily,
+    cheapest gate first, so the heavy model work only runs on plausible rows.
     """
     lake_path = INTERIM_DATA_DIR / "complaints.parquet"
     if not lake_path.exists():
@@ -106,21 +233,57 @@ def sample_complaints(n: int, seed: int) -> tuple[pl.DataFrame, dict[str, list[s
     random.Random(seed).shuffle(order)
 
     s3 = S3Service()
+    gates = DocumentGates()
     picked_rows: list[int] = []
-    picked_keys: dict[str, list[str]] = {}
+    evidence: list[dict[str, object]] = []
+    picked_paths: dict[str, list[Path]] = {}
     checked = 0
     for idx in order:
         row = complaints.row(idx, named=True)
+        ticket = row["ticket_no"]
         checked += 1
         if not is_english(row["grievance"]):
             continue
-        keys = _standard_class_documents(s3, row["ticket_no"])
+        keys = _standard_class_documents(s3, ticket)
         if not keys:
-            logger.info(f"{row['ticket_no']}: no STANDARD-class document, skipping")
+            logger.info(f"{ticket}: no STANDARD-class document, skipping")
             continue
+
+        kept: list[Path] = []
+        verdicts: list[DocVerdict] = []
+        for key in keys:
+            local = workdir / key
+            local.parent.mkdir(parents=True, exist_ok=True)
+            if not s3.download_file(key, str(local)):
+                logger.warning(f"{ticket}: download failed for {key}, skipping key")
+                continue
+            
+            logger.info(f"Assessing documents for language and PII for {ticket}")
+            verdict = gates.assess(local)
+            if verdict.ok:
+                kept.append(local)
+                verdicts.append(verdict)
+            else:
+                logger.info(f"{ticket}: dropped {key} — {verdict.reason}")
+                local.unlink()
+        if not kept:
+            continue
+
         picked_rows.append(idx)
-        picked_keys[row["ticket_no"]] = keys
-        logger.info(f"picked {row['ticket_no']} ({len(keys)} document(s))")
+        picked_paths[ticket] = kept
+        evidence.append(
+            {
+                "ticket_no": ticket,
+                "doc_languages": "; ".join(
+                    ", ".join(v.languages) for v in verdicts
+                ),
+                "doc_page_types": "; ".join(
+                    ", ".join(v.page_types) for v in verdicts
+                ),
+                "doc_english_share": min(v.english_share for v in verdicts),
+            }
+        )
+        logger.info(f"picked {ticket} ({len(kept)} document(s))")
         if len(picked_rows) == n:
             break
 
@@ -130,29 +293,31 @@ def sample_complaints(n: int, seed: int) -> tuple[pl.DataFrame, dict[str, list[s
             f"after checking {checked} candidates"
         )
     logger.info(f"selected {n} complaints after checking {checked} candidates")
-    return complaints[picked_rows], picked_keys
+    metadata = complaints[picked_rows].join(
+        pl.DataFrame(evidence), on="ticket_no", how="left"
+    )
+    return metadata, picked_paths
 
 
-def build_zip(out_path: Path, metadata: pl.DataFrame, keys: dict[str, list[str]]) -> None:
-    s3 = S3Service()
+def build_zip(
+    out_path: Path,
+    metadata: pl.DataFrame,
+    paths: dict[str, list[Path]],
+    workdir: Path,
+) -> None:
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    with tempfile.TemporaryDirectory() as tmp:
-        tmp_dir = Path(tmp)
-        parquet_path = tmp_dir / "complaints.parquet"
-        metadata.write_parquet(parquet_path)
-
-        with zipfile.ZipFile(out_path, "w", zipfile.ZIP_DEFLATED) as zf:
-            zf.write(parquet_path, "complaints.parquet")
-            for ticket_no, ticket_keys in sorted(keys.items()):
-                for key in ticket_keys:
-                    local = tmp_dir / "doc"
-                    if not s3.download_file(key, str(local)):
-                        raise SystemExit(f"download failed for s3 key {key}")
-                    zf.write(local, f"documents/{key}")
-                    local.unlink()
+    parquet_path = workdir / "complaints.parquet"
+    metadata.write_parquet(parquet_path)
+    n_docs = 0
+    with zipfile.ZipFile(out_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.write(parquet_path, "complaints.parquet")
+        for _, ticket_paths in sorted(paths.items()):
+            for local in ticket_paths:
+                zf.write(local, f"documents/{local.relative_to(workdir)}")
+                n_docs += 1
     logger.success(
         f"wrote {out_path} ({out_path.stat().st_size / 1e6:.1f} MB): "
-        f"{metadata.height} complaints, {sum(len(v) for v in keys.values())} document(s)"
+        f"{metadata.height} complaints, {n_docs} document(s)"
     )
 
 
@@ -167,8 +332,10 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    metadata, keys = sample_complaints(n=args.n, seed=args.seed)
-    build_zip(args.out, metadata, keys)
+    with tempfile.TemporaryDirectory() as tmp:
+        workdir = Path(tmp)
+        metadata, paths = sample_complaints(n=args.n, seed=args.seed, workdir=workdir)
+        build_zip(args.out, metadata, paths, workdir=workdir)
     return 0
 
 

--- a/scripts/sample_english_complaints.py
+++ b/scripts/sample_english_complaints.py
@@ -1,0 +1,176 @@
+"""Sample N English-subject complaints and pack their documents into a zip.
+
+Selects complaints from the Parquet lake whose grievance subject is written in
+English — not Odia script and not romanized Odia — and which have at least one
+STANDARD-storage-class document in the S3 documents bucket (parts of the bucket
+are GLACIER-archived and can't be downloaded directly). Downloads those
+documents and writes one zip containing:
+
+    documents/<s3-key>...     the complaint documents (key paths preserved,
+                              so nested tickets keep their directory structure
+                              for the pipeline's ticket parsing)
+    complaints.parquet        the sampled complaints' full metadata rows
+
+Needs the lake locally (`dvc pull` / `janasunani-materialize`) and AWS
+credentials (default chain). langdetect is not a base dependency — run with:
+
+    uv run --with langdetect python scripts/sample_english_complaints.py \
+        [--n 10] [--seed 7] [--out data/output/english_complaints_sample.zip]
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+import re
+import tempfile
+import zipfile
+from pathlib import Path
+
+import polars as pl
+from loguru import logger
+
+from janasunani.config import INTERIM_DATA_DIR, OUTPUT_DATA_DIR
+from janasunani.ingestion.s3service import S3Service
+
+# Words that appear in essentially any English sentence but not in romanized
+# Odia (which langdetect often can't classify reliably). Requiring a few of
+# these is the cheap, explainable guard against "mo ghara pakhare nala..."
+# style subjects slipping through as "English".
+_ENGLISH_STOPWORDS = frozenset(
+    """a an and are as at be been by for from has have he her his i in is it
+    my not of on or our please she sir that the their there this to was we
+    which will with you your""".split()
+)
+_MIN_STOPWORD_HITS = 2
+_MIN_SUBJECT_CHARS = 30
+
+_ODIA_RANGE = re.compile(r"[଀-୿]")
+_WORD = re.compile(r"[a-z']+")
+
+
+def is_english(text: str) -> bool:
+    """True when ``text`` reads as English prose.
+
+    Three gates: no Odia codepoints, langdetect says 'en', and the text
+    contains common English function words (romanized Odia has none even
+    when langdetect guesses 'en').
+    """
+    if len(text.strip()) < _MIN_SUBJECT_CHARS:
+        return False
+    if _ODIA_RANGE.search(text):
+        return False
+    words = _WORD.findall(text.lower())
+    if sum(1 for w in words if w in _ENGLISH_STOPWORDS) < _MIN_STOPWORD_HITS:
+        return False
+
+    from langdetect import DetectorFactory, LangDetectException, detect
+
+    DetectorFactory.seed = 0  # langdetect is nondeterministic by default
+    try:
+        return detect(text) == "en"
+    except LangDetectException:
+        return False
+
+
+def _standard_class_documents(s3: S3Service, ticket_no: str) -> list[str]:
+    """S3 keys of the ticket's documents that are directly downloadable."""
+    objects = s3.list_objects(prefix=f"{ticket_no}_complaint_")
+    return [
+        obj["Key"]
+        for obj in objects
+        if obj.get("StorageClass", "STANDARD") == "STANDARD"
+    ]
+
+
+def sample_complaints(n: int, seed: int) -> tuple[pl.DataFrame, dict[str, list[str]]]:
+    """Pick ``n`` English-subject complaints with downloadable documents.
+
+    Returns (metadata rows, {ticket_no: [s3 keys]}). Candidates are shuffled
+    deterministically and language-checked lazily, so the expensive work only
+    runs on rows actually considered.
+    """
+    lake_path = INTERIM_DATA_DIR / "complaints.parquet"
+    if not lake_path.exists():
+        raise SystemExit(
+            f"{lake_path} missing — run `dvc pull` or `janasunani-materialize` first."
+        )
+    complaints = pl.read_parquet(lake_path).filter(
+        pl.col("grievance").is_not_null()
+        & (pl.col("grievance").str.len_chars() >= _MIN_SUBJECT_CHARS)
+        & pl.col("document_url").is_not_null()
+    )
+    logger.info(f"{complaints.height} complaints with a subject and a document URL")
+
+    order = list(range(complaints.height))
+    random.Random(seed).shuffle(order)
+
+    s3 = S3Service()
+    picked_rows: list[int] = []
+    picked_keys: dict[str, list[str]] = {}
+    checked = 0
+    for idx in order:
+        row = complaints.row(idx, named=True)
+        checked += 1
+        if not is_english(row["grievance"]):
+            continue
+        keys = _standard_class_documents(s3, row["ticket_no"])
+        if not keys:
+            logger.info(f"{row['ticket_no']}: no STANDARD-class document, skipping")
+            continue
+        picked_rows.append(idx)
+        picked_keys[row["ticket_no"]] = keys
+        logger.info(f"picked {row['ticket_no']} ({len(keys)} document(s))")
+        if len(picked_rows) == n:
+            break
+
+    if len(picked_rows) < n:
+        raise SystemExit(
+            f"only found {len(picked_rows)}/{n} qualifying complaints "
+            f"after checking {checked} candidates"
+        )
+    logger.info(f"selected {n} complaints after checking {checked} candidates")
+    return complaints[picked_rows], picked_keys
+
+
+def build_zip(out_path: Path, metadata: pl.DataFrame, keys: dict[str, list[str]]) -> None:
+    s3 = S3Service()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+        parquet_path = tmp_dir / "complaints.parquet"
+        metadata.write_parquet(parquet_path)
+
+        with zipfile.ZipFile(out_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            zf.write(parquet_path, "complaints.parquet")
+            for ticket_no, ticket_keys in sorted(keys.items()):
+                for key in ticket_keys:
+                    local = tmp_dir / "doc"
+                    if not s3.download_file(key, str(local)):
+                        raise SystemExit(f"download failed for s3 key {key}")
+                    zf.write(local, f"documents/{key}")
+                    local.unlink()
+    logger.success(
+        f"wrote {out_path} ({out_path.stat().st_size / 1e6:.1f} MB): "
+        f"{metadata.height} complaints, {sum(len(v) for v in keys.values())} document(s)"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--n", type=int, default=10, help="complaints to sample")
+    parser.add_argument("--seed", type=int, default=7, help="sampling seed")
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=OUTPUT_DATA_DIR / "english_complaints_sample.zip",
+    )
+    args = parser.parse_args()
+
+    metadata, keys = sample_complaints(n=args.n, seed=args.seed)
+    build_zip(args.out, metadata, keys)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sample_english_complaints.py
+++ b/scripts/sample_english_complaints.py
@@ -28,6 +28,10 @@ pipeline-core env:
 
     uv run --extra pipeline-core python scripts/sample_english_complaints.py \
         [--n 10] [--seed 7] [--out data/output/english_complaints_sample.zip]
+
+Logging: decisions/progress at INFO; per-page model verdicts and timings at
+DEBUG (shown by loguru's default sink); per-candidate subject rejections are
+high-volume and sit at TRACE — run with LOGURU_LEVEL=TRACE to see them.
 """
 
 from __future__ import annotations
@@ -150,14 +154,17 @@ class DocumentGates:
     """
 
     def __init__(self, models_dir: Path = MODELS_DIR) -> None:
+        import time
+
         from janasunani.pipeline.stages.format_classifier.model import FormatClassifier
         from janasunani.pipeline.stages.page_type_classifier import (
             _PageTypeClassifier,
         )
 
-        self._format = FormatClassifier(
-            models_dir / "format_classifier" / "page_split_v3.0_doc_split.pkl"
-        )
+        format_path = models_dir / "format_classifier" / "page_split_v3.0_doc_split.pkl"
+        t0 = time.time()
+        self._format = FormatClassifier(format_path)
+        t1 = time.time()
         vit_local = models_dir / "page_type_classifier" / "vit_type_classifier"
         model_id = (
             str(vit_local)
@@ -165,20 +172,46 @@ class DocumentGates:
             else "DPIC-Pipeline/vit_type_classifier"
         )
         self._page_type = _PageTypeClassifier(model_id)
+        logger.info(
+            f"document gates ready: format classifier {format_path.name} "
+            f"({t1 - t0:.1f}s), page-type ViT {model_id} ({time.time() - t1:.1f}s)"
+        )
 
     def assess(self, doc_path: Path) -> DocVerdict:
+        import time
+
         import numpy as np
 
+        t0 = time.time()
         languages: list[str] = []
         page_types: list[str] = []
-        for image in _page_images(doc_path, _MAX_PAGES_CHECKED):
+        for page_number, image in enumerate(
+            _page_images(doc_path, _MAX_PAGES_CHECKED), start=1
+        ):
             bgr = np.array(image.convert("RGB"))[:, :, ::-1]
+            t_page = time.time()
             prediction = self._format.predict(bgr)
             if prediction is None or not prediction.get("language"):
+                logger.debug(
+                    f"{doc_path.name} p{page_number}: format classifier "
+                    "returned nothing — page skipped"
+                )
                 continue
-            languages.append(prediction["language"])
-            page_types.append(self._page_type.predict(image))
-        return assess_document(languages, page_types)
+            language = prediction["language"]
+            page_type = self._page_type.predict(image)
+            logger.debug(
+                f"{doc_path.name} p{page_number}: language={language!r} "
+                f"page_type={page_type!r} ({time.time() - t_page:.1f}s)"
+            )
+            languages.append(language)
+            page_types.append(page_type)
+        verdict = assess_document(languages, page_types)
+        logger.debug(
+            f"{doc_path.name}: verdict={'ok' if verdict.ok else verdict.reason!r} "
+            f"english_share={verdict.english_share:.2f} "
+            f"pages_judged={len(languages)} ({time.time() - t0:.1f}s)"
+        )
+        return verdict
 
 
 def _page_images(doc_path: Path, max_pages: int):
@@ -227,7 +260,10 @@ def sample_complaints(
         & (pl.col("grievance").str.len_chars() >= _MIN_SUBJECT_CHARS)
         & pl.col("document_url").is_not_null()
     )
-    logger.info(f"{complaints.height} complaints with a subject and a document URL")
+    logger.info(
+        f"{complaints.height} complaints with a subject and a document URL "
+        f"(lake: {lake_path}, seed={seed}, target n={n})"
+    )
 
     order = list(range(complaints.height))
     random.Random(seed).shuffle(order)
@@ -238,16 +274,29 @@ def sample_complaints(
     evidence: list[dict[str, object]] = []
     picked_paths: dict[str, list[Path]] = {}
     checked = 0
+    subject_rejects = 0
+    no_standard_doc = 0
+    docs_dropped = 0
     for idx in order:
         row = complaints.row(idx, named=True)
         ticket = row["ticket_no"]
         checked += 1
+        if checked % 100 == 0:
+            logger.info(
+                f"progress: checked={checked} picked={len(picked_rows)}/{n} "
+                f"(subject rejects={subject_rejects}, docs dropped={docs_dropped})"
+            )
         if not is_english(row["grievance"]):
+            # High-volume: visible with LOGURU_LEVEL=TRACE.
+            logger.trace(f"{ticket}: subject failed the English gate")
+            subject_rejects += 1
             continue
         keys = _standard_class_documents(s3, ticket)
         if not keys:
             logger.info(f"{ticket}: no STANDARD-class document, skipping")
+            no_standard_doc += 1
             continue
+        logger.debug(f"{ticket}: {len(keys)} STANDARD-class document(s): {keys}")
 
         kept: list[Path] = []
         verdicts: list[DocVerdict] = []
@@ -257,7 +306,7 @@ def sample_complaints(
             if not s3.download_file(key, str(local)):
                 logger.warning(f"{ticket}: download failed for {key}, skipping key")
                 continue
-            
+
             logger.info(f"Assessing documents for language and PII for {ticket}")
             verdict = gates.assess(local)
             if verdict.ok:
@@ -265,6 +314,7 @@ def sample_complaints(
                 verdicts.append(verdict)
             else:
                 logger.info(f"{ticket}: dropped {key} — {verdict.reason}")
+                docs_dropped += 1
                 local.unlink()
         if not kept:
             continue
@@ -283,16 +333,26 @@ def sample_complaints(
                 "doc_english_share": min(v.english_share for v in verdicts),
             }
         )
-        logger.info(f"picked {ticket} ({len(kept)} document(s))")
+        logger.info(
+            f"picked {ticket} ({len(kept)} document(s), "
+            f"english_share={min(v.english_share for v in verdicts):.2f}, "
+            f"page_types={sorted({t for v in verdicts for t in v.page_types})})"
+        )
         if len(picked_rows) == n:
             break
 
     if len(picked_rows) < n:
         raise SystemExit(
             f"only found {len(picked_rows)}/{n} qualifying complaints "
-            f"after checking {checked} candidates"
+            f"after checking {checked} candidates "
+            f"(subject rejects={subject_rejects}, docs dropped={docs_dropped})"
         )
-    logger.info(f"selected {n} complaints after checking {checked} candidates")
+    logger.info(
+        f"selected {n} complaints after checking {checked} candidates: "
+        f"subject rejects={subject_rejects}, "
+        f"no-STANDARD-doc skips={no_standard_doc}, "
+        f"documents dropped by gates={docs_dropped}"
+    )
     metadata = complaints[picked_rows].join(
         pl.DataFrame(evidence), on="ticket_no", how="left"
     )

--- a/tests/test_sample_english_complaints.py
+++ b/tests/test_sample_english_complaints.py
@@ -52,23 +52,31 @@ def test_short_subject_rejected():
     assert not mod.is_english("water problem")
 
 
-# --- document gates (pure verdict logic; per-page predictions injected) ---
+# --- document gates (pure verdict logic; per-page judgements injected) ---
 
 
-def test_english_letter_document_accepted():
+def test_english_letter_with_sparse_stamp_page_accepted():
     verdict = mod.assess_document(
-        ["English", "English", "English, Odia"], ["Letter", "Text Only", "Letter"]
+        ["English", "English", "Sparse"], ["Letter", "Text Only", "Misc/Not Sure"]
     )
     assert verdict.ok
     assert verdict.english_share == pytest.approx(2 / 3)
 
 
-def test_mostly_odia_document_rejected():
+def test_any_odia_dominant_page_rejects():
+    # The strict rule: one Odia page poisons the document even if the rest
+    # is English (this is what the earlier share-based rule got wrong).
     verdict = mod.assess_document(
-        ["Odia", "English, Odia", "English"], ["Letter", "Letter", "Letter"]
+        ["English", "English", "Odia"], ["Letter", "Letter", "Letter"]
     )
     assert not verdict.ok
-    assert "not largely English" in verdict.reason
+    assert "Odia-dominant" in verdict.reason
+
+
+def test_all_sparse_document_rejected():
+    verdict = mod.assess_document(["Sparse", "Sparse"], ["Letter", "Letter"])
+    assert not verdict.ok
+    assert "no confidently-English page" in verdict.reason
 
 
 def test_pii_only_document_rejected():

--- a/tests/test_sample_english_complaints.py
+++ b/tests/test_sample_english_complaints.py
@@ -5,6 +5,7 @@ importlib. langdetect lives in the pipeline extras — skip where absent (CI).
 """
 
 import importlib.util
+import sys
 from pathlib import Path
 
 import pytest
@@ -14,6 +15,8 @@ pytest.importorskip("langdetect")
 _SCRIPT = Path(__file__).parents[1] / "scripts" / "sample_english_complaints.py"
 spec = importlib.util.spec_from_file_location("sample_english_complaints", _SCRIPT)
 mod = importlib.util.module_from_spec(spec)
+# dataclass creation resolves the defining module through sys.modules
+sys.modules[spec.name] = mod
 spec.loader.exec_module(mod)
 
 
@@ -47,3 +50,35 @@ def test_romanized_odia_rejected():
 
 def test_short_subject_rejected():
     assert not mod.is_english("water problem")
+
+
+# --- document gates (pure verdict logic; per-page predictions injected) ---
+
+
+def test_english_letter_document_accepted():
+    verdict = mod.assess_document(
+        ["English", "English", "English, Odia"], ["Letter", "Text Only", "Letter"]
+    )
+    assert verdict.ok
+    assert verdict.english_share == pytest.approx(2 / 3)
+
+
+def test_mostly_odia_document_rejected():
+    verdict = mod.assess_document(
+        ["Odia", "English, Odia", "English"], ["Letter", "Letter", "Letter"]
+    )
+    assert not verdict.ok
+    assert "not largely English" in verdict.reason
+
+
+def test_pii_only_document_rejected():
+    # An Aadhaar/voter-ID scan: English pages but only noise-class page types.
+    verdict = mod.assess_document(["English"], ["Identification"])
+    assert not verdict.ok
+    assert "no substantive page" in verdict.reason
+
+
+def test_unreadable_document_rejected():
+    verdict = mod.assess_document([], [])
+    assert not verdict.ok
+    assert verdict.english_share == 0.0

--- a/tests/test_sample_english_complaints.py
+++ b/tests/test_sample_english_complaints.py
@@ -1,0 +1,49 @@
+"""Language gate of scripts/sample_english_complaints.py.
+
+The script is a single file in scripts/ (not a package), so it's loaded via
+importlib. langdetect lives in the pipeline extras — skip where absent (CI).
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("langdetect")
+
+_SCRIPT = Path(__file__).parents[1] / "scripts" / "sample_english_complaints.py"
+spec = importlib.util.spec_from_file_location("sample_english_complaints", _SCRIPT)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+
+def test_english_subject_accepted():
+    assert mod.is_english(
+        "The water supply in our ward has been broken for three weeks "
+        "and nobody from the block office has come to repair it."
+    )
+
+
+def test_odia_script_rejected():
+    assert not mod.is_english(
+        "ଆମ ଗାଁର ପାଣି ସମସ୍ୟା ବିଷୟରେ ଅଭିଯୋଗ କରୁଛି ଦୟାକରି ସମାଧାନ କରନ୍ତୁ"
+    )
+
+
+def test_mixed_script_rejected():
+    assert not mod.is_english(
+        "Complaint regarding ପାଣି ସମସ୍ୟା in our village please resolve the matter"
+    )
+
+
+def test_romanized_odia_rejected():
+    # No English function words — the stopword gate rejects it regardless of
+    # what langdetect guesses.
+    assert not mod.is_english(
+        "mo ghara pakhare nala safai heu nahin bahut asubidha "
+        "hauchi daya kari samadhana karantu"
+    )
+
+
+def test_short_subject_rejected():
+    assert not mod.is_english("water problem")


### PR DESCRIPTION
## Summary
- `scripts/sample_english_complaints.py` — samples N complaints (default 10) whose **grievance subject is English**, via three gates: no Odia codepoints → ≥2 common English stopwords (rejects romanized Odia even when langdetect guesses 'en') → langdetect `en` (seeded, deterministic). Only complaints with ≥1 **STANDARD-storage-class** S3 document qualify (GLACIER keys are skipped, per the known bucket state). Output: one zip with `documents/<s3-key>` (key paths preserved so nested tickets keep the directory structure the pipeline's ticket parsing needs) + `complaints.parquet` (full metadata rows).
- Reads the Parquet lake locally; S3 via the existing `S3Service` (default credential chain). langdetect isn't a base dep — run with `uv run --with langdetect python scripts/sample_english_complaints.py`.

## Verification
- [x] Real run against the lake + bucket: 10/10 picked subjects verifiably English (188 shuffled candidates checked), 10 documents downloaded, 0.8 MB zip with the parquet inside
- [x] 5 new tests for the language gate (English accepted; Odia script, mixed script, romanized Odia, too-short rejected) — full suite 68 passed
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)