### PR TITLE
feat(serving): lake-backed /history provider (Phase 10)

### DIFF
--- a/janasunani/serving/api.py
+++ b/janasunani/serving/api.py
@@ -31,7 +31,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from loguru import logger
 from starlette.concurrency import run_in_threadpool
 
-from janasunani.serving.history import HistoryProvider, MockHistory
+from janasunani.serving.history import HistoryProvider, LakeHistory, MockHistory
 from janasunani.serving.processor import GrievanceProcessor, MockGrievanceProcessor
 from janasunani.serving.schemas import (
     GrievanceResult,
@@ -126,7 +126,7 @@ def create_app(
     return app
 
 
-app = create_app()
+app = create_app(history=LakeHistory())
 
 
 def main() -> None:

--- a/janasunani/serving/history.py
+++ b/janasunani/serving/history.py
@@ -12,8 +12,10 @@ from __future__ import annotations
 
 import random
 from datetime import datetime, timedelta
+from pathlib import Path
 from typing import Optional, Protocol
 
+from janasunani.olap import lake
 from janasunani.serving.schemas import HistoryItem, HistoryPage
 
 _DISTRICTS = ("Khordha", "Cuttack", "Ganjam", "Sundargarh", "Balasore")
@@ -95,3 +97,77 @@ class MockHistory:
             limit=limit,
             offset=offset,
         )
+
+
+class LakeHistory:
+    """Parquet-lake backed history provider.
+
+    ``/history`` is historical-only by design: live submissions are fetched via
+    ``GET /grievance/{id}`` until the lake is re-materialized.
+    """
+
+    def __init__(self, lake_dir: Optional[Path] = None) -> None:
+        self._lake_dir = lake_dir
+
+    def search(
+        self,
+        *,
+        q: Optional[str] = None,
+        district: Optional[str] = None,
+        category: Optional[str] = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> HistoryPage:
+        complaints = lake.lake_path("complaints", self._lake_dir)
+        if not complaints.exists():
+            return HistoryPage(items=[], total=0, limit=limit, offset=offset)
+
+        where, params = _history_filters(q=q, district=district, category=category)
+        where_sql = f"WHERE {' AND '.join(where)}" if where else ""
+        columns = (
+            "ticket_no, created_on, district, category, subcategory, dept, "
+            "status, office, grievance"
+        )
+        con = lake.connect(self._lake_dir)
+        try:
+            total = con.execute(
+                f"SELECT count(*) FROM complaints {where_sql}", params
+            ).fetchone()[0]
+            cursor = con.execute(
+                f"""
+                SELECT {columns}
+                FROM complaints
+                {where_sql}
+                ORDER BY created_on DESC NULLS LAST, ticket_no
+                LIMIT ? OFFSET ?
+                """,
+                [*params, limit, offset],
+            )
+            names = [col[0] for col in cursor.description]
+            items = [HistoryItem(**dict(zip(names, row))) for row in cursor.fetchall()]
+        finally:
+            con.close()
+        return HistoryPage(items=items, total=total, limit=limit, offset=offset)
+
+
+def _history_filters(
+    *,
+    q: Optional[str] = None,
+    district: Optional[str] = None,
+    category: Optional[str] = None,
+) -> tuple[list[str], list[str]]:
+    where: list[str] = []
+    params: list[str] = []
+    if district:
+        where.append("district = ?")
+        params.append(district)
+    if category:
+        where.append("category = ?")
+        params.append(category)
+    if q:
+        where.append(
+            "(lower(coalesce(grievance, '')) LIKE ? OR lower(ticket_no) LIKE ?)"
+        )
+        needle = f"%{q.casefold()}%"
+        params.extend([needle, needle])
+    return where, params

--- a/tests/test_lake_history.py
+++ b/tests/test_lake_history.py
@@ -1,0 +1,76 @@
+from datetime import datetime
+
+import polars as pl
+
+from janasunani.serving.history import LakeHistory
+
+
+def _write_complaints(path):
+    pl.DataFrame(
+        [
+            {
+                "ticket_no": "T1",
+                "created_on": datetime(2024, 1, 3),
+                "district": "Cuttack",
+                "category": "Water Supply",
+                "subcategory": "Hand pump repair",
+                "dept": "Rural Water Supply & Sanitation",
+                "status": "Pending",
+                "office": "Collector, Cuttack",
+                "grievance": "Hand pump is broken",
+            },
+            {
+                "ticket_no": "T2",
+                "created_on": datetime(2024, 1, 2),
+                "district": "Puri",
+                "category": "Electricity",
+                "subcategory": "Outage",
+                "dept": "Energy",
+                "status": "Resolved",
+                "office": "Collector, Puri",
+                "grievance": "Frequent outage",
+            },
+            {
+                "ticket_no": "T3",
+                "created_on": datetime(2024, 1, 1),
+                "district": "Cuttack",
+                "category": "Roads & Bridges",
+                "subcategory": "Pothole repair",
+                "dept": "Works",
+                "status": "Escalated",
+                "office": "Collector, Cuttack",
+                "grievance": "Road needs repair",
+            },
+        ]
+    ).write_parquet(path / "complaints.parquet")
+
+
+def test_lake_history_filters_searches_and_paginates(tmp_path):
+    _write_complaints(tmp_path)
+    history = LakeHistory(tmp_path)
+
+    page = history.search(district="Cuttack", limit=1, offset=0)
+    assert page.total == 2
+    assert page.limit == 1
+    assert len(page.items) == 1
+    assert page.items[0].ticket_no == "T1"  # newest first
+
+    second = history.search(district="Cuttack", limit=1, offset=1)
+    assert second.items[0].ticket_no == "T3"
+
+    searched = history.search(q="outage")
+    assert searched.total == 1
+    assert searched.items[0].ticket_no == "T2"
+
+    category = history.search(category="Water Supply")
+    assert category.total == 1
+    assert category.items[0].dept == "Rural Water Supply & Sanitation"
+
+
+def test_lake_history_missing_complaints_file_returns_empty_page(tmp_path):
+    page = LakeHistory(tmp_path).search(limit=5, offset=10)
+
+    assert page.items == []
+    assert page.total == 0
+    assert page.limit == 5
+    assert page.offset == 10


### PR DESCRIPTION
Phase 10 — serve `GET /history` from the real Parquet lake instead of `MockHistory`.

- `LakeHistory` queries `complaints.parquet` (the 1.37M-row lake) via DuckDB with parameterized q/district/category filters + pagination; returns a graceful empty page when the lake isn't materialized. Column set matches the `HistoryItem` contract.
- Module-level app wired to `create_app(history=LakeHistory())`.
- Tests: `tests/test_lake_history.py`.

**⚠ Known conflict:** touches `janasunani/serving/api.py`'s `app = create_app(...)` line, which **`feat/serving-live-persistence` (#19) also edits**. Whichever merges second needs a trivial reconcile to a single `create_app(history=LakeHistory(), result_store=...)`. (Expected — will resolve at merge.)

Branch predates recent `main`; the merge-base diff is clean feature-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)