### PR TITLE
fix(sampler): reject corrupt documents instead of crashing

### DIFF
--- a/scripts/sample_english_complaints.py
+++ b/scripts/sample_english_complaints.py
@@ -201,21 +201,41 @@ class DocumentGates:
     def assess(self, doc_path: Path) -> DocVerdict:
         import time
 
+        from pdf2image.exceptions import PDFPageCountError, PDFSyntaxError
+
         t0 = time.time()
         languages: list[str] = []
         page_types: list[str] = []
-        for page_number, image in enumerate(
-            _page_images(doc_path, _MAX_PAGES_CHECKED), start=1
-        ):
-            t_page = time.time()
-            language = classify_page_language(image)
-            page_type = self._page_type.predict(image)
-            logger.debug(
-                f"{doc_path.name} p{page_number}: language={language!r} "
-                f"page_type={page_type!r} ({time.time() - t_page:.1f}s)"
+        try:
+            for page_number, image in enumerate(
+                _page_images(doc_path, _MAX_PAGES_CHECKED), start=1
+            ):
+                t_page = time.time()
+                language = classify_page_language(image)
+                page_type = self._page_type.predict(image)
+                logger.debug(
+                    f"{doc_path.name} p{page_number}: language={language!r} "
+                    f"page_type={page_type!r} ({time.time() - t_page:.1f}s)"
+                )
+                languages.append(language)
+                page_types.append(page_type)
+        except (OSError, ValueError, PDFPageCountError, PDFSyntaxError) as exc:
+            # The bucket contains corrupt uploads (bad bytes behind a
+            # .jpeg/.pdf name): PIL raises UnidentifiedImageError/OSError,
+            # pdf2image raises PDFPageCountError/PDFSyntaxError (plain
+            # Exception subclasses). An unreadable file is a reject, not a
+            # crash — a --n 50 run died at 19/50 on exactly this before the
+            # guard existed.
+            logger.warning(
+                f"{doc_path.name}: unreadable document "
+                f"({type(exc).__name__}: {exc}) — rejecting"
             )
-            languages.append(language)
-            page_types.append(page_type)
+            return DocVerdict(
+                False,
+                f"unreadable document ({type(exc).__name__})",
+                tuple(languages),
+                tuple(page_types),
+            )
         verdict = assess_document(languages, page_types)
         logger.debug(
             f"{doc_path.name}: verdict={'ok' if verdict.ok else verdict.reason!r} "

--- a/tests/test_sample_english_complaints.py
+++ b/tests/test_sample_english_complaints.py
@@ -90,3 +90,31 @@ def test_unreadable_document_rejected():
     verdict = mod.assess_document([], [])
     assert not verdict.ok
     assert verdict.english_share == 0.0
+
+
+def test_corrupt_file_rejects_instead_of_crashing(tmp_path):
+    # The bucket holds corrupt uploads (bad bytes behind a .jpeg name); a
+    # --n 50 run crashed on one before assess() caught the decode error.
+    # __new__ skips the ViT load — the file fails to open before any model
+    # or OCR code is reached, which is exactly what the guard covers.
+    pytest.importorskip("PIL")
+    gates = object.__new__(mod.DocumentGates)
+    corrupt = tmp_path / "DEPT2025_complaint.jpeg"
+    corrupt.write_bytes(b"<html>Error: upload failed</html>")
+
+    verdict = gates.assess(corrupt)
+
+    assert not verdict.ok
+    assert "unreadable document" in verdict.reason
+
+
+def test_corrupt_pdf_rejects_instead_of_crashing(tmp_path):
+    pytest.importorskip("pdf2image")
+    gates = object.__new__(mod.DocumentGates)
+    corrupt = tmp_path / "DEPT2025_complaint.pdf"
+    corrupt.write_bytes(b"not a pdf")
+
+    verdict = gates.assess(corrupt)
+
+    assert not verdict.ok
+    assert "unreadable document" in verdict.reason


### PR DESCRIPTION
A background `--n 50` sampling run died at 19/50 picks: `PIL.UnidentifiedImageError` on `DEPT20251186148_complaint_20250917_044452.jpeg` — a corrupt upload in the documents bucket (bad bytes behind a `.jpeg` name; same family as the failed-upload rows already handled in the DB layer).

`DocumentGates.assess()` now treats an undecodable file as a **reject with reason `unreadable document (...)`** instead of an unhandled exception: caught are the PIL `OSError` family (`UnidentifiedImageError`, truncated-file errors) and pdf2image's `PDFPageCountError`/`PDFSyntaxError` (which subclass plain `Exception`, not `ValueError`/`OSError` — found by the test). The run continues, and the drop is logged and counted like any other gate rejection.

Two regression tests (corrupt jpeg, corrupt pdf) exercise the real `assess()` path via `object.__new__` (the file fails to open before the ViT or OCR is ever reached, so no model load is needed). 12/12 sampler tests pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)