### PR TITLE
terraform: guard cpu_box against accidental destroy+recreate

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -8,7 +8,10 @@
 > `most_recent = true`, so a newer Canonical image drifts the `ami` attribute and
 > Terraform plans to **destroy and recreate** the box — the root volume is
 > `delete_on_termination = true`, so a recreate **erases the production data** (a
-> subnet-ordering change can force the same). There is no `prevent_destroy` guard.
+> subnet-ordering change can force the same). The instance now carries a
+> `lifecycle` guard (`prevent_destroy = true`, `ignore_changes = [ami,
+> subnet_id]`), so `apply` will **error out rather than replace it** — but
+> don't rely on that as your only check.
 >
 > **Always `terraform plan` first** and scan for `aws_instance.cpu_box must be
 > replaced` or any `N to destroy` — if you see it, **STOP, do not apply.**

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -8,8 +8,10 @@
 > `most_recent = true` ([main.tf](main.tf)), so a newer Canonical image drifts the
 > `ami` attribute and Terraform plans to **destroy and recreate** the box — the
 > root volume is `delete_on_termination = true`, so a recreate **erases the
-> production data** (a subnet-ordering change can force the same). There is no
-> `prevent_destroy` guard.
+> production data** (a subnet-ordering change can force the same). The instance
+> now carries a `lifecycle` guard (`prevent_destroy = true`, `ignore_changes =
+> [ami, subnet_id]`), so `apply` will **error out rather than replace it** — but
+> don't rely on that as your only check.
 >
 > **Always `terraform plan` first** and scan for `aws_instance.cpu_box must be
 > replaced` or any `N to destroy` — if you see it, **STOP, do not apply.** The

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -121,6 +121,15 @@ resource "aws_instance" "cpu_box" {
     delete_on_termination = true
   }
 
+  lifecycle {
+    # Hard backstop: Terraform errors instead of destroying/replacing the box.
+    prevent_destroy = true
+    # AMI drift (most_recent) and default-subnet-list reordering must not
+    # force a replacement of the live, stateful box — keep whatever is
+    # already running instead of chasing the data source.
+    ignore_changes = [ami, subnet_id]
+  }
+
   tags = {
     Name = "janasunani-cpu-box"
   }

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -8,8 +8,10 @@
 > with `most_recent = true`, so when Canonical ships a newer image the `ami`
 > attribute drifts and Terraform plans to **destroy and recreate** the box — and
 > the root volume is `delete_on_termination = true`, so a recreate **erases the
-> production data** (a subnet-ordering change can force the same). There is no
-> `prevent_destroy` guard.
+> production data** (a subnet-ordering change can force the same). The instance
+> now carries a `lifecycle` guard (`prevent_destroy = true`, `ignore_changes =
+> [ami, subnet_id]`), so `apply` will **error out rather than replace it** — but
+> don't rely on that as your only check.
 >
 > **Always run `terraform plan` first** and scan for `aws_instance.cpu_box must
 > be replaced` or any `N to destroy`. If you see it, **STOP — do not apply.**


### PR DESCRIPTION
AMI resolution (most_recent = true) and default-subnet-list ordering can both drift the force-replacement attributes of aws_instance.cpu_box; since the root volume is delete_on_termination = true, a recreate would erase the production data with no confirmation beyond a plan diff. Add a lifecycle block (prevent_destroy = true, ignore_changes = [ami, subnet_id]) as a hard backstop, and correct the three deploy READMEs that said "no prevent_destroy guard" now that one exists.


## Validation

- [ ] `uv run ruff check .`
- [ ] `uv run pytest`
- [ ] Notebooks have been stripped with `uv run nbstripout --install` or equivalent.
- [ ] No proprietary data files are committed directly to Git.
- [ ] DVC pointers / `dvc.lock` are updated when approved data or pipeline outputs changed.



## Data And Delivery Notes

- [x ] This PR does not modify data.
- [x ] This PR ingests or versions data through DVC.
- [ ] This PR updates generated exhibits.
- [ ] This PR requires `make deliver` after merge.

Notes:

-
