### PR TITLE
Demo integration: live frontend + Makefile targets + inference docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,12 @@ EXHIBITS_REMOTE ?= $(BOX_REMOTE):'$(BOX_PROJECT_ROOT)/Analysis/Exhibits/'
 PG_CONTAINER   ?= janasunani-demo-oltp
 PG_PORT        ?= 5432
 API_PORT       ?= 8000
-OLTP_URL       ?= postgresql+asyncpg://postgres:demo@127.0.0.1:$(PG_PORT)/janasunani
+FRONTEND_PORT  ?= 3000
+# Single source of truth for the OLTP database. Settings/preflight/api all read
+# OLTP_DB_URL, so use that one name here too. `?=` means an operator-provided
+# OLTP_DB_URL (shell env or .env) wins over this throwaway-demo default, keeping
+# preflight, db, and api pointed at the SAME database.
+OLTP_DB_URL    ?= postgresql+asyncpg://postgres:demo@127.0.0.1:$(PG_PORT)/janasunani
 API_URL        ?= http://127.0.0.1:$(API_PORT)
 -include .env
 SHELL          := /bin/bash
@@ -38,7 +43,8 @@ help:
 	@echo "  make db              Start throwaway Postgres + run migrations"
 	@echo "  make api             Run the live real-inference API"
 	@echo "  make frontend        Run the Next.js UI against the live API"
-	@echo "  make down            Tear down the demo API + throwaway DB"
+	@echo "  make up              Serve API + frontend together (Ctrl-C stops both)"
+	@echo "  make down            Tear down the demo API + frontend + throwaway DB"
 	@echo ""
 
 setup:
@@ -125,37 +131,65 @@ _check_git_clean:
 # --- Live demo (real-inference API). `models` and `frontend` share names with
 # repo directories, so this whole group must be .PHONY or make treats them as
 # up-to-date files and skips the recipe.
-.PHONY: models preflight db api frontend down
+.PHONY: models preflight db api frontend up down
 
 models:
 	@echo "Pulling ONLY the demo model artifacts (not the PII-bearing data)..."
 	uv run dvc pull models/categorizer.dvc models/page_type_classifier/vit_type_classifier.dvc
 
 preflight:
-	uv run --extra demo janasunani-demo-preflight
+	OLTP_DB_URL="$(OLTP_DB_URL)" uv run --extra demo janasunani-demo-preflight
 
+# Idempotent: create the throwaway Postgres only if missing, start it if stopped,
+# always (re-)apply migrations (alembic upgrade head is a no-op when current).
+# Safe to depend on from `api`/`up`. Guard: only ever provisions/migrates the
+# LOCAL container — if OLTP_DB_URL was overridden to an off-box database we skip
+# entirely and never migrate it (protects prod; that DB is the operator's job).
 db:
-	@echo "Starting throwaway Postgres '$(PG_CONTAINER)' on 127.0.0.1:$(PG_PORT)..."
-	docker run -d --name $(PG_CONTAINER) -e POSTGRES_PASSWORD=demo \
-	  -e POSTGRES_DB=janasunani -p 127.0.0.1:$(PG_PORT):5432 \
-	  -v $(PG_CONTAINER):/var/lib/postgresql/data postgres:17
-	@echo "Waiting for Postgres to accept connections..."
-	@for i in $$(seq 1 30); do \
+	@set -e; \
+	case "$(OLTP_DB_URL)" in \
+	  *@127.0.0.1:*|*@localhost:*) ;; \
+	  *) echo "OLTP_DB_URL is not local ($(OLTP_DB_URL)); skipping throwaway-Postgres provisioning — manage that database yourself."; exit 0 ;; \
+	esac; \
+	if [ -n "$$(docker ps -q -f name=^$(PG_CONTAINER)$$)" ]; then \
+	  echo "Postgres '$(PG_CONTAINER)' already running."; \
+	elif [ -n "$$(docker ps -aq -f name=^$(PG_CONTAINER)$$)" ]; then \
+	  echo "Starting existing Postgres '$(PG_CONTAINER)'..."; docker start $(PG_CONTAINER) >/dev/null; \
+	else \
+	  echo "Creating throwaway Postgres '$(PG_CONTAINER)' on 127.0.0.1:$(PG_PORT)..."; \
+	  docker run -d --name $(PG_CONTAINER) -e POSTGRES_PASSWORD=demo \
+	    -e POSTGRES_DB=janasunani -p 127.0.0.1:$(PG_PORT):5432 \
+	    -v $(PG_CONTAINER):/var/lib/postgresql/data postgres:17 >/dev/null; \
+	fi; \
+	echo "Waiting for Postgres to accept connections..."; \
+	for i in $$(seq 1 30); do \
 	  docker exec $(PG_CONTAINER) pg_isready -U postgres -d janasunani >/dev/null 2>&1 && break; \
 	  sleep 1; \
-	done
-	OLTP_DB_URL="$(OLTP_URL)" uv run alembic upgrade head
-	@echo "Demo DB ready."
+	done; \
+	OLTP_DB_URL="$(OLTP_DB_URL)" uv run alembic upgrade head; \
+	echo "Demo DB ready."
 
-api: preflight
-	OLTP_DB_URL="$(OLTP_URL)" JANASUNANI_API_PORT="$(API_PORT)" \
+api: preflight db
+	OLTP_DB_URL="$(OLTP_DB_URL)" JANASUNANI_API_PORT="$(API_PORT)" \
 	  uv run --extra demo janasunani-api-live
 
 frontend:
 	cd frontend && npm install && NEXT_PUBLIC_API_URL="$(API_URL)" npm run dev
 
+# One command for the demo: ensure the DB, then API in the background + frontend
+# in the foreground. The trap fires on Ctrl-C (INT) or normal exit and reaps the
+# background API, so a single Ctrl-C stops both. `preflight` fails fast if models
+# or OCR binaries are missing; `db` brings up the throwaway Postgres first.
+up: preflight db
+	@echo "Serving API (background, :$(API_PORT)) + frontend (foreground, :$(FRONTEND_PORT)). Ctrl-C stops both."
+	OLTP_DB_URL="$(OLTP_DB_URL)" JANASUNANI_API_PORT="$(API_PORT)" \
+	  uv run --extra demo janasunani-api-live & \
+	trap 'pkill -f janasunani-api-live 2>/dev/null || true' EXIT INT TERM; \
+	cd frontend && npm install && NEXT_PUBLIC_API_URL="$(API_URL)" npm run dev
+
 down:
 	-pkill -f janasunani-api-live
+	-PIDS=$$(lsof -ti tcp:$(FRONTEND_PORT) 2>/dev/null); [ -n "$$PIDS" ] && kill $$PIDS || true
 	-docker rm -f $(PG_CONTAINER)
 	-docker volume rm $(PG_CONTAINER)
 	@echo "Demo stack torn down."

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,13 @@ RAW_LOCAL      ?= data/raw/
 EXHIBITS_LOCAL ?= outputs/
 INCOMING_REMOTE ?= $(BOX_REMOTE):'$(BOX_PROJECT_ROOT)/Data/Raw/'
 EXHIBITS_REMOTE ?= $(BOX_REMOTE):'$(BOX_PROJECT_ROOT)/Analysis/Exhibits/'
+# Live-demo stack (see docs/DEMO.md). Throwaway Postgres only — never the prod
+# volume, never the :5433 pytest-fixture DB.
+PG_CONTAINER   ?= janasunani-demo-oltp
+PG_PORT        ?= 5432
+API_PORT       ?= 8000
+OLTP_URL       ?= postgresql+asyncpg://postgres:demo@127.0.0.1:$(PG_PORT)/janasunani
+API_URL        ?= http://127.0.0.1:$(API_PORT)
 -include .env
 SHELL          := /bin/bash
 .SHELLFLAGS    := -euo pipefail -c
@@ -24,6 +31,14 @@ help:
 	@echo "  make deliver         Copy exhibits to Box without deleting remote files"
 	@echo "  make box-paths       Show resolved local and Box paths"
 	@echo "  make status          Show what has changed"
+	@echo ""
+	@echo "  Live demo (real-inference API — see docs/DEMO.md):"
+	@echo "  make models          DVC-pull ONLY the demo model artifacts"
+	@echo "  make preflight       Fast readiness check (models + OCR binaries)"
+	@echo "  make db              Start throwaway Postgres + run migrations"
+	@echo "  make api             Run the live real-inference API"
+	@echo "  make frontend        Run the Next.js UI against the live API"
+	@echo "  make down            Tear down the demo API + throwaway DB"
 	@echo ""
 
 setup:
@@ -106,3 +121,41 @@ status:
 _check_git_clean:
 	@git diff --quiet && git diff --cached --quiet || \
 	  (echo "Uncommitted changes. Commit or stash first." && exit 1)
+
+# --- Live demo (real-inference API). `models` and `frontend` share names with
+# repo directories, so this whole group must be .PHONY or make treats them as
+# up-to-date files and skips the recipe.
+.PHONY: models preflight db api frontend down
+
+models:
+	@echo "Pulling ONLY the demo model artifacts (not the PII-bearing data)..."
+	uv run dvc pull models/categorizer.dvc models/page_type_classifier/vit_type_classifier.dvc
+
+preflight:
+	uv run --extra demo janasunani-demo-preflight
+
+db:
+	@echo "Starting throwaway Postgres '$(PG_CONTAINER)' on 127.0.0.1:$(PG_PORT)..."
+	docker run -d --name $(PG_CONTAINER) -e POSTGRES_PASSWORD=demo \
+	  -e POSTGRES_DB=janasunani -p 127.0.0.1:$(PG_PORT):5432 \
+	  -v $(PG_CONTAINER):/var/lib/postgresql/data postgres:17
+	@echo "Waiting for Postgres to accept connections..."
+	@for i in $$(seq 1 30); do \
+	  docker exec $(PG_CONTAINER) pg_isready -U postgres -d janasunani >/dev/null 2>&1 && break; \
+	  sleep 1; \
+	done
+	OLTP_DB_URL="$(OLTP_URL)" uv run alembic upgrade head
+	@echo "Demo DB ready."
+
+api: preflight
+	OLTP_DB_URL="$(OLTP_URL)" JANASUNANI_API_PORT="$(API_PORT)" \
+	  uv run --extra demo janasunani-api-live
+
+frontend:
+	cd frontend && npm install && NEXT_PUBLIC_API_URL="$(API_URL)" npm run dev
+
+down:
+	-pkill -f janasunani-api-live
+	-docker rm -f $(PG_CONTAINER)
+	-docker volume rm $(PG_CONTAINER)
+	@echo "Demo stack torn down."

--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,21 @@ EXHIBITS_REMOTE ?= $(BOX_REMOTE):'$(BOX_PROJECT_ROOT)/Analysis/Exhibits/'
 PG_CONTAINER   ?= janasunani-demo-oltp
 PG_PORT        ?= 5432
 API_PORT       ?= 8000
+API_HOST       ?= 127.0.0.1
 FRONTEND_PORT  ?= 3000
-# Single source of truth for the OLTP database. Settings/preflight/api all read
-# OLTP_DB_URL, so use that one name here too. `?=` means an operator-provided
-# OLTP_DB_URL (shell env or .env) wins over this throwaway-demo default, keeping
-# preflight, db, and api pointed at the SAME database.
-OLTP_DB_URL    ?= postgresql+asyncpg://postgres:demo@127.0.0.1:$(PG_PORT)/janasunani
+# The one database `db` will provision/migrate a throwaway container for. `db`
+# acts ONLY when OLTP_DB_URL equals this exact DSN, so it never creates one
+# database and migrates another, and never touches an off-box URL.
+DEMO_OLTP_URL   = postgresql+asyncpg://postgres:demo@127.0.0.1:$(PG_PORT)/janasunani
+# The OLTP database Settings/preflight/api all read. Precedence, highest first:
+#   `make OLTP_DB_URL=... <target>` (command line) > OLTP_DB_URL in .env >
+#   a shell-exported OLTP_DB_URL > this demo default. Use the command-line form
+#   to force a database for one run regardless of .env.
+OLTP_DB_URL    ?= $(DEMO_OLTP_URL)
+# Base URL the browser calls -- baked into the frontend bundle at build time.
+# On a remote/box run this MUST be an address the viewer's browser can reach
+# (not 127.0.0.1); set API_HOST=0.0.0.0 too so the API binds all interfaces.
+# See docs/DEPLOY.md. Example: make up API_URL=http://<box-ip>:8000 API_HOST=0.0.0.0
 API_URL        ?= http://127.0.0.1:$(API_PORT)
 -include .env
 SHELL          := /bin/bash
@@ -137,20 +146,21 @@ models:
 	@echo "Pulling ONLY the demo model artifacts (not the PII-bearing data)..."
 	uv run dvc pull models/categorizer.dvc models/page_type_classifier/vit_type_classifier.dvc
 
+# `@` so the OLTP DSN (may carry a password) is not echoed into terminal logs.
 preflight:
-	OLTP_DB_URL="$(OLTP_DB_URL)" uv run --extra demo janasunani-demo-preflight
+	@OLTP_DB_URL="$(OLTP_DB_URL)" uv run --extra demo janasunani-demo-preflight
 
 # Idempotent: create the throwaway Postgres only if missing, start it if stopped,
 # always (re-)apply migrations (alembic upgrade head is a no-op when current).
-# Safe to depend on from `api`/`up`. Guard: only ever provisions/migrates the
-# LOCAL container — if OLTP_DB_URL was overridden to an off-box database we skip
-# entirely and never migrate it (protects prod; that DB is the operator's job).
+# Safe to depend on from `api`/`up`. Guard: acts ONLY when OLTP_DB_URL is exactly
+# the throwaway DEMO_OLTP_URL, so it never creates one database and migrates
+# another, and never provisions/migrates an operator's own (local or off-box) DB.
 db:
 	@set -e; \
-	case "$(OLTP_DB_URL)" in \
-	  *@127.0.0.1:*|*@localhost:*) ;; \
-	  *) echo "OLTP_DB_URL is not local ($(OLTP_DB_URL)); skipping throwaway-Postgres provisioning — manage that database yourself."; exit 0 ;; \
-	esac; \
+	if [ "$(OLTP_DB_URL)" != "$(DEMO_OLTP_URL)" ]; then \
+	  echo "OLTP_DB_URL is not the throwaway demo default; skipping provisioning — create and migrate that database yourself."; \
+	  exit 0; \
+	fi; \
 	if [ -n "$$(docker ps -q -f name=^$(PG_CONTAINER)$$)" ]; then \
 	  echo "Postgres '$(PG_CONTAINER)' already running."; \
 	elif [ -n "$$(docker ps -aq -f name=^$(PG_CONTAINER)$$)" ]; then \
@@ -169,27 +179,45 @@ db:
 	OLTP_DB_URL="$(OLTP_DB_URL)" uv run alembic upgrade head; \
 	echo "Demo DB ready."
 
+# `@` so the OLTP DSN is not echoed. API_HOST=0.0.0.0 to serve off-box.
 api: preflight db
-	OLTP_DB_URL="$(OLTP_DB_URL)" JANASUNANI_API_PORT="$(API_PORT)" \
-	  uv run --extra demo janasunani-api-live
+	@OLTP_DB_URL="$(OLTP_DB_URL)" JANASUNANI_API_HOST="$(API_HOST)" \
+	  JANASUNANI_API_PORT="$(API_PORT)" uv run --extra demo janasunani-api-live
 
 frontend:
-	cd frontend && npm install && NEXT_PUBLIC_API_URL="$(API_URL)" npm run dev
+	cd frontend && npm install && \
+	  PORT="$(FRONTEND_PORT)" NEXT_PUBLIC_API_URL="$(API_URL)" npm run dev
 
-# One command for the demo: ensure the DB, then API in the background + frontend
-# in the foreground. The trap fires on Ctrl-C (INT) or normal exit and reaps the
-# background API, so a single Ctrl-C stops both. `preflight` fails fast if models
-# or OCR binaries are missing; `db` brings up the throwaway Postgres first.
+# One command for the demo: ensure the DB, start the API in the background, wait
+# for it to report `processor: pipeline`, THEN start the frontend in the
+# foreground. If the API dies or never turns healthy we abort instead of serving
+# a UI against a dead backend. The trap reaps only the API process we launched
+# (its PID + children) -- never a global `pkill` that could hit an unrelated
+# live API on the same box. A single Ctrl-C on the frontend stops both.
 up: preflight db
-	@echo "Serving API (background, :$(API_PORT)) + frontend (foreground, :$(FRONTEND_PORT)). Ctrl-C stops both."
-	OLTP_DB_URL="$(OLTP_DB_URL)" JANASUNANI_API_PORT="$(API_PORT)" \
-	  uv run --extra demo janasunani-api-live & \
-	trap 'pkill -f janasunani-api-live 2>/dev/null || true' EXIT INT TERM; \
-	cd frontend && npm install && NEXT_PUBLIC_API_URL="$(API_URL)" npm run dev
+	@set -e; \
+	echo "Starting live API (:$(API_PORT)) in the background..."; \
+	OLTP_DB_URL="$(OLTP_DB_URL)" JANASUNANI_API_HOST="$(API_HOST)" \
+	  JANASUNANI_API_PORT="$(API_PORT)" uv run --extra demo janasunani-api-live & \
+	API_PID=$$!; \
+	trap 'pkill -P $$API_PID 2>/dev/null; kill $$API_PID 2>/dev/null || true' EXIT INT TERM; \
+	echo "Waiting for the API to report processor=pipeline (model warm-up)..."; \
+	ready=; \
+	for i in $$(seq 1 150); do \
+	  if ! kill -0 $$API_PID 2>/dev/null; then echo "Live API exited during startup; aborting."; exit 1; fi; \
+	  if curl -sf http://127.0.0.1:$(API_PORT)/health 2>/dev/null | grep -q '"processor":"pipeline"'; then ready=1; break; fi; \
+	  sleep 2; \
+	done; \
+	[ -n "$$ready" ] || { echo "Live API did not become healthy in time; aborting."; exit 1; }; \
+	echo "Live API healthy (:$(API_PORT)). Starting frontend (:$(FRONTEND_PORT))..."; \
+	cd frontend && npm install && \
+	  PORT="$(FRONTEND_PORT)" NEXT_PUBLIC_API_URL="$(API_URL)" npm run dev
 
+# Tear down by PORT (overridable), not a global process-name match, so this
+# never kills an unrelated live API/frontend on the same machine.
 down:
-	-pkill -f janasunani-api-live
-	-PIDS=$$(lsof -ti tcp:$(FRONTEND_PORT) 2>/dev/null); [ -n "$$PIDS" ] && kill $$PIDS || true
+	-@PIDS=$$(lsof -ti tcp:$(API_PORT) 2>/dev/null); [ -n "$$PIDS" ] && kill $$PIDS 2>/dev/null || true
+	-@PIDS=$$(lsof -ti tcp:$(FRONTEND_PORT) 2>/dev/null); [ -n "$$PIDS" ] && kill $$PIDS 2>/dev/null || true
 	-docker rm -f $(PG_CONTAINER)
 	-docker volume rm $(PG_CONTAINER)
 	@echo "Demo stack torn down."

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,10 @@ EXHIBITS_REMOTE ?= $(BOX_REMOTE):'$(BOX_PROJECT_ROOT)/Analysis/Exhibits/'
 # Live-demo stack (see docs/DEMO.md). Throwaway Postgres only — never the prod
 # volume, never the :5433 pytest-fixture DB.
 PG_CONTAINER   ?= janasunani-demo-oltp
-PG_PORT        ?= 5432
+# Host port for the throwaway demo Postgres. Deliberately NOT 5432 (the CPU-box
+# production oltp binds 127.0.0.1:5432 in deploy/docker-compose.yml) nor 5433
+# (the pytest-fixture DB, which DROPS TABLES) — keep the demo clear of both.
+PG_PORT        ?= 5544
 API_PORT       ?= 8000
 API_HOST       ?= 127.0.0.1
 FRONTEND_PORT  ?= 3000
@@ -23,9 +26,11 @@ DEMO_OLTP_URL   = postgresql+asyncpg://postgres:demo@127.0.0.1:$(PG_PORT)/janasu
 #   to force a database for one run regardless of .env.
 OLTP_DB_URL    ?= $(DEMO_OLTP_URL)
 # Base URL the browser calls -- baked into the frontend bundle at build time.
-# On a remote/box run this MUST be an address the viewer's browser can reach
-# (not 127.0.0.1); set API_HOST=0.0.0.0 too so the API binds all interfaces.
-# See docs/DEPLOY.md. Example: make up API_URL=http://<box-ip>:8000 API_HOST=0.0.0.0
+# The `make` fast path is LOCAL: a box/remote deployment (open ports, Node,
+# compose) is docs/DEPLOY.md's job, not `make up`. To view a local/box-run demo
+# from another machine, SSH-tunnel the ports and keep this default:
+#   ssh -L $(FRONTEND_PORT):127.0.0.1:$(FRONTEND_PORT) -L $(API_PORT):127.0.0.1:$(API_PORT) <box>
+# API_URL/API_HOST remain overridable for advanced setups.
 API_URL        ?= http://127.0.0.1:$(API_PORT)
 -include .env
 SHELL          := /bin/bash
@@ -214,10 +219,17 @@ up: preflight db
 	  PORT="$(FRONTEND_PORT)" NEXT_PUBLIC_API_URL="$(API_URL)" npm run dev
 
 # Tear down by PORT (overridable), not a global process-name match, so this
-# never kills an unrelated live API/frontend on the same machine.
+# never kills an unrelated live API/frontend on the same machine. Needs `lsof`
+# to find the port owners; if it is absent we say so rather than silently
+# leaving the API/frontend running.
 down:
-	-@PIDS=$$(lsof -ti tcp:$(API_PORT) 2>/dev/null); [ -n "$$PIDS" ] && kill $$PIDS 2>/dev/null || true
-	-@PIDS=$$(lsof -ti tcp:$(FRONTEND_PORT) 2>/dev/null); [ -n "$$PIDS" ] && kill $$PIDS 2>/dev/null || true
+	@if command -v lsof >/dev/null 2>&1; then \
+	  for p in $(API_PORT) $(FRONTEND_PORT); do \
+	    PIDS=$$(lsof -ti tcp:$$p 2>/dev/null); [ -n "$$PIDS" ] && kill $$PIDS 2>/dev/null || true; \
+	  done; \
+	else \
+	  echo "lsof not found — cannot stop API/frontend by port; stop them manually (e.g. 'docker compose down' on the box)."; \
+	fi
 	-docker rm -f $(PG_CONTAINER)
 	-docker volume rm $(PG_CONTAINER)
 	@echo "Demo stack torn down."

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ The GPU box is a `gpu_box_count = 0/1` toggle (~$1/hr while up).
   [ingestion](janasunani/ingestion/README.md) ·
   [olap](janasunani/olap/README.md) ·
   [pipeline](janasunani/pipeline/README.md) ·
+  [inference](janasunani/inference/README.md) ·
   [serving](janasunani/serving/README.md) ·
   [deploy](deploy/README.md) ·
   [terraform](deploy/terraform/README.md) ·

--- a/docs/DEMO.md
+++ b/docs/DEMO.md
@@ -13,11 +13,19 @@ locally first, then repeated on the box.
 
 > **Fast path — `make`.** The `Makefile` wraps every step below:
 > `make models` (scoped DVC pull) · `make preflight` · `make up` (throwaway
-> Postgres + API + frontend, one `Ctrl-C` stops all) · `make down` (tear it
-> down). `make api`/`make up` provision and migrate the local Postgres for you
-> — if you override `OLTP_DB_URL` to an off-box database they skip that step and
-> never migrate it. The numbered sections below are the underlying manual
-> commands, for when you want to run a step by hand or on the CPU box.
+> Postgres + API + frontend, waits for `processor: pipeline` before starting the
+> UI, one `Ctrl-C` stops both) · `make down` (tear down by port). `make api`/
+> `make up` provision and migrate the local Postgres for you — if you point
+> `OLTP_DB_URL` at anything other than the throwaway default they skip that step
+> and never migrate it (you manage that database yourself).
+>
+> **On the box / remote:** `API_URL` is baked into the frontend bundle, so serve
+> with `make up API_URL=http://<box-ip>:$API_PORT API_HOST=0.0.0.0` — otherwise
+> a browser on another machine calls its own `127.0.0.1`. Full cloud path is in
+> [DEPLOY.md](DEPLOY.md).
+>
+> The numbered sections below are the underlying manual commands, for running a
+> step by hand.
 
 ---
 

--- a/docs/DEMO.md
+++ b/docs/DEMO.md
@@ -11,6 +11,14 @@ For the full **cloud** deployment (CPU box + compose + backups) see
 [DEPLOY.md](DEPLOY.md). This document is the **integration bring-up** — proven
 locally first, then repeated on the box.
 
+> **Fast path — `make`.** The `Makefile` wraps every step below:
+> `make models` (scoped DVC pull) · `make preflight` · `make up` (throwaway
+> Postgres + API + frontend, one `Ctrl-C` stops all) · `make down` (tear it
+> down). `make api`/`make up` provision and migrate the local Postgres for you
+> — if you override `OLTP_DB_URL` to an off-box database they skip that step and
+> never migrate it. The numbered sections below are the underlying manual
+> commands, for when you want to run a step by hand or on the CPU box.
+
 ---
 
 ## 1. Prerequisites

--- a/docs/DEMO.md
+++ b/docs/DEMO.md
@@ -19,10 +19,13 @@ locally first, then repeated on the box.
 > `OLTP_DB_URL` at anything other than the throwaway default they skip that step
 > and never migrate it (you manage that database yourself).
 >
-> **On the box / remote:** `API_URL` is baked into the frontend bundle, so serve
-> with `make up API_URL=http://<box-ip>:$API_PORT API_HOST=0.0.0.0` — otherwise
-> a browser on another machine calls its own `127.0.0.1`. Full cloud path is in
-> [DEPLOY.md](DEPLOY.md).
+> This fast path is **local**. It assumes a dev machine with Docker, `uv`,
+> Node/npm, and `lsof`. The CPU box is **not** provisioned for `make up` (no
+> Node, demo ports 3000/8000 closed by the security group, and prod Postgres
+> already on 5432) — deploy there via [DEPLOY.md](DEPLOY.md) (compose), not this
+> fast path. To *view* a locally-run demo from another machine, SSH-tunnel the
+> ports rather than exposing them:
+> `ssh -L 3000:127.0.0.1:3000 -L 8000:127.0.0.1:8000 <box>`.
 >
 > The numbered sections below are the underlying manual commands, for running a
 > step by hand.
@@ -92,11 +95,11 @@ rather than crashing mid-warm-up.
 ```bash
 docker run -d --name janasunani-demo-oltp \
   -e POSTGRES_PASSWORD=demo -e POSTGRES_DB=janasunani \
-  -p 127.0.0.1:5432:5432 \
+  -p 127.0.0.1:5544:5432 \
   -v janasunani-demo-oltp:/var/lib/postgresql/data \
   postgres:17
 
-export OLTP_DB_URL="postgresql+asyncpg://postgres:demo@127.0.0.1:5432/janasunani"
+export OLTP_DB_URL="postgresql+asyncpg://postgres:demo@127.0.0.1:5544/janasunani"
 uv run alembic upgrade head   # creates live_grievances (+ the rest of the schema)
 ```
 
@@ -113,7 +116,7 @@ touches the historical `complaints` data. Never `docker compose down -v`.
 ## 4. Launch + health gate
 
 ```bash
-export OLTP_DB_URL="postgresql+asyncpg://postgres:demo@127.0.0.1:5432/janasunani"
+export OLTP_DB_URL="postgresql+asyncpg://postgres:demo@127.0.0.1:5544/janasunani"
 uv run --extra demo janasunani-api-live      # host/port: JANASUNANI_API_HOST/PORT
 ```
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -249,7 +249,8 @@ start GPU box → health check → demo → stop GPU box; latency pass; stakehol
     OLAP-history crosswalk remains follow-up work.
   - **Phase 10** ✅ serving — frozen mock API, live persistence, lake-backed history, and opt-in real
     processor wiring are built. The module-level API remains mock by design.
-  - **Phase 11** 🔄 frontend — first cut on `feat/frontend-demo` (DPIC-branded, against the mock).
+  - **Phase 11** 🔄 frontend — first cut on `feat/frontend-demo` (DPIC-branded, against the mock);
+    live-wired to `janasunani-api-live` on `feat/demo-frontend-live`.
   - **Phase 12** ⬜ demo integration & deployment.
   - Docs: `chore/handoff-doc-links` (ongoing). *(Dead: `backend-plan-unsplit` — an ancestor of main, no diff.)*
 
@@ -479,7 +480,7 @@ deploy/                           # docker-compose (api, frontend, mlflow, oltp-
 - **Tests**: API tests (TestClient) with mocked processor against a temp OLTP DB — submit→persist→fetch;
   history endpoint returns lake rows.
 
-## Phase 11 — Demo frontend (Next.js)  🔄 *(first cut built 2026-07-08 — ONGOING on branch `feat/frontend-demo`)*
+## Phase 11 — Demo frontend (Next.js)  🔄 *(first cut built 2026-07-08; live-wired 2026-07-10)*
 - 🔄 **First cut built** (branch `feat/frontend-demo`, DPIC-branded): Next.js 16 App Router + TypeScript +
   Tailwind v4. Submit route (text/upload → staged result cards: extracted/redacted text + typed PII token
   badges, classification, summary, routing w/ escalation + confidence) + History browse/search route. Types
@@ -487,6 +488,13 @@ deploy/                           # docker-compose (api, frontend, mlflow, oltp-
   Calibri) read from the installed `dpic` package. `npm run lint`/`build` green; endpoints verified live
   against the mock API. Not merged. **Still mock end-to-end** (mock processor + `MockHistory` on `main`) —
   the UI shape is real; classification/redaction/history become real at the Phase 8/10 wire-up.
+- ✅ **Live-wired** (branch `feat/demo-frontend-live` → `feat/demo-integration`): pointed
+  `NEXT_PUBLIC_API_URL` at `janasunani-api-live` and verified real responses render — real `fallback` and
+  `rules` routing (not just mock's canned value), null `subcategory`, real Presidio PII spans, and the
+  document/OCR path (`source:"document"`, `ocr_model:"pytesseract"`, `pages`). No contract drift found
+  (`lib/types.ts` already matched `serving/schemas.py` exactly); removed stale "results are mocked" copy
+  from the submit/history/layout chrome and added an explanatory note for `fallback`-routed results.
+  `npm run lint`/`build` green.
 - Scaffolded right after the Phase 10 skeleton and built against the mocked contract, so it gets
   Weeks 3–4 of iteration instead of a cramped tail. Submit (text + upload) → staged view
   (extracted/redacted text, category/subcategory/dept, summary, routing + escalation + confidence) +
@@ -502,8 +510,8 @@ deploy/                           # docker-compose (api, frontend, mlflow, oltp-
   a real PDF (OCR → page-type gate → redaction → MuRIL → BART → routing) both round-trip through
   `GET /grievance/{id}` and persist to `live_grievances`. Runbook: [docs/DEMO.md](DEMO.md). Findings logged
   there: routing degrades to `fallback` without the DVC mappings; PII recall is weak on Indian names
-  (feeds the eval work); BART is hub-downloaded at boot (darwin `hf_xet` hang guarded). **Next: repeat on
-  the CPU box; wire the frontend; load routing mappings.**
+  (feeds the eval work); BART is hub-downloaded at boot (darwin `hf_xet` hang guarded). Frontend now
+  wired to this live API (Phase 11). **Next: repeat on the CPU box; load routing mappings.**
 - `deploy/docker-compose.yml` starts in **Week 2** with just `oltp` (replacing the ad-hoc `docker run`)
   and gains each service as it's born (`mlflow` → `api` → `frontend` → `proxy`), so this phase is
   integration + runbook + latency — not the first time the runtime composition exists in the repo.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -251,7 +251,9 @@ start GPU box → health check → demo → stop GPU box; latency pass; stakehol
     processor wiring are built. The module-level API remains mock by design.
   - **Phase 11** 🔄 frontend — first cut on `feat/frontend-demo` (DPIC-branded, against the mock);
     live-wired to `janasunani-api-live` on `feat/demo-frontend-live`.
-  - **Phase 12** ⬜ demo integration & deployment.
+  - **Phase 12** 🔄 demo integration & deployment — local runbook (`docs/DEMO.md`), `Makefile`
+    live-demo targets (`preflight`/`db`/`api`/`frontend`/`up`/`down`), and preflight in place;
+    cloud compose deployment still to come.
   - Docs: `chore/handoff-doc-links` (ongoing). *(Dead: `backend-plan-unsplit` — an ancestor of main, no diff.)*
 
 ## Package structure

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,4 +1,11 @@
-# Base URL of the janasunani serving API (mock or real).
-# Start the mock API with: uv run --extra serving janasunani-api
+# Base URL of the janasunani serving API (mock or real). Both serve the same
+# frozen response contract (janasunani/serving/schemas.py), so the frontend
+# needs no code changes to switch between them — only this URL.
+#
+# Real pipeline (OCR, PII, categorizer, routing) — see docs/DEMO.md:
+#   uv run --extra demo janasunani-api-live
+# Lightweight mock (toy regex redaction, canned classification/routing):
+#   uv run --extra serving janasunani-api
+#
 # Copy this file to .env.local and adjust as needed.
 NEXT_PUBLIC_API_URL=http://127.0.0.1:8000

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -14,6 +14,10 @@ npm run dev
 
 Open [http://localhost:3000](http://localhost:3000).
 
+To bring up the **live API and this frontend together**, run `make up` from the
+repo root (throwaway Postgres + `janasunani-api-live` + `npm run dev`, wired to
+each other; one `Ctrl-C` stops all, `make down` cleans up).
+
 ## Pointing at an API
 
 Set `NEXT_PUBLIC_API_URL` in `.env.local` (see `.env.local.example`). It is

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,36 +1,60 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+Next.js 16 + TypeScript + Tailwind v4 demo frontend for Janasunani, styled to
+the DPIC brand (maroon accent, Calibri type). It talks to the serving API
+defined by `janasunani/serving/schemas.py` — a frozen contract shared by both
+the mock API and the real pipeline API, so the frontend needs no code changes
+to point at either.
 
-## Getting Started
-
-First, run the development server:
+## Getting started
 
 ```bash
+cp .env.local.example .env.local   # then edit NEXT_PUBLIC_API_URL if needed
+npm install
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:3000](http://localhost:3000).
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Pointing at an API
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+Set `NEXT_PUBLIC_API_URL` in `.env.local` (see `.env.local.example`). It is
+read client-side only — the browser calls the API directly, nothing routes
+through Next.js SSR/API routes, and no citizen text ever leaves the browser
+except to this one local endpoint.
 
-## Learn More
+Two backends implement the same contract:
 
-To learn more about Next.js, take a look at the following resources:
+- **Real pipeline** (OCR, Presidio PII redaction, MuRIL categorizer,
+  routing) — `uv run --extra demo janasunani-api-live`. See
+  [`../docs/DEMO.md`](../docs/DEMO.md) for prerequisites (DVC model pull,
+  tesseract/poppler, throwaway Postgres or no `OLTP_DB_URL` for an in-memory
+  store). First boot is slow (model warm-up); `/health` must report
+  `{"processor":"pipeline"}`.
+- **Mock** — `uv run --extra serving janasunani-api`. Canned/regex responses,
+  useful for fast UI iteration without models loaded. Results from this API
+  come back with `routing.method: "mock"` and the UI marks them with a
+  "mock result" badge.
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+Whichever backend is running, note that `routing.method` frequently comes
+back `"fallback"` (low confidence) rather than `"rules"` — the real
+category→department crosswalk is still being built out (see
+[ROADMAP.md](../docs/ROADMAP.md)) and the router degrades to a generic public
+grievance cell rather than failing. This is expected; the UI renders it with
+an explanatory note, not as an error.
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+## Structure
 
-## Deploy on Vercel
+- `app/` — routes: `/` (submit a grievance) and `/history` (browse/search).
+- `components/` — `SubmitForm`, `ResultView` (the five-step result cards),
+  `HistoryView`, and `ui.tsx` (Card/Field/Badge primitives).
+- `lib/api.ts` — the fetch client (`submitGrievance`, `fetchHistory`).
+- `lib/types.ts` — TypeScript mirror of `janasunani/serving/schemas.py`. Do
+  not rename these fields without a matching backend contract change.
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+## Gate
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+```bash
+npm run lint
+npm run build
+```
+
+Both must pass before opening a PR.

--- a/frontend/app/history/page.tsx
+++ b/frontend/app/history/page.tsx
@@ -7,8 +7,7 @@ export default function HistoryPageRoute() {
         <h1 className="text-2xl font-bold text-text-dark">Grievance history</h1>
         <p className="max-w-2xl text-sm text-text-secondary">
           Browse and search historical grievances. Filter by free-text,
-          district, or category. Rows are served by the mock history provider
-          until wire-up.
+          district, or category.
         </p>
       </div>
       <HistoryView />

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -5,7 +5,7 @@ import "./globals.css";
 export const metadata: Metadata = {
   title: "Janasunani — Grievance Redressal Demo",
   description:
-    "DPIC demo: AI-assisted grievance intake, redaction, classification and routing. Illustrative — results are produced by a mock processor.",
+    "DPIC demo: AI-assisted grievance intake, redaction, classification and routing.",
 };
 
 function Header() {
@@ -54,8 +54,9 @@ function Footer() {
           University of Chicago &amp; Government of Odisha
         </span>
         <span className="text-white/70">
-          Data, Policy and Innovation Centre — demo build. Results shown are
-          illustrative and produced by a mock processor.
+          Data, Policy and Innovation Centre — demo build. A &quot;mock
+          result&quot; badge marks illustrative responses; unmarked results
+          come from the live pipeline.
         </span>
       </div>
     </footer>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -10,8 +10,7 @@ export default function SubmitPage() {
         <p className="max-w-2xl text-sm text-text-secondary">
           Enter grievance text or upload a document. The demo extracts the
           text, redacts PII, classifies the grievance, summarises it, and
-          proposes a routing. Results are illustrative — the processor is
-          currently mocked.
+          proposes a routing.
         </p>
       </div>
       <SubmitForm />

--- a/frontend/components/ResultView.tsx
+++ b/frontend/components/ResultView.tsx
@@ -49,6 +49,7 @@ function confidenceTone(c: number): "positive" | "neutral" | "negative" {
 export function ResultView({ result }: { result: GrievanceResult }) {
   const { extraction, redaction, classification, routing } = result;
   const isMock = routing.method === "mock";
+  const isFallbackRouting = routing.method === "fallback";
 
   return (
     <div className="flex flex-col gap-4">
@@ -151,6 +152,13 @@ export function ResultView({ result }: { result: GrievanceResult }) {
         title="Routing"
         hint={`method: ${routing.method}`}
       >
+        {isFallbackRouting && (
+          <p className="mb-3 rounded-sm bg-panel px-3 py-2 text-xs text-text-secondary">
+            No specific rule matched this category/district — routed to the
+            generic public grievance cell as a safety net. Confidence is low
+            by design.
+          </p>
+        )}
         <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2">
           <Field label="Department" value={routing.dept} />
           <Field label="Handling office" value={routing.office} />

--- a/janasunani/inference/README.md
+++ b/janasunani/inference/README.md
@@ -1,0 +1,134 @@
+# janasunani/inference — the warm live processor (Phase 8)
+
+Single-grievance, in-process inference behind the **frozen serving contract**.
+Where `pipeline/` runs the models in batch through the artifact DB one page-row
+at a time, this package orchestrates **one uploaded grievance at a time** with
+no DB in the middle, warms every model **once**, and returns the exact
+`GrievanceResult` shape `serving/` already promises — so the frontend consumes
+real output with zero changes.
+
+It is deliberately **import-light**: nothing here pulls torch/transformers at
+import time, so the default mock API (`janasunani-api`) still runs model-free.
+Heavy dependencies are loaded lazily inside `build_processor`, and the
+single-item wrappers take their OCR/model calls as **injected callables** — so
+`ocr.py`/`service.py` import and unit-test cleanly with no tesseract, poppler,
+or ML libraries installed.
+
+## Modules
+
+| File | What it is |
+|---|---|
+| `service.py` | `PipelineGrievanceProcessor` (the `GrievanceProcessor` seam), `build_processor()` (strict warm start), `preflight()` (weight-free readiness) |
+| `ocr.py` | `ocr_document()` — one document's raw bytes → per-page text; all rendering/OCR/page-type injected |
+| `serve.py` | opt-in entry points: `main` (`janasunani-api-live`), `preflight_main` (`janasunani-demo-preflight`), `create_live_app` |
+
+## Run it
+
+```bash
+# fast, weight-free readiness check (models + OCR binaries + which store)
+uv run --extra demo janasunani-demo-preflight
+
+# warm start the live API (fails closed if anything is missing)
+uv run --extra demo janasunani-api-live
+```
+
+Serves `http://127.0.0.1:8000` (`JANASUNANI_API_HOST`/`JANASUNANI_API_PORT`),
+OpenAPI at `/docs`. The `Makefile` wraps this end-to-end: `make preflight`,
+`make api`, `make up` (API + frontend), `make down`. Full runbook in
+[`docs/DEMO.md`](../../docs/DEMO.md); the API contract lives in
+[`janasunani/serving/README.md`](../serving/README.md).
+
+## What `process()` does
+
+One typed grievance **xor** one uploaded document per call (validated up front —
+providing both, neither, blank text, or an unsupported suffix is a client
+error). Then:
+
+1. **Extraction** — text path: `extracted_text = text`, `source="text"`.
+   Document path: `ocr_document()` renders + OCRs each page (cap
+   `DEFAULT_MAX_PAGES = 50`; a longer doc comes back `truncated=True` and is
+   rejected rather than silently partial), `source="document"`,
+   `ocr_model="pytesseract"`, `pages=N`.
+2. **Page-type gating (document path only)** — only grievance-bearing pages
+   (page-type class 1, via `PAGE_TYPE_CLASS_BY_LABEL`) feed the models;
+   identification/bill/misc pages are dropped so they never reach redaction or
+   classification.
+3. **Redaction** — Presidio `redact_text` + `detect_pii_spans` over the
+   extracted text; spans map `PIISpan(entity,start,end,score)` →
+   `PIIEntity(entity,start,end)`. On the document path each selected page is
+   redacted **before** being joined for the models.
+4. **Classification & summary** — run over the **redacted** text (PII never
+   reaches the models). `langdetect` sets `language`; the same English gate the
+   categorizer uses decides whether MuRIL + BART run, or the non-English
+   fallback (`category="Uncategorized"`, a fixed "summary unavailable" string)
+   applies — BART is only warmed/validated for the English demo target and
+   would otherwise hallucinate over unsupported input.
+5. **Routing** — `DEFAULT_ROUTER.route(category=…, district=…)` → `RoutingResult`
+   straight into the frozen schema. Without the DVC-mirrored ORTPSA mappings
+   this degrades to `method="fallback"` (see the routing crosswalk gap — the
+   masters carry no category→department FK; deferred post-demo).
+
+## Strict warm start (`build_processor`) + `preflight`
+
+`build_processor` is **fail-closed**: it hard-requires the locally mirrored
+model artifacts and the OCR system binaries, then imports and warms page-type →
+summarizer → categorizer → Presidio → OCR/router. Any missing artifact, absent
+binary, failed public BART download, or Presidio init error **aborts startup** —
+it never substitutes the mock.
+
+`preflight()` reports the **same** requirements without loading a single weight
+(milliseconds, not minutes), so an operator can confirm a box is demo-ready
+before the multi-minute warm start. The mandatory-artifact list
+(`_required_model_files`) is a **single source of truth** shared by both, so the
+fast check can never disagree with what real startup loads. Requirements:
+
+| Component | Artifacts (any-of where listed) |
+|---|---|
+| categorizer | `config.json`; `model.safetensors` \| `pytorch_model.bin`; `tokenizer.json` \| `vocab.txt`; `label_encoder_…pkl` |
+| page-type | `config.json`; `model.safetensors` \| `pytorch_model.bin`; `preprocessor_config.json` |
+| OCR binaries | `tesseract` (resolved as the backend does — `TESSERACT_CMD`/PATH/bundled), `pdfinfo` + `pdftoppm` (poppler) |
+
+Models root: `JANASUNANI_MODELS_DIR`, else the package `MODELS_DIR`. The Odia
+(`ori`) traineddata is **not** auto-checked (tesseract's `--list-langs` output
+isn't portable enough) — confirm it manually post-install.
+
+## Store selection & history
+
+`create_live_app` always uses lake-backed `LakeHistory` for `/history` (a
+deliberate real-data run), and selects the result store via the same `Settings`
+layer the rest of the app uses:
+
+| `OLTP_DB_URL` | Result store |
+|---|---|
+| explicitly set (≠ the built-in default) | `DatabaseResultStore` → persists to `live_grievances` (run the Alembic migration first) |
+| unset / default | `InMemoryResultStore` — results lost on restart |
+
+`preflight_main` reports which store `main` would pick **without printing the
+URL** (it can carry a DB password).
+
+## Error mapping
+
+`process()` raises `InferenceInputError` (→ **HTTP 422**) for input the client
+can fix: wrong field combination, blank/unsupported/corrupt or empty document,
+blank OCR output, OCR quality rejection, truncation past the page cap, or a
+document with no grievance-bearing pages. A page-type **model** bug caught
+mid-OCR is wrapped (`_PageTypeModelError`) so it is never mistaken for a corrupt
+document — genuine model/runtime failures propagate as **5xx**.
+
+## macOS guards (`serve.py`)
+
+On `darwin`, before any inference import: `OMP_NUM_THREADS=1` (torch/xgboost/
+spaCy OpenMP collision in one arm64 process) and `HF_HUB_DISABLE_XET=1` (the
+Rust `hf_xet` backend can wedge the first BART download on macOS). The Linux CPU
+box is untouched.
+
+## Tests
+
+- `tests/test_inference_service.py` — real-code-path field assembly, PII
+  mapping, page-type gating, routing, error mapping (heavy internals injected).
+- `tests/test_inference_ocr.py` — `ocr_document` join/pages/labels, truncation,
+  quality rejection, temp-file cleanup (fake render/extract fns).
+- `tests/test_inference_live_builder.py` — `build_processor`/`preflight` drift
+  guards: both consume the same required-file list; a partial mirror fails closed.
+- `tests/test_inference_model_smoke.py` — opt-in real end-to-end (guarded by
+  extras + models present).

--- a/janasunani/serving/README.md
+++ b/janasunani/serving/README.md
@@ -12,7 +12,9 @@ uv run --extra serving janasunani-api
 uv run --extra serving --extra pipeline-core --extra categorizer janasunani-api-live
 ```
 
-Both serve `http://127.0.0.1:8000` by default, with OpenAPI at `/docs`.
+Both serve `http://127.0.0.1:8000` by default, with OpenAPI at `/docs`. The
+live command's warm processor, strict fail-closed startup, and preflight live in
+[`janasunani/inference`](../inference/README.md).
 The live command requires the DVC-mirrored categorizer and page-type artifacts
 under `models/` (override with `JANASUNANI_MODELS_DIR`) and fails startup rather
 than substituting the mock if an artifact, dependency, or model load is missing.


### PR DESCRIPTION
Bundles the demo-integration wiring onto one branch (absorbs the Makefile work from the now-closed #28).

## Frontend → live API
- Next.js UI wired to `janasunani-api-live` against the frozen `serving/schemas.py` contract; stale mock copy removed; `ResultView` notes the `method:"fallback"` routing case.
- `.env.local.example` + README document `NEXT_PUBLIC_API_URL`.

## Makefile — live-demo targets
- `make models` (scoped DVC pull), `preflight`, `db`, `api`, `frontend`, **`up`**, `down`.
- **`make up`**: serve API (background) + frontend (foreground), one `Ctrl-C` traps and reaps both.
- **`make down`**: also stops the frontend (kill by `FRONTEND_PORT` — `pkill` can't match Next's forked `next-server`).
- **`db` is idempotent** (create-if-missing / start-if-stopped / re-migrate) and a prerequisite of `api`/`up`, so neither serves against a nonexistent database. An off-box `OLTP_DB_URL` skips local provisioning and is **never auto-migrated** (protects prod).
- Collapsed `OLTP_URL`/`OLTP_DB_URL` to one canonical `OLTP_DB_URL` that `?=` honors from env/`.env`, so preflight/db/api can't disagree — addresses **Codex #28 P2**.

## Docs
- New `janasunani/inference/README.md` (warm processor, fail-closed `build_processor`/`preflight`, error mapping, store selection).
- README module index links inference; serving README cross-links it.
- `docs/DEMO.md` gains a Makefile fast-path callout; frontend README notes `make up`.
- ROADMAP Phase 12 ⬜ → 🔄.

Base: `feat/demo-integration`. Supersedes #28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)