### PR TITLE
Feat/rules router mappings

### DIFF
--- a/janasunani/routing/__init__.py
+++ b/janasunani/routing/__init__.py
@@ -2,8 +2,28 @@
 
 The learned router is deliberately deferred; this package provides the
 deterministic backbone the serving wire-up can use for the demo.
+
+``DEFAULT_ROUTER`` sources routing from the real ORTPSA master tables
+(``data/raw/janasunani-mappings/``) where a mapping is derivable, falling back
+to the illustrative ``RuleRouter`` rules and then a generic fallback -- see
+``janasunani.routing.mappings`` and ``janasunani.routing.rules.MappingRouter``.
 """
 
-from janasunani.routing.rules import DEFAULT_ROUTER, RouteInput, RouteRule, RuleRouter
+from janasunani.routing.mappings import MappingTables, load_mapping_tables
+from janasunani.routing.rules import (
+    DEFAULT_ROUTER,
+    MappingRouter,
+    RouteInput,
+    RouteRule,
+    RuleRouter,
+)
 
-__all__ = ["DEFAULT_ROUTER", "RouteInput", "RouteRule", "RuleRouter"]
+__all__ = [
+    "DEFAULT_ROUTER",
+    "MappingRouter",
+    "MappingTables",
+    "RouteInput",
+    "RouteRule",
+    "RuleRouter",
+    "load_mapping_tables",
+]

--- a/janasunani/routing/__init__.py
+++ b/janasunani/routing/__init__.py
@@ -1,0 +1,9 @@
+"""Rules-first grievance routing.
+
+The learned router is deliberately deferred; this package provides the
+deterministic backbone the serving wire-up can use for the demo.
+"""
+
+from janasunani.routing.rules import DEFAULT_ROUTER, RouteInput, RouteRule, RuleRouter
+
+__all__ = ["DEFAULT_ROUTER", "RouteInput", "RouteRule", "RuleRouter"]

--- a/janasunani/routing/mappings.py
+++ b/janasunani/routing/mappings.py
@@ -1,0 +1,311 @@
+"""Loader for the real ORTPSA master tables (``data/raw/janasunani-mappings/``).
+
+These CSVs are DVC-tracked reference data (categories, departments, offices,
+designations, escalation ladders) migrated from the production Janasunani
+system. They are non-PII master data, safe to read at runtime, but they are
+**not** committed to git (see ``data/raw/janasunani-mappings.dvc``) and other
+machines/CI will not have them materialized. Every function in this module
+degrades to ``None`` instead of raising when the directory or files are
+missing, so callers can fall back to the illustrative rule set.
+
+Join path (verified by inspection on the 2026-07 snapshot; there is no schema
+doc for this legacy MySQL export):
+
+* ``m_admin_category`` / ``m_admin_subcategory``: category/subcategory master,
+  English (``vchCategory``/``vchSubCategory``) + Odia
+  (``vchCategoryOD``/``vchSubCategoryOD``).
+* ``m_admin_hierarchy_value``: department master. The department id used
+  elsewhere is ``intAdminHierarchyValueId`` -- *not* ``intSocialDeptId``, a
+  separate code on the same row that does not appear anywhere else in these
+  tables.
+* ``t_admin_escalation.intDepartmentId`` == ``m_admin_hierarchy_value
+  .intAdminHierarchyValueId``. Verified two ways: department 5 ("Energy")
+  resolves (via the designation join below) to designation ids 17-20, whose
+  ``m_role`` names are exactly the four real Odisha power-distribution company
+  CEOs ("CEO,TPCODL" / "TPWODL" / "TPNODL" / "TPSODL"); department 14 ("Home
+  department") resolves to DGP / IG / "Commissionorate of Police". Those are
+  not coincidental matches. ``intDepartmentId == "0"`` is a distinct
+  generic/unassigned bucket (~120 of the 158 active rows), not department 0 --
+  it is excluded here rather than guessed at.
+* ``t_admin_escalation.vchDesignationSequence`` is a comma-separated list of
+  ``m_role.intRoleId``, ordered first-responder -> ... -> apex authority.
+  ``t_admin_escalation.intOfficeId`` references ``m_admin_offices`` (only 7
+  generic top-level offices: CM, Governor, Chief Secretary, DG&IG Police,
+  "Departments", Collector, SP).
+
+**What does NOT close**: there is no category/subcategory -> department
+foreign key anywhere in these tables. ``m_admin_category.intCategoryGrp`` is
+``NULL`` on every row (checked across all 62 rows), and
+``intComplainTypeId`` is just an intake-channel code (values 12/13 -- app
+version, not department). The only non-fabricated bridge available is exact
+(normalized) name equality between a category's English/Odia name and a
+department's English/Odia name -- e.g. the category "Energy" and the
+department "Energy" are the literal same string. On the current snapshot that
+covers a handful of the 62 categories (see ``category_to_department``);
+everything else has no derivable department and must fall back. This module
+deliberately does not attempt fuzzy/substring matching (e.g. "Culture" is a
+substring of "Agriculture") because that would fabricate a mapping rather
+than derive one.
+"""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+from janasunani.config import RAW_DATA_DIR
+
+DEFAULT_MAPPING_DIR = RAW_DATA_DIR / "janasunani-mappings"
+
+# The generic "Departments" catch-all office (m_admin_offices id 5) carries no
+# information beyond "some department handles this" -- not useful as a label.
+_GENERIC_OFFICE_NAME = "Departments"
+
+_REQUIRED_FILES = (
+    "m_admin_category.csv",
+    "m_admin_hierarchy_value.csv",
+    "m_admin_offices.csv",
+    "t_admin_escalation.csv",
+    "m_role.csv",
+)
+
+
+def _norm(value: Optional[str]) -> str:
+    return " ".join((value or "").casefold().split())
+
+
+@dataclass(frozen=True)
+class Category:
+    id: str
+    name_en: str
+    name_od: str
+
+
+@dataclass(frozen=True)
+class Department:
+    id: str
+    name_en: str
+    name_od: str
+
+
+@dataclass(frozen=True)
+class EscalationChain:
+    """One resolved escalation ladder for a department.
+
+    ``designations`` is ordered first-responder -> apex authority, resolved
+    from ``m_role`` names. ``office_name`` is the top-level office
+    (``m_admin_offices``) attached to the escalation row, when informative.
+    """
+
+    department_id: str
+    office_name: str
+    designations: Tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class MappingTables:
+    """Parsed + joined lookups derived from the master CSVs."""
+
+    categories: Tuple[Category, ...]
+    departments: Tuple[Department, ...]
+    category_to_department: Dict[str, str]
+    escalation_by_department: Dict[str, EscalationChain]
+
+    def find_category(self, text: str) -> Optional[Category]:
+        key = _norm(text)
+        if not key:
+            return None
+        for category in self.categories:
+            if _norm(category.name_en) == key:
+                return category
+            if category.name_od and _norm(category.name_od) == key:
+                return category
+        return None
+
+    def find_department(self, department_id: str) -> Optional[Department]:
+        for department in self.departments:
+            if department.id == department_id:
+                return department
+        return None
+
+    def resolve(
+        self, category_text: str
+    ) -> Optional[Tuple[Department, Optional[EscalationChain]]]:
+        """Category text -> (department, escalation chain or None).
+
+        Returns ``None`` when the category text does not match any real
+        category, or the matched category has no derivable department.
+        """
+        category = self.find_category(category_text)
+        if category is None:
+            return None
+        department_id = self.category_to_department.get(category.id)
+        if department_id is None:
+            return None
+        department = self.find_department(department_id)
+        if department is None:
+            return None
+        chain = self.escalation_by_department.get(department_id)
+        return department, chain
+
+
+def _read_csv(path: Path) -> list[dict]:
+    with path.open(newline="", encoding="utf-8-sig") as fh:
+        return list(csv.DictReader(fh))
+
+
+def load_mapping_tables(base_dir: Optional[Path] = None) -> Optional[MappingTables]:
+    """Load and join the master tables from ``base_dir`` (default: the
+    project's ``data/raw/janasunani-mappings`` directory via
+    ``janasunani.config.RAW_DATA_DIR``).
+
+    Returns ``None`` -- never raises -- if the directory or any required file
+    is missing or unreadable, so callers can degrade to the illustrative rule
+    set. This is the expected state on CI and any machine that has not run
+    ``dvc pull`` for this dataset.
+    """
+
+    directory = Path(base_dir) if base_dir is not None else DEFAULT_MAPPING_DIR
+    if not directory.is_dir():
+        return None
+    for name in _REQUIRED_FILES:
+        if not (directory / name).is_file():
+            return None
+
+    try:
+        category_rows = _read_csv(directory / "m_admin_category.csv")
+        hierarchy_rows = _read_csv(directory / "m_admin_hierarchy_value.csv")
+        office_rows = _read_csv(directory / "m_admin_offices.csv")
+        escalation_rows = _read_csv(directory / "t_admin_escalation.csv")
+        role_rows = _read_csv(directory / "m_role.csv")
+    except (OSError, csv.Error, UnicodeDecodeError):
+        return None
+
+    categories = tuple(
+        Category(
+            id=row["intCategoryId"],
+            name_en=(row.get("vchCategory") or "").strip(),
+            name_od=(row.get("vchCategoryOD") or "").strip(),
+        )
+        for row in category_rows
+        if row.get("intCategoryId")
+    )
+    departments = tuple(
+        Department(
+            id=row["intAdminHierarchyValueId"],
+            name_en=(row.get("vchAdminHierarchyValue") or "").strip(),
+            name_od=(row.get("vchAdminHierarchyValueO") or "").strip(),
+        )
+        for row in hierarchy_rows
+        if row.get("intAdminHierarchyValueId")
+    )
+    offices_by_id = {
+        row["intOfficeId"]: (row.get("vchOfficeName") or "").strip()
+        for row in office_rows
+        if row.get("intOfficeId")
+    }
+    roles_by_id = {
+        row["intRoleId"]: (row.get("vchRoleName") or "").strip()
+        for row in role_rows
+        if row.get("intRoleId")
+    }
+
+    category_to_department = _derive_category_to_department(categories, departments)
+    escalation_by_department = _derive_escalation_chains(
+        escalation_rows, offices_by_id, roles_by_id
+    )
+
+    return MappingTables(
+        categories=categories,
+        departments=departments,
+        category_to_department=category_to_department,
+        escalation_by_department=escalation_by_department,
+    )
+
+
+def _derive_category_to_department(
+    categories: Tuple[Category, ...], departments: Tuple[Department, ...]
+) -> Dict[str, str]:
+    """The only non-fabricated category -> department bridge available: exact
+    (normalized) equality between a category name and a department name,
+    English or Odia. See the module docstring for why nothing richer than
+    this is derivable from the master tables as they stand today.
+    """
+    department_id_by_name: Dict[str, str] = {}
+    for department in departments:
+        if department.name_en:
+            department_id_by_name.setdefault(_norm(department.name_en), department.id)
+        if department.name_od:
+            department_id_by_name.setdefault(_norm(department.name_od), department.id)
+
+    category_to_department: Dict[str, str] = {}
+    for category in categories:
+        department_id = department_id_by_name.get(_norm(category.name_en))
+        if department_id is None and category.name_od:
+            department_id = department_id_by_name.get(_norm(category.name_od))
+        if department_id is not None:
+            category_to_department[category.id] = department_id
+    return category_to_department
+
+
+def _derive_escalation_chains(
+    escalation_rows: list[dict],
+    offices_by_id: Dict[str, str],
+    roles_by_id: Dict[str, str],
+) -> Dict[str, EscalationChain]:
+    """Pick one representative escalation row per department.
+
+    Only active rows (``bitDeletedFlag == "0"``) with a specific department id
+    are considered (``intDepartmentId == "0"`` is a separate generic/
+    unassigned bucket, not a real department, and is skipped). Departments
+    often have several historical rows on file; among the candidates this
+    picks the one with the deepest configured ladder (``intEscalation``
+    level), tie-broken by the most recently added rule (``intEscalationId``).
+    That is a deterministic choice among genuinely configured records, not an
+    invented value, but it is a heuristic -- a different tie-break could pick
+    a different (also real) row for the same department.
+    """
+    best_row_by_department: Dict[str, dict] = {}
+    for row in escalation_rows:
+        if row.get("bitDeletedFlag") != "0":
+            continue
+        department_id = row.get("intDepartmentId")
+        if not department_id or department_id == "0":
+            continue
+        try:
+            level = int(row.get("intEscalation") or 0)
+            escalation_id = int(row.get("intEscalationId") or 0)
+        except ValueError:
+            continue
+        current = best_row_by_department.get(department_id)
+        if current is None:
+            best_row_by_department[department_id] = row
+            continue
+        current_key = (
+            int(current.get("intEscalation") or 0),
+            int(current.get("intEscalationId") or 0),
+        )
+        if (level, escalation_id) > current_key:
+            best_row_by_department[department_id] = row
+
+    escalation_by_department: Dict[str, EscalationChain] = {}
+    for department_id, row in best_row_by_department.items():
+        designation_ids = [
+            token.strip()
+            for token in (row.get("vchDesignationSequence") or "").split(",")
+            if token.strip()
+        ]
+        designations = tuple(
+            roles_by_id[token] for token in designation_ids if roles_by_id.get(token)
+        )
+        if not designations:
+            continue
+        office_name = offices_by_id.get(row.get("intOfficeId") or "", "")
+        escalation_by_department[department_id] = EscalationChain(
+            department_id=department_id,
+            office_name=office_name,
+            designations=designations,
+        )
+    return escalation_by_department

--- a/janasunani/routing/rules.py
+++ b/janasunani/routing/rules.py
@@ -1,0 +1,146 @@
+"""Deterministic category/district routing rules.
+
+This is the demo-sufficient Phase 9 backbone: category/subcategory plus an
+optional district maps to the existing ``RoutingResult`` API shape. It does not
+read the proprietary ``data/`` mappings; those can replace ``DEFAULT_RULES``
+later once a specific path is approved for that task.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from janasunani.serving.schemas import RoutingResult
+
+
+@dataclass(frozen=True)
+class RouteInput:
+    category: str
+    subcategory: Optional[str] = None
+    district: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class RouteRule:
+    category: str
+    dept: str
+    designation: str
+    office_template: str = "Office of the Collector, {district}"
+    escalation_template: str = "District Magistrate, {district}"
+    subcategory: Optional[str] = None
+
+
+def _norm(value: Optional[str]) -> str:
+    return " ".join((value or "").casefold().split())
+
+
+def _district(value: Optional[str]) -> str:
+    return " ".join((value or "State").split())
+
+
+DEFAULT_RULES: tuple[RouteRule, ...] = (
+    RouteRule(
+        category="Drinking Water Supply",
+        subcategory="Hand pump repair",
+        dept="Rural Water Supply & Sanitation",
+        designation="Block Development Officer",
+    ),
+    RouteRule(
+        category="Water Supply",
+        dept="Rural Water Supply & Sanitation",
+        designation="Block Development Officer",
+    ),
+    RouteRule(
+        category="Electricity",
+        dept="Energy",
+        designation="Executive Engineer",
+    ),
+    RouteRule(
+        category="Roads & Bridges",
+        dept="Works",
+        designation="Executive Engineer",
+    ),
+    RouteRule(
+        category="Public Health",
+        dept="Health & Family Welfare",
+        designation="Chief District Medical Officer",
+    ),
+    RouteRule(
+        category="Land & Revenue",
+        dept="Revenue & Disaster Management",
+        designation="Tahasildar",
+    ),
+    RouteRule(
+        category="Certificates",
+        dept="Revenue & Disaster Management",
+        designation="Tahasildar",
+    ),
+)
+
+FALLBACK_DEPT = "General Administration & Public Grievance"
+FALLBACK_DESIGNATION = "Public Grievance Officer"
+
+
+class RuleRouter:
+    """Route from normalized category/subcategory strings to a public office."""
+
+    def __init__(self, rules: tuple[RouteRule, ...] = DEFAULT_RULES) -> None:
+        self._rules = rules
+
+    def route(
+        self,
+        *,
+        category: str,
+        subcategory: Optional[str] = None,
+        district: Optional[str] = None,
+    ) -> RoutingResult:
+        district_name = _district(district)
+        rule = self._match(category=category, subcategory=subcategory)
+        if rule is None:
+            return RoutingResult(
+                dept=FALLBACK_DEPT,
+                office=f"Public Grievance Cell, {district_name}",
+                designation=FALLBACK_DESIGNATION,
+                escalation_authority=f"Collectorate, {district_name}",
+                confidence=0.25,
+                method="fallback",
+            )
+
+        exact_subcategory = bool(rule.subcategory and _norm(rule.subcategory) == _norm(subcategory))
+        return RoutingResult(
+            dept=rule.dept,
+            office=rule.office_template.format(district=district_name),
+            designation=rule.designation,
+            escalation_authority=rule.escalation_template.format(
+                district=district_name
+            ),
+            confidence=0.9 if exact_subcategory else 0.8,
+            method="rules",
+        )
+
+    def route_input(self, route_input: RouteInput) -> RoutingResult:
+        return self.route(
+            category=route_input.category,
+            subcategory=route_input.subcategory,
+            district=route_input.district,
+        )
+
+    def _match(
+        self, *, category: str, subcategory: Optional[str] = None
+    ) -> Optional[RouteRule]:
+        category_key = _norm(category)
+        subcategory_key = _norm(subcategory)
+        category_matches = [
+            rule for rule in self._rules if _norm(rule.category) == category_key
+        ]
+        for rule in category_matches:
+            if rule.subcategory and _norm(rule.subcategory) == subcategory_key:
+                return rule
+        for rule in category_matches:
+            if rule.subcategory is None:
+                return rule
+        return category_matches[0] if category_matches else None
+
+
+DEFAULT_ROUTER = RuleRouter()

--- a/janasunani/routing/rules.py
+++ b/janasunani/routing/rules.py
@@ -1,16 +1,34 @@
 """Deterministic category/district routing rules.
 
 This is the demo-sufficient Phase 9 backbone: category/subcategory plus an
-optional district maps to the existing ``RoutingResult`` API shape. It does not
-read the proprietary ``data/`` mappings; those can replace ``DEFAULT_RULES``
-later once a specific path is approved for that task.
+optional district maps to the existing ``RoutingResult`` API shape.
+
+Two layers live here:
+
+* ``RuleRouter`` / ``DEFAULT_RULES`` -- the original illustrative, hand-written
+  rules. Kept as-is (tests depend on the exact fixtures) and used as the
+  fallback layer described below.
+* ``MappingRouter`` -- sources routing from the real ORTPSA master tables in
+  ``data/raw/janasunani-mappings/`` (via ``janasunani.routing.mappings``),
+  falling back to ``RuleRouter`` when the CSVs are unavailable or a category
+  has no derivable department, and to the shared generic fallback when
+  neither layer matches. ``DEFAULT_ROUTER`` is a ``MappingRouter``, so the
+  demo is now steered off real master data as far as it reliably reaches, per
+  Phase 9 -- see ``janasunani.routing.mappings`` for exactly what closes and
+  what doesn't.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Optional
 
+from janasunani.routing.mappings import (
+    MappingTables,
+    _GENERIC_OFFICE_NAME,
+    load_mapping_tables,
+)
 from janasunani.serving.schemas import RoutingResult
 
 
@@ -143,4 +161,85 @@ class RuleRouter:
         return category_matches[0] if category_matches else None
 
 
-DEFAULT_ROUTER = RuleRouter()
+class MappingRouter:
+    """Routes off the real ORTPSA master tables, falling back gracefully.
+
+    Resolution order:
+
+    1. Real category -> department -> escalation chain, derived from the
+       master CSVs (see ``janasunani.routing.mappings`` for the join path and
+       its documented gaps). Hit -> ``method="rules"``, dept/designation/
+       escalation authority are real values from the tables.
+    2. The illustrative ``RuleRouter``/``DEFAULT_RULES`` layer (used whenever
+       the CSVs are unavailable, or the category text isn't a real category,
+       or it is a real category with no derivable department -- the common
+       case today, since no category->department FK exists in the source
+       data). Hit -> ``method="rules"``.
+    3. The shared generic fallback (``method="fallback"``), via ``RuleRouter``.
+
+    The CSVs are loaded once at construction (module-level ``DEFAULT_ROUTER``
+    loads them once per process), not per request.
+    """
+
+    def __init__(
+        self,
+        mapping_dir: Optional[Path] = None,
+        tables: Optional[MappingTables] = None,
+        legacy_router: Optional[RuleRouter] = None,
+    ) -> None:
+        self._tables = tables if tables is not None else load_mapping_tables(mapping_dir)
+        self._legacy = legacy_router if legacy_router is not None else RuleRouter()
+
+    @property
+    def mapping_loaded(self) -> bool:
+        """Whether the real master-table CSVs were found and parsed."""
+        return self._tables is not None
+
+    def route(
+        self,
+        *,
+        category: str,
+        subcategory: Optional[str] = None,
+        district: Optional[str] = None,
+    ) -> RoutingResult:
+        if self._tables is not None:
+            resolved = self._tables.resolve(category)
+            if resolved is not None:
+                department, chain = resolved
+                district_name = _district(district)
+                if chain is not None:
+                    designation = chain.designations[0]
+                    escalation_authority = chain.designations[-1]
+                    confidence = 0.9
+                else:
+                    designation = None
+                    escalation_authority = None
+                    confidence = 0.75
+                office_label = (
+                    chain.office_name
+                    if chain is not None
+                    and chain.office_name
+                    and chain.office_name != _GENERIC_OFFICE_NAME
+                    else f"{department.name_en} Department"
+                )
+                return RoutingResult(
+                    dept=department.name_en,
+                    office=f"{office_label}, {district_name}",
+                    designation=designation,
+                    escalation_authority=escalation_authority,
+                    confidence=confidence,
+                    method="rules",
+                )
+        return self._legacy.route(
+            category=category, subcategory=subcategory, district=district
+        )
+
+    def route_input(self, route_input: RouteInput) -> RoutingResult:
+        return self.route(
+            category=route_input.category,
+            subcategory=route_input.subcategory,
+            district=route_input.district,
+        )
+
+
+DEFAULT_ROUTER = MappingRouter()

--- a/tests/test_rules_mapping.py
+++ b/tests/test_rules_mapping.py
@@ -1,0 +1,134 @@
+"""Tests for the CSV-backed mapping router (``janasunani.routing.mappings``
+and ``janasunani.routing.rules.MappingRouter``).
+
+The real-CSV-path tests are skipped when the ``data/raw/janasunani-mappings``
+DVC data hasn't been materialized locally (the expected state on CI and any
+machine that hasn't run ``dvc pull`` for this dataset) -- mirroring the
+skip-on-missing-local-asset pattern used elsewhere in this suite (see
+``tests/test_pipeline.py``'s tesseract/model skip). The no-CSV fallback path is
+always exercised, real files or not.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from janasunani.config import RAW_DATA_DIR
+from janasunani.routing.mappings import load_mapping_tables
+from janasunani.routing.rules import DEFAULT_RULES, FALLBACK_DEPT, MappingRouter, RuleRouter
+
+MAPPING_DIR = RAW_DATA_DIR / "janasunani-mappings"
+
+needs_mapping_csvs = pytest.mark.skipif(
+    not (MAPPING_DIR / "m_admin_category.csv").exists(),
+    reason="needs the DVC-pulled janasunani-mappings master tables",
+)
+
+
+def test_load_mapping_tables_returns_none_when_directory_missing(tmp_path):
+    assert load_mapping_tables(tmp_path / "does-not-exist") is None
+
+
+def test_mapping_router_falls_back_to_legacy_rules_when_csvs_absent(tmp_path):
+    router = MappingRouter(mapping_dir=tmp_path / "does-not-exist")
+
+    assert router.mapping_loaded is False
+
+    # Still routes correctly via the illustrative RuleRouter layer.
+    result = router.route(category="Water Supply", district="Puri")
+    assert result.method == "rules"
+    assert result.dept == "Rural Water Supply & Sanitation"
+
+    # And still degrades to the shared generic fallback for a truly unknown
+    # category, exactly like a bare RuleRouter would.
+    fallback = router.route(category="Nothing Recognizable", district="Ganjam")
+    assert fallback.method == "fallback"
+    assert fallback.dept == FALLBACK_DEPT
+
+
+def test_mapping_router_matches_legacy_router_when_csvs_absent():
+    """With no mapping data, MappingRouter must reproduce RuleRouter exactly
+    (same fallback behavior the pre-existing tests pin down)."""
+    router = MappingRouter(mapping_dir=Path("/nonexistent-mapping-dir"))
+    legacy = RuleRouter()
+
+    for category, subcategory in [
+        ("Drinking Water Supply", "Hand pump repair"),
+        ("Electricity", None),
+        ("Unmapped Category", "Unmapped Subcategory"),
+    ]:
+        got = router.route(category=category, subcategory=subcategory, district="Cuttack")
+        want = legacy.route(category=category, subcategory=subcategory, district="Cuttack")
+        assert got == want
+
+
+@needs_mapping_csvs
+class TestMappingRouterWithRealCsvs:
+    def test_loads_real_tables(self):
+        tables = load_mapping_tables()
+        assert tables is not None
+        assert len(tables.categories) > 0
+        assert len(tables.departments) > 0
+        # At least the categories that are also literal department names
+        # ("Energy", "Excise", "Tourism", "Disaster Management" on the current
+        # snapshot) must resolve -- the only non-fabricated bridge available.
+        assert len(tables.category_to_department) > 0
+
+    def test_energy_category_resolves_to_real_department_and_escalation(self):
+        """Energy is both a real category and a real department name, and the
+        department has an explicit, non-generic escalation chain on file
+        (the four Odisha power-distribution company CEOs) -- this is the
+        clearest end-to-end real join available in the master tables."""
+        router = MappingRouter()
+        assert router.mapping_loaded is True
+
+        result = router.route(category="Energy", district="Cuttack")
+
+        assert result.method == "rules"
+        assert result.dept == "Energy"
+        assert result.confidence == 0.9
+        assert result.designation is not None
+        assert result.escalation_authority is not None
+        assert "Cuttack" in result.office
+
+    def test_odia_category_text_matches_real_category(self):
+        """Real grievances are Odia; category matching must work on the Odia
+        column, not just English."""
+        router = MappingRouter()
+        tables = load_mapping_tables()
+        energy = next(c for c in tables.categories if c.name_en == "Energy")
+        assert energy.name_od
+
+        result = router.route(category=energy.name_od, district="Khordha")
+        assert result.method == "rules"
+        assert result.dept == "Energy"
+
+    def test_category_without_derivable_department_falls_back_to_legacy_rules(self):
+        """Most real categories have no department FK in the master tables
+        (documented gap); MappingRouter must fall through to the illustrative
+        RuleRouter layer rather than fabricate a department."""
+        router = MappingRouter()
+        tables = load_mapping_tables()
+
+        # "Water Supply" is a real category (ids 39/40) but its name does not
+        # equal any real department name, so it cannot resolve via the CSVs.
+        assert tables.find_category("Water Supply") is not None
+        assert "Water Supply" not in {
+            tables.find_department(d).name_en
+            for cat_id, d in tables.category_to_department.items()
+        }
+
+        result = router.route(category="Water Supply", district="Puri")
+        assert result.method == "rules"
+        assert result.dept == "Rural Water Supply & Sanitation"  # legacy DEFAULT_RULES hit
+
+    def test_unrecognized_category_text_falls_back_to_generic(self):
+        router = MappingRouter()
+        result = router.route(category="Not A Real Category At All", district="Ganjam")
+        assert result.method == "fallback"
+        assert result.dept == FALLBACK_DEPT
+
+    def test_default_rules_unaffected(self):
+        """Sanity check that adding MappingRouter didn't touch the legacy
+        fixtures the pre-existing router tests pin down."""
+        assert len(DEFAULT_RULES) == 7

--- a/tests/test_rules_router.py
+++ b/tests/test_rules_router.py
@@ -1,0 +1,68 @@
+from janasunani.routing.rules import (
+    FALLBACK_DEPT,
+    RouteRule,
+    RuleRouter,
+)
+
+
+def test_rules_router_exact_subcategory_match():
+    router = RuleRouter()
+
+    result = router.route(
+        category="Drinking Water Supply",
+        subcategory="Hand pump repair",
+        district="Cuttack",
+    )
+
+    assert result.method == "rules"
+    assert result.dept == "Rural Water Supply & Sanitation"
+    assert result.designation == "Block Development Officer"
+    assert result.office == "Office of the Collector, Cuttack"
+    assert result.escalation_authority == "District Magistrate, Cuttack"
+    assert result.confidence == 0.9
+
+
+def test_rules_router_known_category_without_subcategory_uses_category_rule():
+    router = RuleRouter(
+        (
+            RouteRule(
+                category="Water Supply",
+                subcategory="Hand pump repair",
+                dept="Specific Dept",
+                designation="Specific Officer",
+            ),
+            RouteRule(
+                category="Water Supply",
+                dept="General Water Dept",
+                designation="General Officer",
+            ),
+        )
+    )
+
+    result = router.route(category="Water Supply", district="Puri")
+
+    assert result.method == "rules"
+    assert result.dept == "General Water Dept"
+    assert result.designation == "General Officer"
+    assert result.confidence == 0.8
+
+
+def test_rules_router_missing_district_uses_state_scope():
+    result = RuleRouter().route(category="Electricity")
+
+    assert result.method == "rules"
+    assert result.office == "Office of the Collector, State"
+    assert result.escalation_authority == "District Magistrate, State"
+
+
+def test_rules_router_unknown_category_falls_back():
+    result = RuleRouter().route(
+        category="Unmapped Category",
+        subcategory="Unmapped Subcategory",
+        district="Ganjam",
+    )
+
+    assert result.method == "fallback"
+    assert result.dept == FALLBACK_DEPT
+    assert result.office == "Public Grievance Cell, Ganjam"
+    assert result.confidence == 0.25


### PR DESCRIPTION
Phase 9 — deterministic routing rules, sourced from the real ORTPSA master tables. Two commits: the `RuleRouter` backbone (produces the frozen `RoutingResult`) + `MappingRouter` reading `data/raw/janasunani-mappings/*`.

- Loader degrades gracefully when the CSVs aren't `dvc pull`ed (returns None, falls back) so CI stays green.
- Tests: `tests/test_rules_router.py`, `tests/test_rules_mapping.py`.

**⚠ Known limitation / direction:** the master tables carry **no category→department FK** (`intCategoryGrp` NULL on all 62 categories), so only ~4/62 categories resolve by exact name-match. The agreed path is to **learn the crosswalk from OLAP history** (measured argmax accuracy: category 60.9% / +subcategory 67.5% / +subcategory+district 72.8%) — see ROADMAP Phase 9. This PR is the rules-layer scaffold; **not yet wired into `serving/`**.