### PR TITLE
Phase 10 API skeleton: full endpoint surface with mocked processor (API-contract-first)

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -48,8 +48,11 @@ jobs:
           chmod 600 ~/.ssh/id_ed25519
           ssh-keyscan github.com >> ~/.ssh/known_hosts
 
+      # --extra serving: light (fastapi/uvicorn/multipart), conflicts with
+      # nothing, and lets the API contract tests run instead of skipping.
+      # The heavy ML extras stay out of CI (models + GPU live elsewhere).
       - name: Sync dependencies
-        run: uv sync --all-groups
+        run: uv sync --all-groups --extra serving
 
       - name: Run tests
         run: uv run pytest

--- a/README.md
+++ b/README.md
@@ -115,6 +115,18 @@ Downloads each complaint's document to S3 (or local disk in dev) and records
 status back into OLTP. *Currently parked: live Janasunani API credentials are
 unavailable.*
 
+### 7 · Demo API (Phase 10 skeleton — mocked processor)
+
+```bash
+uv run --extra serving janasunani-api        # http://127.0.0.1:8000, docs at /docs
+```
+
+The full endpoint surface the frontend builds against (`POST /grievance`,
+`GET /grievance/{id}`, `GET /history`, `/health`) with a mocked processor
+returning the real response shapes — no models load. Real inference/routing
+swap in behind the same contract at Phase 8–9 wire-up.
+Contract details: [janasunani/serving/README.md](janasunani/serving/README.md).
+
 ### Tests (the gate for every change)
 
 ```bash
@@ -141,6 +153,7 @@ The GPU box is a `gpu_box_count = 0/1` toggle (~$1/hr while up).
   [ingestion](janasunani/ingestion/README.md) ·
   [olap](janasunani/olap/README.md) ·
   [pipeline](janasunani/pipeline/README.md) ·
+  [serving](janasunani/serving/README.md) ·
   [deploy](deploy/README.md) ·
   [terraform](deploy/terraform/README.md) ·
   [scripts](scripts/README.md) ·

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -149,8 +149,13 @@ ingestion smoke — blocked on the Janasunani API credentials.
 
 *Week 3 — API-contract-first (re-ordered: the frontend must not sit at the tail of a
 serial chain with zero float).*
-1. **Phase 10 skeleton first** (~a day): the three endpoints + `/health` with a
-   **mocked processor** returning the real response shapes.
+1. ✅ **Phase 10 skeleton first** (2026-07-06): `janasunani/serving/` — the three
+   endpoints + `/health` + CORS behind a `serving` extra (`janasunani-api` CLI);
+   `schemas.py` is the frozen contract (field names mirror the pipeline DB /
+   `PIISpan` / lake columns so wire-up is plumbing, not renaming); processor,
+   history, and result store are injectable seams (`create_app`) — mock today,
+   Phase 8/9 inference + lake + `live_grievances` OLTP later. TestClient tests
+   pin the contract and must pass unchanged after wire-up.
 2. **Phase 11 scaffold immediately after**, built against the mocked contract — the
    demo's visible deliverable gets Weeks 3–4 of iteration instead of a cramped tail.
 3. Phases 8 + 9 fill in behind the stable contract: single-item inference, then the

--- a/janasunani/serving/README.md
+++ b/janasunani/serving/README.md
@@ -1,0 +1,44 @@
+# janasunani/serving — the demo API (Phase 10)
+
+FastAPI app the Next.js frontend talks to. Built **skeleton-first** (roadmap
+Week 3): the full endpoint surface with a **mocked processor** ships before
+Phases 8–9, so the frontend gets weeks of iteration against a stable contract
+instead of a cramped tail. The wire-up later swaps the mock for the real warm
+inference + routing behind the same seams — endpoints and shapes unchanged.
+
+## Run it
+
+```bash
+uv run --extra serving janasunani-api      # http://127.0.0.1:8000, docs at /docs
+```
+
+`JANASUNANI_API_HOST` / `JANASUNANI_API_PORT` / `JANASUNANI_CORS_ORIGINS`
+(comma-separated; default `*` — pin to the frontend origin at deploy).
+
+## The contract
+
+| Endpoint | In | Out |
+|---|---|---|
+| `POST /grievance` (201) | multipart: `text` **xor** `file`, optional `district` | `GrievanceResult` |
+| `GET /grievance/{id}` | — | the submitted `GrievanceResult` (404 if unknown) |
+| `GET /history` | `q`, `district`, `category`, `limit` (≤100), `offset` | `HistoryPage` (lake column names) |
+| `GET /health` | — | `{status, processor}` — `processor: "mock"` until wire-up |
+
+**`schemas.py` is the contract.** Field names mirror what already exists —
+pipeline artifact DB (`extracted_text`/`redacted_text`/`ocr_model`),
+`PIISpan` (entity/start/end over the *extracted* text), lake columns for
+history rows — so wire-up is plumbing, not renaming. Changing a field is an
+API break; the frontend is built against exactly these shapes, and
+`tests/test_serving_api.py` pins them (those tests must pass unchanged after
+wire-up).
+
+## What's mock vs real (as of the skeleton)
+
+| Seam | Skeleton | Wire-up (Phases 8–9) |
+|---|---|---|
+| `processor.GrievanceProcessor` | `MockGrievanceProcessor` — deterministic canned values; **toy regex "redaction", NOT Presidio** | warm `GrievanceProcessor` (models loaded once; text skips OCR; `ocr_engine` per env) + hybrid router |
+| `history.HistoryProvider` | `MockHistory` — 120 seeded fake rows, real filter semantics | Parquet lake via `olap/lake.py` (historical only — freshness decision in ROADMAP open items) |
+| result store | in-process dict (dies with the process) | `live_grievances` OLTP table via `crud.py` |
+
+The mock must never serve real citizen submissions — it exists so the
+frontend and API tests are model-free.

--- a/janasunani/serving/__init__.py
+++ b/janasunani/serving/__init__.py
@@ -1,0 +1,6 @@
+"""Serving layer: the demo API (Phase 10).
+
+Week-3 skeleton first (endpoints + mocked processor = the stable contract the
+frontend builds against), real inference/routing/persistence wired in behind
+the same shapes after Phases 8-9. See janasunani/serving/README.md.
+"""

--- a/janasunani/serving/api.py
+++ b/janasunani/serving/api.py
@@ -20,6 +20,8 @@ the skeleton; pin to the frontend origin at deploy).
 
 from __future__ import annotations
 
+import functools
+import itertools
 import os
 import uuid
 from typing import Optional
@@ -27,6 +29,7 @@ from typing import Optional
 from fastapi import FastAPI, File, Form, HTTPException, Query, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from loguru import logger
+from starlette.concurrency import run_in_threadpool
 
 from janasunani.serving.history import HistoryProvider, MockHistory
 from janasunani.serving.processor import GrievanceProcessor, MockGrievanceProcessor
@@ -55,6 +58,9 @@ def create_app(
 
     # Skeleton-only store for GET /grievance/{id}; replaced by OLTP at wire-up.
     results: dict[str, GrievanceResult] = {}
+    # next() has no await point, so concurrent submissions can't mint the same
+    # number (len(results)+1 could: requests overlap at `await file.read()`).
+    ticket_seq = itertools.count(1)
 
     @app.get("/health", response_model=HealthResponse)
     def health() -> HealthResponse:
@@ -75,14 +81,20 @@ def create_app(
             raise HTTPException(status_code=422, detail="'text' is empty.")
 
         grievance_id = uuid.uuid4().hex[:12]
-        ticket_no = f"JS{len(results) + 1:07d}"
-        result = processor.process(
-            grievance_id=grievance_id,
-            ticket_no=ticket_no,
-            text=text,
-            document_name=file.filename if file else None,
-            document_bytes=await file.read() if file else None,
-            district=district,
+        ticket_no = f"JS{next(ticket_seq):07d}"
+        # The processor protocol is sync (real inference is CPU/GPU-bound
+        # work); run it off the event loop so a slow OCR/model call doesn't
+        # block /health and other requests on this worker at wire-up.
+        result = await run_in_threadpool(
+            functools.partial(
+                processor.process,
+                grievance_id=grievance_id,
+                ticket_no=ticket_no,
+                text=text,
+                document_name=file.filename if file else None,
+                document_bytes=await file.read() if file else None,
+                district=district,
+            )
         )
         results[grievance_id] = result
         logger.info(

--- a/janasunani/serving/api.py
+++ b/janasunani/serving/api.py
@@ -1,0 +1,131 @@
+"""FastAPI app — the demo API (Phase 10 skeleton).
+
+Endpoints (the full surface; shapes in schemas.py are the frozen contract):
+
+- ``POST /grievance``       multipart: ``text`` XOR ``file`` (+ optional
+                            ``district``) -> full ``GrievanceResult``, 201
+- ``GET  /grievance/{id}``  a previously submitted result
+- ``GET  /history``         browse/search historical complaints (lake shape)
+- ``GET  /health``          liveness + which processor is mounted
+
+Skeleton wiring (swapped at Phase 8/9 wire-up, endpoints unchanged):
+processor = ``MockGrievanceProcessor``; history = ``MockHistory``; submitted
+results live in an in-process dict (wire-up persists to the ``live_grievances``
+OLTP table instead — the dict, like everything mock, dies with the process).
+
+Run:  uv run --extra serving janasunani-api          # 127.0.0.1:8000
+CORS: comma-separated ``JANASUNANI_CORS_ORIGINS`` (default ``*`` — fine for
+the skeleton; pin to the frontend origin at deploy).
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Optional
+
+from fastapi import FastAPI, File, Form, HTTPException, Query, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
+from loguru import logger
+
+from janasunani.serving.history import HistoryProvider, MockHistory
+from janasunani.serving.processor import GrievanceProcessor, MockGrievanceProcessor
+from janasunani.serving.schemas import (
+    GrievanceResult,
+    HealthResponse,
+    HistoryPage,
+)
+
+
+def create_app(
+    processor: Optional[GrievanceProcessor] = None,
+    history: Optional[HistoryProvider] = None,
+) -> FastAPI:
+    """App factory; tests and the wire-up inject their own processor/history."""
+    processor = processor or MockGrievanceProcessor()
+    history = history or MockHistory()
+
+    app = FastAPI(title="Janasunani 2.0 API", version="0.1.0")
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=os.environ.get("JANASUNANI_CORS_ORIGINS", "*").split(","),
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    # Skeleton-only store for GET /grievance/{id}; replaced by OLTP at wire-up.
+    results: dict[str, GrievanceResult] = {}
+
+    @app.get("/health", response_model=HealthResponse)
+    def health() -> HealthResponse:
+        return HealthResponse(status="ok", processor=processor.name)
+
+    @app.post("/grievance", response_model=GrievanceResult, status_code=201)
+    async def submit_grievance(
+        text: Optional[str] = Form(None),
+        file: Optional[UploadFile] = File(None),
+        district: Optional[str] = Form(None),
+    ) -> GrievanceResult:
+        if (text is None) == (file is None):
+            raise HTTPException(
+                status_code=422,
+                detail="Provide exactly one of 'text' or 'file'.",
+            )
+        if text is not None and not text.strip():
+            raise HTTPException(status_code=422, detail="'text' is empty.")
+
+        grievance_id = uuid.uuid4().hex[:12]
+        ticket_no = f"JS{len(results) + 1:07d}"
+        result = processor.process(
+            grievance_id=grievance_id,
+            ticket_no=ticket_no,
+            text=text,
+            document_name=file.filename if file else None,
+            document_bytes=await file.read() if file else None,
+            district=district,
+        )
+        results[grievance_id] = result
+        logger.info(
+            f"grievance {grievance_id} ({ticket_no}): "
+            f"{result.extraction.source} via {processor.name} -> "
+            f"{result.classification.category} / {result.routing.dept}"
+        )
+        return result
+
+    @app.get("/grievance/{grievance_id}", response_model=GrievanceResult)
+    def get_grievance(grievance_id: str) -> GrievanceResult:
+        result = results.get(grievance_id)
+        if result is None:
+            raise HTTPException(status_code=404, detail="No such grievance.")
+        return result
+
+    @app.get("/history", response_model=HistoryPage)
+    def get_history(
+        q: Optional[str] = Query(None, description="substring of grievance/ticket"),
+        district: Optional[str] = None,
+        category: Optional[str] = None,
+        limit: int = Query(20, ge=1, le=100),
+        offset: int = Query(0, ge=0),
+    ) -> HistoryPage:
+        return history.search(
+            q=q, district=district, category=category, limit=limit, offset=offset
+        )
+
+    return app
+
+
+app = create_app()
+
+
+def main() -> None:
+    import uvicorn
+
+    uvicorn.run(
+        "janasunani.serving.api:app",
+        host=os.environ.get("JANASUNANI_API_HOST", "127.0.0.1"),
+        port=int(os.environ.get("JANASUNANI_API_PORT", "8000")),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/janasunani/serving/history.py
+++ b/janasunani/serving/history.py
@@ -1,0 +1,97 @@
+"""History providers behind ``GET /history``.
+
+The real one (wire-up) reads the Parquet lake via ``olap/lake.py`` — history
+is *historical* data, refreshed by re-materialization, per the roadmap's
+freshness decision. The skeleton ships ``MockHistory``: ~120 deterministic
+fake rows in the lake's column shape, with the same filter semantics the real
+provider will honor, so the frontend's browse/search UX is built against
+working pagination and filters.
+"""
+
+from __future__ import annotations
+
+import random
+from datetime import datetime, timedelta
+from typing import Optional, Protocol
+
+from janasunani.serving.schemas import HistoryItem, HistoryPage
+
+_DISTRICTS = ("Khordha", "Cuttack", "Ganjam", "Sundargarh", "Balasore")
+_STATUSES = ("Resolved", "Pending", "In Progress", "Escalated")
+_CATEGORIES = (
+    ("Drinking Water Supply", "Hand pump repair", "Rural Water Supply & Sanitation"),
+    ("Electricity", "Frequent outage", "Energy"),
+    ("Roads & Bridges", "Pothole repair", "Works"),
+    ("Public Health", "PHC staffing", "Health & Family Welfare"),
+    ("Land & Revenue", "Record correction", "Revenue & Disaster Management"),
+)
+
+
+class HistoryProvider(Protocol):
+    def search(
+        self,
+        *,
+        q: Optional[str] = None,
+        district: Optional[str] = None,
+        category: Optional[str] = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> HistoryPage: ...
+
+
+class MockHistory:
+    """Seeded fake lake rows; same process, same rows."""
+
+    def __init__(self, n_rows: int = 120, seed: int = 7) -> None:
+        rng = random.Random(seed)
+        base = datetime(2024, 1, 1)
+        self._rows: list[HistoryItem] = []
+        for i in range(n_rows):
+            category, subcategory, dept = rng.choice(_CATEGORIES)
+            district = rng.choice(_DISTRICTS)
+            self._rows.append(
+                HistoryItem(
+                    ticket_no=f"CMO2024{100000 + i}",
+                    created_on=base + timedelta(days=rng.randrange(500)),
+                    district=district,
+                    category=category,
+                    subcategory=subcategory,
+                    dept=dept,
+                    status=rng.choice(_STATUSES),
+                    office=f"Office of the Collector, {district}",
+                    grievance=(
+                        f"[fake row {i}] {subcategory} issue reported in "
+                        f"{district} — awaiting {dept} action."
+                    ),
+                )
+            )
+        self._rows.sort(key=lambda r: r.created_on, reverse=True)
+
+    def search(
+        self,
+        *,
+        q: Optional[str] = None,
+        district: Optional[str] = None,
+        category: Optional[str] = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> HistoryPage:
+        rows = self._rows
+        if district:
+            rows = [r for r in rows if r.district == district]
+        if category:
+            rows = [r for r in rows if r.category == category]
+        if q:
+            needle = q.lower()
+            rows = [
+                r
+                for r in rows
+                if needle in (r.grievance or "").lower()
+                or needle in r.ticket_no.lower()
+            ]
+        return HistoryPage(
+            items=rows[offset : offset + limit],
+            total=len(rows),
+            limit=limit,
+            offset=offset,
+        )

--- a/janasunani/serving/processor.py
+++ b/janasunani/serving/processor.py
@@ -1,0 +1,145 @@
+"""Grievance processors behind the API.
+
+``GrievanceProcessor`` is the seam Phase 8/9 fills: the skeleton ships only
+``MockGrievanceProcessor``, which returns the real response *shapes* with
+canned-but-deterministic values so the frontend can be built (and the API
+tested) before any model loads. The wire-up swaps in the warm inference
+service behind the same protocol — no endpoint changes.
+
+⚠ The mock's "redaction" is a toy regex (digit runs + emails), NOT the
+production Presidio analyzer, and its category/routing are hash-picked from
+fixed lists. Nothing here may ever serve real citizen submissions.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from datetime import UTC, datetime
+from typing import Optional, Protocol
+
+from janasunani.serving.schemas import (
+    ClassificationResult,
+    ExtractionResult,
+    GrievanceResult,
+    PIIEntity,
+    RedactionResult,
+    RoutingResult,
+)
+
+
+class GrievanceProcessor(Protocol):
+    """What Phase 8/9 must provide. Exactly one of text/document is set."""
+
+    name: str
+
+    def process(
+        self,
+        *,
+        grievance_id: str,
+        ticket_no: str,
+        text: Optional[str] = None,
+        document_name: Optional[str] = None,
+        document_bytes: Optional[bytes] = None,
+        district: Optional[str] = None,
+    ) -> GrievanceResult: ...
+
+
+# Real top-level categories from the historical lake, so frontend styling is
+# developed against strings of realistic length/wording.
+_MOCK_CATEGORIES: tuple[tuple[str, str], ...] = (
+    ("Drinking Water Supply", "Rural Water Supply & Sanitation"),
+    ("Electricity", "Energy"),
+    ("Roads & Bridges", "Works"),
+    ("Public Health", "Health & Family Welfare"),
+    ("Land & Revenue", "Revenue & Disaster Management"),
+)
+
+# Toy patterns for the mock only — see module docstring.
+_MOCK_PHONE = re.compile(r"\b\d{10}\b")
+_MOCK_EMAIL = re.compile(r"\b[\w.+-]+@[\w-]+\.[\w.]+\b")
+
+
+class MockGrievanceProcessor:
+    """Deterministic canned results: same input -> same output (frontend
+    snapshots and API tests stay stable)."""
+
+    name = "mock"
+
+    def process(
+        self,
+        *,
+        grievance_id: str,
+        ticket_no: str,
+        text: Optional[str] = None,
+        document_name: Optional[str] = None,
+        document_bytes: Optional[bytes] = None,
+        district: Optional[str] = None,
+    ) -> GrievanceResult:
+        if text is not None:
+            extraction = ExtractionResult(source="text", extracted_text=text)
+        else:
+            size = len(document_bytes or b"")
+            extraction = ExtractionResult(
+                source="document",
+                extracted_text=(
+                    f"[mock OCR of {document_name} ({size} bytes)] "
+                    "The hand pump in our village has been broken for two "
+                    "months. Contact me at 9876543210."
+                ),
+                ocr_model="mock-ocr",
+                pages=1,
+            )
+
+        redaction = _mock_redact(extraction.extracted_text)
+        category, dept = _pick(_MOCK_CATEGORIES, extraction.extracted_text)
+        district = district or "Khordha"
+
+        return GrievanceResult(
+            id=grievance_id,
+            ticket_no=ticket_no,
+            status="Submitted",
+            submitted_on=datetime.now(UTC),
+            extraction=extraction,
+            redaction=redaction,
+            classification=ClassificationResult(category=category, language="en"),
+            summary=_mock_summary(redaction.redacted_text),
+            routing=RoutingResult(
+                dept=dept,
+                office=f"Office of the Collector, {district}",
+                designation="Block Development Officer",
+                escalation_authority=f"District Magistrate, {district}",
+                confidence=0.42,
+                method="mock",
+            ),
+        )
+
+
+def _pick(options, text: str):
+    """Stable pseudo-random choice keyed on the input text."""
+    digest = hashlib.sha256(text.encode()).digest()
+    return options[digest[0] % len(options)]
+
+
+def _mock_redact(text: str) -> RedactionResult:
+    entities = [
+        PIIEntity(entity=label, start=m.start(), end=m.end())
+        for label, pattern in (("PHONE", _MOCK_PHONE), ("EMAIL", _MOCK_EMAIL))
+        for m in pattern.finditer(text)
+    ]
+    entities.sort(key=lambda e: e.start)
+    redacted = []
+    cursor = 0
+    for ent in entities:
+        redacted.append(text[cursor : ent.start])
+        redacted.append(f"<{ent.entity}>")
+        cursor = ent.end
+    redacted.append(text[cursor:])
+    return RedactionResult(redacted_text="".join(redacted), entities=entities)
+
+
+def _mock_summary(redacted_text: str, max_chars: int = 180) -> str:
+    flat = " ".join(redacted_text.split())
+    if len(flat) <= max_chars:
+        return flat
+    return flat[: max_chars - 1].rsplit(" ", 1)[0] + "…"

--- a/janasunani/serving/schemas.py
+++ b/janasunani/serving/schemas.py
@@ -1,0 +1,105 @@
+"""Response shapes for the serving API — THE contract (Phases 8/9/11 build
+against these; the frontend is developed against exactly these models).
+
+Field names deliberately mirror what already exists elsewhere in the repo so
+the wire-up phase is a plumbing job, not a renaming exercise:
+
+- extraction/redaction fields match the pipeline artifact DB
+  (``pages.extracted_text`` / ``pages.redacted_text`` / ``pages.ocr_model``);
+- PII spans match ``pii_tagger.PIISpan`` (entity/start/end over the ORIGINAL
+  text, exactly what ``detect_pii_spans`` returns);
+- classification matches ``documents.grievance_category`` plus the
+  category/subcategory split the lake uses;
+- routing matches the Phase 9 contract (category + district -> dept ->
+  office/designation + escalation, with a confidence and the router that
+  produced it);
+- history rows are a browse-friendly subset of the lake's ``complaints``
+  columns, names unchanged (``ticket_no``, ``dept``, ``created_on``, ...).
+
+Changing a field here is an API break — coordinate with the frontend.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class PIIEntity(BaseModel):
+    """One detected PII span over the *extracted* (unredacted) text."""
+
+    entity: str  # normalized label: NAME / PHONE / EMAIL / AADHAAR / ...
+    start: int
+    end: int
+
+
+class ExtractionResult(BaseModel):
+    source: Literal["text", "document"]
+    extracted_text: str
+    # None for direct-text submissions (no OCR ran)
+    ocr_model: Optional[str] = None
+    pages: Optional[int] = None
+
+
+class RedactionResult(BaseModel):
+    redacted_text: str
+    entities: list[PIIEntity]
+
+
+class ClassificationResult(BaseModel):
+    category: str
+    # the lake splits category/subcategory; the current categorizer predicts
+    # only the top level, so subcategory may stay None even after wire-up
+    subcategory: Optional[str] = None
+    language: str  # ISO-ish code the categorizer gate produced ("en", "or")
+
+
+class RoutingResult(BaseModel):
+    dept: str
+    office: str
+    designation: Optional[str] = None
+    escalation_authority: Optional[str] = None
+    confidence: float = Field(ge=0.0, le=1.0)
+    method: Literal["rules", "learned", "fallback", "mock"]
+
+
+class GrievanceResult(BaseModel):
+    """Everything the demo shows for one submitted grievance."""
+
+    id: str
+    ticket_no: str
+    status: str
+    submitted_on: datetime
+    extraction: ExtractionResult
+    redaction: RedactionResult
+    classification: ClassificationResult
+    summary: str
+    routing: RoutingResult
+
+
+class HistoryItem(BaseModel):
+    """One historical complaint — lake column names, unchanged."""
+
+    ticket_no: str
+    created_on: Optional[datetime] = None
+    district: Optional[str] = None
+    category: Optional[str] = None
+    subcategory: Optional[str] = None
+    dept: Optional[str] = None
+    status: Optional[str] = None
+    office: Optional[str] = None
+    grievance: Optional[str] = None
+
+
+class HistoryPage(BaseModel):
+    items: list[HistoryItem]
+    total: int  # rows matching the filters, before pagination
+    limit: int
+    offset: int
+
+
+class HealthResponse(BaseModel):
+    status: Literal["ok"]
+    processor: str  # "mock" until Phase 8/9 wire-up

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,13 @@ ocr-deepseek = [
     "torchvision",
     "transformers==4.46.3",
 ]
+# Demo API (Phase 10) — light, conflicts with nothing; the skeleton's mocked
+# processor keeps it model-free until the Phase 8/9 wire-up
+serving = [
+    "fastapi>=0.115",
+    "uvicorn>=0.30",
+    "python-multipart>=0.0.9",  # multipart form parsing for POST /grievance
+]
 # MuRIL grievance categorizer
 categorizer = [
     "huggingface-hub",
@@ -98,6 +105,7 @@ janasunani-ingest-documents = "janasunani.ingestion.document_ingestion:main"
 janasunani-pipeline = "janasunani.pipeline.cli:main"
 janasunani-export-pipeline = "janasunani.pipeline.export:main"
 janasunani-evaluate-pii = "janasunani.pipeline.pii_eval:main"
+janasunani-api = "janasunani.serving.api:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/test_serving_api.py
+++ b/tests/test_serving_api.py
@@ -8,7 +8,11 @@ Phase 8/9 wire-up swaps the processor/history implementations behind
 
 import pytest
 
+# fastapi alone isn't enough: it arrives transitively (mlflow) in envs without
+# the serving extra, but the Form/File routes need python-multipart — and
+# api.py builds the app at import time, so collection itself would crash.
 pytest.importorskip("fastapi")
+pytest.importorskip("python_multipart")
 
 from fastapi.testclient import TestClient  # noqa: E402
 

--- a/tests/test_serving_api.py
+++ b/tests/test_serving_api.py
@@ -133,6 +133,33 @@ def test_cors_header_present(client):
     assert resp.headers.get("access-control-allow-origin") == "*"
 
 
+async def test_concurrent_uploads_get_distinct_ticket_numbers():
+    # Regression (Codex on PR #12): the ticket number used to be
+    # len(results)+1, computed before `await file.read()` — overlapping
+    # uploads could mint the same user-visible ticket_no.
+    import asyncio
+
+    import httpx
+
+    app = create_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://test"
+    ) as client:
+        responses = await asyncio.gather(
+            *(
+                client.post(
+                    "/grievance",
+                    files={"file": (f"c{i}.pdf", b"%PDF fake", "application/pdf")},
+                )
+                for i in range(8)
+            )
+        )
+    tickets = [r.json()["ticket_no"] for r in responses]
+    assert all(r.status_code == 201 for r in responses)
+    assert len(set(tickets)) == len(tickets)
+
+
 def test_same_text_gets_deterministic_classification(client):
     a = client.post("/grievance", data={"text": _TEXT}).json()
     b = client.post("/grievance", data={"text": _TEXT}).json()

--- a/tests/test_serving_api.py
+++ b/tests/test_serving_api.py
@@ -1,0 +1,136 @@
+"""Contract tests for the Phase 10 API skeleton (TestClient, mocked processor).
+
+These pin the API *shape* the frontend is built against: endpoint paths,
+status codes, response field names, filter/pagination semantics, CORS. The
+Phase 8/9 wire-up swaps the processor/history implementations behind
+``create_app`` — every test here must still pass unchanged afterwards.
+"""
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from janasunani.serving.api import create_app  # noqa: E402
+
+_TEXT = (
+    "The hand pump in Balianta village has been broken for two months. "
+    "Please contact me at 9876543210 or ramesh@example.com."
+)
+
+
+@pytest.fixture()
+def client():
+    return TestClient(create_app())
+
+
+def test_health(client):
+    body = client.get("/health").json()
+    assert body == {"status": "ok", "processor": "mock"}
+
+
+def test_submit_text_returns_full_result_shape(client):
+    resp = client.post("/grievance", data={"text": _TEXT, "district": "Cuttack"})
+    assert resp.status_code == 201
+    body = resp.json()
+
+    assert set(body) == {
+        "id",
+        "ticket_no",
+        "status",
+        "submitted_on",
+        "extraction",
+        "redaction",
+        "classification",
+        "summary",
+        "routing",
+    }
+    assert body["extraction"]["source"] == "text"
+    assert body["extraction"]["extracted_text"] == _TEXT
+    # the mock masks the phone and email; spans point into the extracted text
+    assert "9876543210" not in body["redaction"]["redacted_text"]
+    assert "<PHONE>" in body["redaction"]["redacted_text"]
+    entities = body["redaction"]["entities"]
+    assert {e["entity"] for e in entities} == {"PHONE", "EMAIL"}
+    for e in entities:
+        assert _TEXT[e["start"] : e["end"]] in ("9876543210", "ramesh@example.com")
+    assert body["classification"]["category"]
+    assert body["routing"]["method"] == "mock"
+    assert "Cuttack" in body["routing"]["office"]
+    assert 0.0 <= body["routing"]["confidence"] <= 1.0
+
+
+def test_submit_file_reports_document_source(client):
+    resp = client.post(
+        "/grievance",
+        files={"file": ("complaint.pdf", b"%PDF-1.4 fake", "application/pdf")},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["extraction"]["source"] == "document"
+    assert body["extraction"]["ocr_model"] is not None
+
+
+def test_submitted_grievance_is_fetchable_by_id(client):
+    submitted = client.post("/grievance", data={"text": _TEXT}).json()
+    fetched = client.get(f"/grievance/{submitted['id']}")
+    assert fetched.status_code == 200
+    assert fetched.json() == submitted
+
+
+def test_missing_grievance_404s(client):
+    assert client.get("/grievance/nope").status_code == 404
+
+
+def test_text_and_file_are_mutually_exclusive(client):
+    assert client.post("/grievance").status_code == 422  # neither
+    both = client.post(
+        "/grievance",
+        data={"text": _TEXT},
+        files={"file": ("c.pdf", b"x", "application/pdf")},
+    )
+    assert both.status_code == 422
+    assert client.post("/grievance", data={"text": "   "}).status_code == 422
+
+
+def test_history_pagination_and_shape(client):
+    body = client.get("/history", params={"limit": 5, "offset": 5}).json()
+    assert body["limit"] == 5 and body["offset"] == 5
+    assert len(body["items"]) == 5
+    assert body["total"] > 5
+    # lake column names, unchanged
+    assert set(body["items"][0]) == {
+        "ticket_no",
+        "created_on",
+        "district",
+        "category",
+        "subcategory",
+        "dept",
+        "status",
+        "office",
+        "grievance",
+    }
+
+
+def test_history_filters_and_search(client):
+    filtered = client.get("/history", params={"district": "Cuttack"}).json()
+    assert filtered["total"] > 0
+    assert all(item["district"] == "Cuttack" for item in filtered["items"])
+
+    searched = client.get("/history", params={"q": filtered["items"][0]["ticket_no"]})
+    assert searched.json()["total"] == 1
+
+    assert client.get("/history", params={"limit": 101}).status_code == 422
+
+
+def test_cors_header_present(client):
+    resp = client.get("/health", headers={"Origin": "http://localhost:3000"})
+    assert resp.headers.get("access-control-allow-origin") == "*"
+
+
+def test_same_text_gets_deterministic_classification(client):
+    a = client.post("/grievance", data={"text": _TEXT}).json()
+    b = client.post("/grievance", data={"text": _TEXT}).json()
+    assert a["classification"] == b["classification"]
+    assert a["ticket_no"] != b["ticket_no"]  # but each submission is distinct

--- a/uv.lock
+++ b/uv.lock
@@ -2174,6 +2174,11 @@ pipeline-core = [
     { name = "transformers", version = "4.57.6", source = { registry = "https://pypi.org/simple" } },
     { name = "xgboost" },
 ]
+serving = [
+    { name = "fastapi" },
+    { name = "python-multipart" },
+    { name = "uvicorn" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -2201,6 +2206,7 @@ requires-dist = [
     { name = "easydict", marker = "extra == 'ocr-deepseek'" },
     { name = "einops", marker = "extra == 'ocr-deepseek'" },
     { name = "en-core-web-sm", marker = "extra == 'pipeline-core'", url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl" },
+    { name = "fastapi", marker = "extra == 'serving'", specifier = ">=0.115" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "huggingface-hub", marker = "extra == 'categorizer'" },
     { name = "huggingface-hub", marker = "extra == 'pipeline-core'" },
@@ -2228,6 +2234,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.9" },
     { name = "pymysql", specifier = ">=1.1.1" },
     { name = "pytesseract", marker = "extra == 'pipeline-core'" },
+    { name = "python-multipart", marker = "extra == 'serving'", specifier = ">=0.0.9" },
     { name = "pytz", specifier = ">=2024.1" },
     { name = "scikit-image", marker = "extra == 'pipeline-core'" },
     { name = "scikit-learn", marker = "extra == 'categorizer'", specifier = ">=1.8,<1.9" },
@@ -2243,9 +2250,10 @@ requires-dist = [
     { name = "transformers", marker = "extra == 'categorizer'", specifier = ">=4.57,<5" },
     { name = "transformers", marker = "extra == 'ocr-deepseek'", specifier = "==4.46.3" },
     { name = "transformers", marker = "extra == 'pipeline-core'", specifier = ">=4.57,<5" },
+    { name = "uvicorn", marker = "extra == 'serving'", specifier = ">=0.30" },
     { name = "xgboost", marker = "extra == 'pipeline-core'" },
 ]
-provides-extras = ["pipeline-core", "ocr-deepseek", "categorizer"]
+provides-extras = ["pipeline-core", "ocr-deepseek", "serving", "categorizer"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -4487,6 +4495,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f7/ff/3cc9165fd44106973cd7ac9facb674a65ed853494592541d339bdc9a30eb/python_json_logger-4.1.0.tar.gz", hash = "sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195", size = 17573, upload-time = "2026-03-29T04:39:56.805Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/be/0631a861af4d1c875f096c07d34e9a63639560a717130e7a87cbc82b7e3f/python_json_logger-4.1.0-py3-none-any.whl", hash = "sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2", size = 15021, upload-time = "2026-03-29T04:39:55.266Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

The roadmap's Week-3 item 1: the demo API's **entire endpoint surface**, shipped before Phases 8–9 so the frontend gets weeks of iteration against a stable contract instead of a cramped tail.

- `janasunani/serving/` — new package behind a light `serving` extra (fastapi/uvicorn/python-multipart; conflicts with nothing). `uv run --extra serving janasunani-api` → http://127.0.0.1:8000 with OpenAPI docs at `/docs`.
- **Endpoints**: `POST /grievance` (multipart, `text` xor `file`, optional `district`, 201) · `GET /grievance/{id}` · `GET /history` (`q`/`district`/`category`/`limit≤100`/`offset`) · `GET /health` · CORS (`JANASUNANI_CORS_ORIGINS`).
- **`schemas.py` is the frozen contract.** Field names deliberately mirror what already exists — the pipeline artifact DB (`extracted_text`/`redacted_text`/`ocr_model`), `PIISpan` (entity/start/end over the extracted text), lake columns for history rows — so wire-up is plumbing, not renaming.
- **Injectable seams** on `create_app(processor, history)`: today `MockGrievanceProcessor` (deterministic canned values; **toy regex masking, NOT Presidio** — loudly documented) and `MockHistory` (120 seeded lake-shaped rows with real filter/pagination semantics); Phase 8/9 swaps in warm inference + `olap/lake.py` + the `live_grievances` OLTP store behind the same protocols.

## Tests

`tests/test_serving_api.py` — 10 TestClient tests pinning the contract (shapes, status codes, xor validation, filters/pagination, CORS, determinism, submit→fetch round-trip). These must pass **unchanged** after the Phase 8/9 wire-up. Full suite: 83 passed; ruff clean.

## Docs

`janasunani/serving/README.md` (contract + mock-vs-real table), root README §7, ROADMAP Week-3 item 1 ticked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)