### PR TITLE
feat(serving): persist live grievance results

### DIFF
--- a/janasunani/db/alembic/versions/8d4ab4f6d5e2_live_grievances_table.py
+++ b/janasunani/db/alembic/versions/8d4ab4f6d5e2_live_grievances_table.py
@@ -1,0 +1,52 @@
+"""live grievances table
+
+Revision ID: 8d4ab4f6d5e2
+Revises: dd0eea37cac6
+Create Date: 2026-07-08 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '8d4ab4f6d5e2'
+down_revision: Union[str, None] = 'dd0eea37cac6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'live_grievances',
+        sa.Column('id', sa.String(), nullable=False),
+        sa.Column('ticket_no', sa.String(), nullable=False),
+        sa.Column('status', sa.String(), nullable=False),
+        sa.Column('submitted_on', sa.DateTime(), nullable=False),
+        sa.Column('district', sa.String(), nullable=True),
+        sa.Column('source', sa.String(), nullable=False),
+        sa.Column('category', sa.String(), nullable=True),
+        sa.Column('subcategory', sa.String(), nullable=True),
+        sa.Column('language', sa.String(), nullable=True),
+        sa.Column('dept', sa.String(), nullable=True),
+        sa.Column('office', sa.String(), nullable=True),
+        sa.Column('routing_method', sa.String(), nullable=True),
+        sa.Column('routing_confidence', sa.Float(), nullable=True),
+        sa.Column('result_json', sa.JSON(), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('ix_live_grievances_ticket_no', 'live_grievances', ['ticket_no'], unique=True)
+    op.create_index('ix_live_grievances_submitted_on', 'live_grievances', ['submitted_on'])
+    op.create_index('ix_live_grievances_district', 'live_grievances', ['district'])
+    op.create_index('ix_live_grievances_category', 'live_grievances', ['category'])
+    op.create_index('ix_live_grievances_dept', 'live_grievances', ['dept'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_live_grievances_dept', table_name='live_grievances')
+    op.drop_index('ix_live_grievances_category', table_name='live_grievances')
+    op.drop_index('ix_live_grievances_district', table_name='live_grievances')
+    op.drop_index('ix_live_grievances_submitted_on', table_name='live_grievances')
+    op.drop_index('ix_live_grievances_ticket_no', table_name='live_grievances')
+    op.drop_table('live_grievances')

--- a/janasunani/db/crud.py
+++ b/janasunani/db/crud.py
@@ -1,5 +1,5 @@
 import asyncio
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, List, Mapping, Optional
 
 import pytz
@@ -134,11 +134,22 @@ async def get_complaints_by_status(
 
 
 def _parse_datetime(value: Any) -> datetime:
-    if isinstance(value, datetime):
-        return value
+    """Parse to a **naive UTC** datetime, matching the naive ``DateTime`` columns.
+
+    ``GrievanceResult.model_dump(mode="json")`` emits offset-bearing ISO
+    strings (the processor stamps ``datetime.now(UTC)``), but every timestamp
+    column in this schema is ``TIMESTAMP WITHOUT TIME ZONE``. Postgres/asyncpg
+    (unlike SQLite) refuses to bind a tz-aware value into a naive column, so
+    any aware datetime is normalized to naive UTC before it's handed back.
+    """
     if isinstance(value, str):
-        return datetime.fromisoformat(value.replace("Z", "+00:00"))
-    raise TypeError(f"Expected datetime or ISO string, got {type(value).__name__}")
+        value = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    elif not isinstance(value, datetime):
+        raise TypeError(f"Expected datetime or ISO string, got {type(value).__name__}")
+
+    if value.tzinfo is not None:
+        value = value.astimezone(timezone.utc).replace(tzinfo=None)
+    return value
 
 
 async def get_live_grievance_by_id(

--- a/janasunani/db/crud.py
+++ b/janasunani/db/crud.py
@@ -1,6 +1,6 @@
 import asyncio
 from datetime import datetime, timedelta
-from typing import List, Optional
+from typing import Any, List, Mapping, Optional
 
 import pytz
 from loguru import logger
@@ -16,6 +16,7 @@ from .models import ActionHistory as ActionHistoryModel
 from .models import ActionHistoryAPIRequestTracking, APIRequestTracking
 from .models import Complaint as ComplaintModel
 from .models import District
+from .models import LiveGrievance
 from .session import get_db
 
 
@@ -130,6 +131,66 @@ async def get_complaints_by_status(
         select(ComplaintModel).filter(ComplaintModel.status == status)
     )
     return result.scalars().all()
+
+
+def _parse_datetime(value: Any) -> datetime:
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    raise TypeError(f"Expected datetime or ISO string, got {type(value).__name__}")
+
+
+async def get_live_grievance_by_id(
+    db: AsyncSession, grievance_id: str
+) -> Optional[LiveGrievance]:
+    """Get a persisted live demo grievance by API id."""
+    result = await db.execute(
+        select(LiveGrievance).filter(LiveGrievance.id == grievance_id)
+    )
+    return result.scalars().first()
+
+
+async def create_or_update_live_grievance(
+    db: AsyncSession,
+    result_payload: Mapping[str, Any],
+    *,
+    district: Optional[str] = None,
+) -> LiveGrievance:
+    """Persist a serving ``GrievanceResult`` payload without changing its shape."""
+    extraction = result_payload.get("extraction") or {}
+    classification = result_payload.get("classification") or {}
+    routing = result_payload.get("routing") or {}
+    grievance_id = str(result_payload["id"])
+
+    values = {
+        "id": grievance_id,
+        "ticket_no": str(result_payload["ticket_no"]),
+        "status": str(result_payload["status"]),
+        "submitted_on": _parse_datetime(result_payload["submitted_on"]),
+        "district": district,
+        "source": str(extraction.get("source")),
+        "category": classification.get("category"),
+        "subcategory": classification.get("subcategory"),
+        "language": classification.get("language"),
+        "dept": routing.get("dept"),
+        "office": routing.get("office"),
+        "routing_method": routing.get("method"),
+        "routing_confidence": routing.get("confidence"),
+        "result_json": dict(result_payload),
+    }
+
+    live = await get_live_grievance_by_id(db, grievance_id)
+    if live is None:
+        live = LiveGrievance(**values)
+        db.add(live)
+    else:
+        for key, value in values.items():
+            setattr(live, key, value)
+
+    await db.commit()
+    await db.refresh(live)
+    return live
 
 
 # Action History CRUD operations

--- a/janasunani/db/models.py
+++ b/janasunani/db/models.py
@@ -22,9 +22,11 @@ from sqlalchemy import (
     Boolean,
     Column,
     DateTime,
+    Float,
     ForeignKey,
     Index,
     Integer,
+    JSON,
     String,
     UniqueConstraint,
     func,
@@ -264,6 +266,33 @@ class PipelineDocument(Base):
     grievance = Column(String, nullable=True)
     summary = Column(String, nullable=True)
     grievance_category = Column(String, nullable=True)
+
+
+class LiveGrievance(Base):
+    """One live demo submission persisted by the serving API.
+
+    Historical complaints stay faithful to the dump in ``complaints``. Demo
+    submissions use this sibling table so the API can write/read live results
+    without mutating the historical schema. The full API response is kept in
+    ``result_json`` to preserve the frozen serving contract exactly.
+    """
+
+    __tablename__ = "live_grievances"
+
+    id = Column(String, primary_key=True)
+    ticket_no = Column(String, unique=True, nullable=False, index=True)
+    status = Column(String, nullable=False)
+    submitted_on = Column(DateTime, nullable=False, index=True)
+    district = Column(String, nullable=True, index=True)
+    source = Column(String, nullable=False)
+    category = Column(String, nullable=True, index=True)
+    subcategory = Column(String, nullable=True)
+    language = Column(String, nullable=True)
+    dept = Column(String, nullable=True, index=True)
+    office = Column(String, nullable=True)
+    routing_method = Column(String, nullable=True)
+    routing_confidence = Column(Float, nullable=True)
+    result_json = Column(JSON, nullable=False)
 
 
 class APIRequestTracking(Base):

--- a/janasunani/serving/api.py
+++ b/janasunani/serving/api.py
@@ -93,7 +93,11 @@ def create_app(
             raise HTTPException(status_code=422, detail="'text' is empty.")
 
         grievance_id = uuid.uuid4().hex[:12]
-        ticket_no = f"JS{next(ticket_seq):07d}{grievance_id[:4].upper()}"
+        # Full grievance_id (not just a 4-hex slice) as the suffix: the counter
+        # resets on process restart / repeats across workers, so the ~48 bits
+        # of the full id are what actually keep ticket_no unique against the
+        # DB's UNIQUE index once persistence is live.
+        ticket_no = f"JS{next(ticket_seq):07d}{grievance_id.upper()}"
         # The processor protocol is sync (real inference is CPU/GPU-bound
         # work); run it off the event loop so a slow OCR/model call doesn't
         # block /health and other requests on this worker at wire-up.

--- a/janasunani/serving/api.py
+++ b/janasunani/serving/api.py
@@ -10,8 +10,8 @@ Endpoints (the full surface; shapes in schemas.py are the frozen contract):
 
 Skeleton wiring (swapped at Phase 8/9 wire-up, endpoints unchanged):
 processor = ``MockGrievanceProcessor``; history = ``MockHistory``; submitted
-results live in an in-process dict (wire-up persists to the ``live_grievances``
-OLTP table instead — the dict, like everything mock, dies with the process).
+results go through an injectable store. The module-level app uses the
+``live_grievances`` OLTP table; tests keep the process-local store.
 
 Run:  uv run --extra serving janasunani-api          # 127.0.0.1:8000
 CORS: comma-separated ``JANASUNANI_CORS_ORIGINS`` (default ``*`` — fine for
@@ -31,6 +31,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from loguru import logger
 from starlette.concurrency import run_in_threadpool
 
+from janasunani.config import settings
 from janasunani.serving.history import HistoryProvider, MockHistory
 from janasunani.serving.processor import GrievanceProcessor, MockGrievanceProcessor
 from janasunani.serving.schemas import (
@@ -38,15 +39,22 @@ from janasunani.serving.schemas import (
     HealthResponse,
     HistoryPage,
 )
+from janasunani.serving.store import (
+    DatabaseResultStore,
+    InMemoryResultStore,
+    ResultStore,
+)
 
 
 def create_app(
     processor: Optional[GrievanceProcessor] = None,
     history: Optional[HistoryProvider] = None,
+    result_store: Optional[ResultStore] = None,
 ) -> FastAPI:
     """App factory; tests and the wire-up inject their own processor/history."""
     processor = processor or MockGrievanceProcessor()
     history = history or MockHistory()
+    result_store = result_store or InMemoryResultStore()
 
     app = FastAPI(title="Janasunani 2.0 API", version="0.1.0")
     app.add_middleware(
@@ -56,8 +64,6 @@ def create_app(
         allow_headers=["*"],
     )
 
-    # Skeleton-only store for GET /grievance/{id}; replaced by OLTP at wire-up.
-    results: dict[str, GrievanceResult] = {}
     # next() has no await point, so concurrent submissions can't mint the same
     # number (len(results)+1 could: requests overlap at `await file.read()`).
     ticket_seq = itertools.count(1)
@@ -81,7 +87,7 @@ def create_app(
             raise HTTPException(status_code=422, detail="'text' is empty.")
 
         grievance_id = uuid.uuid4().hex[:12]
-        ticket_no = f"JS{next(ticket_seq):07d}"
+        ticket_no = f"JS{next(ticket_seq):07d}{grievance_id[:4].upper()}"
         # The processor protocol is sync (real inference is CPU/GPU-bound
         # work); run it off the event loop so a slow OCR/model call doesn't
         # block /health and other requests on this worker at wire-up.
@@ -96,7 +102,7 @@ def create_app(
                 district=district,
             )
         )
-        results[grievance_id] = result
+        await result_store.save(result, district=district)
         logger.info(
             f"grievance {grievance_id} ({ticket_no}): "
             f"{result.extraction.source} via {processor.name} -> "
@@ -105,8 +111,8 @@ def create_app(
         return result
 
     @app.get("/grievance/{grievance_id}", response_model=GrievanceResult)
-    def get_grievance(grievance_id: str) -> GrievanceResult:
-        result = results.get(grievance_id)
+    async def get_grievance(grievance_id: str) -> GrievanceResult:
+        result = await result_store.get(grievance_id)
         if result is None:
             raise HTTPException(status_code=404, detail="No such grievance.")
         return result
@@ -126,7 +132,7 @@ def create_app(
     return app
 
 
-app = create_app()
+app = create_app(result_store=DatabaseResultStore(settings.OLTP_DB_URL))
 
 
 def main() -> None:

--- a/janasunani/serving/api.py
+++ b/janasunani/serving/api.py
@@ -10,8 +10,13 @@ Endpoints (the full surface; shapes in schemas.py are the frozen contract):
 
 Skeleton wiring (swapped at Phase 8/9 wire-up, endpoints unchanged):
 processor = ``MockGrievanceProcessor``; history = ``MockHistory``; submitted
-results go through an injectable store. The module-level app uses the
-``live_grievances`` OLTP table; tests keep the process-local store.
+results go through an injectable store. The module-level app keeps the
+in-memory store — zero DB setup to run the mock skeleton — so the frontend's
+``uv run --extra serving janasunani-api`` target never depends on Alembic
+migrations having run. ``DatabaseResultStore`` (the ``live_grievances`` OLTP
+table) is available for explicit injection and is exercised by
+``tests/test_serving_persistence.py``; the real Phase 10 wire-up will inject
+it into ``create_app`` explicitly.
 
 Run:  uv run --extra serving janasunani-api          # 127.0.0.1:8000
 CORS: comma-separated ``JANASUNANI_CORS_ORIGINS`` (default ``*`` — fine for
@@ -31,7 +36,6 @@ from fastapi.middleware.cors import CORSMiddleware
 from loguru import logger
 from starlette.concurrency import run_in_threadpool
 
-from janasunani.config import settings
 from janasunani.serving.history import HistoryProvider, MockHistory
 from janasunani.serving.processor import GrievanceProcessor, MockGrievanceProcessor
 from janasunani.serving.schemas import (
@@ -39,11 +43,13 @@ from janasunani.serving.schemas import (
     HealthResponse,
     HistoryPage,
 )
-from janasunani.serving.store import (
-    DatabaseResultStore,
-    InMemoryResultStore,
-    ResultStore,
-)
+from janasunani.serving.store import InMemoryResultStore, ResultStore
+
+# DatabaseResultStore is deliberately not imported/used at module scope: the
+# module-level ``app`` below stays on the in-memory store so the mock
+# skeleton runs with zero DB setup. Callers that want OLTP persistence
+# construct their own app via ``create_app(result_store=DatabaseResultStore(...))``
+# (see janasunani.serving.store.DatabaseResultStore).
 
 
 def create_app(
@@ -132,7 +138,7 @@ def create_app(
     return app
 
 
-app = create_app(result_store=DatabaseResultStore(settings.OLTP_DB_URL))
+app = create_app()
 
 
 def main() -> None:

--- a/janasunani/serving/store.py
+++ b/janasunani/serving/store.py
@@ -1,0 +1,64 @@
+"""Submitted-result stores for ``GET /grievance/{id}``.
+
+The API factory keeps an in-memory store available for contract tests and the
+mock skeleton. The module-level app uses ``DatabaseResultStore`` so live demo
+submissions survive process restarts once the Alembic migration has run.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Protocol
+
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from janasunani.db import crud
+from janasunani.serving.schemas import GrievanceResult
+
+
+class ResultStore(Protocol):
+    async def save(
+        self, result: GrievanceResult, *, district: Optional[str] = None
+    ) -> None: ...
+
+    async def get(self, grievance_id: str) -> Optional[GrievanceResult]: ...
+
+
+class InMemoryResultStore:
+    """Process-local store used by tests and explicit mock apps."""
+
+    def __init__(self) -> None:
+        self._results: dict[str, GrievanceResult] = {}
+
+    async def save(
+        self, result: GrievanceResult, *, district: Optional[str] = None
+    ) -> None:
+        self._results[result.id] = result
+
+    async def get(self, grievance_id: str) -> Optional[GrievanceResult]:
+        return self._results.get(grievance_id)
+
+
+class DatabaseResultStore:
+    """OLTP-backed live grievance store."""
+
+    def __init__(self, oltp_url: str) -> None:
+        self._engine = create_async_engine(oltp_url)
+        self._sessions = async_sessionmaker(self._engine, expire_on_commit=False)
+
+    async def save(
+        self, result: GrievanceResult, *, district: Optional[str] = None
+    ) -> None:
+        async with self._sessions() as session:
+            await crud.create_or_update_live_grievance(
+                session, result.model_dump(mode="json"), district=district
+            )
+
+    async def get(self, grievance_id: str) -> Optional[GrievanceResult]:
+        async with self._sessions() as session:
+            row = await crud.get_live_grievance_by_id(session, grievance_id)
+            if row is None:
+                return None
+            return GrievanceResult.model_validate(row.result_json)
+
+    async def dispose(self) -> None:
+        await self._engine.dispose()

--- a/janasunani/serving/store.py
+++ b/janasunani/serving/store.py
@@ -1,7 +1,9 @@
 """Submitted-result stores for ``GET /grievance/{id}``.
 
 The API factory keeps an in-memory store available for contract tests and the
-mock skeleton. The module-level app uses ``DatabaseResultStore`` so live demo
+mock skeleton (the module-level app in ``api.py`` uses it by default, so the
+skeleton needs no DB setup). ``DatabaseResultStore`` is available for explicit
+injection (``create_app(result_store=DatabaseResultStore(...))``) so live demo
 submissions survive process restarts once the Alembic migration has run.
 """
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,7 +2,7 @@
 
 from sqlalchemy import create_engine, inspect
 
-from janasunani.db.models import ActionHistory, Base, Complaint
+from janasunani.db.models import ActionHistory, Base, Complaint, LiveGrievance
 
 
 def test_metadata_creates_expected_tables():
@@ -15,6 +15,7 @@ def test_metadata_creates_expected_tables():
         "districts",
         "api_request_tracking",
         "action_history_api_request_tracking",
+        "live_grievances",
     } <= tables
 
 
@@ -38,3 +39,20 @@ def test_complaint_models_full_dump_plus_ingestion_columns():
 def test_action_history_has_ticket_and_tracking_keys():
     cols = set(ActionHistory.__table__.columns.keys())
     assert {"ticket_no", "tracking_id", "action_taken_by", "action_status"} <= cols
+
+
+def test_live_grievance_preserves_result_payload():
+    cols = set(LiveGrievance.__table__.columns.keys())
+    assert {
+        "id",
+        "ticket_no",
+        "status",
+        "submitted_on",
+        "district",
+        "source",
+        "category",
+        "dept",
+        "routing_method",
+        "routing_confidence",
+        "result_json",
+    } <= cols

--- a/tests/test_serving_api.py
+++ b/tests/test_serving_api.py
@@ -165,3 +165,14 @@ def test_same_text_gets_deterministic_classification(client):
     b = client.post("/grievance", data={"text": _TEXT}).json()
     assert a["classification"] == b["classification"]
     assert a["ticket_no"] != b["ticket_no"]  # but each submission is distinct
+
+
+def test_ticket_no_carries_full_grievance_id_suffix(client):
+    # Regression (Codex P2 on PR #19): the ticket_no used to suffix only the
+    # first 4 hex chars of grievance_id. ticket_seq is an in-process
+    # itertools.count that repeats across process restarts/workers, so a
+    # 4-hex suffix could collide against the DB's UNIQUE(ticket_no) index
+    # once persistence is live. The suffix must be the *entire* id.
+    body = client.post("/grievance", data={"text": _TEXT}).json()
+    assert body["ticket_no"].endswith(body["id"].upper())
+    assert len(body["ticket_no"]) == len("JS") + 7 + len(body["id"])

--- a/tests/test_serving_persistence.py
+++ b/tests/test_serving_persistence.py
@@ -1,0 +1,52 @@
+import asyncio
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+
+pytest.importorskip("fastapi")
+pytest.importorskip("python_multipart")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from janasunani.db.models import Base, LiveGrievance  # noqa: E402
+from janasunani.serving.api import create_app  # noqa: E402
+from janasunani.serving.store import DatabaseResultStore  # noqa: E402
+
+
+def _make_oltp(tmp_path):
+    url = f"sqlite+aiosqlite:///{tmp_path}/live.db"
+    sync = create_engine(url.replace("+aiosqlite", ""))
+    Base.metadata.create_all(sync)
+    sync.dispose()
+    return url
+
+
+def test_submit_persists_and_fetches_from_oltp(tmp_path):
+    url = _make_oltp(tmp_path)
+    store = DatabaseResultStore(url)
+    client = TestClient(create_app(result_store=store))
+
+    submitted = client.post(
+        "/grievance",
+        data={"text": "The road is damaged. Call 9876543210.", "district": "Ganjam"},
+    ).json()
+
+    fresh_store = DatabaseResultStore(url)
+    fresh_client = TestClient(create_app(result_store=fresh_store))
+    fetched = fresh_client.get(f"/grievance/{submitted['id']}")
+
+    assert fetched.status_code == 200
+    assert fetched.json() == submitted
+
+    sync = create_engine(url.replace("+aiosqlite", ""))
+    with Session(sync) as session:
+        row = session.execute(select(LiveGrievance)).scalar_one()
+        assert row.ticket_no == submitted["ticket_no"]
+        assert row.district == "Ganjam"
+        assert row.source == "text"
+        assert row.routing_method == "mock"
+        assert row.result_json["id"] == submitted["id"]
+    sync.dispose()
+    asyncio.run(store.dispose())
+    asyncio.run(fresh_store.dispose())

--- a/tests/test_serving_persistence.py
+++ b/tests/test_serving_persistence.py
@@ -1,4 +1,6 @@
 import asyncio
+import os
+from datetime import datetime, timezone
 
 import pytest
 from sqlalchemy import create_engine, select
@@ -9,8 +11,16 @@ pytest.importorskip("python_multipart")
 
 from fastapi.testclient import TestClient  # noqa: E402
 
+from janasunani.db import crud  # noqa: E402
 from janasunani.db.models import Base, LiveGrievance  # noqa: E402
 from janasunani.serving.api import create_app  # noqa: E402
+from janasunani.serving.schemas import (  # noqa: E402
+    ClassificationResult,
+    ExtractionResult,
+    GrievanceResult,
+    RedactionResult,
+    RoutingResult,
+)
 from janasunani.serving.store import DatabaseResultStore  # noqa: E402
 
 
@@ -20,6 +30,23 @@ def _make_oltp(tmp_path):
     Base.metadata.create_all(sync)
     sync.dispose()
     return url
+
+
+def _sample_result(grievance_id: str = "aware-1") -> GrievanceResult:
+    """A GrievanceResult with a tz-aware ``submitted_on``, as the processor
+    actually produces (``datetime.now(UTC)``) and as
+    ``model_dump(mode="json")`` serializes it (offset-bearing ISO string)."""
+    return GrievanceResult(
+        id=grievance_id,
+        ticket_no=f"JS{grievance_id}",
+        status="submitted",
+        submitted_on=datetime(2026, 7, 8, 12, 30, tzinfo=timezone.utc),
+        extraction=ExtractionResult(source="text", extracted_text="road is bad"),
+        redaction=RedactionResult(redacted_text="road is bad", entities=[]),
+        classification=ClassificationResult(category="Roads", language="en"),
+        summary="road is bad",
+        routing=RoutingResult(dept="PWD", office="PWD Cuttack", confidence=0.5, method="mock"),
+    )
 
 
 def test_submit_persists_and_fetches_from_oltp(tmp_path):
@@ -50,3 +77,105 @@ def test_submit_persists_and_fetches_from_oltp(tmp_path):
     sync.dispose()
     asyncio.run(store.dispose())
     asyncio.run(fresh_store.dispose())
+
+
+def test_parse_datetime_normalizes_aware_values_to_naive_utc():
+    """Regression (Codex on PR #19): ``submitted_on`` arrives as an
+    offset-bearing ISO string (the processor stamps ``datetime.now(UTC)``),
+    but ``LiveGrievance.submitted_on`` is a naive ``DateTime`` column.
+    Postgres/asyncpg raises on a tz-aware bind into a naive column (SQLite
+    silently accepts it), so ``_parse_datetime`` must strip tzinfo after
+    converting to UTC."""
+    aware_iso = "2026-07-08T18:00:00+05:30"
+    parsed = crud._parse_datetime(aware_iso)
+    assert parsed.tzinfo is None
+    assert parsed == datetime(2026, 7, 8, 12, 30, 0)
+
+    aware_dt = datetime(2026, 7, 8, 12, 30, tzinfo=timezone.utc)
+    assert crud._parse_datetime(aware_dt) == datetime(2026, 7, 8, 12, 30)
+
+    naive_dt = datetime(2026, 7, 8, 12, 30)
+    assert crud._parse_datetime(naive_dt) == naive_dt
+    assert crud._parse_datetime(naive_dt).tzinfo is None
+
+
+def test_persist_tz_aware_submitted_on_stores_and_reads_back_naive(tmp_path):
+    """Real-code-path regression for the same bug via the actual
+    ``DatabaseResultStore`` -> ``crud.create_or_update_live_grievance`` path,
+    using the exact JSON shape ``GrievanceResult.model_dump(mode="json")``
+    produces (an offset-bearing ``submitted_on`` string)."""
+    url = _make_oltp(tmp_path)
+    store = DatabaseResultStore(url)
+    result = _sample_result()
+
+    asyncio.run(store.save(result, district="Cuttack"))
+
+    sync = create_engine(url.replace("+aiosqlite", ""))
+    with Session(sync) as session:
+        row = session.execute(select(LiveGrievance)).scalar_one()
+        assert row.submitted_on == datetime(2026, 7, 8, 12, 30)
+        assert row.submitted_on.tzinfo is None
+    sync.dispose()
+
+    fetched = asyncio.run(store.get(result.id))
+    assert fetched is not None
+    assert fetched.submitted_on == result.submitted_on
+
+    asyncio.run(store.dispose())
+
+
+PG_URL = os.getenv(
+    "TEST_OLTP_PG_URL", "postgresql+asyncpg://postgres:pass@127.0.0.1:5433/janasunani"
+)
+
+
+def _pg_available() -> bool:
+    try:
+        engine = create_engine(PG_URL.replace("+asyncpg", "+psycopg2"), connect_args={"connect_timeout": 2})
+        with engine.connect():
+            pass
+        engine.dispose()
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(
+    not _pg_available(), reason="no reachable Postgres test DB (set TEST_OLTP_PG_URL)"
+)
+def test_persist_tz_aware_submitted_on_against_postgres():
+    """The bug this regression guards against only reproduces against a real
+    Postgres/asyncpg backend (SQLite accepts tz-aware values into a naive
+    column silently); see README for the throwaway container this targets."""
+    sync_url = PG_URL.replace("+asyncpg", "+psycopg2")
+    sync_engine = create_engine(sync_url)
+    Base.metadata.drop_all(sync_engine)
+    Base.metadata.create_all(sync_engine)
+    sync_engine.dispose()
+
+    result = _sample_result(grievance_id="aware-pg-1")
+
+    async def _save_and_fetch():
+        # A single event loop for the whole store lifetime: asyncpg
+        # connections can't be reused across `asyncio.run()` calls (each
+        # mints a fresh loop), so save/get/dispose must share one here.
+        store = DatabaseResultStore(PG_URL)
+        try:
+            await store.save(result, district="Cuttack")
+            return await store.get(result.id)
+        finally:
+            await store.dispose()
+
+    try:
+        fetched = asyncio.run(_save_and_fetch())
+        assert fetched is not None
+        assert fetched.submitted_on == result.submitted_on
+
+        with Session(create_engine(sync_url)) as session:
+            row = session.execute(select(LiveGrievance)).scalar_one()
+            assert row.submitted_on == datetime(2026, 7, 8, 12, 30)
+            assert row.submitted_on.tzinfo is None
+    finally:
+        cleanup_engine = create_engine(sync_url)
+        Base.metadata.drop_all(cleanup_engine)
+        cleanup_engine.dispose()


### PR DESCRIPTION

Phase 10 — persist live grievance submissions to OLTP.

- `LiveGrievance` **sibling** table (keeps `complaints` faithful to the dump) + Alembic revision `8d4ab4f6d5e2`.
- Injectable `ResultStore` seam (`InMemoryResultStore` for tests, `DatabaseResultStore` for the app); `POST /grievance` persists, `GET /grievance/{id}` reads it back. Full response kept in `result_json`.
- Tests: `tests/test_serving_persistence.py`, `tests/test_models.py`.

**Notes:** touches `serving/api.py`'s `app = create_app(...)` line — **trivially conflicts with `feat/lake-history-provider`** (reconcile to one `create_app(history=…, result_store=…)`). Still uses the mock processor — real inference is Phase 8.