### PR TITLE
Phase 8C — live PipelineGrievanceProcessor + janasunani-api-live

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,8 @@ The repo is one Python package (`janasunani/`) built **phase by phase** (see
   routing, FastAPI serving, and the Next.js demo. The serving API skeleton is on
   `main`; the routing engine, live persistence, lake-backed history, MLflow
   registry, and a first-cut DPIC-branded Next.js frontend are ongoing on feature
-  branches. The demo runs **mock end-to-end** today (mock processor + synthetic
-  history) — real-time inference (Phase 8) is the gap that swaps the mocks for
-  real models behind the same contract.
+  branches. Phase 8 now provides an opt-in real local-model server behind the
+  same contract; the default API remains mocked for frontend development.
 
 New here? Read [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) first;
 [docs/ROADMAP.md](docs/ROADMAP.md) is the plan and current status.
@@ -121,16 +120,18 @@ Downloads each complaint's document to S3 (or local disk in dev) and records
 status back into OLTP. *Currently parked: live Janasunani API credentials are
 unavailable.*
 
-### 7 · Demo API (Phase 10 skeleton — mocked processor)
+### 7 · Demo API (default mock or opt-in live processor)
 
 ```bash
 uv run --extra serving janasunani-api        # http://127.0.0.1:8000, docs at /docs
+uv run --extra serving --extra pipeline-core --extra categorizer janasunani-api-live
 ```
 
 The full endpoint surface the frontend builds against (`POST /grievance`,
 `GET /grievance/{id}`, `GET /history`, `/health`) with a mocked processor
-returning the real response shapes — no models load. Real inference/routing
-swap in behind the same contract at Phase 8–9 wire-up.
+returning the real response shapes — no models load. The live command strictly
+loads local DVC model artifacts and runs pytesseract, Presidio, MuRIL, BART,
+and rules routing behind the same contract.
 Contract details: [janasunani/serving/README.md](janasunani/serving/README.md).
 
 ### Tests (the gate for every change)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -32,12 +32,12 @@ six-stage document pipeline (incl. the Presidio PII rebuild) are done; productio
 Postgres holds the migrated data on the always-on CPU box (nightly `pg_dump` →
 S3), and the on-demand GPU box was shaken down for real (DeepSeek OCR) on
 2026-07-04. **The automation-prototype phases (8–12) are in progress**, built
-API-contract-first: the Phase 10 serving skeleton is on `main`, and the routing
-engine, live-persistence, lake-backed history, MLflow registry, and a first-cut
-DPIC-branded Next.js frontend are **ongoing on feature branches** (see the
-per-Phase status below). The demo today is **mock end-to-end** (mock processor +
-`MockHistory`); **Phase 8 real-time inference is the one gap** before it runs on
-real models.
+API-contract-first: the Phase 10 serving skeleton, live persistence/history,
+Phase 9 rules router, and Phase 8 warm inference processor are built, while the
+MLflow registry and a first-cut DPIC-branded Next.js frontend remain in
+progress (see the per-Phase status below). The default API deliberately remains
+mocked; the opt-in `janasunani-api-live` command runs local real models behind
+the same frozen contract.
 
 **Source provenance — this repo consolidates code from two earlier projects**
 - **DB/ORM layer + document ingestion → S3 + config** — from `../grievance`,
@@ -241,13 +241,14 @@ start GPU box → health check → demo → stop GPU box; latency pass; stakehol
   PII rebuild, GPU shakedown 2026-07-04).
 - 🔄 **Phase 6** — MLflow slim: helpers on branch `feat/mlflow-slim-registry` (ongoing). ✅ **Phase 7 CI** —
   green with Postgres service container; docs stay late.
-- 🔄 **Phases 8–12** — built API-contract-first; several components **ongoing on feature branches,
-  awaiting review/merge/integration** (none merged past the Phase 10 skeleton yet):
-  - **Phase 8** ⬜ real-time inference core — NOT started; this is the gap that keeps the demo mock.
-  - **Phase 9** 🔄 routing — `feat/rules-router` / `feat/rules-router-mappings` (rules layer; crosswalk to be
-    learned from OLAP history — see Phase 9). Not wired into serving.
-  - **Phase 10** 🔄 serving — skeleton merged; `feat/serving-live-persistence` (live→OLTP) +
-    `feat/lake-history-provider` (real `/history`) ongoing on branches.
+- 🔄 **Phases 8–12** — built API-contract-first; the real backend path is now available opt-in while
+  frontend/deployment integration remains:
+  - **Phase 8** ✅ real-time inference core — 8A warm summarizer, 8B standalone OCR, and 8C warm
+    processor/live CLI complete. Local DVC model artifacts are required and startup fails closed.
+  - **Phase 9** 🔄 routing — deterministic rules/mappings route the live processor now; the learned
+    OLAP-history crosswalk remains follow-up work.
+  - **Phase 10** ✅ serving — frozen mock API, live persistence, lake-backed history, and opt-in real
+    processor wiring are built. The module-level API remains mock by design.
   - **Phase 11** 🔄 frontend — first cut on `feat/frontend-demo` (DPIC-branded, against the mock).
   - **Phase 12** ⬜ demo integration & deployment.
   - Docs: `chore/handoff-doc-links` (ongoing). *(Dead: `backend-plan-unsplit` — an ancestor of main, no diff.)*
@@ -401,12 +402,29 @@ frontend/                         # Next.js + React + Tailwind
 deploy/                           # docker-compose (api, frontend, mlflow, oltp-postgres, proxy) + terraform/
 ```
 
-## Phase 8 — Real-time inference core  ⬜ *(NOT started — the one gap keeping the demo mock end-to-end)*
-- Each pipeline stage gets a single-item `process(text|image_bytes)->dict` beside its batch path. Warm
-  `GrievanceProcessor` loads models once from the MLflow registry; text skips OCR. **OCR engine is
-  configurable** (the existing `ocr_engine` switch): DeepSeek when CUDA is present (GPU box up during
-  demo windows), pytesseract fallback otherwise — the doc path never hard-fails without a GPU.
-- **Tests**: one sample text + one PDF → structured result; heavy model-load mocked.
+## Phase 8 — Real-time inference core  ✅ *(8A + 8B + 8C complete)*
+- ✅ **8A:** `Summarizer` is a warm single-item wrapper over public
+  `facebook/bart-large-cnn`; short inputs avoid an unnecessary generation call.
+- ✅ **8B:** `ocr_document()` renders and OCRs one uploaded document without the
+  batch artifact DB, preserves per-page text/type metadata, rejects quality
+  collapse, and reports truncation at the synchronous page cap.
+- ✅ **8C:** `PipelineGrievanceProcessor` warms the local DVC-mirrored page-type
+  and MuRIL models, BART, then Presidio once. Typed text skips OCR; documents use
+  pytesseract and feed only non-empty Letter/Form/Application/Text Only pages to
+  classification and summarization while preserving all accepted OCR text in
+  the response. Non-English-compatible text is `Uncategorized`; routing uses
+  `DEFAULT_ROUTER` (`rules`/`fallback`, never `mock`). Corrupt, unsupported,
+  blank, quality-rejected, truncated, and irrelevant-only documents fail with
+  a typed input error surfaced as HTTP 422.
+- ✅ **Strict live server:** `janasunani-api-live` loads local models directly,
+  fails startup if dependencies/artifacts are missing, serves `LakeHistory`,
+  and uses OLTP persistence only when `OLTP_DB_URL` is explicitly set. The
+  module-level `janasunani.serving.api:app` and `janasunani-api` stay mocked.
+  DeepSeek (separate process) and MLflow runtime model resolution remain
+  follow-up work.
+- **Tests:** dependency-injected text/PDF processor paths, page gating,
+  invalid/unsafe input rejection, warm reuse, strict builder/store selection,
+  unchanged serving contract, and an opt-in real-model smoke.
 
 ## Phase 9 — Routing engine (hybrid)  🔄 *(components on branches; not yet wired into serving)*
 - **Rules layer built** (`routing/rules.py`, branches `feat/rules-router` → `feat/rules-router-mappings`):
@@ -426,25 +444,26 @@ deploy/                           # docker-compose (api, frontend, mlflow, oltp-
   little/no history. This **replaces the name-match hack** and becomes the rules layer.
 - `routing/model.py`: learned router trained on the OLAP history (features → handling office); MLflow-
   registered — layered **above** the empirical crosswalk. `routing/router.py`: combine + confidence/fallback.
-- **Not yet wired into `serving/`** — the API still routes via the mock processor (`method:"mock"`); wiring
-  the router in is part of the Phase 8/10 wire-up.
+- **Live wiring complete for the deterministic layer** — `janasunani-api-live`
+  routes through `DEFAULT_ROUTER`; only the default mock command returns
+  `method:"mock"`.
 - **Sequencing:** the empirical crosswalk ships **first** (demo-sufficient, real data-derived confidence);
   the learned router lands only after the E2E demo path works, so the demo never blocks on training.
 - **Tests**: crosswalk lookups + fallback ladder; learned-router top-k on held-out; combiner fallback.
 
-## Phase 10 — Serving API + live wiring  🔄 *(skeleton ✅ on main; persistence + real history ONGOING on branches)*
+## Phase 10 — Serving API + live wiring  ✅ *(default mock + opt-in live)*
 - ✅ **Skeleton (merged to main, PR #12):** all endpoints + `/health` + CORS with a **mocked processor**
   returning the real response shapes — the stable `serving/schemas.py` contract Phases 8/9/11 build against.
-- 🔄 **ONGOING — live persistence** (branch `feat/serving-live-persistence`, reviewed, tested): the
+- ✅ **Live persistence:** the
   `live_grievances` sibling OLTP table + Alembic revision + injectable `ResultStore`
-  (`InMemory`/`Database`); `POST /grievance` persists, `GET /grievance/{id}` reads it back. Not merged.
-- 🔄 **ONGOING — real history** (branch `feat/lake-history-provider`, reviewed, tested): `LakeHistory`
+  (`InMemory`/`Database`); `POST /grievance` persists, `GET /grievance/{id}` reads it back.
+- ✅ **Real history:** `LakeHistory`
   serves `GET /history` from the real 1.37M-row Parquet lake (`olap/lake.py`) instead of `MockHistory`.
-  Not merged — **the app on `main` still uses `MockHistory` (synthetic rows) and the mock processor.**
-  Note: `feat/serving-live-persistence` and `feat/lake-history-provider` both edit `api.py`'s
-  `app = create_app(...)` line — a trivial conflict to reconcile into one `create_app(history=…, result_store=…)`.
-- ⬜ **Wire-up remaining (after Phase 8):** swap the mocked processor for real inference + routing so the
-  submit path is genuinely end-to-end. Models warm from MLflow. **Seed fake live grievances.**
+  The module-level app uses it with the mock processor; the live CLI uses it
+  with the real processor.
+- ✅ **Opt-in wire-up:** `janasunani-api-live` mounts real inference/routing.
+  Local DVC artifacts are loaded directly for Phase 8C; MLflow runtime
+  resolution and seeded fake live grievances remain follow-up work.
 - **Tests**: API tests (TestClient) with mocked processor against a temp OLTP DB — submit→persist→fetch;
   history endpoint returns lake rows.
 

--- a/janasunani/config.py
+++ b/janasunani/config.py
@@ -31,6 +31,12 @@ OUTPUT_DATA_DIR = DATA_DIR / "output"
 OLTP_DATA_DIR = DATA_DIR / "oltp"
 DOCUMENTS_DIR = RAW_DATA_DIR / "documents"
 
+# The built-in local-SQLite fallback for `Settings.OLTP_DB_URL`. Exposed so
+# callers (e.g. `janasunani.inference.serve`) can tell an *explicit* OLTP
+# configuration (shell env var or `.env`) apart from this default without
+# duplicating the literal.
+DEFAULT_OLTP_DB_URL = f"sqlite+aiosqlite:///{OLTP_DATA_DIR.as_posix()}/janasunani.db"
+
 OUTPUTS_DIR = ROOT_DIR / "outputs"
 FIGURES_DIR = OUTPUTS_DIR / "figures"
 REPORTS_DIR = OUTPUTS_DIR / "reports"
@@ -95,9 +101,7 @@ class Settings(BaseSettings):
 
     # OLTP store (async SQLAlchemy; swappable engine via this URL).
     # Default: local SQLite. Deploy: e.g. postgresql+asyncpg://user:pass@host/db
-    OLTP_DB_URL: str = os.getenv(
-        "OLTP_DB_URL", f"sqlite+aiosqlite:///{OLTP_DATA_DIR.as_posix()}/janasunani.db"
-    )
+    OLTP_DB_URL: str = os.getenv("OLTP_DB_URL", DEFAULT_OLTP_DB_URL)
     DB_PASSWORD: Optional[str] = os.getenv("DB_PASSWORD")
 
     # MySQL source for migration (cold-start dump restore or live sync)

--- a/janasunani/inference/serve.py
+++ b/janasunani/inference/serve.py
@@ -15,6 +15,7 @@ import sys
 if sys.platform == "darwin":
     os.environ.setdefault("OMP_NUM_THREADS", "1")
 
+from janasunani.config import DEFAULT_OLTP_DB_URL, Settings  # noqa: E402
 from janasunani.inference.service import build_processor  # noqa: E402
 from janasunani.serving.api import create_app  # noqa: E402
 from janasunani.serving.history import LakeHistory  # noqa: E402
@@ -24,10 +25,29 @@ from janasunani.serving.store import (  # noqa: E402
 )
 
 
+def _resolve_explicit_oltp_url() -> str | None:
+    """Resolve `OLTP_DB_URL` through the same `Settings` layer the rest of the
+    app uses, so a value set in the project `.env` (not just a shell-exported
+    env var) is honored -- a raw `os.environ` read misses it and store
+    selection silently falls back to `InMemoryResultStore`.
+
+    Re-instantiates `Settings()` (rather than importing the module-level
+    singleton) so this always reflects the current process environment and
+    `.env` file at call time.
+
+    Returns None unless OLTP is *explicitly* configured: a value equal to
+    `DEFAULT_OLTP_DB_URL` (the built-in local-SQLite fallback `Settings`
+    itself falls back to) is treated as "not configured", matching Phase 8C's
+    contract of using `DatabaseResultStore` only for an explicit OLTP URL.
+    """
+    resolved = Settings().OLTP_DB_URL
+    return resolved if resolved != DEFAULT_OLTP_DB_URL else None
+
+
 def create_live_app():
     """Build the real processor, lake history, and explicitly chosen store."""
     processor = build_processor()
-    oltp_url = os.environ.get("OLTP_DB_URL")
+    oltp_url = _resolve_explicit_oltp_url()
     result_store = (
         DatabaseResultStore(oltp_url) if oltp_url else InMemoryResultStore()
     )

--- a/janasunani/inference/serve.py
+++ b/janasunani/inference/serve.py
@@ -1,0 +1,52 @@
+"""Opt-in live API entry point.
+
+Unlike :mod:`janasunani.serving.api`, importing this module does not construct
+an app.  Startup is intentionally strict and happens only through ``main`` or
+``create_live_app``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Importing torch/xgboost/spaCy in one arm64 process can otherwise collide in
+# OpenMP initialization. This must run before any inference imports.
+if sys.platform == "darwin":
+    os.environ.setdefault("OMP_NUM_THREADS", "1")
+
+from janasunani.inference.service import build_processor  # noqa: E402
+from janasunani.serving.api import create_app  # noqa: E402
+from janasunani.serving.history import LakeHistory  # noqa: E402
+from janasunani.serving.store import (  # noqa: E402
+    DatabaseResultStore,
+    InMemoryResultStore,
+)
+
+
+def create_live_app():
+    """Build the real processor, lake history, and explicitly chosen store."""
+    processor = build_processor()
+    oltp_url = os.environ.get("OLTP_DB_URL")
+    result_store = (
+        DatabaseResultStore(oltp_url) if oltp_url else InMemoryResultStore()
+    )
+    return create_app(
+        processor=processor,
+        history=LakeHistory(),
+        result_store=result_store,
+    )
+
+
+def main() -> None:
+    import uvicorn
+
+    uvicorn.run(
+        create_live_app(),
+        host=os.environ.get("JANASUNANI_API_HOST", "127.0.0.1"),
+        port=int(os.environ.get("JANASUNANI_API_PORT", "8000")),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/janasunani/inference/service.py
+++ b/janasunani/inference/service.py
@@ -276,11 +276,48 @@ def _require_file(path: Path, component: str) -> None:
         )
 
 
-def _require_binary(binary: str, install_hint: str) -> None:
-    if shutil.which(binary) is None:
+def _require_binary(present: bool, binary: str, install_hint: str) -> None:
+    if not present:
         raise RuntimeError(
             f"missing required OCR system binary {binary!r}. {install_hint}"
         )
+
+
+def _tesseract_available() -> bool:
+    """Resolve tesseract exactly as `pytesseract_backend` does, not just PATH.
+
+    Reuses `pytesseract_backend._configure_tesseract` -- the backend's own
+    resolver -- so this preflight can never drift from what OCR calls will
+    actually find. That function tries, in order, `TESSERACT_CMD`, `PATH`,
+    and the bundled `~/.local/tesseract` install, and sets
+    `pytesseract.pytesseract.tesseract_cmd` as a side effect when one exists.
+    A bare PATH-only check would false-abort startup on a box where the
+    binary is only reachable via one of the other two mechanisms.
+    """
+    import pytesseract
+    from janasunani.pipeline.stages.ocr_extraction.pytesseract_backend import (
+        _configure_tesseract,
+    )
+
+    _configure_tesseract()
+    resolved = pytesseract.pytesseract.tesseract_cmd
+    return Path(resolved).is_file() or shutil.which(resolved) is not None
+
+
+def _poppler_available() -> bool:
+    """Resolve pdftoppm exactly as `page_renderer` does, not just PATH.
+
+    Reuses `page_renderer.POPPLER_PATH` -- computed at import time from the
+    bundled `~/.local/poppler` install (falling back to `/usr/bin`) -- the
+    same value `page_renderer.render_page` passes to `pdf2image` as
+    `poppler_path`. Falls back to a plain PATH lookup when that isn't set.
+    """
+    from janasunani.pipeline.stages.ocr_extraction import page_renderer
+
+    poppler_dir = page_renderer.POPPLER_PATH
+    if poppler_dir and (Path(poppler_dir) / "pdftoppm").is_file():
+        return True
+    return shutil.which("pdftoppm") is not None
 
 
 def _require_ocr_dependencies() -> None:
@@ -299,12 +336,14 @@ def _require_ocr_dependencies() -> None:
     check reliably here. Operators should confirm it manually post-install.
     """
     _require_binary(
+        _tesseract_available(),
         "tesseract",
         "Install Tesseract OCR and the Odia language pack, e.g. "
         "`apt-get install tesseract-ocr tesseract-ocr-ori` or "
         "`brew install tesseract tesseract-lang`.",
     )
     _require_binary(
+        _poppler_available(),
         "pdftoppm",
         "Install Poppler so PDF pages can be rendered for OCR, e.g. "
         "`apt-get install poppler-utils` or `brew install poppler`.",

--- a/janasunani/inference/service.py
+++ b/janasunani/inference/service.py
@@ -9,6 +9,7 @@ component exactly once.
 from __future__ import annotations
 
 import os
+import shutil
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Callable, Optional, Protocol
@@ -275,6 +276,41 @@ def _require_file(path: Path, component: str) -> None:
         )
 
 
+def _require_binary(binary: str, install_hint: str) -> None:
+    if shutil.which(binary) is None:
+        raise RuntimeError(
+            f"missing required OCR system binary {binary!r}. {install_hint}"
+        )
+
+
+def _require_ocr_dependencies() -> None:
+    """Fail startup when the OCR system binaries pytesseract/pdf2image shell
+    out to are absent.
+
+    Without this, `build_processor` only imports the OCR *functions* -- it
+    never checks that `tesseract`/Poppler are actually installed. `/health`
+    would then report the `pipeline` processor healthy, and every document
+    upload would only fail later, mid-request, as "corrupt/quality-rejected"
+    input, instead of failing loudly at startup.
+
+    Deliberately does not verify the Odia (`ori`) traineddata is installed:
+    that requires shelling out to `tesseract --list-langs`, whose output
+    format is not consistent enough across tesseract versions/platforms to
+    check reliably here. Operators should confirm it manually post-install.
+    """
+    _require_binary(
+        "tesseract",
+        "Install Tesseract OCR and the Odia language pack, e.g. "
+        "`apt-get install tesseract-ocr tesseract-ocr-ori` or "
+        "`brew install tesseract tesseract-lang`.",
+    )
+    _require_binary(
+        "pdftoppm",
+        "Install Poppler so PDF pages can be rendered for OCR, e.g. "
+        "`apt-get install poppler-utils` or `brew install poppler`.",
+    )
+
+
 def build_processor(models_dir: str | Path | None = None) -> PipelineGrievanceProcessor:
     """Strictly construct and warm the production processor.
 
@@ -293,6 +329,7 @@ def build_processor(models_dir: str | Path | None = None) -> PipelineGrievancePr
         "categorizer label encoder",
     )
     _require_file(page_type_dir / "config.json", "page-type model")
+    _require_ocr_dependencies()
 
     # Import and construct in pipeline order. This also keeps the module-level
     # mock app usable when none of the ML extras are installed.

--- a/janasunani/inference/service.py
+++ b/janasunani/inference/service.py
@@ -34,6 +34,10 @@ RELEVANT_PAGE_TYPES = frozenset(
 SUPPORTED_DOCUMENT_SUFFIXES = frozenset(
     {".pdf", ".png", ".jpg", ".jpeg", ".tiff", ".tif", ".bmp", ".gif"}
 )
+# Matches the categorizer's own non-English fallback (`category="Uncategorized"`,
+# see PHASE-8C.md): the first real-model demo targets English, so a non-English
+# summary would otherwise be a hallucinated BART guess over unsupported input.
+UNSUPPORTED_LANGUAGE_SUMMARY = "Summary unavailable for non-English submission."
 
 
 class InferenceInputError(ValueError):
@@ -174,11 +178,17 @@ class PipelineGrievanceProcessor:
             redacted_text if extraction.source == "text" else model_text_source
         )
         language = self._detect_language(classifier_text)
-        if self._is_english_compatible(classifier_text):
+        is_english = self._is_english_compatible(classifier_text)
+        if is_english:
             category = self._categorizer.predict(classifier_text)
+            summary = self._summarizer.summarize(classifier_text)
         else:
+            # Same gate as the categorizer: BART is only warmed for the
+            # English demo target, and would otherwise hallucinate a summary
+            # over text it was never validated on (both the typed-text and
+            # document paths share this single check).
             category = "Uncategorized"
-        summary = self._summarizer.summarize(classifier_text)
+            summary = UNSUPPORTED_LANGUAGE_SUMMARY
         routing = self._router.route(category=category, district=district)
 
         return GrievanceResult(
@@ -305,19 +315,29 @@ def _tesseract_available() -> bool:
 
 
 def _poppler_available() -> bool:
-    """Resolve pdftoppm exactly as `page_renderer` does, not just PATH.
+    """Resolve Poppler exactly as `page_renderer` does, not just PATH.
 
     Reuses `page_renderer.POPPLER_PATH` -- computed at import time from the
     bundled `~/.local/poppler` install (falling back to `/usr/bin`) -- the
     same value `page_renderer.render_page` passes to `pdf2image` as
     `poppler_path`. Falls back to a plain PATH lookup when that isn't set.
+
+    `pdf2image.convert_from_path` (what `render_page` calls) shells out to
+    BOTH `pdfinfo` (to read the page count) and `pdftoppm` (to rasterize
+    pages) -- a partial install with only one of the two still raises
+    `PDFInfoNotInstalledError` at request time. Both binaries must resolve
+    for either the configured `POPPLER_PATH` or the PATH fallback to count.
     """
     from janasunani.pipeline.stages.ocr_extraction import page_renderer
 
     poppler_dir = page_renderer.POPPLER_PATH
-    if poppler_dir and (Path(poppler_dir) / "pdftoppm").is_file():
-        return True
-    return shutil.which("pdftoppm") is not None
+    if poppler_dir:
+        poppler_path = Path(poppler_dir)
+        if (poppler_path / "pdfinfo").is_file() and (
+            poppler_path / "pdftoppm"
+        ).is_file():
+            return True
+    return shutil.which("pdfinfo") is not None and shutil.which("pdftoppm") is not None
 
 
 def _require_ocr_dependencies() -> None:
@@ -344,7 +364,7 @@ def _require_ocr_dependencies() -> None:
     )
     _require_binary(
         _poppler_available(),
-        "pdftoppm",
+        "pdfinfo/pdftoppm",
         "Install Poppler so PDF pages can be rendered for OCR, e.g. "
         "`apt-get install poppler-utils` or `brew install poppler`.",
     )

--- a/janasunani/inference/service.py
+++ b/janasunani/inference/service.py
@@ -1,0 +1,349 @@
+"""Warm, single-grievance inference behind the frozen serving contract.
+
+The module stays import-light so the default mock API does not require any ML
+extras.  ``build_processor`` is the strict production constructor: it checks
+for the locally mirrored model artifacts, then imports and warms every heavy
+component exactly once.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Callable, Optional, Protocol
+
+from janasunani.config import MODELS_DIR
+from janasunani.inference.ocr import OcrQualityError, OcrResult
+from janasunani.pipeline.stages.page_type_classifier import PAGE_TYPE_CLASS_BY_LABEL
+from janasunani.serving.schemas import (
+    ClassificationResult,
+    ExtractionResult,
+    GrievanceResult,
+    PIIEntity,
+    RedactionResult,
+    RoutingResult,
+)
+
+# Derived from the canonical label->class map (class 1 = grievance-bearing)
+# instead of a parallel hardcoded literal, so the two can't drift apart.
+RELEVANT_PAGE_TYPES = frozenset(
+    label for label, cls in PAGE_TYPE_CLASS_BY_LABEL.items() if cls == 1
+)
+SUPPORTED_DOCUMENT_SUFFIXES = frozenset(
+    {".pdf", ".png", ".jpg", ".jpeg", ".tiff", ".tif", ".bmp", ".gif"}
+)
+
+
+class InferenceInputError(ValueError):
+    """A submitted grievance cannot safely be processed as inference input."""
+
+
+class _Categorizer(Protocol):
+    def predict(self, text: str) -> str: ...
+
+
+class _Summarizer(Protocol):
+    def summarize(self, text: str) -> str: ...
+
+
+class _Router(Protocol):
+    def route(
+        self,
+        *,
+        category: str,
+        subcategory: Optional[str] = None,
+        district: Optional[str] = None,
+    ) -> RoutingResult: ...
+
+
+class PipelineGrievanceProcessor:
+    """Warm real processor with dependency injection for deterministic tests."""
+
+    name = "pipeline"
+
+    def __init__(
+        self,
+        *,
+        ocr: Callable[[bytes, str], OcrResult],
+        redact: Callable[[str], str],
+        detect_pii: Callable[[str], list[Any]],
+        categorizer: _Categorizer,
+        summarizer: _Summarizer,
+        router: _Router,
+        is_english_compatible: Callable[[str], bool],
+        detect_language: Callable[[str], str],
+        now: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._ocr = ocr
+        self._redact = redact
+        self._detect_pii = detect_pii
+        self._categorizer = categorizer
+        self._summarizer = summarizer
+        self._router = router
+        self._is_english_compatible = is_english_compatible
+        self._detect_language = detect_language
+        self._now = now or (lambda: datetime.now(UTC))
+
+    def process(
+        self,
+        *,
+        grievance_id: str,
+        ticket_no: str,
+        text: Optional[str] = None,
+        document_name: Optional[str] = None,
+        document_bytes: Optional[bytes] = None,
+        district: Optional[str] = None,
+    ) -> GrievanceResult:
+        """Process exactly one typed grievance or uploaded document."""
+        _validate_input(
+            text=text,
+            document_name=document_name,
+            document_bytes=document_bytes,
+        )
+
+        if text is not None:
+            extracted_text = text
+            extraction = ExtractionResult(source="text", extracted_text=text)
+        else:
+            assert document_name is not None and document_bytes is not None
+            try:
+                ocr_result = self._ocr(document_bytes, document_name)
+            except OcrQualityError as exc:
+                # Quality-rejected input is a legitimate client error -> 422.
+                raise InferenceInputError(
+                    f"document OCR failed the quality check: {exc}"
+                ) from exc
+            except Exception as exc:
+                # Only genuine render/parse failures (corrupt or unsupported
+                # file) map to a 422 here. `_is_document_input_failure` is
+                # deliberately narrow: the injected page-type predictor also
+                # runs inside `self._ocr` and is wrapped (see
+                # `_guard_page_type_predict`) so its own bugs raise
+                # `_PageTypeModelError` instead of a bare `ValueError`/
+                # `IndexError` that could otherwise be misread as a corrupt
+                # document — those propagate unchanged and become a 5xx.
+                if not _is_document_input_failure(exc):
+                    raise
+                raise InferenceInputError(
+                    f"document is corrupt or unsupported: {exc}"
+                ) from exc
+
+            if ocr_result.truncated:
+                raise InferenceInputError(
+                    "document exceeds the live page limit; no partial result was used"
+                )
+            if not ocr_result.full_text.strip():
+                raise InferenceInputError("document OCR produced no text")
+
+            relevant_pages = [
+                page_text
+                for page_text, page_type in ocr_result.per_page
+                if page_type in RELEVANT_PAGE_TYPES and page_text.strip()
+            ]
+            if not relevant_pages:
+                raise InferenceInputError(
+                    "document contains no grievance-bearing pages"
+                )
+
+            extracted_text = ocr_result.full_text
+            # Redact each selected page before joining so no irrelevant page
+            # (identification, bill, miscellaneous) reaches either model.
+            model_text_source = "\n\n".join(
+                self._redact(page_text) for page_text in relevant_pages
+            )
+            extraction = ExtractionResult(
+                source="document",
+                extracted_text=extracted_text,
+                ocr_model="pytesseract",
+                pages=ocr_result.pages,
+            )
+
+        redacted_text = self._redact(extracted_text)
+        pii_entities = [
+            PIIEntity(entity=span.entity, start=span.start, end=span.end)
+            for span in self._detect_pii(extracted_text)
+        ]
+        redaction = RedactionResult(
+            redacted_text=redacted_text,
+            entities=pii_entities,
+        )
+
+        classifier_text = (
+            redacted_text if extraction.source == "text" else model_text_source
+        )
+        language = self._detect_language(classifier_text)
+        if self._is_english_compatible(classifier_text):
+            category = self._categorizer.predict(classifier_text)
+        else:
+            category = "Uncategorized"
+        summary = self._summarizer.summarize(classifier_text)
+        routing = self._router.route(category=category, district=district)
+
+        return GrievanceResult(
+            id=grievance_id,
+            ticket_no=ticket_no,
+            status="Submitted",
+            submitted_on=self._now(),
+            extraction=extraction,
+            redaction=redaction,
+            classification=ClassificationResult(
+                category=category,
+                language=language,
+            ),
+            summary=summary,
+            routing=routing,
+        )
+
+
+def _validate_input(
+    *,
+    text: Optional[str],
+    document_name: Optional[str],
+    document_bytes: Optional[bytes],
+) -> None:
+    has_document_field = document_name is not None or document_bytes is not None
+    if text is not None and has_document_field:
+        raise InferenceInputError("provide exactly one of text or document")
+    if text is None and not has_document_field:
+        raise InferenceInputError("provide exactly one of text or document")
+    if text is not None:
+        if not text.strip():
+            raise InferenceInputError("text is blank")
+        return
+    if not document_name or document_bytes is None:
+        raise InferenceInputError("document name and bytes are both required")
+    if not document_bytes:
+        raise InferenceInputError("document is empty")
+    suffix = Path(document_name).suffix.casefold()
+    if suffix not in SUPPORTED_DOCUMENT_SUFFIXES:
+        raise InferenceInputError(f"unsupported document type: {suffix or '(none)'}")
+
+
+def _is_document_input_failure(exc: Exception) -> bool:
+    """Recognize renderer/parser failures without importing their libraries."""
+    return isinstance(exc, (ValueError, IndexError)) or exc.__class__.__name__ in {
+        "PDFInfoNotInstalledError",
+        "PDFPageCountError",
+        "PDFSyntaxError",
+        "PDFPopplerTimeoutError",
+        "UnidentifiedImageError",
+    }
+
+
+class _PageTypeModelError(RuntimeError):
+    """A page-type predictor bug caught mid-OCR.
+
+    Deliberately not a `ValueError`/`IndexError` (and not one of the named
+    renderer/parser exceptions) so `_is_document_input_failure` never mistakes
+    it for a corrupt/unsupported document: page-type classification runs
+    interleaved with page rendering inside `ocr_document`, and its own model
+    bugs can surface as the same exception types a bad PDF does.
+    """
+
+
+def _guard_page_type_predict(
+    predict: Callable[[Any], str],
+) -> Callable[[Any], str]:
+    """Wrap an injected page-type predictor so its failures can't be
+    misreported as a corrupt/unsupported document (see `_PageTypeModelError`)."""
+
+    def guarded(image: Any) -> str:
+        try:
+            return predict(image)
+        except Exception as exc:
+            raise _PageTypeModelError(str(exc)) from exc
+
+    return guarded
+
+
+def _detect_language(text: str) -> str:
+    try:
+        from langdetect import DetectorFactory, detect
+
+        DetectorFactory.seed = 42
+        return str(detect(text))
+    except Exception:
+        return "unknown"
+
+
+def _require_file(path: Path, component: str) -> None:
+    if not path.is_file():
+        raise RuntimeError(
+            f"missing local {component} artifact: {path}. Run `dvc pull` "
+            "for the mirrored models before starting the live API."
+        )
+
+
+def build_processor(models_dir: str | Path | None = None) -> PipelineGrievanceProcessor:
+    """Strictly construct and warm the production processor.
+
+    Local page-type and categorizer artifacts are mandatory.  Any missing
+    dependency, artifact, public BART load, or Presidio initialization error
+    propagates and aborts startup; this function never substitutes the mock.
+    """
+    configured_dir = models_dir or os.environ.get("JANASUNANI_MODELS_DIR")
+    root = Path(configured_dir).expanduser() if configured_dir else MODELS_DIR
+    categorizer_dir = root / "categorizer"
+    page_type_dir = root / "page_type_classifier" / "vit_type_classifier"
+
+    _require_file(categorizer_dir / "config.json", "categorizer")
+    _require_file(
+        categorizer_dir / "label_encoder_ROS_wDOCS_english.pkl",
+        "categorizer label encoder",
+    )
+    _require_file(page_type_dir / "config.json", "page-type model")
+
+    # Import and construct in pipeline order. This also keeps the module-level
+    # mock app usable when none of the ML extras are installed.
+    from janasunani.pipeline.stages.page_type_classifier import _PageTypeClassifier
+
+    page_type = _PageTypeClassifier(str(page_type_dir))
+
+    from janasunani.pipeline.stages.summarizer import Summarizer
+
+    summarizer = Summarizer()
+
+    from janasunani.pipeline.stages.categorizer.model import GrievanceCategorizer
+
+    categorizer = GrievanceCategorizer(str(categorizer_dir))
+
+    from janasunani.pipeline.stages.pii_tagger import (
+        _get_engines,
+        detect_pii_spans,
+        redact_text,
+    )
+
+    _get_engines()
+
+    from janasunani.pipeline.ocr_quality import is_repetition_collapsed
+    from janasunani.pipeline.stages.categorizer.stage import _is_english
+    from janasunani.pipeline.stages.ocr_extraction.page_renderer import render_page
+    from janasunani.pipeline.stages.ocr_extraction.pytesseract_backend import (
+        extract_text,
+    )
+    from janasunani.routing.rules import DEFAULT_ROUTER
+
+    def run_ocr(document_bytes: bytes, document_name: str) -> OcrResult:
+        from janasunani.inference.ocr import ocr_document
+
+        return ocr_document(
+            document_bytes,
+            document_name,
+            extract_text_fn=extract_text,
+            render_page_fn=render_page,
+            page_type_predict=_guard_page_type_predict(page_type.predict),
+            quality_check_fn=lambda value: bool(value.strip())
+            and not is_repetition_collapsed(value),
+        )
+
+    return PipelineGrievanceProcessor(
+        ocr=run_ocr,
+        redact=redact_text,
+        detect_pii=detect_pii_spans,
+        categorizer=categorizer,
+        summarizer=summarizer,
+        router=DEFAULT_ROUTER,
+        is_english_compatible=_is_english,
+        detect_language=_detect_language,
+    )

--- a/janasunani/routing/rules.py
+++ b/janasunani/routing/rules.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+from threading import Lock
 from typing import Optional
 
 from janasunani.routing.mappings import (
@@ -177,8 +178,9 @@ class MappingRouter:
        data). Hit -> ``method="rules"``.
     3. The shared generic fallback (``method="fallback"``), via ``RuleRouter``.
 
-    The CSVs are loaded once at construction (module-level ``DEFAULT_ROUTER``
-    loads them once per process), not per request.
+    The CSVs are loaded once at construction. The module-level
+    ``DEFAULT_ROUTER`` defers that construction until its first route so
+    import-only API and test paths do not probe optional local artifacts.
     """
 
     def __init__(
@@ -242,4 +244,39 @@ class MappingRouter:
         )
 
 
-DEFAULT_ROUTER = MappingRouter()
+class _LazyDefaultRouter:
+    """Construct the optional CSV-backed router on its first real request."""
+
+    def __init__(self) -> None:
+        self._router: MappingRouter | None = None
+        self._lock = Lock()
+
+    def _get(self) -> MappingRouter:
+        if self._router is None:
+            with self._lock:
+                if self._router is None:
+                    self._router = MappingRouter()
+        return self._router
+
+    def route(
+        self,
+        *,
+        category: str,
+        subcategory: Optional[str] = None,
+        district: Optional[str] = None,
+    ) -> RoutingResult:
+        return self._get().route(
+            category=category,
+            subcategory=subcategory,
+            district=district,
+        )
+
+    def route_input(self, route_input: RouteInput) -> RoutingResult:
+        return self.route(
+            category=route_input.category,
+            subcategory=route_input.subcategory,
+            district=route_input.district,
+        )
+
+
+DEFAULT_ROUTER = _LazyDefaultRouter()

--- a/janasunani/serving/README.md
+++ b/janasunani/serving/README.md
@@ -20,6 +20,13 @@ It uses `DatabaseResultStore` only when `OLTP_DB_URL` is explicitly set;
 otherwise submitted synthetic results stay in memory. Run the
 `live_grievances` Alembic migration before enabling OLTP persistence.
 
+`janasunani-api`'s `/history` defaults to `MockHistory` -- it never serves
+real citizen data unless you explicitly set `JANASUNANI_REAL_HISTORY=1`, which
+opts it into the lake-backed `LakeHistory`. `janasunani-api-live` always uses
+`LakeHistory`, regardless of that flag -- it's a deliberate real-data run.
+There is still no auth/redaction on `/history`, so the real-history opt-in
+(and the live server generally) is for trusted/local demo runs only.
+
 `JANASUNANI_API_HOST` / `JANASUNANI_API_PORT` / `JANASUNANI_CORS_ORIGINS`
 (comma-separated; default `*` — pin to the frontend origin at deploy).
 
@@ -45,7 +52,7 @@ wire-up).
 | Seam | Default `janasunani-api` | Opt-in `janasunani-api-live` |
 |---|---|---|
 | processor | `MockGrievanceProcessor` — deterministic canned values; **toy regex "redaction", NOT Presidio** | `PipelineGrievanceProcessor`: pytesseract, page-type gating, Presidio, MuRIL, BART, `DEFAULT_ROUTER`; models warmed once |
-| history | Parquet lake via `LakeHistory` | Parquet lake via `LakeHistory` |
+| history | `MockHistory`, unless `JANASUNANI_REAL_HISTORY=1` opts into the Parquet lake via `LakeHistory` | Parquet lake via `LakeHistory`, always |
 | result store | in-process dict | in-process dict unless explicit `OLTP_DB_URL`, then `live_grievances` via `DatabaseResultStore` |
 
 The live processor returns HTTP 422 for invalid combinations and unsafe or

--- a/janasunani/serving/README.md
+++ b/janasunani/serving/README.md
@@ -1,16 +1,24 @@
 # janasunani/serving — the demo API (Phase 10)
 
-FastAPI app the Next.js frontend talks to. Built **skeleton-first** (roadmap
-Week 3): the full endpoint surface with a **mocked processor** ships before
-Phases 8–9, so the frontend gets weeks of iteration against a stable contract
-instead of a cramped tail. The wire-up later swaps the mock for the real warm
-inference + routing behind the same seams — endpoints and shapes unchanged.
+FastAPI app the Next.js frontend talks to. The stable module-level app remains
+mocked for contract/frontend development, while an opt-in live entry point
+mounts the warm Phase 8 processor, real rules routing, and lake history behind
+the same endpoints and response shapes.
 
 ## Run it
 
 ```bash
-uv run --extra serving janasunani-api      # http://127.0.0.1:8000, docs at /docs
+uv run --extra serving janasunani-api
+uv run --extra serving --extra pipeline-core --extra categorizer janasunani-api-live
 ```
+
+Both serve `http://127.0.0.1:8000` by default, with OpenAPI at `/docs`.
+The live command requires the DVC-mirrored categorizer and page-type artifacts
+under `models/` (override with `JANASUNANI_MODELS_DIR`) and fails startup rather
+than substituting the mock if an artifact, dependency, or model load is missing.
+It uses `DatabaseResultStore` only when `OLTP_DB_URL` is explicitly set;
+otherwise submitted synthetic results stay in memory. Run the
+`live_grievances` Alembic migration before enabling OLTP persistence.
 
 `JANASUNANI_API_HOST` / `JANASUNANI_API_PORT` / `JANASUNANI_CORS_ORIGINS`
 (comma-separated; default `*` — pin to the frontend origin at deploy).
@@ -22,7 +30,7 @@ uv run --extra serving janasunani-api      # http://127.0.0.1:8000, docs at /doc
 | `POST /grievance` (201) | multipart: `text` **xor** `file`, optional `district` | `GrievanceResult` |
 | `GET /grievance/{id}` | — | the submitted `GrievanceResult` (404 if unknown) |
 | `GET /history` | `q`, `district`, `category`, `limit` (≤100), `offset` | `HistoryPage` (lake column names) |
-| `GET /health` | — | `{status, processor}` — `processor: "mock"` until wire-up |
+| `GET /health` | — | `{status, processor}` — `mock` or `pipeline` |
 
 **`schemas.py` is the contract.** Field names mirror what already exists —
 pipeline artifact DB (`extracted_text`/`redacted_text`/`ocr_model`),
@@ -32,13 +40,19 @@ API break; the frontend is built against exactly these shapes, and
 `tests/test_serving_api.py` pins them (those tests must pass unchanged after
 wire-up).
 
-## What's mock vs real (as of the skeleton)
+## Mock and live modes
 
-| Seam | Skeleton | Wire-up (Phases 8–9) |
+| Seam | Default `janasunani-api` | Opt-in `janasunani-api-live` |
 |---|---|---|
-| `processor.GrievanceProcessor` | `MockGrievanceProcessor` — deterministic canned values; **toy regex "redaction", NOT Presidio** | warm `GrievanceProcessor` (models loaded once; text skips OCR; `ocr_engine` per env) + hybrid router |
-| `history.HistoryProvider` | `MockHistory` — 120 seeded fake rows, real filter semantics | Parquet lake via `olap/lake.py` (historical only — freshness decision in ROADMAP open items) |
-| result store | in-process dict (dies with the process) | `live_grievances` OLTP table via `crud.py` |
+| processor | `MockGrievanceProcessor` — deterministic canned values; **toy regex "redaction", NOT Presidio** | `PipelineGrievanceProcessor`: pytesseract, page-type gating, Presidio, MuRIL, BART, `DEFAULT_ROUTER`; models warmed once |
+| history | Parquet lake via `LakeHistory` | Parquet lake via `LakeHistory` |
+| result store | in-process dict | in-process dict unless explicit `OLTP_DB_URL`, then `live_grievances` via `DatabaseResultStore` |
 
-The mock must never serve real citizen submissions — it exists so the
-frontend and API tests are model-free.
+The live processor returns HTTP 422 for invalid combinations and unsafe or
+unusable documents (unsupported/corrupt, blank OCR, quality rejection,
+truncation, or no grievance-bearing pages). Unexpected model/runtime failures
+remain server errors. DeepSeek and MLflow runtime resolution are not part of
+this in-process live command.
+
+Only synthetic demo submissions are allowed until the PII gold evaluation gate
+passes. The mock must never serve real citizen submissions.

--- a/janasunani/serving/api.py
+++ b/janasunani/serving/api.py
@@ -36,6 +36,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from loguru import logger
 from starlette.concurrency import run_in_threadpool
 
+from janasunani.inference.service import InferenceInputError
 from janasunani.serving.history import HistoryProvider, LakeHistory, MockHistory
 from janasunani.serving.processor import GrievanceProcessor, MockGrievanceProcessor
 from janasunani.serving.schemas import (
@@ -101,17 +102,20 @@ def create_app(
         # The processor protocol is sync (real inference is CPU/GPU-bound
         # work); run it off the event loop so a slow OCR/model call doesn't
         # block /health and other requests on this worker at wire-up.
-        result = await run_in_threadpool(
-            functools.partial(
-                processor.process,
-                grievance_id=grievance_id,
-                ticket_no=ticket_no,
-                text=text,
-                document_name=file.filename if file else None,
-                document_bytes=await file.read() if file else None,
-                district=district,
+        try:
+            result = await run_in_threadpool(
+                functools.partial(
+                    processor.process,
+                    grievance_id=grievance_id,
+                    ticket_no=ticket_no,
+                    text=text,
+                    document_name=file.filename if file else None,
+                    document_bytes=await file.read() if file else None,
+                    district=district,
+                )
             )
-        )
+        except InferenceInputError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
         await result_store.save(result, district=district)
         logger.info(
             f"grievance {grievance_id} ({ticket_no}): "

--- a/janasunani/serving/api.py
+++ b/janasunani/serving/api.py
@@ -18,6 +18,15 @@ table) is available for explicit injection and is exercised by
 ``tests/test_serving_persistence.py``; the real Phase 10 wire-up will inject
 it into ``create_app`` explicitly.
 
+``history`` defaults to ``MockHistory`` -- the demo/frontend-contract server
+must never serve real citizen ``/history`` rows by default. Set
+``JANASUNANI_REAL_HISTORY=1`` to opt this module-level app into the
+lake-backed ``LakeHistory`` instead (see ``_history_from_env``). There is
+still no auth/redaction on ``/history``, so this opt-in is for trusted/local
+demo runs only, never a public deploy. ``janasunani-api-live``
+(``janasunani/inference/serve.py``) always uses ``LakeHistory`` regardless of
+this flag -- it's a deliberate real-data run by construction.
+
 Run:  uv run --extra serving janasunani-api          # 127.0.0.1:8000
 CORS: comma-separated ``JANASUNANI_CORS_ORIGINS`` (default ``*`` — fine for
 the skeleton; pin to the frontend origin at deploy).
@@ -146,7 +155,21 @@ def create_app(
     return app
 
 
-app = create_app(history=LakeHistory())
+def _history_from_env() -> HistoryProvider:
+    """Pick the module-level app's history provider from ``JANASUNANI_REAL_HISTORY``.
+
+    Defaults to ``MockHistory`` -- the safe choice for the demo/contract
+    server. Only a truthy ``JANASUNANI_REAL_HISTORY`` (``1``/``true``/``yes``,
+    case-insensitive) opts into ``LakeHistory``, which reads real citizen
+    grievances from the Parquet lake with no auth/redaction on `/history`.
+    """
+    flag = os.environ.get("JANASUNANI_REAL_HISTORY", "").strip().lower()
+    if flag in ("1", "true", "yes"):
+        return LakeHistory()
+    return MockHistory()
+
+
+app = create_app(history=_history_from_env())
 
 
 def main() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ janasunani-pipeline = "janasunani.pipeline.cli:main"
 janasunani-export-pipeline = "janasunani.pipeline.export:main"
 janasunani-evaluate-pii = "janasunani.pipeline.pii_eval:main"
 janasunani-api = "janasunani.serving.api:main"
+janasunani-api-live = "janasunani.inference.serve:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/test_inference_live_builder.py
+++ b/tests/test_inference_live_builder.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 pytest.importorskip("fastapi")
@@ -7,7 +9,9 @@ pytest.importorskip("python_multipart")
 
 from fastapi.testclient import TestClient  # noqa: E402
 
+from janasunani.config import Settings  # noqa: E402
 from janasunani.inference import serve  # noqa: E402
+from janasunani.inference import service  # noqa: E402
 from janasunani.inference.service import (  # noqa: E402
     InferenceInputError,
     build_processor,
@@ -15,9 +19,57 @@ from janasunani.inference.service import (  # noqa: E402
 from janasunani.serving.api import create_app  # noqa: E402
 
 
+def _write_dummy_model_artifacts(root: Path) -> None:
+    """Satisfy `build_processor`'s `_require_file` artifact checks with
+    placeholder files so a test can reach the code that runs after them
+    (e.g. the OCR-dependency preflight) without needing real DVC-mirrored
+    model weights."""
+    categorizer_dir = root / "categorizer"
+    categorizer_dir.mkdir(parents=True)
+    (categorizer_dir / "config.json").write_text("{}")
+    (categorizer_dir / "label_encoder_ROS_wDOCS_english.pkl").write_bytes(b"")
+    page_type_dir = root / "page_type_classifier" / "vit_type_classifier"
+    page_type_dir.mkdir(parents=True)
+    (page_type_dir / "config.json").write_text("{}")
+
+
 def test_build_processor_fails_closed_when_local_models_are_missing(tmp_path):
     with pytest.raises(RuntimeError, match="missing local categorizer artifact"):
         build_processor(tmp_path)
+
+
+def test_build_processor_fails_when_tesseract_binary_is_missing(tmp_path, monkeypatch):
+    """(Codex P2 on PR #25) With model artifacts present but no `tesseract`
+    executable, startup must fail loudly instead of `/health` reporting
+    `pipeline` healthy and uploads only failing later, mid-request."""
+    _write_dummy_model_artifacts(tmp_path)
+    monkeypatch.setattr(service.shutil, "which", lambda _binary: None)
+
+    with pytest.raises(
+        RuntimeError, match="missing required OCR system binary 'tesseract'"
+    ):
+        build_processor(tmp_path)
+
+
+def test_build_processor_fails_when_pdftoppm_binary_is_missing(tmp_path, monkeypatch):
+    """Same as above for Poppler's `pdftoppm`, needed by the PDF page renderer."""
+    _write_dummy_model_artifacts(tmp_path)
+    monkeypatch.setattr(
+        service.shutil,
+        "which",
+        lambda binary: "/usr/bin/tesseract" if binary == "tesseract" else None,
+    )
+
+    with pytest.raises(
+        RuntimeError, match="missing required OCR system binary 'pdftoppm'"
+    ):
+        build_processor(tmp_path)
+
+
+def test_ocr_preflight_passes_when_binaries_are_present(monkeypatch):
+    monkeypatch.setattr(service.shutil, "which", lambda _binary: "/usr/bin/fake")
+
+    service._require_ocr_dependencies()  # must not raise
 
 
 class RejectingProcessor:
@@ -100,4 +152,40 @@ def test_live_app_uses_database_store_only_for_explicit_oltp(monkeypatch):
     assert captured["result_store"] == (
         database_store,
         "sqlite+aiosqlite:////tmp/synthetic.db",
+    )
+
+
+def test_live_app_uses_database_store_for_dotenv_only_oltp(tmp_path, monkeypatch):
+    """(Codex P2 on PR #25) An operator who sets `OLTP_DB_URL` only in the
+    project `.env` file -- never exporting it in the shell -- must still get
+    a `DatabaseResultStore`. Before this fix, `create_live_app` read raw
+    `os.environ`, missed the `.env`-provided value, and silently fell back to
+    `InMemoryResultStore` (live submissions would vanish on restart)."""
+    database_store = object()
+    captured = {}
+
+    env_file = tmp_path / ".env"
+    env_file.write_text("OLTP_DB_URL=postgresql+asyncpg://user:pass@db/janasunani\n")
+
+    monkeypatch.delenv("OLTP_DB_URL", raising=False)  # never exported in the shell
+    monkeypatch.setattr(serve, "Settings", lambda: Settings(_env_file=env_file))
+    monkeypatch.setattr(serve, "build_processor", object)
+    monkeypatch.setattr(serve, "LakeHistory", object)
+    monkeypatch.setattr(
+        serve,
+        "DatabaseResultStore",
+        lambda url: (database_store, url),
+    )
+    monkeypatch.setattr(
+        serve,
+        "InMemoryResultStore",
+        lambda: pytest.fail("memory store must not be constructed"),
+    )
+    monkeypatch.setattr(serve, "create_app", lambda **kwargs: captured.update(kwargs))
+
+    serve.create_live_app()
+
+    assert captured["result_store"] == (
+        database_store,
+        "postgresql+asyncpg://user:pass@db/janasunani",
     )

--- a/tests/test_inference_live_builder.py
+++ b/tests/test_inference_live_builder.py
@@ -6,7 +6,12 @@ import pytest
 
 pytest.importorskip("fastapi")
 pytest.importorskip("python_multipart")
+# The OCR preflight (below) now resolves tesseract exactly as
+# `pytesseract_backend` does, so exercising it needs the real package, not
+# just stdlib `shutil.which`.
+pytest.importorskip("pytesseract")
 
+import pytesseract  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 
 from janasunani.config import Settings  # noqa: E402
@@ -16,7 +21,19 @@ from janasunani.inference.service import (  # noqa: E402
     InferenceInputError,
     build_processor,
 )
+from janasunani.pipeline.stages.ocr_extraction import page_renderer  # noqa: E402
 from janasunani.serving.api import create_app  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_ocr_binary_resolution(monkeypatch):
+    """`_configure_tesseract` mutates a process-global
+    (`pytesseract.pytesseract.tesseract_cmd`) the first time it resolves a
+    binary, and `TESSERACT_CMD` can leak in from a real dev/CI environment.
+    Reset both before every test in this module so one test's resolved value
+    can never leak into another, regardless of run order."""
+    monkeypatch.setattr(pytesseract.pytesseract, "tesseract_cmd", "tesseract")
+    monkeypatch.delenv("TESSERACT_CMD", raising=False)
 
 
 def _write_dummy_model_artifacts(root: Path) -> None:
@@ -40,10 +57,15 @@ def test_build_processor_fails_closed_when_local_models_are_missing(tmp_path):
 
 def test_build_processor_fails_when_tesseract_binary_is_missing(tmp_path, monkeypatch):
     """(Codex P2 on PR #25) With model artifacts present but no `tesseract`
-    executable, startup must fail loudly instead of `/health` reporting
-    `pipeline` healthy and uploads only failing later, mid-request."""
+    executable resolvable via PATH *or* the backend's own mechanism
+    (`TESSERACT_CMD` / bundled `~/.local/tesseract` install), startup must
+    fail loudly instead of `/health` reporting `pipeline` healthy and uploads
+    only failing later, mid-request."""
     _write_dummy_model_artifacts(tmp_path)
     monkeypatch.setattr(service.shutil, "which", lambda _binary: None)
+    # Null the backend's `~/.local/tesseract` fallback too, regardless of
+    # what happens to exist on the machine actually running this test.
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "fake-home")
 
     with pytest.raises(
         RuntimeError, match="missing required OCR system binary 'tesseract'"
@@ -52,13 +74,15 @@ def test_build_processor_fails_when_tesseract_binary_is_missing(tmp_path, monkey
 
 
 def test_build_processor_fails_when_pdftoppm_binary_is_missing(tmp_path, monkeypatch):
-    """Same as above for Poppler's `pdftoppm`, needed by the PDF page renderer."""
+    """Same as above for Poppler's `pdftoppm`, needed by the PDF page
+    renderer -- nulls both PATH and the backend's `POPPLER_PATH` mechanism."""
     _write_dummy_model_artifacts(tmp_path)
     monkeypatch.setattr(
         service.shutil,
         "which",
         lambda binary: "/usr/bin/tesseract" if binary == "tesseract" else None,
     )
+    monkeypatch.setattr(page_renderer, "POPPLER_PATH", None)
 
     with pytest.raises(
         RuntimeError, match="missing required OCR system binary 'pdftoppm'"
@@ -70,6 +94,51 @@ def test_ocr_preflight_passes_when_binaries_are_present(monkeypatch):
     monkeypatch.setattr(service.shutil, "which", lambda _binary: "/usr/bin/fake")
 
     service._require_ocr_dependencies()  # must not raise
+
+
+def test_tesseract_available_via_backend_env_when_absent_from_path(
+    tmp_path, monkeypatch
+):
+    """(Codex P2 on PR #25) `TESSERACT_CMD` is exactly how
+    `pytesseract_backend._configure_tesseract` resolves a non-PATH install;
+    the preflight must honor it instead of false-aborting startup."""
+    fake_tesseract = tmp_path / "tesseract"
+    fake_tesseract.write_bytes(b"")
+    monkeypatch.setenv("TESSERACT_CMD", str(fake_tesseract))
+    monkeypatch.setattr(service.shutil, "which", lambda _binary: None)
+
+    assert service._tesseract_available() is True
+
+
+def test_tesseract_unavailable_when_neither_env_nor_path_resolve(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(service.shutil, "which", lambda _binary: None)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "fake-home")
+
+    assert service._tesseract_available() is False
+
+
+def test_poppler_available_via_backend_path_when_absent_from_path(
+    tmp_path, monkeypatch
+):
+    """(Codex P2 on PR #25) `page_renderer.POPPLER_PATH` is exactly how the
+    renderer resolves a non-PATH Poppler install; the preflight must honor
+    it instead of false-aborting startup."""
+    fake_bin_dir = tmp_path / "poppler-bin"
+    fake_bin_dir.mkdir()
+    (fake_bin_dir / "pdftoppm").write_bytes(b"")
+    monkeypatch.setattr(page_renderer, "POPPLER_PATH", str(fake_bin_dir))
+    monkeypatch.setattr(service.shutil, "which", lambda _binary: None)
+
+    assert service._poppler_available() is True
+
+
+def test_poppler_unavailable_when_neither_backend_path_nor_path_resolve(monkeypatch):
+    monkeypatch.setattr(page_renderer, "POPPLER_PATH", None)
+    monkeypatch.setattr(service.shutil, "which", lambda _binary: None)
+
+    assert service._poppler_available() is False
 
 
 class RejectingProcessor:
@@ -189,3 +258,29 @@ def test_live_app_uses_database_store_for_dotenv_only_oltp(tmp_path, monkeypatch
         database_store,
         "postgresql+asyncpg://user:pass@db/janasunani",
     )
+
+
+def test_live_app_always_uses_lake_history_regardless_of_real_history_flag(
+    monkeypatch,
+):
+    """(Codex P1 on PR #25) `JANASUNANI_REAL_HISTORY` only gates the
+    module-level mock app in `janasunani.serving.api`. `janasunani-api-live`
+    is a deliberate real-data run and must keep using `LakeHistory`
+    unconditionally, whether the flag is unset, off, or on."""
+    history = object()
+    captured = {}
+
+    monkeypatch.delenv("OLTP_DB_URL", raising=False)
+    monkeypatch.delenv("JANASUNANI_REAL_HISTORY", raising=False)
+    monkeypatch.setattr(serve, "build_processor", object)
+    monkeypatch.setattr(serve, "LakeHistory", lambda: history)
+    monkeypatch.setattr(serve, "InMemoryResultStore", object)
+    monkeypatch.setattr(serve, "create_app", lambda **kwargs: captured.update(kwargs))
+
+    serve.create_live_app()
+    assert captured["history"] is history
+
+    captured.clear()
+    monkeypatch.setenv("JANASUNANI_REAL_HISTORY", "0")
+    serve.create_live_app()
+    assert captured["history"] is history

--- a/tests/test_inference_live_builder.py
+++ b/tests/test_inference_live_builder.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("python_multipart")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from janasunani.inference import serve  # noqa: E402
+from janasunani.inference.service import (  # noqa: E402
+    InferenceInputError,
+    build_processor,
+)
+from janasunani.serving.api import create_app  # noqa: E402
+
+
+def test_build_processor_fails_closed_when_local_models_are_missing(tmp_path):
+    with pytest.raises(RuntimeError, match="missing local categorizer artifact"):
+        build_processor(tmp_path)
+
+
+class RejectingProcessor:
+    name = "pipeline"
+
+    def process(self, **_kwargs):
+        raise InferenceInputError("synthetic invalid document")
+
+
+def test_typed_inference_input_error_becomes_http_422():
+    client = TestClient(create_app(processor=RejectingProcessor()))
+
+    response = client.post("/grievance", data={"text": "synthetic text"})
+
+    assert response.status_code == 422
+    assert response.json() == {"detail": "synthetic invalid document"}
+
+
+class ExplodingProcessor:
+    name = "pipeline"
+
+    def process(self, **_kwargs):
+        raise RuntimeError("synthetic model failure")
+
+
+def test_unexpected_processor_failure_remains_a_server_error():
+    client = TestClient(create_app(processor=ExplodingProcessor()))
+
+    with pytest.raises(RuntimeError, match="synthetic model failure"):
+        client.post("/grievance", data={"text": "synthetic text"})
+
+
+def test_live_app_uses_memory_store_without_explicit_oltp(monkeypatch):
+    processor = object()
+    history = object()
+    memory_store = object()
+    captured = {}
+
+    monkeypatch.delenv("OLTP_DB_URL", raising=False)
+    monkeypatch.setattr(serve, "build_processor", lambda: processor)
+    monkeypatch.setattr(serve, "LakeHistory", lambda: history)
+    monkeypatch.setattr(serve, "InMemoryResultStore", lambda: memory_store)
+    monkeypatch.setattr(
+        serve,
+        "DatabaseResultStore",
+        lambda _url: pytest.fail("database store must not be constructed"),
+    )
+    monkeypatch.setattr(serve, "create_app", lambda **kwargs: captured.update(kwargs))
+
+    serve.create_live_app()
+
+    assert captured == {
+        "processor": processor,
+        "history": history,
+        "result_store": memory_store,
+    }
+
+
+def test_live_app_uses_database_store_only_for_explicit_oltp(monkeypatch):
+    database_store = object()
+    captured = {}
+
+    monkeypatch.setenv("OLTP_DB_URL", "sqlite+aiosqlite:////tmp/synthetic.db")
+    monkeypatch.setattr(serve, "build_processor", object)
+    monkeypatch.setattr(serve, "LakeHistory", object)
+    monkeypatch.setattr(
+        serve,
+        "DatabaseResultStore",
+        lambda url: (database_store, url),
+    )
+    monkeypatch.setattr(
+        serve,
+        "InMemoryResultStore",
+        lambda: pytest.fail("memory store must not be constructed"),
+    )
+    monkeypatch.setattr(serve, "create_app", lambda **kwargs: captured.update(kwargs))
+
+    serve.create_live_app()
+
+    assert captured["result_store"] == (
+        database_store,
+        "sqlite+aiosqlite:////tmp/synthetic.db",
+    )

--- a/tests/test_inference_live_builder.py
+++ b/tests/test_inference_live_builder.py
@@ -85,7 +85,7 @@ def test_build_processor_fails_when_pdftoppm_binary_is_missing(tmp_path, monkeyp
     monkeypatch.setattr(page_renderer, "POPPLER_PATH", None)
 
     with pytest.raises(
-        RuntimeError, match="missing required OCR system binary 'pdftoppm'"
+        RuntimeError, match="missing required OCR system binary 'pdfinfo/pdftoppm'"
     ):
         build_processor(tmp_path)
 
@@ -124,9 +124,12 @@ def test_poppler_available_via_backend_path_when_absent_from_path(
 ):
     """(Codex P2 on PR #25) `page_renderer.POPPLER_PATH` is exactly how the
     renderer resolves a non-PATH Poppler install; the preflight must honor
-    it instead of false-aborting startup."""
+    it instead of false-aborting startup. Both `pdfinfo` and `pdftoppm` must
+    be present in the configured dir -- `pdf2image.convert_from_path` needs
+    both."""
     fake_bin_dir = tmp_path / "poppler-bin"
     fake_bin_dir.mkdir()
+    (fake_bin_dir / "pdfinfo").write_bytes(b"")
     (fake_bin_dir / "pdftoppm").write_bytes(b"")
     monkeypatch.setattr(page_renderer, "POPPLER_PATH", str(fake_bin_dir))
     monkeypatch.setattr(service.shutil, "which", lambda _binary: None)
@@ -139,6 +142,29 @@ def test_poppler_unavailable_when_neither_backend_path_nor_path_resolve(monkeypa
     monkeypatch.setattr(service.shutil, "which", lambda _binary: None)
 
     assert service._poppler_available() is False
+
+
+def test_poppler_unavailable_when_pdfinfo_missing_from_path(monkeypatch):
+    """(Codex P2 re-review on PR #25) A partial Poppler install that only
+    exposes `pdftoppm` on PATH must still fail preflight: `pdf2image` also
+    shells out to `pdfinfo` to read the page count, and a partial install
+    previously passed here only to fail later, mid-request, with
+    `PDFInfoNotInstalledError`."""
+    monkeypatch.setattr(page_renderer, "POPPLER_PATH", None)
+    monkeypatch.setattr(
+        service.shutil,
+        "which",
+        lambda binary: "/usr/bin/pdftoppm" if binary == "pdftoppm" else None,
+    )
+
+    assert service._poppler_available() is False
+
+
+def test_poppler_available_when_both_binaries_are_on_path(monkeypatch):
+    monkeypatch.setattr(page_renderer, "POPPLER_PATH", None)
+    monkeypatch.setattr(service.shutil, "which", lambda _binary: "/usr/bin/fake")
+
+    assert service._poppler_available() is True
 
 
 class RejectingProcessor:

--- a/tests/test_inference_model_smoke.py
+++ b/tests/test_inference_model_smoke.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from janasunani.config import MODELS_DIR
+from janasunani.inference.service import build_processor
+
+
+@pytest.mark.skipif(
+    not os.environ.get("JANASUNANI_RUN_MODEL_SMOKE"),
+    reason="set JANASUNANI_RUN_MODEL_SMOKE=1 to run local real models",
+)
+def test_real_models_process_synthetic_english_text():
+    models_dir = Path(os.environ.get("JANASUNANI_MODELS_DIR", MODELS_DIR))
+    required = (
+        models_dir / "categorizer" / "config.json",
+        models_dir / "categorizer" / "label_encoder_ROS_wDOCS_english.pkl",
+        models_dir / "page_type_classifier" / "vit_type_classifier" / "config.json",
+    )
+    if not all(path.is_file() for path in required):
+        pytest.skip("local DVC model artifacts are not available")
+
+    processor = build_processor(models_dir)
+    result = processor.process(
+        grievance_id="synthetic-smoke",
+        ticket_no="JSSYNTHETIC",
+        text=(
+            "The public road beside our synthetic village school has several "
+            "large potholes and becomes impassable after rain. Please arrange "
+            "an inspection and repair so the school bus can travel safely."
+        ),
+        district="Cuttack",
+    )
+
+    assert result.extraction.extracted_text
+    assert result.redaction.redacted_text
+    assert result.classification.category
+    assert result.summary
+    assert result.routing.method != "mock"

--- a/tests/test_inference_service.py
+++ b/tests/test_inference_service.py
@@ -7,6 +7,7 @@ import pytest
 
 from janasunani.inference.ocr import OcrQualityError, OcrResult
 from janasunani.inference.service import (
+    UNSUPPORTED_LANGUAGE_SUMMARY,
     InferenceInputError,
     PipelineGrievanceProcessor,
     _guard_page_type_predict,
@@ -266,8 +267,10 @@ def test_rejects_unusable_ocr_results(ocr_result, message):
 
 def test_non_english_is_uncategorized_and_uses_routing_fallback():
     categorizer = RecordingCategorizer()
+    summarizer = RecordingSummarizer()
     processor = _processor(
         categorizer=categorizer,
+        summarizer=summarizer,
         english=False,
         language="or",
     )
@@ -275,9 +278,82 @@ def test_non_english_is_uncategorized_and_uses_routing_fallback():
     result = _process(processor, text="ମୋ ଗାଁର ରାସ୍ତା ଭାଙ୍ଗି ଯାଇଛି।")
 
     assert categorizer.inputs == []
+    assert summarizer.inputs == []
     assert result.classification.category == "Uncategorized"
     assert result.classification.language == "or"
+    assert result.summary == UNSUPPORTED_LANGUAGE_SUMMARY
     assert result.routing.method == "fallback"
+
+
+def test_non_english_pdf_skips_bart_summary_on_class_one_pages():
+    """(Codex P2 re-review on PR #25) The same language gate that skips the
+    English-only categorizer must also skip BART summarization -- on the
+    document path this means the gated class-1 pages that feed the model
+    text source, not just the typed-text path."""
+
+    def ocr(_bytes, _name):
+        return OcrResult(
+            full_text="ମୋ ଗାଁର ରାସ୍ତା ଭାଙ୍ଗି ଯାଇଛି।",
+            pages=1,
+            per_page=[("ମୋ ଗାଁର ରାସ୍ତା ଭାଙ୍ଗି ଯାଇଛି।", "Letter")],
+        )
+
+    categorizer = RecordingCategorizer()
+    summarizer = RecordingSummarizer()
+    processor = _processor(
+        ocr=ocr,
+        categorizer=categorizer,
+        summarizer=summarizer,
+        english=False,
+        language="or",
+    )
+
+    result = _process(
+        processor,
+        text=None,
+        document_name="complaint.pdf",
+        document_bytes=b"%PDF-synthetic",
+    )
+
+    assert categorizer.inputs == []
+    assert summarizer.inputs == []
+    assert result.classification.category == "Uncategorized"
+    assert result.summary == UNSUPPORTED_LANGUAGE_SUMMARY
+    assert result.routing.method == "fallback"
+
+
+def test_english_pdf_still_gets_real_bart_summary():
+    """Guards the happy path byte-for-byte: English-compatible document text
+    must still reach BART and get the real (non-fallback) summary."""
+
+    def ocr(_bytes, _name):
+        return OcrResult(
+            full_text="Ramesh needs a road repair.",
+            pages=1,
+            per_page=[("Ramesh needs a road repair.", "Letter")],
+        )
+
+    categorizer = RecordingCategorizer(category="Roads & Bridges")
+    summarizer = RecordingSummarizer()
+    processor = _processor(
+        ocr=ocr,
+        categorizer=categorizer,
+        summarizer=summarizer,
+        english=True,
+        language="en",
+    )
+
+    result = _process(
+        processor,
+        text=None,
+        document_name="complaint.pdf",
+        document_bytes=b"%PDF-synthetic",
+    )
+
+    model_input = "[NAME] needs a road repair."
+    assert summarizer.inputs == [model_input]
+    assert result.summary == f"summary: {model_input}"
+    assert result.classification.category == "Roads & Bridges"
 
 
 def test_warm_components_are_constructed_once_and_reused():

--- a/tests/test_inference_service.py
+++ b/tests/test_inference_service.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+import pytest
+
+from janasunani.inference.ocr import OcrQualityError, OcrResult
+from janasunani.inference.service import (
+    InferenceInputError,
+    PipelineGrievanceProcessor,
+    _guard_page_type_predict,
+    _PageTypeModelError,
+)
+from janasunani.routing.rules import RuleRouter
+
+
+@dataclass
+class Span:
+    entity: str
+    start: int
+    end: int
+    score: float
+
+
+class RecordingCategorizer:
+    instances = 0
+
+    def __init__(self, category: str = "Water Supply") -> None:
+        type(self).instances += 1
+        self.category = category
+        self.inputs: list[str] = []
+
+    def predict(self, text: str) -> str:
+        self.inputs.append(text)
+        return self.category
+
+
+class RecordingSummarizer:
+    instances = 0
+
+    def __init__(self) -> None:
+        type(self).instances += 1
+        self.inputs: list[str] = []
+
+    def summarize(self, text: str) -> str:
+        self.inputs.append(text)
+        return f"summary: {text}"
+
+
+def _redact(text: str) -> str:
+    return text.replace("9876543210", "[PHONE]").replace("Ramesh", "[NAME]")
+
+
+def _detect(text: str) -> list[Span]:
+    spans = []
+    for value, entity in (("Ramesh", "NAME"), ("9876543210", "PHONE")):
+        start = text.find(value)
+        if start >= 0:
+            spans.append(Span(entity, start, start + len(value), 0.99))
+    return spans
+
+
+def _processor(
+    *,
+    ocr=None,
+    categorizer=None,
+    summarizer=None,
+    english=True,
+    language="en",
+):
+    return PipelineGrievanceProcessor(
+        ocr=ocr
+        or (lambda _document_bytes, _document_name: OcrResult("unused", 1, [])),
+        redact=_redact,
+        detect_pii=_detect,
+        categorizer=categorizer or RecordingCategorizer(),
+        summarizer=summarizer or RecordingSummarizer(),
+        router=RuleRouter(),
+        is_english_compatible=lambda _text: english,
+        detect_language=lambda _text: language,
+        now=lambda: datetime(2026, 7, 10, 8, 0, tzinfo=UTC),
+    )
+
+
+def _process(processor, **overrides):
+    values = {
+        "grievance_id": "g1",
+        "ticket_no": "JS1",
+        "text": "Ramesh reports that the village pump is broken. Call 9876543210.",
+        "district": "Cuttack",
+    }
+    values.update(overrides)
+    return processor.process(**values)
+
+
+def test_typed_text_maps_pii_and_feeds_only_redacted_text_to_models():
+    categorizer = RecordingCategorizer()
+    summarizer = RecordingSummarizer()
+    processor = _processor(categorizer=categorizer, summarizer=summarizer)
+
+    result = _process(processor)
+
+    expected = "[NAME] reports that the village pump is broken. Call [PHONE]."
+    assert result.extraction.source == "text"
+    assert result.extraction.extracted_text.startswith("Ramesh")
+    assert result.redaction.redacted_text == expected
+    assert [entity.model_dump() for entity in result.redaction.entities] == [
+        {"entity": "NAME", "start": 0, "end": 6},
+        {"entity": "PHONE", "start": 53, "end": 63},
+    ]
+    assert categorizer.inputs == [expected]
+    assert summarizer.inputs == [expected]
+    assert result.summary == f"summary: {expected}"
+    assert result.classification.language == "en"
+    assert result.classification.category == "Water Supply"
+    assert result.routing.method == "rules"
+    assert result.routing.dept == "Rural Water Supply & Sanitation"
+
+
+def test_pdf_preserves_all_ocr_but_gates_models_to_class_one_pages():
+    def ocr(_bytes, _name):
+        return OcrResult(
+            full_text=(
+                "Ramesh needs a road repair.\n\n"
+                "IDENTITY 9876543210\n\n"
+                "The damaged road blocks the school bus."
+            ),
+            pages=3,
+            per_page=[
+                ("Ramesh needs a road repair.", "Letter"),
+                ("IDENTITY 9876543210", "Identification"),
+                ("The damaged road blocks the school bus.", "Text Only"),
+            ],
+        )
+    categorizer = RecordingCategorizer(category="Roads & Bridges")
+    summarizer = RecordingSummarizer()
+    processor = _processor(
+        ocr=ocr,
+        categorizer=categorizer,
+        summarizer=summarizer,
+    )
+
+    result = _process(
+        processor,
+        text=None,
+        document_name="complaint.pdf",
+        document_bytes=b"%PDF-synthetic",
+    )
+
+    model_input = (
+        "[NAME] needs a road repair.\n\n"
+        "The damaged road blocks the school bus."
+    )
+    assert result.extraction.model_dump() == {
+        "source": "document",
+        "extracted_text": (
+            "Ramesh needs a road repair.\n\n"
+            "IDENTITY 9876543210\n\n"
+            "The damaged road blocks the school bus."
+        ),
+        "ocr_model": "pytesseract",
+        "pages": 3,
+    }
+    assert "IDENTITY [PHONE]" in result.redaction.redacted_text
+    assert categorizer.inputs == [model_input]
+    assert summarizer.inputs == [model_input]
+    assert "IDENTITY" not in categorizer.inputs[0]
+    assert result.routing.method == "rules"
+    assert result.routing.dept == "Works"
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        {},
+        {"text": "   "},
+        {"text": "valid", "document_name": "x.pdf", "document_bytes": b"x"},
+        {"document_name": "x.pdf"},
+        {"document_bytes": b"x"},
+        {"document_name": "x.pdf", "document_bytes": b""},
+        {"document_name": "x.txt", "document_bytes": b"x"},
+    ],
+)
+def test_rejects_invalid_input_combinations(values):
+    with pytest.raises(InferenceInputError):
+        _processor().process(grievance_id="g", ticket_no="JS", **values)
+
+
+@pytest.mark.parametrize(
+    ("failure", "message"),
+    [
+        (ValueError("bad PDF"), "corrupt or unsupported"),
+        (OcrQualityError("collapsed"), "quality check"),
+    ],
+)
+def test_rejects_corrupt_and_quality_rejected_documents(failure, message):
+    def failing_ocr(_bytes, _name):
+        raise failure
+
+    with pytest.raises(InferenceInputError, match=message):
+        _process(
+            _processor(ocr=failing_ocr),
+            text=None,
+            document_name="bad.pdf",
+            document_bytes=b"bad",
+        )
+
+
+def test_page_type_model_bug_is_not_reported_as_corrupt_document():
+    """A page-type predictor bug surfaces mid-OCR as `_PageTypeModelError`
+    (see `_guard_page_type_predict`), which is neither `ValueError` nor
+    `IndexError` nor a named renderer/parser exception -- it must propagate
+    unchanged (a 5xx upstream), not be reported as a 422 corrupt document."""
+
+    def failing_ocr(_bytes, _name):
+        raise _PageTypeModelError("id2label lookup failed")
+
+    with pytest.raises(_PageTypeModelError, match="id2label lookup failed"):
+        _process(
+            _processor(ocr=failing_ocr),
+            text=None,
+            document_name="bad.pdf",
+            document_bytes=b"bad",
+        )
+
+
+@pytest.mark.parametrize("failure", [ValueError("bad tensor shape"), IndexError(3)])
+def test_guard_page_type_predict_reclassifies_predictor_failures(failure):
+    def broken_predict(_image):
+        raise failure
+
+    guarded = _guard_page_type_predict(broken_predict)
+
+    with pytest.raises(_PageTypeModelError):
+        guarded(object())
+
+
+def test_guard_page_type_predict_passes_through_successful_predictions():
+    guarded = _guard_page_type_predict(lambda _image: "Letter")
+
+    assert guarded(object()) == "Letter"
+
+
+@pytest.mark.parametrize(
+    ("ocr_result", "message"),
+    [
+        (OcrResult("  ", 1, [("  ", "Letter")]), "produced no text"),
+        (OcrResult("partial", 50, [("partial", "Letter")], True), "page limit"),
+        (
+            OcrResult("identity", 1, [("identity", "Identification")]),
+            "no grievance-bearing pages",
+        ),
+        (OcrResult("letter", 1, [("  ", "Letter")]), "no grievance-bearing pages"),
+    ],
+)
+def test_rejects_unusable_ocr_results(ocr_result, message):
+    with pytest.raises(InferenceInputError, match=message):
+        _process(
+            _processor(ocr=lambda _bytes, _name: ocr_result),
+            text=None,
+            document_name="bad.pdf",
+            document_bytes=b"bad",
+        )
+
+
+def test_non_english_is_uncategorized_and_uses_routing_fallback():
+    categorizer = RecordingCategorizer()
+    processor = _processor(
+        categorizer=categorizer,
+        english=False,
+        language="or",
+    )
+
+    result = _process(processor, text="ମୋ ଗାଁର ରାସ୍ତା ଭାଙ୍ଗି ଯାଇଛି।")
+
+    assert categorizer.inputs == []
+    assert result.classification.category == "Uncategorized"
+    assert result.classification.language == "or"
+    assert result.routing.method == "fallback"
+
+
+def test_warm_components_are_constructed_once_and_reused():
+    RecordingCategorizer.instances = 0
+    RecordingSummarizer.instances = 0
+    categorizer = RecordingCategorizer()
+    summarizer = RecordingSummarizer()
+    processor = _processor(categorizer=categorizer, summarizer=summarizer)
+
+    _process(processor)
+    _process(processor, grievance_id="g2", ticket_no="JS2")
+
+    assert RecordingCategorizer.instances == 1
+    assert RecordingSummarizer.instances == 1
+    assert len(categorizer.inputs) == 2
+    assert len(summarizer.inputs) == 2

--- a/tests/test_serving_api.py
+++ b/tests/test_serving_api.py
@@ -16,7 +16,9 @@ pytest.importorskip("python_multipart")
 
 from fastapi.testclient import TestClient  # noqa: E402
 
+from janasunani.serving import api as api_module  # noqa: E402
 from janasunani.serving.api import create_app  # noqa: E402
+from janasunani.serving.history import LakeHistory, MockHistory  # noqa: E402
 
 _TEXT = (
     "The hand pump in Balianta village has been broken for two months. "
@@ -176,3 +178,41 @@ def test_ticket_no_carries_full_grievance_id_suffix(client):
     body = client.post("/grievance", data={"text": _TEXT}).json()
     assert body["ticket_no"].endswith(body["id"].upper())
     assert len(body["ticket_no"]) == len("JS") + 7 + len(body["id"])
+
+
+# --- Codex P1 on PR #25: the module-level app must default to MockHistory ---
+# (never real citizen /history rows) unless an operator explicitly opts in.
+
+
+def test_history_from_env_defaults_to_mock_history_when_flag_is_unset(monkeypatch):
+    monkeypatch.delenv("JANASUNANI_REAL_HISTORY", raising=False)
+    assert isinstance(api_module._history_from_env(), MockHistory)
+
+
+@pytest.mark.parametrize("falsy_value", ["", "0", "false", "False", "no", "off"])
+def test_history_from_env_treats_falsy_values_as_mock(monkeypatch, falsy_value):
+    monkeypatch.setenv("JANASUNANI_REAL_HISTORY", falsy_value)
+    assert isinstance(api_module._history_from_env(), MockHistory)
+
+
+@pytest.mark.parametrize("truthy_value", ["1", "true", "True", "TRUE", "yes", "Yes"])
+def test_history_from_env_selects_lake_history_when_flag_is_truthy(
+    monkeypatch, truthy_value
+):
+    monkeypatch.setenv("JANASUNANI_REAL_HISTORY", truthy_value)
+    # LakeHistory() itself never touches the lake on disk -- it only opens
+    # the Parquet file lazily inside `.search()` -- so this stays a type
+    # assertion and never reads real citizen data.
+    assert isinstance(api_module._history_from_env(), LakeHistory)
+
+
+def test_module_app_serves_mock_history_data_by_default(monkeypatch):
+    """End-to-end: the same construction the module-level `app` uses, with
+    the flag unset, must serve the deterministic MockHistory rows (never
+    reach for the real lake)."""
+    monkeypatch.delenv("JANASUNANI_REAL_HISTORY", raising=False)
+    app = create_app(history=api_module._history_from_env())
+    client = TestClient(app)
+
+    body = client.get("/history", params={"limit": 1}).json()
+    assert body["items"][0]["ticket_no"].startswith("CMO2024")


### PR DESCRIPTION
Completes **Phase 8** — an opt-in real inference server behind the frozen serving contract. The default API stays mock; the live path is opt-in.

Follows `docs/plans/PHASE-8C.md` and the approved Phase 8 plan. Depends on the merged 8A (Summarizer wrapper, #23) and 8B (OCR wrapper, #24).

## What's in it
- **`PipelineGrievanceProcessor`** (`janasunani/inference/service.py`) — warm processor implementing the `GrievanceProcessor` protocol. Pipeline: OCR (pytesseract) → PII redaction → language/category (MuRIL) → summary (BART) → routing (`DEFAULT_ROUTER`). Models load **once** in `build_processor`.
  - **PII stays out of the models** — the categorizer and summarizer receive only *redacted* text on both the text and document paths.
  - **Page-type gating** — only class-1 pages (`Letter`, `Form/Application`, `Text Only`, derived from `PAGE_TYPE_CLASS_BY_LABEL`) feed categorization/summarization; documents with no grievance-bearing page are rejected, never falling back to IDs/bills/misc.
  - **Strict / fail-closed** — `build_processor` requires local DVC artifacts and raises on missing deps; it never silently substitutes the mock.
- **`janasunani-api-live`** (`janasunani/inference/serve.py`) — live entry point: darwin `OMP_NUM_THREADS=1` guard before heavy imports; `DatabaseResultStore` only when `OLTP_DB_URL` is set, else `InMemoryResultStore`; app built with the real processor + `LakeHistory`.
- **Error mapping** — typed `InferenceInputError` (corrupt/blank/quality-rejected/truncated docs) → **HTTP 422** in `create_app`; unexpected model/runtime errors stay **5xx** (a guarded page-type predictor keeps model bugs off the 422 path).
- **Lazy `DEFAULT_ROUTER`** (`routing/rules.py`) so import-only paths don't probe artifacts.
- **No `demo` extra** — run with `uv run --extra serving --extra pipeline-core --extra categorizer janasunani-api-live`.

## Unchanged
Module-level `janasunani.serving.api:app` stays mock by default; frozen `GrievanceResult` schema and frontend types untouched.

## Testing
Real-code-path tests (heavy model internals monkeypatched) assert redacted-text-into-models, exact PII offset mapping, class-1 gating, real routing, doc-rejection → 422, and model-bug → 5xx. Live-builder tests prove fail-closed on missing artifacts and `OLTP_DB_URL`-gated persistence. Opt-in real-model smoke via `JANASUNANI_RUN_MODEL_SMOKE`.

```
uv run --extra serving --extra pipeline-core --extra categorizer pytest  →  197 passed, 1 skipped
uv run ruff check .                                                       →  clean
```

Independently reviewed by a `reviewer-opus` pass against both spec docs (ready-to-commit verdict); its P3 findings — page-type set derived from the canonical map, narrowed OCR exception so model bugs stay 5xx, dead-assignment removal — are folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)