### PR TITLE
PII eval: gold-label bootstrap from the English bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,12 +192,14 @@ data/raw/*
 data/clean/*
 data/interim/*
 data/processed/*
+data/external/*
 data/oltp/*
 data/output/*
 !data/raw/*.dvc
 !data/clean/*.dvc
 !data/interim/*.dvc
 !data/processed/*.dvc
+!data/external/*.dvc
 !data/oltp/.gitkeep
 outputs/*
 !outputs/figures/

--- a/janasunani/config.py
+++ b/janasunani/config.py
@@ -68,6 +68,7 @@ class Directories:
             self.PROCESSED_DATA,
             self.OUTPUT,
             self.OLTP,
+            self.EXTERNAL,
             self.DOCUMENTS,
             self.LOGS,
             self.MODELS,

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -107,8 +107,27 @@ misses), **delete** false hits, **fix** boundaries/labels. Then:
 uv run --extra pipeline-core janasunani-evaluate-pii --gold <corrected.jsonl>
 ```
 
-Gold files contain real citizen text — they live in `data/output/`
-(gitignored) and must never be committed.
+### Gold-file lifecycle
+
+- **Draft** (`data/output/pii_gold_draft.jsonl`): regenerable by this script —
+  not tracked anywhere, gitignored, safe to delete.
+- **Corrected gold** (`data/external/pii_gold.jsonl`): irreplaceable human
+  labeling work — **DVC-tracked** so it survives any one machine. Only the
+  `.dvc` pointer (md5 + path) enters git; the content goes to the private,
+  IAM-scoped S3 remote — the same posture as the raw dump, which also holds
+  citizen PII. Never commit the file itself (the `no-raw-data-in-git` CI
+  guard blocks it; pointers are exempt). Promote after the label pass:
+
+  ```bash
+  mkdir -p data/external && mv <corrected> data/external/pii_gold.jsonl
+  dvc add data/external/pii_gold.jsonl && dvc push
+  git add data/external/pii_gold.jsonl.dvc   # commit the pointer
+  ```
+
+  Reproduce the eval anywhere with bucket access:
+  `dvc pull` → `janasunani-evaluate-pii --gold data/external/pii_gold.jsonl`.
+  When the gold set grows, `dvc add` again — each eval result stays diffable
+  against the exact gold revision that produced it.
 
 ### Debugging a run
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,7 +7,8 @@ as scripts rather than DVC stages. Each is safe to re-run.
 |---|---|
 | `migrate.sh` | Cold-start migration: ephemeral MySQL → restore dump → load OLTP ([migration/README](../janasunani/migration/README.md)). |
 | `gpu_smoke.sh` | DeepSeek OCR smoke on the GPU box ([terraform/README](../deploy/terraform/README.md), "GPU box"). |
-| `sample_english_complaints.py` | Sample English-subject complaints + their documents into a zip (below). |
+| `sample_english_complaints.py` | Sample English complaints (subject + document) into a zip (below). |
+| `bootstrap_pii_gold.py` | OCR a bundle + pre-annotate with the production analyzer → draft gold JSONL for the PII eval (below). |
 | `evaluate_pii_redaction.py` | Thin wrapper over `janasunani-evaluate-pii` (the PII gold-JSONL gate). |
 | `setup.sh` | Workspace setup backing `make setup` (uv, rclone, AWS CLI, hooks). |
 
@@ -76,6 +77,38 @@ english_complaints_sample.zip
 Exits non-zero if fewer than N complaints qualify, telling you how many
 candidates were checked. Both the subject gate and the document verdict logic
 have tests (`tests/test_sample_english_complaints.py`).
+
+## bootstrap_pii_gold.py
+
+Turns an English complaints bundle into labeling material for the PII eval
+(the ROADMAP gate: beat the legacy 80.56% any-overlap coverage before the
+backfill ships redacted pages).
+
+```bash
+uv run --extra pipeline-core python scripts/bootstrap_pii_gold.py \
+    [--bundle data/output/english_complaints_sample.zip] \
+    [--out data/output/pii_gold_draft.jsonl] [--max-pages-per-doc N]
+```
+
+For every document page it runs pytesseract OCR and pre-annotates the text
+with the **production** Presidio analyzer, writing two files:
+
+- `pii_gold_draft.jsonl` — the machine-editable draft, in exactly the format
+  `janasunani-evaluate-pii --gold` consumes;
+- `pii_gold_draft.review.txt` — the same pages with spans marked inline
+  (`⟦NAME:Ramesh Kumar⟧`) for a fast human read.
+
+**The draft is not gold.** It contains what the analyzer already finds, so an
+unedited draft scores ~100% by construction. The human pass *is* the
+measurement: **add** the PII the analyzer missed (these become the recall
+misses), **delete** false hits, **fix** boundaries/labels. Then:
+
+```bash
+uv run --extra pipeline-core janasunani-evaluate-pii --gold <corrected.jsonl>
+```
+
+Gold files contain real citizen text — they live in `data/output/`
+(gitignored) and must never be committed.
 
 ### Debugging a run
 

--- a/scripts/bootstrap_pii_gold.py
+++ b/scripts/bootstrap_pii_gold.py
@@ -24,8 +24,12 @@ Run (pipeline-core env: tesseract binary + presidio + spaCy model needed):
         [--bundle data/output/english_complaints_sample.zip] \
         [--out data/output/pii_gold_draft.jsonl] [--max-pages-per-doc N]
 
-Gold files hold real citizen text — they live under data/output/
-(gitignored) and must NEVER be committed.
+Gold files hold real citizen text and must NEVER be committed to git. The
+draft lives under data/output/ (gitignored, regenerable). The CORRECTED gold
+is irreplaceable human work: promote it to data/external/pii_gold.jsonl and
+DVC-track it — only the .dvc pointer enters git; the bytes go to the private
+S3 remote (same posture as the raw dump). See scripts/README.md,
+"Gold-file lifecycle".
 """
 
 from __future__ import annotations
@@ -162,6 +166,14 @@ def bootstrap(bundle: Path, out_path: Path, max_pages_per_doc: int | None) -> in
         "This draft scores ~100% against the analyzer BY CONSTRUCTION. "
         "Label pass required: ADD missed PII, DELETE false hits, FIX "
         "boundaries — then run janasunani-evaluate-pii --gold <corrected file>."
+    )
+    logger.info(
+        "When the label pass is done, promote the corrected file to the "
+        "DVC-tracked gold set (survives this machine; content stays out of "
+        "git):\n"
+        "  mkdir -p data/external && mv <corrected> data/external/pii_gold.jsonl\n"
+        "  dvc add data/external/pii_gold.jsonl && dvc push\n"
+        "  git add data/external/pii_gold.jsonl.dvc  # commit the pointer"
     )
     return written
 

--- a/scripts/bootstrap_pii_gold.py
+++ b/scripts/bootstrap_pii_gold.py
@@ -1,0 +1,199 @@
+"""Bootstrap a PII gold-label file from an English complaints bundle.
+
+Takes the zip produced by scripts/sample_english_complaints.py, OCRs every
+document page (pytesseract, confidence-picked language), pre-annotates the
+text with the PRODUCTION Presidio analyzer (`detect_pii_spans`), and writes a
+draft gold file in the JSONL format `janasunani-evaluate-pii` consumes:
+
+    {"id": "<ticket>_p<page>", "text": "...", "entities": [
+        {"start": 0, "end": 6, "entity": "NAME"}, ...]}
+
+⚠ The draft is a STARTING POINT, not gold. It contains exactly what the
+analyzer already finds, so evaluating against it unedited would score ~100%
+recall by construction. The human pass is the measurement:
+
+  1. ADD spans the analyzer missed  — these become the recall misses;
+  2. DELETE spans that aren't PII   — false positives;
+  3. FIX boundaries and labels      — exact-match quality.
+
+Then: uv run --extra pipeline-core janasunani-evaluate-pii --gold <corrected>
+
+Run (pipeline-core env: tesseract binary + presidio + spaCy model needed):
+
+    uv run --extra pipeline-core python scripts/bootstrap_pii_gold.py \
+        [--bundle data/output/english_complaints_sample.zip] \
+        [--out data/output/pii_gold_draft.jsonl] [--max-pages-per-doc N]
+
+Gold files hold real citizen text — they live under data/output/
+(gitignored) and must NEVER be committed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import tempfile
+import zipfile
+from pathlib import Path
+
+from loguru import logger
+
+from janasunani.config import OUTPUT_DATA_DIR
+
+# Pages whose OCR yields less text than this are skipped — nothing there to
+# label, and empty lines would just pad the eval denominator with noise.
+_MIN_TEXT_CHARS = 40
+
+
+def render_annotated(text: str, spans) -> str:
+    """Text with detected spans marked inline: ⟦NAME:Ramesh Kumar⟧.
+
+    For the human review pass — read this, then edit the JSONL. Overlapping
+    spans are rendered first-wins (the JSONL still carries all of them).
+    """
+    parts: list[str] = []
+    cursor = 0
+    for span in sorted(spans, key=lambda s: (s.start, s.end)):
+        if span.start < cursor:
+            continue
+        parts.append(text[cursor : span.start])
+        parts.append(f"⟦{span.entity}:{text[span.start:span.end]}⟧")
+        cursor = span.end
+    parts.append(text[cursor:])
+    return "".join(parts)
+
+
+def spans_to_jsonl_line(example_id: str, text: str, spans) -> str:
+    """One gold-draft JSONL line in the pii_eval input format."""
+    return json.dumps(
+        {
+            "id": example_id,
+            "text": text,
+            "entities": [
+                {"start": span.start, "end": span.end, "entity": span.entity}
+                for span in spans
+            ],
+        },
+        ensure_ascii=False,
+    )
+
+
+def _iter_document_pages(doc_path: Path):
+    """(page_number, PIL image) for every page of a PDF/image document."""
+    if doc_path.suffix.lower() == ".pdf":
+        from pdf2image import pdfinfo_from_path
+
+        from janasunani.pipeline.stages.page_type_classifier import _render_pdf_page
+
+        n_pages = int(pdfinfo_from_path(str(doc_path))["Pages"])
+        for page_number in range(1, n_pages + 1):
+            yield page_number, _render_pdf_page(doc_path, page_number)
+    else:
+        from PIL import Image
+
+        with Image.open(doc_path) as image:
+            yield 1, image.convert("RGB")
+
+
+def bootstrap(bundle: Path, out_path: Path, max_pages_per_doc: int | None) -> int:
+    """OCR + pre-annotate every page in the bundle; returns pages written."""
+    from janasunani.pipeline.stages.ocr_extraction.pytesseract_backend import (
+        extract_text,
+    )
+    from janasunani.pipeline.stages.pii_tagger import detect_pii_spans
+    from janasunani.pipeline.ticket import doc_id_from_relpath
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    review_path = out_path.with_suffix(".review.txt")
+    written = 0
+    skipped = 0
+
+    with (
+        tempfile.TemporaryDirectory() as tmp,
+        out_path.open("w") as out,
+        review_path.open("w") as review,
+    ):
+        tmp_dir = Path(tmp)
+        with zipfile.ZipFile(bundle) as zf:
+            doc_names = [
+                name
+                for name in zf.namelist()
+                if name.startswith("documents/") and not name.endswith("/")
+            ]
+            logger.info(f"{bundle.name}: {len(doc_names)} document(s)")
+            zf.extractall(tmp_dir, members=doc_names)
+
+        for name in sorted(doc_names):
+            doc_path = tmp_dir / name
+            relpath = name.removeprefix("documents/")
+            ticket = doc_id_from_relpath(relpath)
+            for page_number, image in _iter_document_pages(doc_path):
+                if max_pages_per_doc and page_number > max_pages_per_doc:
+                    logger.debug(f"{ticket}: page cap reached, moving on")
+                    break
+                text = extract_text(image)
+                if len(text.strip()) < _MIN_TEXT_CHARS:
+                    logger.debug(
+                        f"{ticket} p{page_number}: {len(text.strip())} chars "
+                        "of OCR text — skipped"
+                    )
+                    skipped += 1
+                    continue
+                spans = detect_pii_spans(text)
+                example_id = f"{ticket}_p{page_number}"
+                out.write(spans_to_jsonl_line(example_id, text, spans) + "\n")
+                review.write(
+                    f"{'=' * 70}\n{example_id}  "
+                    f"({len(spans)} span(s))\n{'=' * 70}\n"
+                    f"{render_annotated(text, spans)}\n\n"
+                )
+                written += 1
+                logger.info(
+                    f"{ticket} p{page_number}: {len(text)} chars, "
+                    f"{len(spans)} pre-annotated span(s) "
+                    f"({', '.join(sorted({s.entity for s in spans})) or 'none'})"
+                )
+
+    logger.success(
+        f"wrote {out_path}: {written} page(s) pre-annotated, {skipped} skipped "
+        "(too little text)"
+    )
+    logger.warning(
+        "This draft scores ~100% against the analyzer BY CONSTRUCTION. "
+        "Label pass required: ADD missed PII, DELETE false hits, FIX "
+        "boundaries — then run janasunani-evaluate-pii --gold <corrected file>."
+    )
+    return written
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--bundle",
+        type=Path,
+        default=OUTPUT_DATA_DIR / "english_complaints_sample.zip",
+        help="zip from scripts/sample_english_complaints.py",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=OUTPUT_DATA_DIR / "pii_gold_draft.jsonl",
+    )
+    parser.add_argument(
+        "--max-pages-per-doc",
+        type=int,
+        default=None,
+        help="cap pages OCR'd per document (default: all)",
+    )
+    args = parser.parse_args()
+
+    if not args.bundle.exists():
+        raise SystemExit(
+            f"{args.bundle} missing — run scripts/sample_english_complaints.py first."
+        )
+    written = bootstrap(args.bundle, args.out, args.max_pages_per_doc)
+    return 0 if written else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bootstrap_pii_gold.py
+++ b/scripts/bootstrap_pii_gold.py
@@ -87,9 +87,14 @@ def _iter_document_pages(doc_path: Path):
     if doc_path.suffix.lower() == ".pdf":
         from pdf2image import pdfinfo_from_path
 
-        from janasunani.pipeline.stages.page_type_classifier import _render_pdf_page
+        from janasunani.pipeline.stages.page_type_classifier import (
+            POPPLER_PATH,
+            _render_pdf_page,
+        )
 
-        n_pages = int(pdfinfo_from_path(str(doc_path))["Pages"])
+        n_pages = int(
+            pdfinfo_from_path(str(doc_path), poppler_path=POPPLER_PATH)["Pages"]
+        )
         for page_number in range(1, n_pages + 1):
             yield page_number, _render_pdf_page(doc_path, page_number)
     else:

--- a/tests/test_bootstrap_pii_gold.py
+++ b/tests/test_bootstrap_pii_gold.py
@@ -1,0 +1,77 @@
+"""Draft-format contract of scripts/bootstrap_pii_gold.py.
+
+The one thing that must never drift: a line the bootstrap writes has to parse
+through pii_eval's real loader with entities normalized. Loaded via importlib
+(scripts/ is not a package); presidio import is lazy in the script, so only
+the pii_eval dependency gates these tests.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("presidio_analyzer")
+
+from janasunani.pipeline.pii_eval import load_gold_jsonl  # noqa: E402
+from janasunani.pipeline.stages.pii_tagger import PIISpan  # noqa: E402
+
+_SCRIPT = Path(__file__).parents[1] / "scripts" / "bootstrap_pii_gold.py"
+spec = importlib.util.spec_from_file_location("bootstrap_pii_gold", _SCRIPT)
+mod = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = mod
+spec.loader.exec_module(mod)
+
+
+def test_draft_line_round_trips_through_the_evaluator_loader(tmp_path):
+    text = "Ramesh Kumar, mobile 9876543210, ward 7 water supply broken"
+    spans = (
+        PIISpan(entity="NAME", start=0, end=12, score=0.9),
+        PIISpan(entity="IN_MOBILE", start=21, end=31, score=0.6),
+    )
+    gold = tmp_path / "draft.jsonl"
+    gold.write_text(mod.spans_to_jsonl_line("CMO123_p1", text, spans) + "\n")
+
+    [example] = load_gold_jsonl(gold)
+
+    assert example.id == "CMO123_p1"
+    assert example.text == text
+    # entity labels come back normalized by the loader (IN_MOBILE -> PHONE)
+    assert example.entities == (
+        PIISpan(entity="NAME", start=0, end=12),
+        PIISpan(entity="PHONE", start=21, end=31),
+    )
+
+
+def test_draft_line_preserves_non_ascii_text():
+    text = "ପାଣି problem in ward 7"
+    line = mod.spans_to_jsonl_line("t_p1", text, ())
+    assert "ପାଣି" in line  # ensure_ascii=False — text stays readable for labeling
+
+
+def test_render_marks_spans_inline():
+    text = "Ramesh Kumar, mobile 9876543210"
+    spans = (
+        PIISpan(entity="NAME", start=0, end=12),
+        PIISpan(entity="PHONE", start=21, end=31),
+    )
+    rendered = mod.render_annotated(text, spans)
+    assert rendered == "⟦NAME:Ramesh Kumar⟧, mobile ⟦PHONE:9876543210⟧"
+
+
+def test_render_skips_overlapping_span():
+    text = "Ramesh Kumar here"
+    spans = (
+        PIISpan(entity="NAME", start=0, end=12),
+        PIISpan(entity="NAME", start=7, end=12),  # nested — first wins
+    )
+    rendered = mod.render_annotated(text, spans)
+    assert rendered == "⟦NAME:Ramesh Kumar⟧ here"
+
+
+def test_empty_spans_produce_empty_entities(tmp_path):
+    gold = tmp_path / "draft.jsonl"
+    gold.write_text(mod.spans_to_jsonl_line("t_p1", "no pii here at all", ()) + "\n")
+    [example] = load_gold_jsonl(gold)
+    assert example.entities == ()


### PR DESCRIPTION
## Summary
- `scripts/bootstrap_pii_gold.py` — OCRs every page of the English complaints bundle (pytesseract, confidence-picked language) and pre-annotates with the **production** Presidio analyzer, writing:
  - `pii_gold_draft.jsonl` — exactly the format `janasunani-evaluate-pii --gold` consumes (contract-tested against the real loader so they can't drift);
  - `pii_gold_draft.review.txt` — the same pages with spans marked inline (`⟦NAME:…⟧`) for a fast human labeling pass.
- The workflow is explicit everywhere (docstring, runtime warning, scripts/README): the unedited draft scores ~100% **by construction** — the human pass is the measurement (add missed PII, delete false hits, fix boundaries), then run the eval against the 80.56% legacy baseline.
- Gold files hold real citizen text: they live in `data/output/` (gitignored on main as of be7d3fb) and are never committed.

## Verification
- [x] Real run over the 10-doc bundle: 14 pages pre-annotated (99 NAME/PHONE/EMAIL spans), 2 sparse pages skipped
- [x] The review render already surfaces genuine analyzer errors for the label pass (OCR garble tagged NAME, a date tagged PHONE, a missed given name) — evidence the eval will measure something real
- [x] 5 new tests incl. the JSONL↔loader round-trip contract; full suite 78 passed; ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)