### PR TITLE
ci: report pytest coverage on PRs

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   test-and-validate-pipeline:
@@ -32,8 +31,15 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     steps:
+      # PR-controlled code (test suite, deps) runs in this job, so the
+      # checkout must not persist a token: this job only ever holds the
+      # default read-only GITHUB_TOKEN, but persisting it is needless
+      # exposure and would become a real problem if permissions here ever
+      # change.
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -62,11 +68,50 @@ jobs:
         run: uv run pytest --cov=janasunani --cov-report=term-missing:skip-covered --cov-report=xml
 
       - name: Write coverage markdown
-        if: github.event_name == 'pull_request'
+        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
         run: uv run coverage report -m --skip-covered --format=markdown > coverage.md
 
+      - name: Upload coverage XML
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml
+
+      - name: Upload coverage markdown
+        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-md
+          path: coverage.md
+
+      # Validate the pipeline DEFINITION only — do not execute data stages in CI.
+      # `materialize` needs the operational OLTP DB (SQLite dev file or the box's
+      # Postgres), and the cold-start migration needs the 3.2 GB DVC-tracked dump
+      # plus Docker + MySQL. These produce data and run on the operational box /
+      # a scheduled job, never on a clean CI runner.
+      - name: Validate DVC pipeline definition
+        run: |
+          uv run dvc dag
+          uv run dvc dag --md >> "$GITHUB_STEP_SUMMARY" || true
+
+  # Kept separate from the test job so the write-scoped token never shares a
+  # job with PR-controlled code (test suite, deps): that job only checks out
+  # code and runs it, this job only downloads a plain-text artifact and
+  # posts a comment.
+  post-coverage-comment:
+    needs: test-and-validate-pipeline
+    if: ${{ !cancelled() && github.event_name == 'pull_request' && needs.test-and-validate-pipeline.result != 'skipped' }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Download coverage markdown
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-md
+
       - name: Comment coverage on PR
-        if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |
@@ -110,19 +155,3 @@ jobs:
                 body,
               });
             }
-
-      - name: Upload coverage XML
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-xml
-          path: coverage.xml
-
-      # Validate the pipeline DEFINITION only — do not execute data stages in CI.
-      # `materialize` needs the operational OLTP DB (SQLite dev file or the box's
-      # Postgres), and the cold-start migration needs the 3.2 GB DVC-tracked dump
-      # plus Docker + MySQL. These produce data and run on the operational box /
-      # a scheduled job, never on a clean CI runner.
-      - name: Validate DVC pipeline definition
-        run: |
-          uv run dvc dag
-          uv run dvc dag --md >> "$GITHUB_STEP_SUMMARY" || true

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   test-and-validate-pipeline:
     runs-on: ubuntu-latest
@@ -54,8 +58,64 @@ jobs:
       - name: Sync dependencies
         run: uv sync --all-groups --extra serving
 
-      - name: Run tests
-        run: uv run pytest
+      - name: Run tests with coverage
+        run: uv run pytest --cov=janasunani --cov-report=term-missing:skip-covered --cov-report=xml
+
+      - name: Write coverage markdown
+        if: github.event_name == 'pull_request'
+        run: uv run coverage report -m --skip-covered --format=markdown > coverage.md
+
+      - name: Comment coverage on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+            const marker = "<!-- janasunani-coverage-report -->";
+            const report = fs.readFileSync("coverage.md", "utf8");
+            const body = `${marker}
+            ## Test Coverage
+
+            ${report}
+
+            Full XML report is available as the \`coverage-xml\` workflow artifact.`;
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+
+            const comments = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            const existing = comments.data.find(
+              (comment) =>
+                comment.user.type === "Bot" && comment.body.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }
+
+      - name: Upload coverage XML
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml
 
       # Validate the pipeline DEFINITION only — do not execute data stages in CI.
       # `materialize` needs the operational OLTP DB (SQLite dev file or the box's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,7 @@ dev = [
     "nbstripout>=0.9.1",
     "pytest>=9.0.3",
     "pytest-asyncio>=0.24",
+    "pytest-cov>=7.1.0",
     "respx>=0.21",
     "ruff>=0.15.15",
 ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,82 @@
+"""Tests for janasunani.pipeline.cli: argument parsing (already covered in
+test_pipeline.py) and main()'s dispatch/validation, which was previously
+untested."""
+
+import pytest
+
+from janasunani.pipeline import cli
+from janasunani.pipeline.config import PipelineConfig
+
+
+def test_main_init_db_calls_initialize_database(tmp_path, monkeypatch, capsys):
+    db_path = tmp_path / "pipeline.sqlite"
+    calls = []
+    monkeypatch.setattr(cli, "initialize_database", lambda p: calls.append(p))
+    monkeypatch.setattr("sys.argv", ["prog", "init-db", "--db", str(db_path)])
+
+    assert cli.main() == 0
+    assert calls == [db_path]
+    assert f"Initialized database: {db_path}" in capsys.readouterr().out
+
+
+def test_main_run_builds_config_and_calls_run_pipeline(tmp_path, monkeypatch):
+    captured = {}
+    monkeypatch.setattr(cli, "run_pipeline", lambda config: captured.setdefault("config", config))
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "prog",
+            "run",
+            "--input",
+            str(tmp_path / "in"),
+            "--db",
+            str(tmp_path / "p.sqlite"),
+            "--models",
+            str(tmp_path / "models"),
+            "--stages",
+            "ocr_extraction",
+            "--ocr-engine",
+            "pytesseract",
+            "--worker-id",
+            "1",
+            "--num-workers",
+            "3",
+        ],
+    )
+
+    assert cli.main() == 0
+    config = captured["config"]
+    assert isinstance(config, PipelineConfig)
+    assert config.stages == ("ocr_extraction",)
+    assert config.worker_id == 1
+    assert config.num_workers == 3
+    assert config.ocr_engine == "pytesseract"
+
+
+def test_main_run_rejects_num_workers_below_one(tmp_path, monkeypatch):
+    monkeypatch.setattr(cli, "run_pipeline", lambda config: pytest.fail("should not run"))
+    monkeypatch.setattr(
+        "sys.argv",
+        ["prog", "run", "--db", str(tmp_path / "p.sqlite"), "--num-workers", "0"],
+    )
+    with pytest.raises(SystemExit, match="--num-workers must be >= 1"):
+        cli.main()
+
+
+def test_main_run_rejects_worker_id_out_of_range(tmp_path, monkeypatch):
+    monkeypatch.setattr(cli, "run_pipeline", lambda config: pytest.fail("should not run"))
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "prog",
+            "run",
+            "--db",
+            str(tmp_path / "p.sqlite"),
+            "--worker-id",
+            "5",
+            "--num-workers",
+            "2",
+        ],
+    )
+    with pytest.raises(SystemExit, match=r"--worker-id \(5\) must be in \[0, --num-workers=2\)"):
+        cli.main()

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -1,0 +1,387 @@
+"""Tests for the async CRUD layer against a real (SQLite) session — the
+create/update/bulk-load/tracking helpers in janasunani.db.crud."""
+
+from datetime import datetime, timedelta
+
+import pytest
+import pytz
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from janasunani.db import crud
+from janasunani.db.models import ActionHistoryAPIRequestTracking, APIRequestTracking, Base
+from janasunani.ingestion.schemas import ActionHistory as ActionHistorySchema
+from janasunani.ingestion.schemas import Complaint as ComplaintSchema
+from janasunani.ingestion.schemas import District as DistrictSchema
+
+IST = pytz.timezone("Asia/Kolkata")
+
+
+def _district(dist_id, dist_name="Cuttack"):
+    return DistrictSchema(distId=dist_id, distName=dist_name)
+
+
+def _complaint(ticket_no, **kw):
+    return ComplaintSchema(ticketNumber=ticket_no, **kw)
+
+
+def _action(ticket_no, **kw):
+    return ActionHistorySchema(ticketNumber=ticket_no, **kw)
+
+
+@pytest.fixture
+async def db(tmp_path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'crud.db'}")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    Session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with Session() as s:
+        yield s
+    await engine.dispose()
+
+
+# --- districts ---
+
+
+async def test_create_or_update_district_creates_then_updates(db):
+    created = await crud.create_or_update_district(db, _district(1, "Cuttack"))
+    assert created.dist_name == "Cuttack"
+
+    updated = await crud.create_or_update_district(db, _district(1, "Cuttack Renamed"))
+    assert updated.id == created.id
+    assert updated.dist_name == "Cuttack Renamed"
+
+    assert (await crud.get_district_by_id(db, 1)).dist_name == "Cuttack Renamed"
+    assert (await crud.get_district_by_name(db, "Cuttack Renamed")) is not None
+    assert await crud.get_district_by_id(db, 999) is None
+
+
+async def test_get_all_districts(db):
+    await crud.create_or_update_district(db, _district(1, "Cuttack"))
+    await crud.create_or_update_district(db, _district(2, "Puri"))
+    assert {d.dist_id for d in await crud.get_all_districts(db)} == {1, 2}
+
+
+async def test_batch_create_or_update_districts(db):
+    result = await crud.batch_create_or_update_districts(
+        db, [_district(1, "Cuttack"), _district(2, "Puri")]
+    )
+    assert {d.dist_id for d in result} == {1, 2}
+
+
+# --- complaints ---
+
+
+async def test_create_or_update_complaint_creates_then_updates(db):
+    created = await crud.create_or_update_complaint(
+        db, _complaint("T1", grievanceSubject="water", districtName="Puri")
+    )
+    assert created.grievance == "water"
+
+    updated = await crud.create_or_update_complaint(
+        db, _complaint("T1", grievanceSubject="water fixed", districtName="Puri")
+    )
+    assert updated.id == created.id
+    assert updated.grievance == "water fixed"
+
+    fetched = await crud.get_complaint_by_ticket(db, "T1")
+    assert fetched is not None and fetched.grievance == "water fixed"
+    assert await crud.get_complaint_by_ticket(db, "missing") is None
+
+
+async def test_get_all_complaints(db):
+    await crud.create_or_update_complaint(db, _complaint("T1"))
+    await crud.create_or_update_complaint(db, _complaint("T2"))
+    assert {c.ticket_no for c in await crud.get_all_complaints(db)} == {"T1", "T2"}
+
+
+async def test_get_complaints_by_district_and_status(db):
+    await crud.create_or_update_complaint(
+        db, _complaint("T1", districtName="Puri", StatusName="Pending")
+    )
+    await crud.create_or_update_complaint(
+        db, _complaint("T2", districtName="Cuttack", StatusName="Disposed")
+    )
+    by_dist = await crud.get_complaints_by_district(db, "Puri")
+    assert [c.ticket_no for c in by_dist] == ["T1"]
+
+    by_status = await crud.get_complaints_by_status(db, "Disposed")
+    assert [c.ticket_no for c in by_status] == ["T2"]
+
+
+async def test_batch_create_or_update_complaints(db):
+    result = await crud.batch_create_or_update_complaints(
+        db, [_complaint("T1"), _complaint("T2")]
+    )
+    assert {c.ticket_no for c in result} == {"T1", "T2"}
+
+
+# --- action history ---
+
+
+async def test_create_action_history_and_get_by_ticket(db):
+    await crud.create_or_update_complaint(db, _complaint("T1"))
+    await crud.create_action_history(
+        db, _action("T1", action_taken_by="Officer A", action_status="Forwarded")
+    )
+    await crud.create_action_history(
+        db, _action("T1", action_taken_by="Officer B", action_status="Resolved")
+    )
+    history = await crud.get_action_history_by_ticket(db, "T1")
+    assert {h.action_taken_by for h in history} == {"Officer A", "Officer B"}
+    assert await crud.get_action_history_by_ticket(db, "missing") == []
+
+
+async def test_batch_create_action_history(db):
+    await crud.create_or_update_complaint(db, _complaint("T1"))
+    result = await crud.batch_create_action_history(
+        db,
+        [
+            _action("T1", action_taken_by="Officer A"),
+            _action("T1", action_taken_by="Officer B"),
+        ],
+    )
+    assert len(result) == 2
+
+
+# --- bulk loaders ---
+
+
+async def test_bulk_load_districts_skips_existing(db):
+    await crud.create_or_update_district(db, _district(1, "Cuttack"))
+    inserted = await crud.bulk_load_districts(
+        db, [_district(1, "Cuttack"), _district(2, "Puri")]
+    )
+    assert [d.dist_id for d in inserted] == [2]
+    assert {d.dist_id for d in await crud.get_all_districts(db)} == {1, 2}
+
+
+async def test_bulk_load_districts_noop_when_all_exist(db):
+    await crud.create_or_update_district(db, _district(1, "Cuttack"))
+    inserted = await crud.bulk_load_districts(db, [_district(1, "Cuttack")])
+    assert inserted == []
+
+
+async def test_bulk_load_complaints_inserts_and_updates(db):
+    await crud.create_or_update_complaint(db, _complaint("T1", grievanceSubject="old"))
+
+    result = await crud.bulk_load_complaints(
+        db,
+        [
+            _complaint("T1", grievanceSubject="new"),  # update
+            _complaint("T2", grievanceSubject="brand new"),  # insert
+        ],
+    )
+    assert len(result) == 2
+
+    t1 = await crud.get_complaint_by_ticket(db, "T1")
+    t2 = await crud.get_complaint_by_ticket(db, "T2")
+    assert t1.grievance == "new"
+    assert t2.grievance == "brand new"
+
+
+async def test_bulk_load_complaints_noop_when_unchanged(db):
+    await crud.create_or_update_complaint(db, _complaint("T1", grievanceSubject="same"))
+    result = await crud.bulk_load_complaints(db, [_complaint("T1", grievanceSubject="same")])
+    assert result == []
+
+
+async def test_bulk_load_action_histories_inserts_and_updates(db):
+    await crud.create_or_update_complaint(db, _complaint("T1"))
+    await crud.create_action_history(
+        db,
+        _action(
+            "T1",
+            action_taken_by="Officer A",
+            action_taken_date=datetime(2024, 1, 1),
+            action_status="Forwarded",
+        ),
+    )
+
+    result = await crud.bulk_load_action_histories(
+        db,
+        [
+            _action(
+                "T1",
+                action_taken_by="Officer A",
+                action_taken_date=datetime(2024, 1, 1),
+                action_status="Resolved",  # changed -> update
+            ),
+            _action(
+                "T1",
+                action_taken_by="Officer B",
+                action_taken_date=datetime(2024, 1, 2),
+                action_status="Forwarded",  # new key -> insert
+            ),
+        ],
+    )
+    assert len(result) == 2
+    history = await crud.get_action_history_by_ticket(db, "T1")
+    statuses = {h.action_taken_by: h.action_status for h in history}
+    assert statuses == {"Officer A": "Resolved", "Officer B": "Forwarded"}
+
+
+# --- document status / lookups ---
+
+
+async def test_update_document_status_is_deprecated_and_updates_fields(db):
+    await crud.create_or_update_complaint(db, _complaint("T1"))
+    with pytest.deprecated_call():
+        updated = await crud.update_document_status(
+            db, ticket_no="T1", local_path="/tmp/t1.pdf", success=True
+        )
+    assert updated.document_downloaded is True
+    assert updated.local_document_path == "/tmp/t1.pdf"
+    assert updated.document_download_error is None
+
+
+async def test_update_document_status_missing_ticket_returns_none(db):
+    with pytest.deprecated_call():
+        result = await crud.update_document_status(
+            db, ticket_no="missing", local_path="/tmp/x.pdf", success=False, error="404"
+        )
+    assert result is None
+
+
+async def test_get_complaints_without_documents_filters_by_error_flag(db):
+    await crud.create_or_update_complaint(
+        db, _complaint("T1", Document="http://x/1.pdf")
+    )
+    await crud.create_or_update_complaint(
+        db, _complaint("T2", Document="http://x/2.pdf")
+    )
+    t2 = await crud.get_complaint_by_ticket(db, "T2")
+    t2.document_download_error = "boom"
+    await db.commit()
+
+    no_errors = await crud.get_complaints_without_documents(db)
+    assert [c.ticket_no for c in no_errors] == ["T1"]
+
+    with_errors = await crud.get_complaints_without_documents(
+        db, get_docs_where_errors_occurred=True
+    )
+    assert [c.ticket_no for c in with_errors] == ["T2"]
+
+
+async def test_get_complaints_with_document_urls(db):
+    # `isnot("")` is a null-safe SQL comparison: NULL passes through (NULL IS
+    # NOT '' is TRUE), only an explicit empty string is excluded.
+    await crud.create_or_update_complaint(db, _complaint("T1", Document="http://x/1.pdf"))
+    await crud.create_or_update_complaint(db, _complaint("T2"))  # document_url NULL
+    t3 = await crud.create_or_update_complaint(db, _complaint("T3", Document="http://x/3.pdf"))
+    t3.document_url = ""
+    await db.commit()
+
+    urls = await crud.get_complaints_with_document_urls(db)
+    assert {c.ticket_no for c in urls} == {"T1", "T2"}
+
+
+# --- API request tracking ---
+
+
+async def test_record_and_get_complaint_api_request_success_create_then_update(db):
+    first = await crud.record_complaint_api_request_success(
+        db, year=2024, dist_id=1, status=1, office=1, record_count=5
+    )
+    assert first.records_count == 5 and first.failure_count == 0
+
+    second = await crud.record_complaint_api_request_success(
+        db, year=2024, dist_id=1, status=1, office=1, record_count=9
+    )
+    assert second.id == first.id
+    assert second.records_count == 9
+
+
+async def test_mark_complaints_api_request_failed_create_then_increment(db):
+    first = await crud.mark_complaints_api_request_failed(
+        db, year=2024, dist_id=1, status=1, office=1
+    )
+    assert first.failure_count == 1
+
+    second = await crud.mark_complaints_api_request_failed(
+        db, year=2024, dist_id=1, status=1, office=1
+    )
+    assert second.id == first.id
+    assert second.failure_count == 2
+
+
+async def test_filter_complaints_api_request(db):
+    # No tracking row at all -> not recently processed.
+    assert (
+        await crud.filter_complaints_api_request(db, year=2024, dist_id=1, status=1, office=1)
+        is False
+    )
+
+    await crud.record_complaint_api_request_success(
+        db, year=2024, dist_id=1, status=1, office=1, record_count=1
+    )
+    # Just succeeded -> within threshold -> True.
+    assert (
+        await crud.filter_complaints_api_request(db, year=2024, dist_id=1, status=1, office=1)
+        is True
+    )
+
+    # Old success but few failures -> False.
+    await crud.record_complaint_api_request_success(
+        db, year=2024, dist_id=2, status=1, office=1, record_count=1
+    )
+    tracking = (
+        await db.execute(select(APIRequestTracking).filter(APIRequestTracking.dist_id == 2))
+    ).scalars().first()
+    tracking.last_successful_fetch = datetime.now(IST) - timedelta(days=30)
+    await db.commit()
+    assert (
+        await crud.filter_complaints_api_request(db, year=2024, dist_id=2, status=1, office=1)
+        is False
+    )
+
+    # Old success but failure_count over threshold -> True.
+    tracking.failure_count = 5
+    await db.commit()
+    assert (
+        await crud.filter_complaints_api_request(db, year=2024, dist_id=2, status=1, office=1)
+        is True
+    )
+
+
+async def test_record_and_mark_action_history_api_request(db):
+    await crud.create_or_update_complaint(db, _complaint("T1"))
+
+    created = await crud.record_action_history_api_request_success(db, "T1", record_count=3)
+    assert created.records_count == 3 and created.failure_count == 0
+
+    updated = await crud.record_action_history_api_request_success(db, "T1", record_count=7)
+    assert updated.id == created.id and updated.records_count == 7
+
+    failed_first = await crud.mark_action_history_api_request_failed(db, "T2")
+    assert failed_first.failure_count == 1
+    failed_second = await crud.mark_action_history_api_request_failed(db, "T2")
+    assert failed_second.id == failed_first.id and failed_second.failure_count == 2
+
+
+async def test_get_tickets_needing_action_history(db):
+    await crud.create_or_update_complaint(db, _complaint("NEVER_TRACKED"))
+    await crud.create_or_update_complaint(db, _complaint("STALE"))
+    await crud.create_or_update_complaint(db, _complaint("RECENT"))
+    await crud.create_or_update_complaint(db, _complaint("EXHAUSTED"))
+
+    # STALE: successful fetch far in the past -> needs refresh.
+    await crud.record_action_history_api_request_success(db, "STALE", record_count=1)
+    stale_tracking = (
+        await db.execute(
+            select(ActionHistoryAPIRequestTracking).filter_by(ticket_no="STALE")
+        )
+    ).scalars().first()
+    stale_tracking.last_successful_fetch = datetime.now(IST) - timedelta(days=30)
+    await db.commit()
+
+    # RECENT: successful fetch just now -> does not need refresh.
+    await crud.record_action_history_api_request_success(db, "RECENT", record_count=1)
+
+    # EXHAUSTED: never succeeded, failure count past threshold -> excluded.
+    for _ in range(4):
+        await crud.mark_action_history_api_request_failed(db, "EXHAUSTED")
+
+    needing = set(await crud.get_tickets_needing_action_history(db))
+    assert needing == {"NEVER_TRACKED", "STALE"}

--- a/tests/test_pipeline_dispatch.py
+++ b/tests/test_pipeline_dispatch.py
@@ -1,0 +1,54 @@
+"""Tests for run_pipeline's stage-dispatch loop in janasunani.pipeline.pipeline.
+
+Each stage module is faked via sys.modules so this exercises the dispatch
+logic (canonical ordering, stage selection, db init) without importing any
+stage's real (and possibly heavy: cv2/sklearn/torch) dependencies."""
+
+import sys
+import types
+
+from janasunani.pipeline.config import PipelineConfig
+from janasunani.pipeline.pipeline import STAGE_ORDER, run_pipeline
+
+
+def _fake_stages(monkeypatch):
+    calls = []
+    run_attr = {
+        "format_classifier": "run_format_classifier",
+        "ocr_extraction": "run_ocr_extraction",
+        "pii_tagger": "run_pii_tagger",
+        "page_type_classifier": "run_page_type_classifier",
+        "summarizer": "run_summarizer",
+        "categorizer": "run_categorizer",
+    }
+    for stage_name, attr in run_attr.items():
+        module = types.ModuleType(f"janasunani.pipeline.stages.{stage_name}")
+        setattr(module, attr, lambda config, name=stage_name: calls.append(name))
+        monkeypatch.setitem(
+            sys.modules, f"janasunani.pipeline.stages.{stage_name}", module
+        )
+    return calls
+
+
+def test_run_pipeline_runs_all_stages_in_canonical_order(tmp_path, monkeypatch):
+    calls = _fake_stages(monkeypatch)
+    config = PipelineConfig(
+        input_dir=tmp_path, db_path=tmp_path / "p.sqlite", models_dir=tmp_path
+    )
+    run_pipeline(config)
+    assert calls == STAGE_ORDER
+    assert (tmp_path / "p.sqlite").exists()
+
+
+def test_run_pipeline_runs_only_selected_stages_in_canonical_order(tmp_path, monkeypatch):
+    calls = _fake_stages(monkeypatch)
+    config = PipelineConfig(
+        input_dir=tmp_path,
+        db_path=tmp_path / "p.sqlite",
+        models_dir=tmp_path,
+        # Given out of canonical order; the loop must still run them in
+        # STAGE_ORDER (OCR depends on format_classifier's output).
+        stages=("categorizer", "format_classifier"),
+    )
+    run_pipeline(config)
+    assert calls == ["format_classifier", "categorizer"]

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -1,0 +1,40 @@
+"""Tests for janasunani.pipeline.ticket: deriving ticket numbers / doc ids from
+a document's path relative to the documents/ root."""
+
+from janasunani.pipeline.ticket import ticket_from_relpath
+
+
+def test_ticket_from_relpath_nested():
+    assert (
+        ticket_from_relpath("OR107/E/2021/00324_complaint_20250916_102200.pdf")
+        == "OR107/E/2021/00324"
+    )
+
+
+def test_ticket_from_relpath_flat():
+    assert ticket_from_relpath("CMO2022115810_complaint_20250915_144909.jpeg") == "CMO2022115810"
+
+
+def test_ticket_from_relpath_normalizes_windows_separators():
+    assert (
+        ticket_from_relpath("OR107\\E\\2021\\00324_complaint_20250916_102200.pdf")
+        == "OR107/E/2021/00324"
+    )
+
+
+def test_ticket_from_relpath_no_extension():
+    assert ticket_from_relpath("CMO2022115810_complaint_20250915_144909") == "CMO2022115810"
+
+
+def test_ticket_from_relpath_empty_string_returns_none():
+    assert ticket_from_relpath("") is None
+
+
+def test_ticket_from_relpath_none_returns_none():
+    assert ticket_from_relpath(None) is None
+
+
+def test_ticket_from_relpath_missing_complaint_marker_returns_none():
+    # No "_complaint_" marker -> can't reliably parse a ticket.
+    assert ticket_from_relpath("OR107/E/2021/random_file.pdf") is None
+

--- a/uv.lock
+++ b/uv.lock
@@ -834,6 +834,60 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/8b/adeb62ea8951f13c4c7fef2e7a85e1a06b499c8d8237ea589d496029e53f/coverage-7.15.0.tar.gz", hash = "sha256:9ac3fe7a1435986463eaa8ee253ae2f2a268709ba4ae5c7dd1f52a05391ad78f", size = 925362, upload-time = "2026-07-02T13:10:50.535Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/04/145a3748098bcc86b631a85408d2c3dc5c104e0bd86d605468239b25b6c4/coverage-7.15.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5be4caf3b28836f078abe700f8944dac4a65d78f16d6c600c89cb624e5535782", size = 220863, upload-time = "2026-07-02T13:09:25.371Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/5c/4ed55708fed2c64b63c9bc5715daef670872202101938869b7fe5d5fbb8f/coverage-7.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dd58ad1404704303ca8d4f4b8a1095e7cbc7040ef17a66df1e6619aa10176430", size = 221230, upload-time = "2026-07-02T13:09:26.897Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/19/3a80b97d3b2a5c77a01ae359c6bed20c13738fe3d9380f08616d4fec0281/coverage-7.15.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bbcbb317c2e5ded5b21104af81c29f391be2af98d065693ffbe8d23949b948e5", size = 252227, upload-time = "2026-07-02T13:09:28.543Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fa/b70062750686bd7da454da27927622f48bbac6990ac7a4c4a4653e7b0036/coverage-7.15.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:27f31ecb458da3f859aab3f15ada871eb7a7768807d88df4a9f186bb17737970", size = 254823, upload-time = "2026-07-02T13:09:30.177Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/09/dad6a75a2e561b9dc5086a8c5257a7591d584246f67e23e70d2995b89ab6/coverage-7.15.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:13fb759be317fdc62e0f56bffdf61cfcb45c7761ad6b71e3e583e71a67ae753c", size = 256059, upload-time = "2026-07-02T13:09:31.979Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/e7/b5d2941fa9564573d44b693a871ff3156f0c42cbefe977a09fa7fdc59971/coverage-7.15.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d5cf007add5ab4bb8fa9f4c77e3732127c9e6cad501d7db43355fbfafca0be84", size = 258190, upload-time = "2026-07-02T13:09:34.035Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/1d/8e895bcde3c57ccd46d896dda5f2b3d5df761a1b0c6c9d450d175dedc632/coverage-7.15.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cc78d9843bd576fbe2118248258d485e968dc535f95ed504a7b0867ba9b51389", size = 252456, upload-time = "2026-07-02T13:09:35.765Z" },
+    { url = "https://files.pythonhosted.org/packages/14/4c/f6997da343ddeb959be82c3b05322793f92c071ad45f7cb8a96336e2dd5f/coverage-7.15.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a263060f1de0b4b74b4e089c2a70b8003b3781c733329a9c8fd54995328f9950", size = 254192, upload-time = "2026-07-02T13:09:37.445Z" },
+    { url = "https://files.pythonhosted.org/packages/17/27/a0bc09d032267b9da89d95a2d874cfbef2a5aebbf0e87cf7aba221d79a99/coverage-7.15.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:c48decf16e0dfd5b049c7d5e82200c23c08126719142998d4f172444e3d0529e", size = 252153, upload-time = "2026-07-02T13:09:39.422Z" },
+    { url = "https://files.pythonhosted.org/packages/54/c0/77fc233d9fba07b244c40948c53fe27308b8f21732fb3417f87fbd6fd992/coverage-7.15.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:08fb028000ed0aaa0a4cbdfbb98be7cb42f370db973fbbb469733505ab20e13e", size = 256310, upload-time = "2026-07-02T13:09:41.006Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/24/601cecfb5825becacb8d45219a018a3b55b9dbaec624efdb0ea249d08be2/coverage-7.15.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:fb7dc0c3b7d8a1077abea0b8546ebc5e26d6ef6ecefc2f0f5ad2b8a53bdad837", size = 251974, upload-time = "2026-07-02T13:09:42.733Z" },
+    { url = "https://files.pythonhosted.org/packages/47/1e/6f45e5a5b3d5484318d368702af6716b5ab8913b0428bec981a562fcf296/coverage-7.15.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6cb3602054ccbe9f0d8c2dc04bbeba90d5719236e2cd06e042ddd6d3fc7b6e37", size = 253745, upload-time = "2026-07-02T13:09:44.376Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/db/4df027a77bd11d0e527f44c53557c76e54ad027413d0304252ea3a78d67e/coverage-7.15.0-cp313-cp313-win32.whl", hash = "sha256:0bf781da64326b677be344df505171435b6f58716108606621d5d27d964fff8b", size = 222902, upload-time = "2026-07-02T13:09:46.122Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/10/0355894d34e231f2c5449e71287e81a50793a325df2e2b027b7bcd9dfd19/coverage-7.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:2c57a275078ee3fa185f83e400f765bc764a549de66d99b47881645cbd4ea629", size = 223444, upload-time = "2026-07-02T13:09:47.687Z" },
+    { url = "https://files.pythonhosted.org/packages/06/ef/bb725f263befaaff851203ab338e68af15e195d7f7b5f323162532d9b6a8/coverage-7.15.0-cp313-cp313-win_arm64.whl", hash = "sha256:3812c61afc6685c7999b39320779ab8f43b7a3081fdb0def39976e56fbdb9a21", size = 222839, upload-time = "2026-07-02T13:09:49.717Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/9c/1e3ca54f72a3185ece06c58d871099898c48f0ed6430d17b6ab75f0d180a/coverage-7.15.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:41cb79af843222e11da87127ad0ecbfa878abadd0f770a4a99391a27d3887324", size = 220906, upload-time = "2026-07-02T13:09:51.339Z" },
+    { url = "https://files.pythonhosted.org/packages/09/37/f718613d83b274880382f6b67e78f3802549ae39b0b3e65ae5b5974df56e/coverage-7.15.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7d2008989ef8fe54188d3f3bfa2e3099b025af11e90a6a1b9e7dc433d04263d8", size = 221239, upload-time = "2026-07-02T13:09:53.138Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/ce/22bae91e0b75445f68d365c7643ed0aa4880bbf77450ee74ca65bdae53a7/coverage-7.15.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:769e8ece11a596315ebf5aa7ec383aeeed016c091d2bf6363ffb996d41529092", size = 252286, upload-time = "2026-07-02T13:09:54.996Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/1e/bec5e32aa508615d9d7a2790effb25fb4dc28606e995816afe400b25ece3/coverage-7.15.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:65a6b6164ee5c39e2f3803f314292d6c61a607ba7fee253d1e03c42dc3903502", size = 254789, upload-time = "2026-07-02T13:09:56.678Z" },
+    { url = "https://files.pythonhosted.org/packages/17/29/0e865435b4354e4a7c03b1b7920046d31d0a273d55decefea27e011cb9bf/coverage-7.15.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:75128817f95a5c45bb01d65fd2d8b9cb54bbe03d81608fb70e3e14b437ad56c2", size = 256135, upload-time = "2026-07-02T13:09:58.343Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ff/33a870b58a13325d62fc0a6c8f01fa0ff667cef60c7498e2382a147dfa18/coverage-7.15.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9887bb428fe2d4cd4bee89bac1a6c9932f484afd5b36fbd4ff6ea5f825bb1f5e", size = 258449, upload-time = "2026-07-02T13:10:00.057Z" },
+    { url = "https://files.pythonhosted.org/packages/18/7b/6fffe596bf3ddba8462758d02c5dad730fd91055a6634aa2e4226229181a/coverage-7.15.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0bfc0be1f702042207a93a00523b1065ee1fe951e96edf311581c0bbc2e34888", size = 252313, upload-time = "2026-07-02T13:10:01.946Z" },
+    { url = "https://files.pythonhosted.org/packages/58/1b/11468dd6c1676ab831a70cb9a8d4e198e8607fa0b7220ab918b73fe9bfbd/coverage-7.15.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f64627d55def5a43282d70e08396672692f77e4da610a5bb8bb4060b432b6859", size = 254142, upload-time = "2026-07-02T13:10:04.065Z" },
+    { url = "https://files.pythonhosted.org/packages/79/41/29328e21d16b1b95092c30dd700e08cf915bd3734f836df8f3bdb0e8fa9f/coverage-7.15.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:2c6f0fa473003905c6d5bac328ee4eba9fbea654f15bc24b8a3274b23363fa99", size = 252108, upload-time = "2026-07-02T13:10:06.11Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/de/05ccfb990439655b35afbfd8e0d13fe66677565a7d4eb38c3f5ef2635e1c/coverage-7.15.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2bcf9afaf064172c6ec3c58a325a9957ad1178c05dd934e25f253321776e0676", size = 256385, upload-time = "2026-07-02T13:10:08.141Z" },
+    { url = "https://files.pythonhosted.org/packages/51/0e/486828a3d2695ea7a2609f17ff572f6b01905e608379440a11da4b8dffbe/coverage-7.15.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:baf06bc987115d6fb938d403f7eab684a057766c490367999a2b71a6883110c6", size = 251923, upload-time = "2026-07-02T13:10:10.179Z" },
+    { url = "https://files.pythonhosted.org/packages/18/c7/03582b6715f078e5e558354c87616d945b9894cda2dace8e4009b17035e4/coverage-7.15.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f0405f2ff97b1c4c0e782cb32e02f32369bcf2e6b618b591d67e1ea754575dfe", size = 253580, upload-time = "2026-07-02T13:10:12.052Z" },
+    { url = "https://files.pythonhosted.org/packages/db/dc/9e578bbaf2ecb4959a81b7e7601ad8cca772cba2892e8d144cb749b4a71a/coverage-7.15.0-cp314-cp314-win32.whl", hash = "sha256:ab282853ed5fbd64bbb162f19cb8fcb7087187508a6374b4f9c34ec1577c4e8f", size = 223107, upload-time = "2026-07-02T13:10:13.994Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3e/c8c3b75d8dbe0e35f7b0cc3ff5e949fc59500f70b21d0398813f66740664/coverage-7.15.0-cp314-cp314-win_amd64.whl", hash = "sha256:3bb3040e9f4bbe26fcb0cd7cc85ac63e630d3f3a9c74f027abf4caa27e706663", size = 223597, upload-time = "2026-07-02T13:10:15.906Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/bc/3cbc9fb036eb388519bccd521f783499c39b64256013fbc362782f196fe1/coverage-7.15.0-cp314-cp314-win_arm64.whl", hash = "sha256:346771144d34f7fa84ec28386f78e0f31653f33cf35e19d253d5b35f9e8201da", size = 223020, upload-time = "2026-07-02T13:10:17.844Z" },
+    { url = "https://files.pythonhosted.org/packages/28/00/199c4a8d656dff63102577a056c0fce2ff6a79e40adac092fc986c49cbf1/coverage-7.15.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d34a010905fb6401324ba016b5da03d574967f7b21ce48ea41e66f0f1f95f641", size = 221638, upload-time = "2026-07-02T13:10:19.703Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8e/9d0092c96a3d3a26951ecc7020826aa57bcb1b119ca81acbba996884ab13/coverage-7.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:bb25d825d885ca8036795dacfc3924d33091fc76d71ebc99420c6b79e77d96fa", size = 221903, upload-time = "2026-07-02T13:10:21.514Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b4/c0ca3028f42c9a08e51feb4561ef1192e5de99797cd1db5b04590c215bda/coverage-7.15.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:94c9686bfe8a9a6810297aecbd99beaa3445f9e8dc2f80b1382cca0d86b64461", size = 263267, upload-time = "2026-07-02T13:10:23.261Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/aa/a375e3846e5d3c013dc600b2a3231089055c73d77f5393dd2192a8d64da6/coverage-7.15.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9bd671c25f9d85f09d7ec481d0e43d5139f486c06a37139847a7ce569788af72", size = 265390, upload-time = "2026-07-02T13:10:25.152Z" },
+    { url = "https://files.pythonhosted.org/packages/92/e1/5783cdabb797305e1c9e4809fea496d31834c51fa772514f73dc148bcfc9/coverage-7.15.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:110cbdf8d2e216577312cf06ccf85539c0e5a5420ef747e4a4719b5e483c88cd", size = 267811, upload-time = "2026-07-02T13:10:27.249Z" },
+    { url = "https://files.pythonhosted.org/packages/85/31/96d8bbf58b8e9193bc8389574a91a0db48355ee98feb66aa6bf8d1b32eea/coverage-7.15.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2c5d4619214f1d9993e7b00a8600d14614b7e9d84e89507460b126aa5e6559e5", size = 268928, upload-time = "2026-07-02T13:10:29.242Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/7a/5294567e811a1cb7eda93140c628fa050d66189da28da320f93d1d815c73/coverage-7.15.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:781a704516e2d8346fbbd5be6c6f3412dd824785146528b3a01816f26c081007", size = 262378, upload-time = "2026-07-02T13:10:31.107Z" },
+    { url = "https://files.pythonhosted.org/packages/69/3f/3f48538421f899f28946f90a3d272136a4686e1abf461cc9249a783ee0f3/coverage-7.15.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd4a1b44bcb65ee29e947ac92bbee04956df3a6bfc6143641bb6cae7ede00fc9", size = 265263, upload-time = "2026-07-02T13:10:32.942Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/d3/092df15efcab8a9c1467ee960eb8019bbad3f9300d115d89ea6195f369ff/coverage-7.15.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:0e4950c9d6d3e39c64c991814ff315e2d0b9cb8152363594212c9e55208c0a8f", size = 262866, upload-time = "2026-07-02T13:10:35.104Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/ab/0254d2b88665efb2c57ad368cc77ab5de3435bd8d5add4729c1b0e79431e/coverage-7.15.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:fe9c87ff42e5472d80d21704972e1f96e104a0a599d77c5e35db5a3c562e2571", size = 266599, upload-time = "2026-07-02T13:10:37.05Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/79/1cfa4023e489ce6fbc7be4a5d442dbc375edb4f4fda39a352cedb53263c2/coverage-7.15.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f00d5ae1dd2fe13fb8186e3e7d37bcbd8b25c0d764ff7d1b32cef9be058510a8", size = 261714, upload-time = "2026-07-02T13:10:38.966Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/eb/fee5c8665656be63f497418d410484637c438172568688e8ac92e06574e7/coverage-7.15.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:363ab38cc78b615f11c9cac3cf1d7eef950c18b9fdedfb9066f59461dcf84d68", size = 264025, upload-time = "2026-07-02T13:10:40.789Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/99/63005db722f91edc81abc16302f9cc2f6228c1679e46e15be9ae144b14d0/coverage-7.15.0-cp314-cp314t-win32.whl", hash = "sha256:54fd9c53a5fafff509195f1b6a3f9be615d8e8362a3629ff1de23d270c03c86b", size = 223413, upload-time = "2026-07-02T13:10:42.597Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/e8/2bc6181c4fb06f1a6b981eb85330cc57bfad7e3f710fc9c9d350013ba228/coverage-7.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:87b47553097ba185ed964866078e7e63adea9f5f51b5f39691c34f30afd21080", size = 224245, upload-time = "2026-07-02T13:10:44.47Z" },
+    { url = "https://files.pythonhosted.org/packages/79/b8/4d959bf9cc45d0cfed2f4d35cafcab978cdb6ea02eb5100009cd740632a3/coverage-7.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aeefb2dd178fe7eee79f0ad25d75855cb35ee9ed472db2c5ea06f5b4fd00cec5", size = 223558, upload-time = "2026-07-02T13:10:46.368Z" },
+    { url = "https://files.pythonhosted.org/packages/52/30/21b2ad45959cd50e909e02ebac1e30b4ceb7162e91c11d4c570223a458b7/coverage-7.15.0-py3-none-any.whl", hash = "sha256:56da6a4cbe8f7e9e80bd072ca9cefe67d7106a440a7ec06519ec6507ac94ad19", size = 212632, upload-time = "2026-07-02T13:10:48.641Z" },
+]
+
+[[package]]
 name = "cryptography"
 version = "46.0.7"
 source = { registry = "https://pypi.org/simple" }
@@ -2188,6 +2242,7 @@ dev = [
     { name = "nbstripout" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
     { name = "respx" },
     { name = "ruff" },
 ]
@@ -2263,6 +2318,7 @@ dev = [
     { name = "nbstripout", specifier = ">=0.9.1" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=0.24" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "respx", specifier = ">=0.21" },
     { name = "ruff", specifier = ">=0.15.15" },
 ]
@@ -4452,6 +4508,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Run the CI test suite with `pytest-cov`, generating terminal, XML, and markdown coverage reports
- Post/update a coverage summary as a PR comment via `actions/github-script`, and upload the full XML report as a workflow artifact
- Grant the workflow `pull-requests: write` permission needed to post the comment

## Test plan
- [x] Open this PR and confirm the coverage comment is posted with a markdown table
- [x] Push an additional commit and confirm the existing coverage comment is updated in place rather than duplicated
- [ ] Confirm the `coverage-xml` artifact is attached to the workflow run

🤖 Generated with [Claude Code](https://claude.com/claude-code)