### PR TITLE
feat(pipeline): single-call Summarizer wrapper (Phase 8 A)

### DIFF
--- a/janasunani/pipeline/stages/summarizer.py
+++ b/janasunani/pipeline/stages/summarizer.py
@@ -159,3 +159,26 @@ def _summarize_text(text: str, tokenizer, model, torch, device: str) -> str:
             num_beams=4,
         )
     return tokenizer.decode(summary_ids[0], skip_special_tokens=True)
+
+
+class Summarizer:
+    """Single-call, warm wrapper around the summarizer model.
+
+    Loads the model once in __init__ (unlike run_summarizer, which loads it
+    per batch run) and reuses the cached tokenizer/model/device handles across
+    calls to summarize(). Intended for in-process callers (e.g. a warm
+    inference processor) that summarize one document at a time.
+    """
+
+    def __init__(self) -> None:
+        self._tokenizer, self._model, self._torch, self._device = _load_model()
+
+    def summarize(self, text: str) -> str:
+        """Summarize a single piece of text using the warm model handles."""
+        flattened = " ".join(text.split())
+        if len(flattened.split()) < MIN_SUMMARY_LENGTH:
+            # Too short to meaningfully summarize (shorter than the model's
+            # own minimum summary length) - return the flattened text as-is
+            # instead of calling .generate().
+            return flattened
+        return _summarize_text(text, self._tokenizer, self._model, self._torch, self._device)

--- a/tests/test_summarizer_wrapper.py
+++ b/tests/test_summarizer_wrapper.py
@@ -1,0 +1,66 @@
+"""Real-code-path tests for the warm Summarizer wrapper.
+
+The HF model is mocked out (via monkeypatching `_load_model`/`_summarize_text`)
+so these tests never download or run a real model - they exercise the actual
+Summarizer class logic: loading once, threading cached handles, and the
+short-input guard.
+"""
+
+from janasunani.pipeline.stages import summarizer as summarizer_module
+from janasunani.pipeline.stages.summarizer import MIN_SUMMARY_LENGTH, Summarizer
+
+
+def test_summarize_loads_model_once_and_threads_cached_handles(monkeypatch):
+    load_calls = []
+
+    def fake_load_model():
+        load_calls.append(1)
+        return "fake-tokenizer", "fake-model", "fake-torch", "fake-device"
+
+    summarize_calls = []
+
+    def fake_summarize_text(text, tokenizer, model, torch, device):
+        summarize_calls.append((text, tokenizer, model, torch, device))
+        return "the summary"
+
+    monkeypatch.setattr(summarizer_module, "_load_model", fake_load_model)
+    monkeypatch.setattr(summarizer_module, "_summarize_text", fake_summarize_text)
+
+    long_text = " ".join(f"word{i}" for i in range(MIN_SUMMARY_LENGTH + 5))
+
+    wrapper = Summarizer()
+    assert load_calls == [1]  # model loaded exactly once, in __init__
+
+    result = wrapper.summarize(long_text)
+
+    assert result == "the summary"
+    assert summarize_calls == [
+        (long_text, "fake-tokenizer", "fake-model", "fake-torch", "fake-device")
+    ]
+
+    # A second call reuses the same cached handles without reloading.
+    wrapper.summarize(long_text)
+    assert load_calls == [1]
+    assert len(summarize_calls) == 2
+
+
+def test_summarize_short_input_guard_skips_model_call(monkeypatch):
+    load_calls = []
+
+    def fake_load_model():
+        load_calls.append(1)
+        return "fake-tokenizer", "fake-model", "fake-torch", "fake-device"
+
+    def fake_summarize_text(*args, **kwargs):
+        raise AssertionError("_summarize_text should not be called for short input")
+
+    monkeypatch.setattr(summarizer_module, "_load_model", fake_load_model)
+    monkeypatch.setattr(summarizer_module, "_summarize_text", fake_summarize_text)
+
+    wrapper = Summarizer()
+    short_text = "too   short\nto summarize"
+
+    result = wrapper.summarize(short_text)
+
+    # Flattened (whitespace-collapsed) version of the short input is returned.
+    assert result == "too short to summarize"


### PR DESCRIPTION
## Summary
- Part of the Phase 8 warm in-process inference split (this is task A of a 3-way executor split).
- Adds a public `Summarizer` class in `janasunani/pipeline/stages/summarizer.py` that loads the model once (`__init__`) and exposes a single-call `summarize(text)` that reuses the cached tokenizer/model/torch/device handles — needed by the upcoming warm inference processor so it doesn't reload the model per call.
- Model logic stays single-sourced in the stage module: the wrapper only calls the existing private `_load_model()` / `_summarize_text()` helpers used by the batch `run_summarizer()`; those functions and their signatures are untouched.
- Includes a short-input guard (reusing the existing `MIN_SUMMARY_LENGTH` constant) that returns a flattened/trimmed version of trivially short text instead of calling `.generate()`.

Pinned signature (as specified):
```python
class Summarizer:
    def __init__(self) -> None:
        self._tokenizer, self._model, self._torch, self._device = _load_model()
    def summarize(self, text: str) -> str:
        ...
        return _summarize_text(text, self._tokenizer, self._model, self._torch, self._device)
```

## Test plan
- [x] `uv run --extra pipeline-core pytest tests/test_summarizer_wrapper.py` — 2 passed (HF model mocked via monkeypatched `_load_model`/`_summarize_text`, no real model downloaded)
- [x] `uv run ruff check .` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)