### PR TITLE
feat(inference): OCR bytes->text wrapper (Phase 8 B)

### DIFF
--- a/janasunani/inference/__init__.py
+++ b/janasunani/inference/__init__.py
@@ -1,0 +1,7 @@
+"""Single-item inference wrappers for the live warm processor.
+
+Unlike the batch `pipeline/` package, modules here orchestrate a single
+document/grievance at a time and take their heavy dependencies (OCR
+backends, model calls) as injected callables, so they stay importable and
+unit-testable without tesseract/poppler/torch installed.
+"""

--- a/janasunani/inference/ocr.py
+++ b/janasunani/inference/ocr.py
@@ -28,6 +28,17 @@ DEFAULT_SUFFIX = ".pdf"
 DEFAULT_MAX_PAGES = 50
 
 
+class OcrQualityError(Exception):
+    """Raised when `quality_check_fn` rejected every rendered page.
+
+    Distinct from a genuinely empty/page-less document: this only fires when
+    at least one page rendered *and* a quality hook was supplied, so the
+    caller can mark the grievance unreadable instead of routing an
+    indistinguishable-from-legitimate blank `OcrResult` into redaction,
+    classification, and routing.
+    """
+
+
 @dataclass
 class OcrResult:
     """Result of OCR-ing one uploaded document."""
@@ -35,6 +46,11 @@ class OcrResult:
     full_text: str
     pages: int
     per_page: list[tuple[str, str | None]]  # (page_text, page_type_label_or_None)
+    # True when the page loop stopped because it hit `max_pages` and at
+    # least one more page existed beyond the cap — signals that `full_text`
+    # / `per_page` are a partial document, not the whole thing. Defaulted
+    # for backward compatibility with existing positional/partial callers.
+    truncated: bool = False
 
 
 def ocr_document(
@@ -69,15 +85,25 @@ def ocr_document(
         max_pages: Stop after this many pages (default `DEFAULT_MAX_PAGES`),
             protecting the live worker from a huge/accidental multi-hundred
             -page document. Pass a larger int, or `None`, to lift the cap.
+            If the document has more pages than the cap, the result comes
+            back with `truncated=True` (see `OcrResult`) instead of silently
+            looking like a complete document.
         quality_check_fn: Optional `(page_text) -> bool` run on each page's
             extracted text. A page whose text fails the check (returns
             `False`) is skipped — excluded from `full_text` and `per_page`
             — so looped/garbage OCR output can't reach redaction or
             classification downstream. `None` (default) applies no check.
+            If every rendered page fails the check, `OcrQualityError` is
+            raised rather than returning an `OcrResult` indistinguishable
+            from a legitimate blank document.
 
     Returns:
-        OcrResult with the joined full text, page count, and per-page
-        (text, label) pairs.
+        OcrResult with the joined full text, page count, per-page
+        (text, label) pairs, and a `truncated` flag.
+
+    Raises:
+        OcrQualityError: `quality_check_fn` was supplied, at least one page
+            rendered, and every rendered page failed the quality check.
     """
     suffix = Path(document_name).suffix or DEFAULT_SUFFIX
     with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
@@ -88,6 +114,7 @@ def ocr_document(
         per_page: list[tuple[str, str | None]] = []
         page_number = 1
         rendered_any_page = False
+        truncated = False
         while max_pages is None or page_number <= max_pages:
             try:
                 image = render_page_fn(tmp_path, page_number)
@@ -111,8 +138,38 @@ def ocr_document(
                 continue
             per_page.append((text, label))
             page_number += 1
+        else:
+            # The `while` condition went false (`page_number > max_pages`),
+            # not a `break` — the loop stopped because of the cap, not
+            # because we ran out of document. Probe exactly one page past
+            # the cap to tell "cap == document length" (not truncated) apart
+            # from "more content was dropped" (truncated), without OCR-ing
+            # any further pages.
+            if max_pages is not None:
+                try:
+                    render_page_fn(tmp_path, max_pages + 1)
+                except (ValueError, IndexError):
+                    truncated = False
+                else:
+                    truncated = True
+
+        if quality_check_fn is not None and rendered_any_page and not per_page:
+            # Every rendered page failed the quality check. Returning an
+            # empty OcrResult here would be indistinguishable from a
+            # legitimately blank document, so a blank grievance would flow
+            # into redaction/classification/routing — raise instead so the
+            # caller can mark the grievance unreadable.
+            raise OcrQualityError(
+                f"all {page_number - 1} rendered page(s) of {document_name!r} "
+                "failed the quality check"
+            )
 
         full_text = "\n\n".join(text for text, _ in per_page)
-        return OcrResult(full_text=full_text, pages=len(per_page), per_page=per_page)
+        return OcrResult(
+            full_text=full_text,
+            pages=len(per_page),
+            per_page=per_page,
+            truncated=truncated,
+        )
     finally:
         os.unlink(tmp_path)

--- a/janasunani/inference/ocr.py
+++ b/janasunani/inference/ocr.py
@@ -21,6 +21,12 @@ from typing import Callable
 
 DEFAULT_SUFFIX = ".pdf"
 
+# Conservative page cap for the live path: protects the serving worker from
+# a huge/accidental multi-hundred-page upload monopolizing it synchronously.
+# Callers that need more (or an unbounded document) pass `max_pages`
+# explicitly (a larger int, or `None`).
+DEFAULT_MAX_PAGES = 50
+
 
 @dataclass
 class OcrResult:
@@ -39,6 +45,8 @@ def ocr_document(
     render_page_fn: Callable[[Path, int], object],
     page_type_predict: Callable[[object], str] | None = None,
     force_lang: str | None = None,
+    max_pages: int | None = DEFAULT_MAX_PAGES,
+    quality_check_fn: Callable[[str], bool] | None = None,
 ) -> OcrResult:
     """OCR one uploaded document (bytes) into text, page by page.
 
@@ -51,11 +59,21 @@ def ocr_document(
         render_page_fn: `(file_path, page_number) -> PIL.Image`, e.g.
             `page_renderer.render_page`. Must raise `ValueError` or
             `IndexError` once `page_number` exceeds the document's page
-            count (as `render_page` does).
+            count (as `render_page` does). If the *first* page can't be
+            rendered, that's treated as an unsupported/corrupt upload and
+            the error is re-raised rather than swallowed as end-of-document.
         page_type_predict: Optional `(image) -> label` classifier run per
             page before OCR.
         force_lang: Optional tesseract-style forced language, passed through
             to `extract_text_fn`.
+        max_pages: Stop after this many pages (default `DEFAULT_MAX_PAGES`),
+            protecting the live worker from a huge/accidental multi-hundred
+            -page document. Pass a larger int, or `None`, to lift the cap.
+        quality_check_fn: Optional `(page_text) -> bool` run on each page's
+            extracted text. A page whose text fails the check (returns
+            `False`) is skipped — excluded from `full_text` and `per_page`
+            — so looped/garbage OCR output can't reach redaction or
+            classification downstream. `None` (default) applies no check.
 
     Returns:
         OcrResult with the joined full text, page count, and per-page
@@ -69,16 +87,28 @@ def ocr_document(
     try:
         per_page: list[tuple[str, str | None]] = []
         page_number = 1
-        while True:
+        rendered_any_page = False
+        while max_pages is None or page_number <= max_pages:
             try:
                 image = render_page_fn(tmp_path, page_number)
             except (ValueError, IndexError):
+                if not rendered_any_page:
+                    # The renderer also raises ValueError for an
+                    # unsupported/corrupt file, not just end-of-document —
+                    # if page 1 never rendered, propagate rather than
+                    # silently returning an empty result that would route
+                    # as a blank grievance.
+                    raise
                 # Renderer signals "no such page" this way (see
                 # page_renderer.render_page) — that's the end of the document.
                 break
+            rendered_any_page = True
 
             label = page_type_predict(image) if page_type_predict else None
             text = extract_text_fn(image, force_lang)
+            if quality_check_fn is not None and not quality_check_fn(text):
+                page_number += 1
+                continue
             per_page.append((text, label))
             page_number += 1
 

--- a/janasunani/inference/ocr.py
+++ b/janasunani/inference/ocr.py
@@ -1,0 +1,88 @@
+"""Single-document OCR: raw bytes -> text, for the live warm processor.
+
+The batch pipeline (`pipeline/stages/ocr_extraction/`) only wires OCR
+primitives together through its artifact DB (see `stage.py`'s
+`_process_page`), one page row at a time. Serving one uploaded grievance
+document needs a standalone orchestration wrapper with the same per-page
+shape but no DB in the middle.
+
+Everything heavy — rendering (poppler/pdf2image), text extraction
+(tesseract or a future out-of-process DeepSeek backend), page-type
+classification — is dependency-injected, so this module imports cleanly
+with no OCR/ML libraries installed and is unit-testable with fakes.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+DEFAULT_SUFFIX = ".pdf"
+
+
+@dataclass
+class OcrResult:
+    """Result of OCR-ing one uploaded document."""
+
+    full_text: str
+    pages: int
+    per_page: list[tuple[str, str | None]]  # (page_text, page_type_label_or_None)
+
+
+def ocr_document(
+    document_bytes: bytes,
+    document_name: str,
+    *,
+    extract_text_fn: Callable[..., str],
+    render_page_fn: Callable[[Path, int], object],
+    page_type_predict: Callable[[object], str] | None = None,
+    force_lang: str | None = None,
+) -> OcrResult:
+    """OCR one uploaded document (bytes) into text, page by page.
+
+    Args:
+        document_bytes: Raw bytes of the uploaded file (PDF or image).
+        document_name: Original filename, used only to derive the file
+            extension (`render_page_fn` needs a real file path, not bytes).
+        extract_text_fn: `(image, force_lang) -> str`, e.g.
+            `pytesseract_backend.extract_text`.
+        render_page_fn: `(file_path, page_number) -> PIL.Image`, e.g.
+            `page_renderer.render_page`. Must raise `ValueError` or
+            `IndexError` once `page_number` exceeds the document's page
+            count (as `render_page` does).
+        page_type_predict: Optional `(image) -> label` classifier run per
+            page before OCR.
+        force_lang: Optional tesseract-style forced language, passed through
+            to `extract_text_fn`.
+
+    Returns:
+        OcrResult with the joined full text, page count, and per-page
+        (text, label) pairs.
+    """
+    suffix = Path(document_name).suffix or DEFAULT_SUFFIX
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+        tmp.write(document_bytes)
+        tmp_path = Path(tmp.name)
+
+    try:
+        per_page: list[tuple[str, str | None]] = []
+        page_number = 1
+        while True:
+            try:
+                image = render_page_fn(tmp_path, page_number)
+            except (ValueError, IndexError):
+                # Renderer signals "no such page" this way (see
+                # page_renderer.render_page) — that's the end of the document.
+                break
+
+            label = page_type_predict(image) if page_type_predict else None
+            text = extract_text_fn(image, force_lang)
+            per_page.append((text, label))
+            page_number += 1
+
+        full_text = "\n\n".join(text for text, _ in per_page)
+        return OcrResult(full_text=full_text, pages=len(per_page), per_page=per_page)
+    finally:
+        os.unlink(tmp_path)

--- a/tests/test_inference_ocr.py
+++ b/tests/test_inference_ocr.py
@@ -128,3 +128,130 @@ def test_temp_file_removed_even_on_extract_error():
         raise AssertionError("expected RuntimeError to propagate")
 
     assert not tmp_paths[0].exists()
+
+
+def test_first_page_render_failure_propagates():
+    """`render_page` raises ValueError for both end-of-document AND an
+    unsupported/corrupt upload. If page 1 itself fails to render, that's
+    never "end of document" (there's no document 0) — it must propagate so
+    an unsupported file isn't silently routed as a blank grievance."""
+    tmp_paths: list[Path] = []
+
+    def render_page_fn(file_path: Path, page_number: int) -> FakeImage:
+        tmp_paths.append(file_path)
+        raise ValueError("could not render page 1: unsupported file type")
+
+    try:
+        ocr_document(
+            document_bytes=b"this is not a pdf or image",
+            document_name="notes.txt",
+            extract_text_fn=fake_extract_text_fn,
+            render_page_fn=render_page_fn,
+        )
+    except ValueError as exc:
+        assert "could not render page 1" in str(exc)
+    else:
+        raise AssertionError("expected ValueError from page 1 to propagate")
+
+    # Temp file must still be cleaned up even though the error propagated.
+    assert not tmp_paths[0].exists()
+
+
+def test_page_n_render_failure_terminates_cleanly_with_earlier_pages():
+    """Once at least one page has rendered, a later render failure is the
+    normal end-of-document signal, not a propagated error — the pages seen
+    so far are kept."""
+    tmp_paths: list[Path] = []
+    result = ocr_document(
+        document_bytes=b"%PDF-fake-bytes",
+        document_name="complaint.pdf",
+        extract_text_fn=fake_extract_text_fn,
+        render_page_fn=make_render_page_fn(2, tmp_paths),
+    )
+
+    assert result.pages == 2
+    assert result.full_text == "page 1 text (auto)\n\npage 2 text (auto)"
+    assert result.per_page == [
+        ("page 1 text (auto)", None),
+        ("page 2 text (auto)", None),
+    ]
+
+
+def test_max_pages_caps_the_page_loop():
+    """A document with more pages than `max_pages` stops at the cap instead
+    of OCR-ing every page synchronously."""
+    tmp_paths: list[Path] = []
+    result = ocr_document(
+        document_bytes=b"%PDF-fake-bytes",
+        document_name="huge.pdf",
+        extract_text_fn=fake_extract_text_fn,
+        render_page_fn=make_render_page_fn(10, tmp_paths),
+        max_pages=3,
+    )
+
+    assert result.pages == 3
+    assert result.per_page == [
+        ("page 1 text (auto)", None),
+        ("page 2 text (auto)", None),
+        ("page 3 text (auto)", None),
+    ]
+    # The loop must stop at the cap without even attempting page 4.
+    assert len(tmp_paths) == 3
+
+
+def test_default_max_pages_protects_a_huge_document():
+    """The out-of-the-box default caps the live path even when the caller
+    doesn't pass `max_pages` explicitly."""
+    tmp_paths: list[Path] = []
+    result = ocr_document(
+        document_bytes=b"%PDF-fake-bytes",
+        document_name="huge.pdf",
+        extract_text_fn=fake_extract_text_fn,
+        render_page_fn=make_render_page_fn(500, tmp_paths),
+    )
+
+    assert result.pages == 50
+    assert len(tmp_paths) == 50
+
+
+def test_quality_check_fn_skips_pages_that_fail_the_check():
+    """An injected quality_check_fn that rejects a page's text excludes that
+    page from both `full_text` and `per_page`, so looped/garbage OCR output
+    can't reach redaction/classification downstream."""
+    tmp_paths: list[Path] = []
+
+    def quality_check_fn(text: str) -> bool:
+        return "page 2" not in text
+
+    result = ocr_document(
+        document_bytes=b"%PDF-fake-bytes",
+        document_name="complaint.pdf",
+        extract_text_fn=fake_extract_text_fn,
+        render_page_fn=make_render_page_fn(3, tmp_paths),
+        quality_check_fn=quality_check_fn,
+    )
+
+    assert result.pages == 2
+    assert result.full_text == "page 1 text (auto)\n\npage 3 text (auto)"
+    assert result.per_page == [
+        ("page 1 text (auto)", None),
+        ("page 3 text (auto)", None),
+    ]
+
+
+def test_quality_check_fn_default_none_is_a_no_op():
+    """Without a quality_check_fn (the default), the pytesseract path is
+    unchanged — no pages are filtered."""
+    tmp_paths: list[Path] = []
+    result = ocr_document(
+        document_bytes=b"%PDF-fake-bytes",
+        document_name="complaint.pdf",
+        extract_text_fn=fake_extract_text_fn,
+        render_page_fn=make_render_page_fn(2, tmp_paths),
+    )
+
+    assert result.pages == 2
+    assert result.per_page == [
+        ("page 1 text (auto)", None),
+        ("page 2 text (auto)", None),
+    ]

--- a/tests/test_inference_ocr.py
+++ b/tests/test_inference_ocr.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from janasunani.inference.ocr import OcrResult, ocr_document
+from janasunani.inference.ocr import OcrQualityError, OcrResult, ocr_document
 
 
 class FakeImage:
@@ -195,8 +195,10 @@ def test_max_pages_caps_the_page_loop():
         ("page 2 text (auto)", None),
         ("page 3 text (auto)", None),
     ]
-    # The loop must stop at the cap without even attempting page 4.
-    assert len(tmp_paths) == 3
+    assert result.truncated is True
+    # The loop must stop at the cap and OCR nothing past it — the only
+    # extra render is the page-4 truncation probe (no extract/classify).
+    assert len(tmp_paths) == 4
 
 
 def test_default_max_pages_protects_a_huge_document():
@@ -211,7 +213,42 @@ def test_default_max_pages_protects_a_huge_document():
     )
 
     assert result.pages == 50
-    assert len(tmp_paths) == 50
+    assert result.truncated is True
+    assert len(tmp_paths) == 51  # 50 rendered pages + 1 truncation probe
+
+
+def test_max_pages_not_truncated_when_document_ends_exactly_at_the_cap():
+    """A document with exactly `max_pages` pages is not truncated — the
+    probe past the cap hits the renderer's normal end-of-document error."""
+    tmp_paths: list[Path] = []
+    result = ocr_document(
+        document_bytes=b"%PDF-fake-bytes",
+        document_name="exact.pdf",
+        extract_text_fn=fake_extract_text_fn,
+        render_page_fn=make_render_page_fn(3, tmp_paths),
+        max_pages=3,
+    )
+
+    assert result.pages == 3
+    assert result.truncated is False
+    assert len(tmp_paths) == 4  # 3 rendered pages + 1 truncation probe
+
+
+def test_unbounded_max_pages_is_never_truncated():
+    """`max_pages=None` (unbounded) always runs to real end-of-document via
+    `break`, so the truncation probe never fires and `truncated` stays
+    False."""
+    tmp_paths: list[Path] = []
+    result = ocr_document(
+        document_bytes=b"%PDF-fake-bytes",
+        document_name="complaint.pdf",
+        extract_text_fn=fake_extract_text_fn,
+        render_page_fn=make_render_page_fn(5, tmp_paths),
+        max_pages=None,
+    )
+
+    assert result.pages == 5
+    assert result.truncated is False
 
 
 def test_quality_check_fn_skips_pages_that_fail_the_check():
@@ -237,6 +274,81 @@ def test_quality_check_fn_skips_pages_that_fail_the_check():
         ("page 1 text (auto)", None),
         ("page 3 text (auto)", None),
     ]
+
+
+def test_quality_check_fn_rejecting_every_page_raises_ocr_quality_error():
+    """If `quality_check_fn` was supplied and every rendered page fails it,
+    an empty OcrResult would be indistinguishable from a legitimately blank
+    document — so this must raise instead of returning a blank result that
+    would silently route into redaction/classification."""
+    tmp_paths: list[Path] = []
+
+    def quality_check_fn(text: str) -> bool:
+        return False
+
+    try:
+        ocr_document(
+            document_bytes=b"%PDF-fake-bytes",
+            document_name="garbage.pdf",
+            extract_text_fn=fake_extract_text_fn,
+            render_page_fn=make_render_page_fn(3, tmp_paths),
+            quality_check_fn=quality_check_fn,
+        )
+    except OcrQualityError as exc:
+        assert "garbage.pdf" in str(exc)
+    else:
+        raise AssertionError("expected OcrQualityError")
+
+    # Temp file must still be cleaned up even though the error propagated.
+    assert not tmp_paths[0].exists()
+
+
+def test_quality_check_fn_rejecting_single_page_document_raises():
+    """A single-page document whose one page fails the quality check is the
+    same "every page rejected" case, not a special-cased empty document."""
+    tmp_paths: list[Path] = []
+
+    def quality_check_fn(text: str) -> bool:
+        return False
+
+    try:
+        ocr_document(
+            document_bytes=b"fake-image-bytes",
+            document_name="scan.jpg",
+            extract_text_fn=fake_extract_text_fn,
+            render_page_fn=make_render_page_fn(1, tmp_paths),
+            quality_check_fn=quality_check_fn,
+        )
+    except OcrQualityError:
+        pass
+    else:
+        raise AssertionError("expected OcrQualityError")
+
+
+def test_no_quality_check_fn_does_not_raise_ocr_quality_error():
+    """`OcrQualityError` is scoped to "a quality hook was supplied and
+    rejected everything." A page-less/empty document with *no* hook is a
+    separate, legitimately-empty case: page 1's render failure still
+    propagates as the existing `ValueError` (unrelated, pre-existing
+    behavior) — not the new `OcrQualityError` — because the quality gate
+    never engages when `quality_check_fn` is None."""
+
+    def render_page_fn(file_path: Path, page_number: int):
+        raise ValueError("could not render page 1: unsupported file type")
+
+    try:
+        ocr_document(
+            document_bytes=b"bytes",
+            document_name="empty.pdf",
+            extract_text_fn=fake_extract_text_fn,
+            render_page_fn=render_page_fn,
+        )
+    except OcrQualityError:
+        raise AssertionError("must not raise OcrQualityError without a hook") from None
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected ValueError from page 1 to propagate")
 
 
 def test_quality_check_fn_default_none_is_a_no_op():

--- a/tests/test_inference_ocr.py
+++ b/tests/test_inference_ocr.py
@@ -1,0 +1,130 @@
+"""Tests for janasunani.inference.ocr — real-code-path with fake injected
+render/extract functions (no tesseract/poppler/torch required).
+
+`ocr_document` is exercised end-to-end: real temp-file writing/cleanup,
+real page-loop / end-of-document detection, real text joining. Only the
+heavy OCR/render primitives are fakes, matching how the real
+`render_page`/`extract_text` behave (out-of-range page -> ValueError).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from janasunani.inference.ocr import OcrResult, ocr_document
+
+
+class FakeImage:
+    """Sentinel standing in for a PIL.Image, tagged with its page number."""
+
+    def __init__(self, page_number: int):
+        self.page_number = page_number
+
+
+def make_render_page_fn(num_pages: int, tmp_paths: list[Path]):
+    """Fake render_page_fn: returns a FakeImage per page, raises ValueError
+    past `num_pages` (mirrors page_renderer.render_page's out-of-range
+    behavior)."""
+
+    def render_page_fn(file_path: Path, page_number: int) -> FakeImage:
+        tmp_paths.append(file_path)
+        assert file_path.exists(), "temp file must exist while rendering"
+        if page_number > num_pages:
+            raise ValueError(
+                f"could not render page {page_number} of {file_path.name}"
+            )
+        return FakeImage(page_number)
+
+    return render_page_fn
+
+
+def fake_extract_text_fn(image: FakeImage, force_lang: str | None) -> str:
+    lang_tag = force_lang or "auto"
+    return f"page {image.page_number} text ({lang_tag})"
+
+
+def fake_page_type_predict(image: FakeImage) -> str:
+    return "letter" if image.page_number == 1 else "attachment"
+
+
+def test_single_page_image_document():
+    tmp_paths: list[Path] = []
+    result = ocr_document(
+        document_bytes=b"fake-image-bytes",
+        document_name="scan.jpg",
+        extract_text_fn=fake_extract_text_fn,
+        render_page_fn=make_render_page_fn(1, tmp_paths),
+    )
+
+    assert isinstance(result, OcrResult)
+    assert result.pages == 1
+    assert result.full_text == "page 1 text (auto)"
+    assert result.per_page == [("page 1 text (auto)", None)]
+
+    # Temp file must be cleaned up afterward.
+    assert len(tmp_paths) == 2  # called once for page 1, once for out-of-range page 2
+    assert not tmp_paths[0].exists()
+    assert tmp_paths[0].suffix == ".jpg"
+
+
+def test_multi_page_pdf_document_with_labels_and_lang():
+    tmp_paths: list[Path] = []
+    result = ocr_document(
+        document_bytes=b"%PDF-fake-bytes",
+        document_name="complaint.pdf",
+        extract_text_fn=fake_extract_text_fn,
+        render_page_fn=make_render_page_fn(3, tmp_paths),
+        page_type_predict=fake_page_type_predict,
+        force_lang="eng",
+    )
+
+    assert result.pages == 3
+    assert result.full_text == (
+        "page 1 text (eng)\n\npage 2 text (eng)\n\npage 3 text (eng)"
+    )
+    assert result.per_page == [
+        ("page 1 text (eng)", "letter"),
+        ("page 2 text (eng)", "attachment"),
+        ("page 3 text (eng)", "attachment"),
+    ]
+
+    assert not tmp_paths[0].exists()
+    assert tmp_paths[0].suffix == ".pdf"
+
+
+def test_default_suffix_when_document_name_has_no_extension():
+    tmp_paths: list[Path] = []
+    ocr_document(
+        document_bytes=b"bytes",
+        document_name="no_extension_here",
+        extract_text_fn=fake_extract_text_fn,
+        render_page_fn=make_render_page_fn(1, tmp_paths),
+    )
+
+    assert tmp_paths[0].suffix == ".pdf"
+
+
+def test_temp_file_removed_even_on_extract_error():
+    tmp_paths: list[Path] = []
+
+    def render_page_fn(file_path: Path, page_number: int) -> FakeImage:
+        tmp_paths.append(file_path)
+        if page_number > 1:
+            raise ValueError("no more pages")
+        return FakeImage(page_number)
+
+    def failing_extract_text_fn(image: FakeImage, force_lang: str | None) -> str:
+        raise RuntimeError("ocr backend exploded")
+
+    try:
+        ocr_document(
+            document_bytes=b"bytes",
+            document_name="doc.pdf",
+            extract_text_fn=failing_extract_text_fn,
+            render_page_fn=render_page_fn,
+        )
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("expected RuntimeError to propagate")
+
+    assert not tmp_paths[0].exists()


### PR DESCRIPTION
## Summary

Part of the Phase 8 inference split (Executor B's disjoint slice). Adds a standalone, single-item OCR orchestration wrapper for the warm processor: given one uploaded document's raw bytes, it OCRs it into text page-by-page and returns the joined full text plus per-page detail.

The batch pipeline (`pipeline/stages/ocr_extraction/stage.py`, `_process_page`) only wires OCR primitives together through its artifact DB, one row at a time — there was no standalone way to OCR a single in-memory document. This fills that gap.

- New `janasunani/inference/` package (minimal `__init__.py`).
- `janasunani/inference/ocr.py`: `OcrResult` dataclass + `ocr_document(...)`, pinned signature:
  ```python
  def ocr_document(
      document_bytes: bytes,
      document_name: str,
      *,
      extract_text_fn,          # (PIL.Image, force_lang) -> str
      render_page_fn,           # (Path, page_number) -> PIL.Image
      page_type_predict=None,   # optional (PIL.Image) -> label
      force_lang=None,
  ) -> OcrResult
  ```
- Everything heavy (rendering via poppler/pdf2image, text extraction via tesseract, or a future out-of-process DeepSeek backend, page-type classification) is dependency-injected — `ocr.py` imports with **stdlib-only** deps (`os`, `tempfile`, `dataclasses`, `pathlib`, `typing`), no tesseract/poppler/torch required.
- Writes `document_bytes` to a `NamedTemporaryFile` (suffix derived from `document_name`, default `.pdf`), iterates pages until `render_page_fn` raises `ValueError`/`IndexError` (mirrors the real `render_page`'s out-of-range signal), and always cleans up the temp file via `try/finally`.

## Test plan
- [x] `uv run pytest tests/test_inference_ocr.py` — 4 passed (single-page image doc, multi-page pdf doc with labels/lang, no-extension default-suffix case, temp-file cleanup on extract error)
- [x] `uv run pytest` (full suite) — 113 passed, 12 skipped (pre-existing, gated by extras not installed)
- [x] `uv run ruff check .` — all checks passed
- [x] Verified `ocr.py` imports with no heavy deps present

🤖 Generated with [Claude Code](https://claude.com/claude-code)