### PR TITLE
fix(setup): preflight-check poppler + tesseract, fail early with install command

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -112,33 +112,46 @@ install_aws() {
 }
 
 # Poppler (pdfinfo/pdftoppm) and tesseract are system packages the OCR pipeline
-# shells out to at runtime. Unlike uv/rclone/aws they can't be installed into
-# ~/.local without sudo, so setup doesn't install them — it fails early with the
-# platform's install command rather than letting the pipeline crash on the first
-# PDF (pdf2image PDFInfoNotInstalledError). See docs/DEMO.md.
+# shells out to at runtime; without them it crashes on the first PDF (pdf2image
+# PDFInfoNotInstalledError). Unlike uv/rclone/aws they need a system package
+# manager, so on Debian/WSL (apt) we install them with sudo; elsewhere we print
+# the platform's install command and fail early. See docs/DEMO.md.
 check_system_ocr_deps() {
-    local missing=()
-    command -v pdfinfo   >/dev/null || missing+=("poppler-utils")
-    command -v pdftoppm  >/dev/null || missing+=("poppler-utils")
-    command -v tesseract >/dev/null || missing+=("tesseract-ocr")
+    command -v pdfinfo >/dev/null \
+        && command -v pdftoppm >/dev/null \
+        && command -v tesseract >/dev/null \
+        && { warn_missing_odia_traineddata; return; }
 
-    if [ "${#missing[@]}" -gt 0 ]; then
-        # de-duplicate (poppler-utils provides both pdfinfo and pdftoppm)
-        local unique
-        unique="$(printf '%s\n' "${missing[@]}" | sort -u | tr '\n' ' ')"
-        echo "Missing system OCR/PDF binaries: ${unique% }"
-        if [ "$(uname -s)" = "Darwin" ]; then
-            echo "Install with: brew install poppler tesseract tesseract-lang"
-        else
-            echo "Install with: sudo apt-get update && sudo apt-get install -y \\"
-            echo "    poppler-utils tesseract-ocr tesseract-ocr-ori"
+    echo "Missing system OCR/PDF binaries (poppler and/or tesseract)."
+
+    # Debian/Ubuntu/WSL: install directly. sudo elevates just this command,
+    # which is fine even though setup itself must not run as root.
+    if command -v apt-get >/dev/null; then
+        echo "Installing poppler-utils + tesseract-ocr (+ Odia) via apt..."
+        if sudo apt-get update && sudo apt-get install -y \
+            poppler-utils tesseract-ocr tesseract-ocr-ori; then
+            warn_missing_odia_traineddata
+            return
         fi
-        echo "Then rerun: make setup"
+        echo "Automatic install failed — install the packages above manually,"
+        echo "then rerun: make setup"
         exit 1
     fi
 
-    # binary present, but the Odia (ori) traineddata may not be — the pipeline
-    # needs it for the ori OCR pass. Warn rather than fail; eng-only still runs.
+    # No apt (macOS / other distros): can't assume a package manager or sudo.
+    if [ "$(uname -s)" = "Darwin" ]; then
+        echo "Install with: brew install poppler tesseract tesseract-lang"
+    else
+        echo "Install poppler-utils, tesseract-ocr and tesseract-ocr-ori with"
+        echo "your system package manager."
+    fi
+    echo "Then rerun: make setup"
+    exit 1
+}
+
+# The tesseract binary can be present without the Odia (ori) traineddata the
+# pipeline needs for its ori OCR pass. Warn rather than fail; eng-only still runs.
+warn_missing_odia_traineddata() {
     if ! tesseract --list-langs 2>/dev/null | grep -qx ori; then
         echo "WARNING: tesseract 'ori' (Odia) traineddata not found."
         echo "  Debian/WSL: sudo apt-get install -y tesseract-ocr-ori"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -111,6 +111,41 @@ install_aws() {
     rm -rf "${tmpdir}"
 }
 
+# Poppler (pdfinfo/pdftoppm) and tesseract are system packages the OCR pipeline
+# shells out to at runtime. Unlike uv/rclone/aws they can't be installed into
+# ~/.local without sudo, so setup doesn't install them — it fails early with the
+# platform's install command rather than letting the pipeline crash on the first
+# PDF (pdf2image PDFInfoNotInstalledError). See docs/DEMO.md.
+check_system_ocr_deps() {
+    local missing=()
+    command -v pdfinfo   >/dev/null || missing+=("poppler-utils")
+    command -v pdftoppm  >/dev/null || missing+=("poppler-utils")
+    command -v tesseract >/dev/null || missing+=("tesseract-ocr")
+
+    if [ "${#missing[@]}" -gt 0 ]; then
+        # de-duplicate (poppler-utils provides both pdfinfo and pdftoppm)
+        local unique
+        unique="$(printf '%s\n' "${missing[@]}" | sort -u | tr '\n' ' ')"
+        echo "Missing system OCR/PDF binaries: ${unique% }"
+        if [ "$(uname -s)" = "Darwin" ]; then
+            echo "Install with: brew install poppler tesseract tesseract-lang"
+        else
+            echo "Install with: sudo apt-get update && sudo apt-get install -y \\"
+            echo "    poppler-utils tesseract-ocr tesseract-ocr-ori"
+        fi
+        echo "Then rerun: make setup"
+        exit 1
+    fi
+
+    # binary present, but the Odia (ori) traineddata may not be — the pipeline
+    # needs it for the ori OCR pass. Warn rather than fail; eng-only still runs.
+    if ! tesseract --list-langs 2>/dev/null | grep -qx ori; then
+        echo "WARNING: tesseract 'ori' (Odia) traineddata not found."
+        echo "  Debian/WSL: sudo apt-get install -y tesseract-ocr-ori"
+        echo "  macOS:      brew install tesseract-lang"
+    fi
+}
+
 install_missing_prereqs() {
     ensure_user_bin_on_path
 
@@ -123,6 +158,7 @@ install_missing_prereqs() {
     command -v uv >/dev/null || install_uv
     command -v rclone >/dev/null || install_rclone
     command -v aws >/dev/null || install_aws
+    check_system_ocr_deps
 
     command -v git >/dev/null
     command -v uv >/dev/null

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -111,16 +111,49 @@ install_aws() {
     rm -rf "${tmpdir}"
 }
 
+# Resolve the tesseract binary the same way the runtime does
+# (pytesseract_backend.py / features.py): $TESSERACT_CMD, then PATH, then the
+# repo's no-sudo ~/.local install. Echoes the path on success.
+resolve_tesseract() {
+    local candidate
+    for candidate in "${TESSERACT_CMD:-}" "$(command -v tesseract 2>/dev/null)" \
+        "${HOME}/.local/tesseract/usr/bin/tesseract"; do
+        if [ -n "${candidate}" ] && [ -x "${candidate}" ]; then
+            echo "${candidate}"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Resolve a poppler binary (pdfinfo/pdftoppm) the same way the runtime does
+# (page_renderer.py / stage.py): the ~/.local poppler dir first, then PATH.
+resolve_poppler_bin() {
+    local user_bin="${HOME}/.local/poppler/usr/bin/$1"
+    if [ -x "${user_bin}" ]; then
+        echo "${user_bin}"
+        return 0
+    fi
+    command -v "$1" 2>/dev/null
+}
+
 # Poppler (pdfinfo/pdftoppm) and tesseract are system packages the OCR pipeline
 # shells out to at runtime; without them it crashes on the first PDF (pdf2image
 # PDFInfoNotInstalledError). Unlike uv/rclone/aws they need a system package
 # manager, so on Debian/WSL (apt) we install them with sudo; elsewhere we print
-# the platform's install command and fail early. See docs/DEMO.md.
+# the platform's install command and fail early. A valid ~/.local (no-sudo) or
+# $TESSERACT_CMD install is accepted here too — matching the runtime resolvers —
+# so it isn't false-failed. See docs/DEMO.md.
 check_system_ocr_deps() {
-    command -v pdfinfo >/dev/null \
-        && command -v pdftoppm >/dev/null \
-        && command -v tesseract >/dev/null \
-        && { warn_missing_odia_traineddata; return; }
+    local tesseract_bin poppler_ok=1
+    resolve_poppler_bin pdfinfo  >/dev/null || poppler_ok=0
+    resolve_poppler_bin pdftoppm >/dev/null || poppler_ok=0
+    tesseract_bin="$(resolve_tesseract || true)"
+
+    if [ "${poppler_ok}" -eq 1 ] && [ -n "${tesseract_bin}" ]; then
+        warn_missing_odia_traineddata "${tesseract_bin}"
+        return
+    fi
 
     echo "Missing system OCR/PDF binaries (poppler and/or tesseract)."
 
@@ -151,8 +184,10 @@ check_system_ocr_deps() {
 
 # The tesseract binary can be present without the Odia (ori) traineddata the
 # pipeline needs for its ori OCR pass. Warn rather than fail; eng-only still runs.
+# $1 = resolved tesseract path (defaults to PATH lookup after an apt install).
 warn_missing_odia_traineddata() {
-    if ! tesseract --list-langs 2>/dev/null | grep -qx ori; then
+    local tesseract_bin="${1:-tesseract}"
+    if ! "${tesseract_bin}" --list-langs 2>/dev/null | grep -qx ori; then
         echo "WARNING: tesseract 'ori' (Odia) traineddata not found."
         echo "  Debian/WSL: sudo apt-get install -y tesseract-ocr-ori"
         echo "  macOS:      brew install tesseract-lang"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -126,15 +126,23 @@ resolve_tesseract() {
     return 1
 }
 
-# Resolve a poppler binary (pdfinfo/pdftoppm) the same way the runtime does
-# (page_renderer.py / stage.py): the ~/.local poppler dir first, then PATH.
-resolve_poppler_bin() {
-    local user_bin="${HOME}/.local/poppler/usr/bin/$1"
-    if [ -x "${user_bin}" ]; then
-        echo "${user_bin}"
-        return 0
+# Is poppler usable the way the runtime uses it? The runtime (page_renderer.py /
+# stage.py) picks ONE poppler directory — keyed on whether pdfinfo exists there —
+# and pdf2image then looks for pdftoppm in that SAME directory. So both binaries
+# must live together: in the ~/.local dir, or in /usr/bin, or (POPPLER_PATH=None)
+# both found on PATH. A pdfinfo in ~/.local with pdftoppm only on PATH fails at
+# runtime, so it must fail here too.
+poppler_usable() {
+    local user_dir="${HOME}/.local/poppler/usr/bin"
+    if [ -x "${user_dir}/pdfinfo" ]; then
+        [ -x "${user_dir}/pdftoppm" ]
+        return
     fi
-    command -v "$1" 2>/dev/null
+    if [ -x "/usr/bin/pdfinfo" ]; then
+        [ -x "/usr/bin/pdftoppm" ]
+        return
+    fi
+    command -v pdfinfo >/dev/null && command -v pdftoppm >/dev/null
 }
 
 # Poppler (pdfinfo/pdftoppm) and tesseract are system packages the OCR pipeline
@@ -145,13 +153,11 @@ resolve_poppler_bin() {
 # $TESSERACT_CMD install is accepted here too — matching the runtime resolvers —
 # so it isn't false-failed. See docs/DEMO.md.
 check_system_ocr_deps() {
-    local tesseract_bin poppler_ok=1
-    resolve_poppler_bin pdfinfo  >/dev/null || poppler_ok=0
-    resolve_poppler_bin pdftoppm >/dev/null || poppler_ok=0
+    local tesseract_bin
     tesseract_bin="$(resolve_tesseract || true)"
 
-    if [ "${poppler_ok}" -eq 1 ] && [ -n "${tesseract_bin}" ]; then
-        warn_missing_odia_traineddata "${tesseract_bin}"
+    if poppler_usable && [ -n "${tesseract_bin}" ]; then
+        check_tesseract_langs "${tesseract_bin}"
         return
     fi
 
@@ -163,7 +169,7 @@ check_system_ocr_deps() {
         echo "Installing poppler-utils + tesseract-ocr (+ Odia) via apt..."
         if sudo apt-get update && sudo apt-get install -y \
             poppler-utils tesseract-ocr tesseract-ocr-ori; then
-            warn_missing_odia_traineddata
+            check_tesseract_langs
             return
         fi
         echo "Automatic install failed — install the packages above manually,"
@@ -182,12 +188,23 @@ check_system_ocr_deps() {
     exit 1
 }
 
-# The tesseract binary can be present without the Odia (ori) traineddata the
-# pipeline needs for its ori OCR pass. Warn rather than fail; eng-only still runs.
-# $1 = resolved tesseract path (defaults to PATH lookup after an apt install).
-warn_missing_odia_traineddata() {
-    local tesseract_bin="${1:-tesseract}"
-    if ! "${tesseract_bin}" --list-langs 2>/dev/null | grep -qx ori; then
+# Validate the resolved tesseract, then check its languages. Two distinct
+# outcomes the caller must not conflate:
+#   - the binary can't run (stale/broken $TESSERACT_CMD or PATH entry) -> FAIL,
+#     because pytesseract calls would later error or return empty OCR;
+#   - it runs but lacks the Odia (ori) traineddata -> WARN only, eng-only runs.
+# --list-langs is captured with 2>&1 so the language list is seen regardless of
+# which stream a given tesseract build prints it on; the exit code decides
+# runnable-vs-broken. $1 = resolved tesseract path (default: PATH after apt).
+check_tesseract_langs() {
+    local tesseract_bin="${1:-tesseract}" langs
+    if ! langs="$("${tesseract_bin}" --list-langs 2>&1)"; then
+        echo "tesseract at '${tesseract_bin}' failed to run (--list-langs):"
+        printf '%s\n' "${langs}"
+        echo "Repair or reinstall tesseract, then rerun: make setup"
+        exit 1
+    fi
+    if ! printf '%s\n' "${langs}" | grep -qx ori; then
         echo "WARNING: tesseract 'ori' (Odia) traineddata not found."
         echo "  Debian/WSL: sudo apt-get install -y tesseract-ocr-ori"
         echo "  macOS:      brew install tesseract-lang"


### PR DESCRIPTION
## Problem

A collaborator ran `make setup` successfully, then hit this at pipeline runtime:

```
pdf2image.exceptions.PDFInfoNotInstalledError: Unable to get page count. Is poppler installed and in PATH?
```

`scripts/setup.sh` installs `uv`/`rclone`/`aws` into `~/.local`, but never handled the **poppler** (`pdfinfo`/`pdftoppm`) and **tesseract** system binaries the OCR pipeline shells out to. Those were only documented as a manual step in `docs/DEMO.md`, so setup reported success and the failure surfaced later on the first PDF.

## Fix

Add `check_system_ocr_deps()`, called from `install_missing_prereqs`:

- **Debian/Ubuntu/WSL (apt-get present):** installs `poppler-utils tesseract-ocr tesseract-ocr-ori` directly via `sudo apt-get`. `sudo` elevates only that command — consistent with the existing `sudo apt-get install git` guidance and not in conflict with the "don't run setup as root" guard (which protects the `~/.local` installs).
- **No apt (macOS / other distros):** prints the platform-appropriate install command (`brew` on macOS) and exits, rather than crashing later at runtime.
- **Install failure:** falls back to manual instructions + exit.
- Non-fatal warning (`warn_missing_odia_traineddata`) when the tesseract `ori` (Odia) traineddata is missing, since eng-only OCR still runs.

## Verification

- `bash -n scripts/setup.sh` passes.
- Exercised both branches with `apt-get`/`sudo` stubbed: apt path runs `apt-get update` + `install -y poppler-utils tesseract-ocr tesseract-ocr-ori`; no-apt path prints manual instructions and exits 1.