### PR TITLE
feat(tracking): add slim MLflow registry helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,6 +212,11 @@ outputs/reports/*
 !data/clean/.gitkeep
 !data/interim/.gitkeep
 !data/processed/.gitkeep
+
+# MLflow default local tracking + artifact store (janasunani/config.py
+# MLFLOW_TRACKING_URI default). Run metadata and logged artifact copies are
+# generated locally and must never be committed alongside DVC-tracked bytes.
+mlruns/
 !outputs/figures/.gitkeep
 !outputs/tables/.gitkeep
 !outputs/reports/.gitkeep

--- a/janasunani/config.py
+++ b/janasunani/config.py
@@ -114,6 +114,13 @@ class Settings(BaseSettings):
     AWS_REGION: str = os.getenv("AWS_REGION", "ap-south-1")
     AWS_S3_DOCUMENTS: str = os.getenv("AWS_S3_DOCUMENTS", "janasunani-documents-main")
 
+    # MLflow slim registry (local file backend by default; CPU box can set S3
+    # artifacts via MLFLOW_ARTIFACT_URI).
+    MLFLOW_TRACKING_URI: str = os.getenv(
+        "MLFLOW_TRACKING_URI", f"file://{(ROOT_DIR / 'mlruns').as_posix()}"
+    )
+    MLFLOW_ARTIFACT_URI: Optional[str] = os.getenv("MLFLOW_ARTIFACT_URI")
+
     model_config = SettingsConfigDict(env_file=ROOT_DIR / ".env", extra="ignore")
 
     @field_validator("DEBUG", mode="before")

--- a/janasunani/tracking/__init__.py
+++ b/janasunani/tracking/__init__.py
@@ -1,3 +1,15 @@
-"""Experiment/model tracking: local file-based MLflow tracking + model registry,
-dual-tracked with DVC (MLflow owns run/metric/registry metadata; DVC versions the
-artifact bytes, referenced from MLflow via path + content-hash tags)."""
+"""Experiment/model tracking helpers."""
+
+from janasunani.tracking.mlflow_utils import (
+    LoggedModelArtifact,
+    configure_tracking,
+    ensure_experiment,
+    log_model_artifact,
+)
+
+__all__ = [
+    "LoggedModelArtifact",
+    "configure_tracking",
+    "ensure_experiment",
+    "log_model_artifact",
+]

--- a/janasunani/tracking/mlflow_utils.py
+++ b/janasunani/tracking/mlflow_utils.py
@@ -47,16 +47,46 @@ def ensure_experiment(
     tracking_uri: Optional[str] = None,
     artifact_uri: Optional[str] = None,
 ) -> str:
-    """Return an MLflow experiment id, creating it if needed."""
+    """Return an MLflow experiment id, creating it if needed.
+
+    MLflow pins an experiment's artifact location at creation time; it cannot be
+    changed later. If ``artifact_uri`` (or ``settings.MLFLOW_ARTIFACT_URI``) names
+    a desired artifact root and an experiment with this name already exists
+    pointing somewhere else, raise instead of silently reusing it — otherwise
+    artifacts would keep landing in the stale location (e.g. the local default)
+    even after the caller configured a durable root (e.g. S3), while
+    registration still reports success.
+    """
     configure_tracking(tracking_uri)
+    desired_artifact_uri = artifact_uri or settings.MLFLOW_ARTIFACT_URI
     client = MlflowClient()
     experiment = client.get_experiment_by_name(name)
     if experiment is not None:
+        if desired_artifact_uri is not None and _normalize_artifact_uri(
+            experiment.artifact_location
+        ) != _normalize_artifact_uri(desired_artifact_uri):
+            raise ValueError(
+                f"Experiment {name!r} already exists with artifact_location "
+                f"{experiment.artifact_location!r}, which differs from the "
+                f"requested artifact root {desired_artifact_uri!r}. MLflow "
+                "cannot relocate an experiment's artifact store after "
+                "creation; use a differently named experiment or reconcile "
+                "the artifact root before proceeding."
+            )
         return experiment.experiment_id
     return client.create_experiment(
         name,
-        artifact_location=artifact_uri or settings.MLFLOW_ARTIFACT_URI,
+        artifact_location=desired_artifact_uri,
     )
+
+
+def _normalize_artifact_uri(uri: Optional[str]) -> Optional[str]:
+    """Normalize an artifact URI for equality comparison across MLflow's
+    own formatting (e.g. trailing slashes) without changing the compared
+    values' meaning."""
+    if uri is None:
+        return None
+    return uri.rstrip("/")
 
 
 def log_model_artifact(
@@ -84,13 +114,15 @@ def log_model_artifact(
     experiment_id = ensure_experiment(
         experiment_name, tracking_uri=tracking_uri, artifact_uri=artifact_uri
     )
-    tags = {
-        DVC_PATH_TAG: dvc_path,
-        DVC_HASH_TAG: dvc_hash,
-        "artifact.local_path": path.as_posix(),
-    }
+    tags: dict[str, str] = {"artifact.local_path": path.as_posix()}
     if extra_tags:
         tags.update(extra_tags)
+    # The DVC provenance tags are the guarantee this module exists to provide:
+    # they must always reflect the artifact actually logged in this call, so
+    # apply them last and let them win over any caller-supplied extra_tags
+    # (accidental or otherwise) that reuse the same reserved keys.
+    tags[DVC_PATH_TAG] = dvc_path
+    tags[DVC_HASH_TAG] = dvc_hash
 
     with mlflow.start_run(experiment_id=experiment_id) as run:
         mlflow.set_tags(tags)

--- a/janasunani/tracking/mlflow_utils.py
+++ b/janasunani/tracking/mlflow_utils.py
@@ -1,0 +1,143 @@
+"""Slim MLflow + DVC metadata helpers.
+
+MLflow owns run/metric/registry metadata. DVC remains the source of truth for
+artifact bytes; every registered model version gets the DVC path/hash tags that
+let operators resolve the exact mirrored artifact.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from pathlib import Path
+from typing import Mapping, Optional
+
+import mlflow
+from mlflow.exceptions import MlflowException
+from mlflow.tracking import MlflowClient
+
+from janasunani.config import settings
+
+
+DVC_PATH_TAG = "dvc.path"
+DVC_HASH_TAG = "dvc.hash"
+
+
+@dataclass(frozen=True)
+class LoggedModelArtifact:
+    run_id: str
+    experiment_id: str
+    artifact_uri: str
+    registered_model_name: Optional[str] = None
+    model_version: Optional[str] = None
+
+
+def configure_tracking(tracking_uri: Optional[str] = None) -> str:
+    """Configure MLflow's tracking backend and return the URI in use."""
+    uri = tracking_uri or settings.MLFLOW_TRACKING_URI
+    if uri.startswith("file:") or "://" not in uri:
+        os.environ.setdefault("MLFLOW_ALLOW_FILE_STORE", "true")
+    mlflow.set_tracking_uri(uri)
+    return uri
+
+
+def ensure_experiment(
+    name: str,
+    *,
+    tracking_uri: Optional[str] = None,
+    artifact_uri: Optional[str] = None,
+) -> str:
+    """Return an MLflow experiment id, creating it if needed."""
+    configure_tracking(tracking_uri)
+    client = MlflowClient()
+    experiment = client.get_experiment_by_name(name)
+    if experiment is not None:
+        return experiment.experiment_id
+    return client.create_experiment(
+        name,
+        artifact_location=artifact_uri or settings.MLFLOW_ARTIFACT_URI,
+    )
+
+
+def log_model_artifact(
+    *,
+    experiment_name: str,
+    local_path: Path | str,
+    dvc_path: str,
+    dvc_hash: str,
+    registered_model_name: Optional[str] = None,
+    tracking_uri: Optional[str] = None,
+    artifact_uri: Optional[str] = None,
+    artifact_subdir: str = "model",
+    extra_tags: Optional[Mapping[str, str]] = None,
+) -> LoggedModelArtifact:
+    """Log an artifact and optionally create a registered model version.
+
+    ``local_path`` may be a file or directory. The registered model version
+    points at the logged MLflow artifact URI; DVC metadata is copied to both the
+    run and model-version tags.
+    """
+    path = Path(local_path)
+    if not path.exists():
+        raise FileNotFoundError(path)
+
+    experiment_id = ensure_experiment(
+        experiment_name, tracking_uri=tracking_uri, artifact_uri=artifact_uri
+    )
+    tags = {
+        DVC_PATH_TAG: dvc_path,
+        DVC_HASH_TAG: dvc_hash,
+        "artifact.local_path": path.as_posix(),
+    }
+    if extra_tags:
+        tags.update(extra_tags)
+
+    with mlflow.start_run(experiment_id=experiment_id) as run:
+        mlflow.set_tags(tags)
+        if path.is_dir():
+            mlflow.log_artifacts(path.as_posix(), artifact_path=artifact_subdir)
+        else:
+            mlflow.log_artifact(path.as_posix(), artifact_path=artifact_subdir)
+        source_uri = mlflow.get_artifact_uri(artifact_subdir)
+        run_id = run.info.run_id
+
+    version = None
+    if registered_model_name:
+        version = _create_model_version(
+            registered_model_name,
+            source_uri=source_uri,
+            run_id=run_id,
+            tags=tags,
+        )
+
+    return LoggedModelArtifact(
+        run_id=run_id,
+        experiment_id=experiment_id,
+        artifact_uri=source_uri,
+        registered_model_name=registered_model_name,
+        model_version=version,
+    )
+
+
+def _create_model_version(
+    name: str,
+    *,
+    source_uri: str,
+    run_id: str,
+    tags: Mapping[str, str],
+) -> str:
+    client = MlflowClient()
+    try:
+        client.create_registered_model(name)
+    except MlflowException as exc:
+        if "already exists" not in str(exc).lower():
+            raise
+
+    model_version = client.create_model_version(
+        name=name,
+        source=source_uri,
+        run_id=run_id,
+    )
+    for key, value in tags.items():
+        client.set_model_version_tag(name, model_version.version, key, value)
+    return model_version.version

--- a/tests/test_mlflow_utils.py
+++ b/tests/test_mlflow_utils.py
@@ -1,5 +1,6 @@
 from uuid import uuid4
 
+import pytest
 from mlflow.tracking import MlflowClient
 
 from janasunani.tracking.mlflow_utils import (
@@ -23,6 +24,50 @@ def test_ensure_experiment_uses_local_artifact_root(tmp_path):
     experiment = client.get_experiment(experiment_id)
     assert experiment.name == name
     assert experiment.artifact_location == artifact_uri
+
+
+def test_ensure_experiment_reuses_when_artifact_root_matches(tmp_path):
+    tracking_uri = (tmp_path / "mlruns").as_uri()
+    artifact_uri = (tmp_path / "artifacts").as_uri()
+    name = f"janasunani-test-{uuid4().hex}"
+
+    first_id = ensure_experiment(
+        name, tracking_uri=tracking_uri, artifact_uri=artifact_uri
+    )
+    second_id = ensure_experiment(
+        name, tracking_uri=tracking_uri, artifact_uri=artifact_uri
+    )
+
+    assert first_id == second_id
+
+
+def test_ensure_experiment_raises_on_artifact_root_mismatch(tmp_path):
+    tracking_uri = (tmp_path / "mlruns").as_uri()
+    original_artifact_uri = (tmp_path / "artifacts-local").as_uri()
+    changed_artifact_uri = (tmp_path / "artifacts-s3-stand-in").as_uri()
+    name = f"janasunani-test-{uuid4().hex}"
+
+    ensure_experiment(name, tracking_uri=tracking_uri, artifact_uri=original_artifact_uri)
+
+    with pytest.raises(ValueError, match="artifact"):
+        ensure_experiment(
+            name, tracking_uri=tracking_uri, artifact_uri=changed_artifact_uri
+        )
+
+
+def test_ensure_experiment_skips_check_when_no_artifact_root_requested(tmp_path):
+    tracking_uri = (tmp_path / "mlruns").as_uri()
+    artifact_uri = (tmp_path / "artifacts").as_uri()
+    name = f"janasunani-test-{uuid4().hex}"
+
+    first_id = ensure_experiment(
+        name, tracking_uri=tracking_uri, artifact_uri=artifact_uri
+    )
+    # No artifact_uri requested this time: reuse should proceed without
+    # comparing against the experiment's existing (different-looking) root.
+    second_id = ensure_experiment(name, tracking_uri=tracking_uri)
+
+    assert first_id == second_id
 
 
 def test_log_model_artifact_registers_dvc_tagged_version(tmp_path):
@@ -55,3 +100,34 @@ def test_log_model_artifact_registers_dvc_tagged_version(tmp_path):
     assert version.tags[DVC_HASH_TAG] == "abc123"
     assert version.tags["model.kind"] == "categorizer"
     assert version.source == logged.artifact_uri
+
+
+def test_log_model_artifact_dvc_tags_survive_clobbering_extra_tags(tmp_path):
+    """extra_tags reusing the reserved dvc.path/dvc.hash keys must never win —
+    the registered version has to keep advertising the DVC object it actually
+    logged, not whatever a caller (accidentally or otherwise) passed in."""
+    artifact = tmp_path / "categorizer.txt"
+    artifact.write_text("demo model", encoding="utf-8")
+    tracking_uri = (tmp_path / "mlruns").as_uri()
+    artifact_uri = (tmp_path / "artifacts").as_uri()
+    model_name = f"categorizer-{uuid4().hex}"
+
+    logged = log_model_artifact(
+        experiment_name="janasunani-test",
+        local_path=artifact,
+        dvc_path="models/categorizer",
+        dvc_hash="abc123",
+        registered_model_name=model_name,
+        tracking_uri=tracking_uri,
+        artifact_uri=artifact_uri,
+        extra_tags={DVC_PATH_TAG: "WRONG", DVC_HASH_TAG: "WRONG"},
+    )
+
+    client = MlflowClient(tracking_uri=tracking_uri)
+    run = client.get_run(logged.run_id)
+    assert run.data.tags[DVC_PATH_TAG] == "models/categorizer"
+    assert run.data.tags[DVC_HASH_TAG] == "abc123"
+
+    version = client.get_model_version(model_name, logged.model_version)
+    assert version.tags[DVC_PATH_TAG] == "models/categorizer"
+    assert version.tags[DVC_HASH_TAG] == "abc123"

--- a/tests/test_mlflow_utils.py
+++ b/tests/test_mlflow_utils.py
@@ -1,0 +1,57 @@
+from uuid import uuid4
+
+from mlflow.tracking import MlflowClient
+
+from janasunani.tracking.mlflow_utils import (
+    DVC_HASH_TAG,
+    DVC_PATH_TAG,
+    ensure_experiment,
+    log_model_artifact,
+)
+
+
+def test_ensure_experiment_uses_local_artifact_root(tmp_path):
+    tracking_uri = (tmp_path / "mlruns").as_uri()
+    artifact_uri = (tmp_path / "artifacts").as_uri()
+    name = f"janasunani-test-{uuid4().hex}"
+
+    experiment_id = ensure_experiment(
+        name, tracking_uri=tracking_uri, artifact_uri=artifact_uri
+    )
+
+    client = MlflowClient(tracking_uri=tracking_uri)
+    experiment = client.get_experiment(experiment_id)
+    assert experiment.name == name
+    assert experiment.artifact_location == artifact_uri
+
+
+def test_log_model_artifact_registers_dvc_tagged_version(tmp_path):
+    artifact = tmp_path / "categorizer.txt"
+    artifact.write_text("demo model", encoding="utf-8")
+    tracking_uri = (tmp_path / "mlruns").as_uri()
+    artifact_uri = (tmp_path / "artifacts").as_uri()
+    model_name = f"categorizer-{uuid4().hex}"
+
+    logged = log_model_artifact(
+        experiment_name="janasunani-test",
+        local_path=artifact,
+        dvc_path="models/categorizer",
+        dvc_hash="abc123",
+        registered_model_name=model_name,
+        tracking_uri=tracking_uri,
+        artifact_uri=artifact_uri,
+        extra_tags={"model.kind": "categorizer"},
+    )
+
+    client = MlflowClient(tracking_uri=tracking_uri)
+    run = client.get_run(logged.run_id)
+    assert run.data.tags[DVC_PATH_TAG] == "models/categorizer"
+    assert run.data.tags[DVC_HASH_TAG] == "abc123"
+    assert run.data.tags["model.kind"] == "categorizer"
+
+    version = client.get_model_version(model_name, logged.model_version)
+    assert version.run_id == logged.run_id
+    assert version.tags[DVC_PATH_TAG] == "models/categorizer"
+    assert version.tags[DVC_HASH_TAG] == "abc123"
+    assert version.tags["model.kind"] == "categorizer"
+    assert version.source == logged.artifact_uri


### PR DESCRIPTION
Phase 6 — slim MLflow + DVC tracking helpers.

- `tracking/mlflow_utils.py`: `configure_tracking` / `ensure_experiment` / `log_model_artifact`, each registered version tagged with `dvc.path` + `dvc.hash` so an operator can resolve the exact mirrored artifact. `MLFLOW_TRACKING_URI` / `MLFLOW_ARTIFACT_URI` in config.
- Tests: `tests/test_mlflow_utils.py`.

**Scope:** standalone helpers only — not yet used to register the mirrored categorizer/summarizer/page-type models (follow-up). Branch predates recent `main`; merge-base diff is clean.
