### PR TITLE
Phase 13: hold raw OCR back from the lake, add the synthetic E2E canary

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -227,9 +227,9 @@ characters). Phase 15 S4 then reads that field over the full corpus by design.
 |---|---|---|
 | `complaints` structured columns, OLTP **and** lake | **Yes** | `petitioner_name`, `petitioner_mobile`, `petitioner_email`, `address`. Faithful to the dump, by design |
 | **`complaints.grievance`, OLTP and lake** | **Yes, raw prose** | Citizen-authored, never passed through `pii_tagger`. Materialized verbatim by `SELECT *` |
-| `pages.extracted_text` (raw OCR) | **Yes** | Never leaves the pipeline artifact DB |
-| `pages.redacted_text` | No, by construction | Typed tokens. This is what the exporter carries onward |
-| Parquet lake, *pipeline-derived* text fields | No | Only redacted page text is exported by the pipeline |
+| `pages.extracted_text` (raw OCR) | **Yes** | Artifact DB **and OLTP** — the exporter copies every column. Held back from the lake by `LAKE_COLUMN_DENYLIST` (`olap/materialize.py`); access-controlled, not redacted |
+| `pages.redacted_text` | No, by construction | Typed tokens. This is what reaches the lake |
+| Parquet lake, *pipeline-derived* text fields | No | Only redacted page text. Enforced by the denylist above and asserted in `tests/test_e2e_synthetic.py`, not merely intended |
 | Dedup index, MinHash signatures | **Yes, derived** | Salted contact hashes, plus signatures over raw `grievance`. A hash is not anonymous |
 | Embeddings over `grievance` (S4) | **Yes, derived** | A vector is not anonymous merely because it is unreadable |
 | API responses, summaries | No | Built only from redacted text |
@@ -442,12 +442,28 @@ pytest.
 - `scripts/e2e_pipeline.sh`: a scripted multi-environment run over a fixed sample.
   Document → S3 → artifact DB → exporter → OLTP → materialize → lake → API
   read-back.
-- Asserts row counts at each hop, and that no un-redacted PII reaches the lake or
-  any API response.
+- Asserts row counts at each hop, and that no un-redacted *page* text reaches the
+  lake. **Not** "no un-redacted PII reaches the lake": §3.2 explains why that is
+  false and cannot be an acceptance criterion.
 - A **non-PII synthetic variant** that runs in CI. This doubles as the readiness
   canary: it proves real history is queryable, the DB result store is selected,
   routing mappings loaded rather than silently `fallback`, and submit→persist→fetch
   succeeds.
+
+✅ **The synthetic variant is built** (`tests/test_e2e_synthetic.py`, PR #59).
+Artifact DB → OLTP → lake → API over invented fixtures, row counts asserted at
+each hop, with only the models replaced by a canned stand-in. History and store
+selection are asserted through `inference.serve.create_live_app`, so a
+deployment that silently keeps `MockHistory` or `InMemoryResultStore` fails the
+canary. Two caveats it records honestly: routing is exercised via `MappingRouter`
+directly, because the router is wired inside `build_processor`, which needs the
+models; and the pipeline's own stages are not run. Both belong to the real-data
+variant, which is still outstanding.
+
+Building it found the leak §3.2 now describes: `materialize.py` was copying
+`pages.extracted_text` into Parquet verbatim. The lake was re-materialized and
+`dvc.lock` updated, because the code fix alone left the pre-fix artifact in
+circulation through `dvc pull`.
 
 **Exit criteria.** Per-entity, per-language PII scorecard published. E2E green on
 real data and synthetic in CI. DSI baselines reproduced or the gap explained.

--- a/dvc.lock
+++ b/dvc.lock
@@ -9,8 +9,8 @@ stages:
       size: 7071113216
     - path: janasunani/olap/materialize.py
       hash: md5
-      md5: ea29e1c583a082cf9bc669f98396f72b
-      size: 3356
+      md5: 9bb2ff8dbbbcc3c9502f5d080c0fbc11
+      size: 5273
     outs:
     - path: data/interim/action_history.parquet
       hash: md5
@@ -26,8 +26,8 @@ stages:
       size: 198
     - path: data/interim/pages.parquet
       hash: md5
-      md5: 816be322183d304d67c042f27ae55d9a
-      size: 10361
+      md5: 4ad7a17893cb22a396f572b899e68c25
+      size: 3925
   pipeline-sample:
     cmd: uv run --extra pipeline-core janasunani-pipeline run --input 
       data/raw/documents-sample --db data/processed/pipeline-sample.sqlite 

--- a/janasunani/olap/materialize.py
+++ b/janasunani/olap/materialize.py
@@ -20,6 +20,25 @@ from janasunani.config import directories, settings
 # document pipeline's outputs (empty until the exporter has run).
 LAKE_TABLES = ("complaints", "action_history", "pages", "documents")
 
+# Columns held back from the lake.
+#
+# ``pages.extracted_text`` is the raw OCR of a scanned document, un-redacted by
+# construction: ``pii_tagger`` reads it and writes its output to
+# ``redacted_text``, leaving this column untouched. It stays in the pipeline's
+# artifact DB and in the access-controlled OLTP store, but it must not reach
+# Parquet, which is the input to every downstream analytical consumer and is
+# not access-controlled per-column. Nothing downstream reads it: the summarizer
+# and categorizer take ``redacted_text`` off the artifact DB, and the OCR
+# benchmark reads the artifact DB directly.
+#
+# This is the page-text half of the guarantee. The other half — the historical
+# ``complaints.grievance``, which has never met ``pii_tagger`` — is controlled
+# by access rather than redaction, and gets its own redaction pass. See
+# ROADMAP §3.2.
+LAKE_COLUMN_DENYLIST: dict[str, frozenset[str]] = {
+    "pages": frozenset({"extracted_text"}),
+}
+
 
 def _attach_oltp(
     con: duckdb.DuckDBPyConnection, oltp_url: str, alias: str = "oltp"
@@ -45,6 +64,26 @@ def _attach_oltp(
         )
 
 
+def _select_list(con: duckdb.DuckDBPyConnection, table: str, alias: str = "oltp") -> str:
+    """Column list for ``table``, minus anything on the denylist.
+
+    Returns ``*`` when nothing is held back, so the emitted SQL stays readable
+    and the common tables keep their existing behaviour exactly.
+    """
+    denied = LAKE_COLUMN_DENYLIST.get(table)
+    if not denied:
+        return "*"
+    cursor = con.execute(f"SELECT * FROM {alias}.{table} LIMIT 0")  # noqa: S608
+    columns = [c[0] for c in cursor.description]
+    kept = [c for c in columns if c not in denied]
+    if not kept:
+        raise ValueError(f"denylist would drop every column of {table!r}")
+    dropped = sorted(set(columns) & denied)
+    if dropped:
+        logger.info(f"{table}: holding back {', '.join(dropped)} from the lake")
+    return ", ".join(f'"{c}"' for c in kept)
+
+
 def materialize(
     oltp_url: Optional[str] = None,
     out_dir: Optional[Path] = None,
@@ -62,7 +101,10 @@ def materialize(
         for table in tables:
             path = out / f"{table}.parquet"
             logger.info(f"Materializing {table} -> {path}")
-            con.execute(f"COPY (SELECT * FROM oltp.{table}) TO '{path}' (FORMAT parquet)")
+            columns = _select_list(con, table)
+            con.execute(
+                f"COPY (SELECT {columns} FROM oltp.{table}) TO '{path}' (FORMAT parquet)"  # noqa: S608
+            )
             counts[table] = con.execute(
                 f"SELECT count(*) FROM read_parquet('{path.as_posix()}')"
             ).fetchone()[0]

--- a/tests/test_e2e_synthetic.py
+++ b/tests/test_e2e_synthetic.py
@@ -17,8 +17,25 @@ silently degraded at least once, and degrades quietly rather than loudly:
 * routing resolves off the real master tables rather than reporting
   ``method="fallback"`` because the CSVs were never materialized.
 
+**Where the wiring is asserted.** The store and history tests below go through
+``inference.serve.create_live_app`` — the function the deployed API actually
+calls — with only ``build_processor`` substituted, because that is the one
+piece that loads models. Injecting ``LakeHistory``/``DatabaseResultStore``
+directly would prove the components work while saying nothing about whether
+production selects them, which is the failure worth catching.
+
+Routing is the exception, and deliberately so: the router is wired inside
+``build_processor`` (``router=DEFAULT_ROUTER``), which cannot run here. The
+test below exercises ``MappingRouter`` directly and therefore covers the
+loader, not the wire-up. Confirming the deployed processor routes off the
+master tables is the real-data E2E's job.
+
 Everything here is invented. No fixture in this file may carry real citizen
 text: that is what makes it runnable in CI.
+
+⚠️ Every test that reaches ``Settings`` sets ``OLTP_DB_URL`` explicitly. An
+ambient value from the project ``.env`` could point at the production Postgres,
+and these tests write. Never let one resolve OLTP by default.
 """
 
 from __future__ import annotations
@@ -31,7 +48,9 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine, insert
 
+from janasunani.config import DEFAULT_OLTP_DB_URL, directories
 from janasunani.db.models import Base, Complaint
+from janasunani.inference import serve
 from janasunani.olap import lake
 from janasunani.olap.materialize import materialize
 from janasunani.pipeline.db import initialize_database
@@ -131,7 +150,7 @@ _MAPPING_CSVS = {
 
 def _write_mapping_dir(tmp_path: Path) -> Path:
     mapping_dir = tmp_path / "janasunani-mappings"
-    mapping_dir.mkdir()
+    mapping_dir.mkdir(exist_ok=True)  # a restart test builds the app twice
     for name, body in _MAPPING_CSVS.items():
         (mapping_dir / name).write_text(body, encoding="utf-8")
     return mapping_dir
@@ -323,13 +342,96 @@ def test_routing_resolves_off_master_tables_not_fallback(tmp_path):
     assert not degraded.mapping_loaded
 
 
-def test_submit_persists_and_fetches_through_the_db_store(tmp_path):
-    """submit -> persist -> fetch, across two app instances.
+def _live_app(monkeypatch, tmp_path, *, oltp_url: str, lake_dir: Path):
+    """Build the app through the real ``create_live_app``.
 
-    The in-memory default would pass a single-process submit/fetch and lose
-    everything on restart. Fetching through a *second* app over the same OLTP
-    is what proves the DB store is the one selected.
+    Only ``build_processor`` is replaced — it is the piece that loads models.
+    Store selection, history selection and the ``Settings`` lookup all run for
+    real, which is the point.
     """
+    processor = _CanaryProcessor(MappingRouter(mapping_dir=_write_mapping_dir(tmp_path)))
+    monkeypatch.setattr(serve, "build_processor", lambda: processor)
+    # LakeHistory() takes no lake_dir, so it resolves directories.INTERIM —
+    # which is the real data/interim/. Redirecting it is what keeps this test
+    # off real citizen data, not just a convenience.
+    monkeypatch.setattr(directories, "INTERIM", lake_dir)
+    monkeypatch.setenv("OLTP_DB_URL", oltp_url)
+    return serve.create_live_app()
+
+
+def test_live_app_wiring_selects_lake_history_and_db_store(monkeypatch, tmp_path):
+    """submit -> persist -> fetch and /history, through ``create_live_app``.
+
+    Two failures this catches that injecting the components could not: the
+    deployed app silently keeping ``InMemoryResultStore`` because OLTP was
+    never explicitly configured, and it serving ``MockHistory``'s fake rows.
+    """
+    oltp_url = _make_oltp(tmp_path)
+    lake_dir = tmp_path / "interim"
+    materialize(oltp_url=oltp_url, out_dir=lake_dir)
+
+    app = _live_app(monkeypatch, tmp_path, oltp_url=oltp_url, lake_dir=lake_dir)
+    with TestClient(app) as client:
+        assert client.get("/health").json()["processor"] == "canary"
+
+        history = client.get("/history", params={"limit": 50}).json()
+        assert {item["ticket_no"] for item in history["items"]} == {
+            "SYN0000001",
+            "SYN0000002",
+        }
+
+        submitted = client.post(
+            "/grievance", data={"text": "Street light out.", "district": "Khordha"}
+        )
+    assert submitted.status_code == 201
+    result = submitted.json()
+    assert result["routing"]["method"] == "rules"
+    assert result["routing"]["dept"] == "Energy"
+
+    # a restart rebuilds the app from scratch; the submission must survive it
+    second = _live_app(monkeypatch, tmp_path, oltp_url=oltp_url, lake_dir=lake_dir)
+    with TestClient(second) as client:
+        fetched = client.get(f"/grievance/{result['id']}")
+        missing = client.get("/grievance/deadbeefdead")
+
+    assert fetched.status_code == 200
+    assert fetched.json()["ticket_no"] == result["ticket_no"]
+    assert missing.status_code == 404
+
+
+def test_live_app_loses_submissions_when_oltp_is_not_explicitly_configured(
+    monkeypatch, tmp_path
+):
+    """The silent fallback, pinned as behaviour rather than left as a surprise.
+
+    ``_resolve_explicit_oltp_url`` treats the built-in SQLite default as "not
+    configured" and hands back ``InMemoryResultStore``. The API stays healthy
+    and submissions still return 201; they just do not survive a restart. If
+    the box's ``deploy/.env`` is missing ``OLTP_DB_URL``, this is what the demo
+    does.
+    """
+    lake_dir = tmp_path / "interim"
+    lake_dir.mkdir()
+    processor = _CanaryProcessor(MappingRouter(mapping_dir=_write_mapping_dir(tmp_path)))
+    monkeypatch.setattr(serve, "build_processor", lambda: processor)
+    monkeypatch.setattr(directories, "INTERIM", lake_dir)
+    # set explicitly to the built-in default: "unset" would let a real .env
+    # through, and this test must never resolve the production database
+    monkeypatch.setenv("OLTP_DB_URL", DEFAULT_OLTP_DB_URL)
+
+    with TestClient(serve.create_live_app()) as client:
+        submitted = client.post("/grievance", data={"text": "Street light out."})
+        assert submitted.status_code == 201
+        grievance_id = submitted.json()["id"]
+        # same process, same store: still there
+        assert client.get(f"/grievance/{grievance_id}").status_code == 200
+
+    with TestClient(serve.create_live_app()) as client:
+        assert client.get(f"/grievance/{grievance_id}").status_code == 404
+
+
+def test_submit_persists_and_fetches_through_the_db_store(tmp_path):
+    """The store itself, isolated from how the live app selects it."""
     oltp_url = _make_oltp(tmp_path)
     mapping_dir = _write_mapping_dir(tmp_path)
     processor = _CanaryProcessor(MappingRouter(mapping_dir=mapping_dir))
@@ -338,32 +440,25 @@ def test_submit_persists_and_fetches_through_the_db_store(tmp_path):
     app = create_app(processor=processor, result_store=store)
     try:
         with TestClient(app) as client:
-            assert client.get("/health").json()["processor"] == "canary"
             submitted = client.post(
                 "/grievance",
                 data={"text": "Street light out.", "district": "Khordha"},
             )
         assert submitted.status_code == 201
         result = submitted.json()
-        assert result["routing"]["method"] == "rules"
-        assert result["routing"]["dept"] == "Energy"
     finally:
         asyncio.run(store.dispose())
 
-    # a fresh process would build a fresh app and a fresh store
     second_store = DatabaseResultStore(oltp_url)
     second_app = create_app(processor=processor, result_store=second_store)
     try:
         with TestClient(second_app) as client:
             fetched = client.get(f"/grievance/{result['id']}")
-            missing = client.get("/grievance/deadbeefdead")
     finally:
         asyncio.run(second_store.dispose())
 
     assert fetched.status_code == 200
     assert fetched.json()["ticket_no"] == result["ticket_no"]
-    assert fetched.json()["routing"]["dept"] == "Energy"
-    assert missing.status_code == 404
 
 
 @pytest.mark.parametrize("table", ["complaints", "action_history", "pages", "documents"])

--- a/tests/test_e2e_synthetic.py
+++ b/tests/test_e2e_synthetic.py
@@ -1,0 +1,379 @@
+"""Synthetic end-to-end canary: artifact DB -> OLTP -> lake -> API.
+
+The Phase 13 end-to-end run has two variants. The real-data one
+(``scripts/e2e_pipeline.sh``) needs S3, the model mirrors and the three
+mutually-exclusive extras, so it cannot run here. This is the other one: the
+same hops, over non-PII synthetic fixtures, with every model replaced by a
+canned stand-in and *everything else* on the real code path.
+
+It doubles as the readiness canary. Each hop below is something that has
+silently degraded at least once, and degrades quietly rather than loudly:
+
+* the exporter writes the artifact DB into OLTP;
+* materialization carries OLTP into Parquet, and holds back the raw OCR column;
+* the lake is queryable as history;
+* the API's result store is the DB one, not the in-memory default that loses
+  submissions on restart;
+* routing resolves off the real master tables rather than reporting
+  ``method="fallback"`` because the CSVs were never materialized.
+
+Everything here is invented. No fixture in this file may carry real citizen
+text: that is what makes it runnable in CI.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, insert
+
+from janasunani.db.models import Base, Complaint
+from janasunani.olap import lake
+from janasunani.olap.materialize import materialize
+from janasunani.pipeline.db import initialize_database
+from janasunani.pipeline.export import export_pipeline_db
+from janasunani.routing.rules import MappingRouter
+from janasunani.serving.api import create_app
+from janasunani.serving.history import LakeHistory
+from janasunani.serving.schemas import (
+    ClassificationResult,
+    ExtractionResult,
+    GrievanceResult,
+    RedactionResult,
+)
+from janasunani.serving.store import DatabaseResultStore
+
+# --- synthetic fixtures ------------------------------------------------------
+#
+# Invented tickets, invented text. The "raw" page text carries a marker string
+# we can grep the whole lake for; the redacted text is what the pipeline would
+# have produced.
+
+_RAW_MARKER = "SYNTHETIC-RAW-ONLY-MUST-NOT-LEAVE-OLTP"
+
+_PAGES = (
+    # (page_id, doc_id, page_number, ticket_no, extracted_text, redacted_text)
+    (
+        "SYN1-p1",
+        "SYN1",
+        1,
+        "SYN0000001",
+        f"{_RAW_MARKER} Street light out on the main road since last month.",
+        "<NAME> Street light out on the main road since last month.",
+    ),
+    (
+        "SYN1-p2",
+        "SYN1",
+        2,
+        "SYN0000001",
+        f"{_RAW_MARKER} Requesting repair before the monsoon.",
+        "<NAME> Requesting repair before the monsoon.",
+    ),
+    (
+        "SYN2-p1",
+        "SYN2",
+        1,
+        "SYN0000002",
+        f"{_RAW_MARKER} The village hand pump has been broken for two months.",
+        "<NAME> The village hand pump has been broken for two months.",
+    ),
+)
+
+_DOCUMENTS = (
+    ("SYN1", "SYN0000001", "Street light out", "Street lighting repair request", "Electricity"),
+    ("SYN2", "SYN0000002", "Hand pump broken", "Hand pump repair request", "Drinking Water Supply"),
+)
+
+_COMPLAINTS = (
+    {
+        "ticket_no": "SYN0000001",
+        "district": "Khordha",
+        "category": "Electricity",
+        "grievance": "Street light out on the main road since last month.",
+    },
+    {
+        "ticket_no": "SYN0000002",
+        "district": "Cuttack",
+        "category": "Drinking Water Supply",
+        "grievance": "The village hand pump has been broken for two months.",
+    },
+)
+
+# Minimal master tables in the real CSV shape, so MappingRouter loads and
+# resolves for real. "Energy" is the literal category==department name match
+# the loader documents as the only non-fabricated bridge.
+_MAPPING_CSVS = {
+    "m_admin_category.csv": (
+        "intCategoryId,vchCategory,vchCategoryOD\n"
+        "1,Energy,ଶକ୍ତି\n"
+        "2,Drinking Water Supply,ପାନୀୟ ଜଳ\n"
+    ),
+    "m_admin_hierarchy_value.csv": (
+        "intAdminHierarchyValueId,vchAdminHierarchyValue,vchAdminHierarchyValueO\n"
+        "5,Energy,ଶକ୍ତି\n"
+    ),
+    "m_admin_offices.csv": "intOfficeId,vchOfficeName\n5,Departments\n6,Collector\n",
+    # vchDesignationSequence is itself comma-separated, hence the quoting.
+    # bitDeletedFlag=0 (active) and a non-zero intDepartmentId are both load
+    # conditions, not decoration.
+    "t_admin_escalation.csv": (
+        "intEscalationId,intDepartmentId,intOfficeId,intEscalation,"
+        "vchDesignationSequence,bitDeletedFlag\n"
+        '1,5,6,2,"17,18",0\n'
+    ),
+    "m_role.csv": "intRoleId,vchRoleName\n17,Executive Engineer\n18,CEO TPCODL\n",
+}
+
+
+def _write_mapping_dir(tmp_path: Path) -> Path:
+    mapping_dir = tmp_path / "janasunani-mappings"
+    mapping_dir.mkdir()
+    for name, body in _MAPPING_CSVS.items():
+        (mapping_dir / name).write_text(body, encoding="utf-8")
+    return mapping_dir
+
+
+def _seed_artifact_db(path: Path) -> None:
+    """Populate the pipeline's own SQLite artifact DB, as the stages would."""
+    initialize_database(path)
+    with sqlite3.connect(path) as con:
+        con.executemany(
+            "INSERT OR REPLACE INTO pages (page_id, doc_id, page_number, full_path,"
+            " ticket_number, language, page_type, extracted_text, redacted_text)"
+            " VALUES (?, ?, ?, ?, ?, 'English', 'Letter', ?, ?)",
+            [
+                (page_id, doc_id, n, f"/synthetic/{doc_id}.pdf", ticket, raw, red)
+                for page_id, doc_id, n, ticket, raw, red in _PAGES
+            ],
+        )
+        con.executemany(
+            "INSERT OR REPLACE INTO documents (doc_id, ticket_number, grievance,"
+            " summary, grievance_category) VALUES (?, ?, ?, ?, ?)",
+            list(_DOCUMENTS),
+        )
+        con.commit()
+
+
+def _make_oltp(tmp_path: Path) -> str:
+    """Create the OLTP schema and seed the synthetic complaint history."""
+    url = f"sqlite+aiosqlite:///{tmp_path}/oltp.db"
+    sync = create_engine(url.replace("+aiosqlite", ""))
+    Base.metadata.create_all(sync)
+    with sync.begin() as conn:
+        conn.execute(insert(Complaint), list(_COMPLAINTS))
+    sync.dispose()
+    return url
+
+
+class _CanaryProcessor:
+    """Canned extraction/classification, **real** routing.
+
+    The models are what the synthetic variant cannot run. Routing is not a
+    model, so it stays on the real code path: that is the half of the
+    submit-path this canary is actually guarding.
+    """
+
+    name = "canary"
+
+    def __init__(self, router: MappingRouter) -> None:
+        self._router = router
+
+    def process(
+        self,
+        *,
+        grievance_id: str,
+        ticket_no: str,
+        text=None,
+        document_name=None,
+        document_bytes=None,
+        district=None,
+    ) -> GrievanceResult:
+        from datetime import UTC, datetime
+
+        body = text or f"[canary OCR of {document_name}]"
+        return GrievanceResult(
+            id=grievance_id,
+            ticket_no=ticket_no,
+            status="Submitted",
+            submitted_on=datetime.now(UTC),
+            extraction=ExtractionResult(source="text", extracted_text=body),
+            redaction=RedactionResult(redacted_text=body, entities=[]),
+            classification=ClassificationResult(category="Energy", language="en"),
+            summary="Canary submission.",
+            routing=self._router.route(category="Energy", district=district),
+        )
+
+
+# --- the canary --------------------------------------------------------------
+
+
+def test_synthetic_pipeline_end_to_end(tmp_path):
+    """Every hop, with row counts asserted where they are checkable."""
+    artifact_db = tmp_path / "pipeline.sqlite"
+    _seed_artifact_db(artifact_db)
+    oltp_url = _make_oltp(tmp_path)
+    lake_dir = tmp_path / "interim"
+
+    # hop 1: artifact DB -> OLTP
+    exported = export_pipeline_db(artifact_db, oltp_url=oltp_url)
+    assert exported == {"pages": len(_PAGES), "documents": len(_DOCUMENTS)}
+
+    # hop 2: OLTP -> Parquet lake. Counts must survive the crossing.
+    materialized = materialize(oltp_url=oltp_url, out_dir=lake_dir)
+    assert materialized == {
+        "complaints": len(_COMPLAINTS),
+        "action_history": 0,
+        "pages": len(_PAGES),
+        "documents": len(_DOCUMENTS),
+    }
+
+    # hop 3: the lake reads back, and the pipeline's own output survived it
+    pages = lake.read("pages", lake_dir=lake_dir)
+    assert pages.height == len(_PAGES)
+    assert set(pages["ticket_number"]) == {"SYN0000001", "SYN0000002"}
+    assert all(t.startswith("<NAME>") for t in pages["redacted_text"])
+
+    documents = lake.read("documents", lake_dir=lake_dir)
+    assert set(documents["grievance_category"]) == {"Electricity", "Drinking Water Supply"}
+
+
+def test_no_raw_page_text_reaches_the_lake(tmp_path):
+    """The guarantee that actually holds (ROADMAP §3.2, issue #49).
+
+    Not "no un-redacted PII reaches the lake" — that is false, because
+    ``complaints.grievance`` is carried from the dump verbatim and has never
+    met ``pii_tagger``. The page-text guarantee is the one this pipeline can
+    make: raw OCR of a scanned document stays behind in OLTP.
+    """
+    artifact_db = tmp_path / "pipeline.sqlite"
+    _seed_artifact_db(artifact_db)
+    oltp_url = _make_oltp(tmp_path)
+    lake_dir = tmp_path / "interim"
+
+    export_pipeline_db(artifact_db, oltp_url=oltp_url)
+    materialize(oltp_url=oltp_url, out_dir=lake_dir)
+
+    # the marker only ever appears in pages.extracted_text
+    for parquet in sorted(lake_dir.glob("*.parquet")):
+        assert _RAW_MARKER.encode() not in parquet.read_bytes(), (
+            f"raw page text reached the lake in {parquet.name}"
+        )
+
+    assert "extracted_text" not in lake.read("pages", lake_dir=lake_dir).columns
+
+    # and it really is still in OLTP — the assertion above is not passing
+    # because the text was lost somewhere upstream
+    sync = create_engine(oltp_url.replace("+aiosqlite", ""))
+    with sync.connect() as conn:
+        from sqlalchemy import text as sql
+
+        raw = conn.execute(sql("SELECT extracted_text FROM pages")).scalars().all()
+    sync.dispose()
+    assert all(_RAW_MARKER in r for r in raw)
+
+
+def test_history_is_queryable_from_the_lake(tmp_path):
+    """`/history` reads real rows, not the mock provider's 120 fake ones."""
+    oltp_url = _make_oltp(tmp_path)
+    lake_dir = tmp_path / "interim"
+    materialize(oltp_url=oltp_url, out_dir=lake_dir)
+
+    app = create_app(history=LakeHistory(lake_dir=lake_dir))
+    with TestClient(app) as client:
+        page = client.get("/history", params={"limit": 50}).json()
+    assert page["total"] == len(_COMPLAINTS)
+    assert {item["ticket_no"] for item in page["items"]} == {
+        "SYN0000001",
+        "SYN0000002",
+    }
+
+    # the filters the frontend sends are wired to the same rows
+    with TestClient(app) as client:
+        filtered = client.get("/history", params={"district": "Cuttack"}).json()
+    assert [item["ticket_no"] for item in filtered["items"]] == ["SYN0000002"]
+
+    with TestClient(app) as client:
+        searched = client.get("/history", params={"q": "hand pump"}).json()
+    assert [item["ticket_no"] for item in searched["items"]] == ["SYN0000002"]
+
+
+def test_routing_resolves_off_master_tables_not_fallback(tmp_path):
+    """A silent ``method="fallback"`` is the failure this catches.
+
+    The master CSVs are DVC-tracked and absent on a fresh machine, and
+    ``load_mapping_tables`` degrades to ``None`` rather than raising. The demo
+    then routes on the illustrative rules while still looking healthy.
+    """
+    router = MappingRouter(mapping_dir=_write_mapping_dir(tmp_path))
+    assert router.mapping_loaded
+
+    result = router.route(category="Energy", district="Khordha")
+    assert result.method == "rules"
+    assert result.dept == "Energy"
+    assert result.designation == "Executive Engineer"
+    assert result.escalation_authority == "CEO TPCODL"
+
+    # the negative control: same call, no CSVs -> the router still answers, and
+    # says so honestly
+    degraded = MappingRouter(mapping_dir=tmp_path / "absent")
+    assert not degraded.mapping_loaded
+
+
+def test_submit_persists_and_fetches_through_the_db_store(tmp_path):
+    """submit -> persist -> fetch, across two app instances.
+
+    The in-memory default would pass a single-process submit/fetch and lose
+    everything on restart. Fetching through a *second* app over the same OLTP
+    is what proves the DB store is the one selected.
+    """
+    oltp_url = _make_oltp(tmp_path)
+    mapping_dir = _write_mapping_dir(tmp_path)
+    processor = _CanaryProcessor(MappingRouter(mapping_dir=mapping_dir))
+
+    store = DatabaseResultStore(oltp_url)
+    app = create_app(processor=processor, result_store=store)
+    try:
+        with TestClient(app) as client:
+            assert client.get("/health").json()["processor"] == "canary"
+            submitted = client.post(
+                "/grievance",
+                data={"text": "Street light out.", "district": "Khordha"},
+            )
+        assert submitted.status_code == 201
+        result = submitted.json()
+        assert result["routing"]["method"] == "rules"
+        assert result["routing"]["dept"] == "Energy"
+    finally:
+        asyncio.run(store.dispose())
+
+    # a fresh process would build a fresh app and a fresh store
+    second_store = DatabaseResultStore(oltp_url)
+    second_app = create_app(processor=processor, result_store=second_store)
+    try:
+        with TestClient(second_app) as client:
+            fetched = client.get(f"/grievance/{result['id']}")
+            missing = client.get("/grievance/deadbeefdead")
+    finally:
+        asyncio.run(second_store.dispose())
+
+    assert fetched.status_code == 200
+    assert fetched.json()["ticket_no"] == result["ticket_no"]
+    assert fetched.json()["routing"]["dept"] == "Energy"
+    assert missing.status_code == 404
+
+
+@pytest.mark.parametrize("table", ["complaints", "action_history", "pages", "documents"])
+def test_every_lake_table_is_materialized(tmp_path, table):
+    """All four tables exist after a run, empty ones included.
+
+    A missing Parquet file and an empty one are different failures, and
+    ``LakeHistory`` returns an empty page for both.
+    """
+    oltp_url = _make_oltp(tmp_path)
+    lake_dir = tmp_path / "interim"
+    materialize(oltp_url=oltp_url, out_dir=lake_dir)
+    assert lake.lake_path(table, lake_dir).exists()

--- a/tests/test_materialize.py
+++ b/tests/test_materialize.py
@@ -5,7 +5,7 @@ import os
 import pytest
 from sqlalchemy import create_engine, insert
 
-from janasunani.db.models import ActionHistory, Base, Complaint
+from janasunani.db.models import ActionHistory, Base, Complaint, PipelinePage
 from janasunani.olap import lake
 from janasunani.olap.materialize import materialize
 
@@ -51,6 +51,51 @@ def test_materialize_sqlite_and_read_back(tmp_path):
         "SELECT count(*) AS n FROM complaints WHERE govt_ticket", lake_dir=out
     )
     assert res["n"][0] == 1
+
+
+def test_raw_ocr_text_never_reaches_the_lake(tmp_path):
+    """``pages.extracted_text`` is un-redacted OCR and must not be materialized.
+
+    ``pii_tagger`` writes ``redacted_text`` and leaves ``extracted_text`` as the
+    raw page text. Parquet is not access-controlled per-column, so the raw
+    column stays behind in OLTP while everything else rides along.
+    """
+    oltp = tmp_path / "oltp.db"
+    engine = create_engine(f"sqlite:///{oltp}")
+    Base.metadata.create_all(engine)
+    with engine.begin() as conn:
+        conn.execute(
+            insert(PipelinePage),
+            [
+                {
+                    "page_id": "D1-p1",
+                    "doc_id": "D1",
+                    "page_number": 1,
+                    "full_path": "/x/D1.pdf",
+                    "ticket_number": "T1",
+                    "language": "English",
+                    "extracted_text": "Ramesh Kumar, 9876543210, needs water",
+                    "redacted_text": "<NAME>, <PHONE>, needs water",
+                }
+            ],
+        )
+    engine.dispose()
+
+    out = tmp_path / "interim"
+    counts = materialize(oltp_url=f"sqlite+aiosqlite:///{oltp}", out_dir=out)
+    assert counts["pages"] == 1
+
+    df = lake.read("pages", lake_dir=out)
+    assert "extracted_text" not in df.columns
+    # everything else still rides along, redaction included
+    assert "redacted_text" in df.columns
+    assert df["redacted_text"][0] == "<NAME>, <PHONE>, needs water"
+    assert df["ticket_number"][0] == "T1"
+
+    # and the raw text is nowhere in the file, under any column
+    raw = (out / "pages.parquet").read_bytes()
+    assert b"Ramesh Kumar" not in raw
+    assert b"9876543210" not in raw
 
 
 PG_URL = os.getenv(


### PR DESCRIPTION
## Summary

Phase 13 (#49), end-to-end run, synthetic half. The real-data variant (`scripts/e2e_pipeline.sh`) needs S3, the model mirrors and the three mutually exclusive extras, and is not in this PR.

Two things: a PII leak into the lake, and the canary that would have caught it.

## What Changed

**Raw OCR was reaching the lake.** `export.py` copies every `PipelinePage` column into OLTP, and `materialize.py` did `COPY (SELECT * FROM oltp.pages)`, so `pages.extracted_text` landed in `pages.parquet` verbatim. That column is un-redacted page text by construction: `pii_tagger` reads it and writes its output to `redacted_text`, leaving the original alone.

- Fixed with `LAKE_COLUMN_DENYLIST` in `olap/materialize.py`. The column stays in OLTP, which is access-controlled; it does not reach Parquet, which is not.
- No schema change, so no Alembic migration.
- Nothing downstream reads it: the summarizer and categorizer take `redacted_text` off the artifact DB, `/history` reads `complaints`, and Phase 17's OCR benchmark reads the artifact DB directly.
- `ExtractionResult.extracted_text` in the frozen serving contract is untouched. Returning raw OCR to the submitter looks deliberate (they are the data subject, and the UI shows extracted vs redacted side by side).

**`tests/test_e2e_synthetic.py`** — artifact DB → OLTP → lake → API, row counts asserted at each hop, with the models replaced by a canned stand-in and everything else on the real code path. Routing is not a model, so it stays real.

The store and history assertions go through `inference.serve.create_live_app` — the function the deployed API actually calls — with only `build_processor` substituted, since that is the piece that loads models. Store selection, history selection and the `Settings` lookup all run for real.

| Guarded | Failure it catches | Asserted through |
|---|---|---|
| Raw page text in Parquet | the leak above, and any regression of it | `materialize` |
| `/history` reads the lake | silently serving `MockHistory`'s fake rows | `create_live_app` |
| DB result store selected | in-memory default, submissions lost on restart | `create_live_app` |
| Routing resolves off master tables | silent `method="fallback"` when the CSVs were never `dvc pull`ed | `MappingRouter` directly |

Mutation-tested by breaking the **production** wiring in `serve.py` (not the tests) and confirming the canary reddens: `MockHistory` instead of `LakeHistory`, always-`InMemoryResultStore`, and always-`DatabaseResultStore`. All fail correctly.

Also pins the silent fallback as behaviour: `_resolve_explicit_oltp_url` treats the built-in SQLite default as "not configured", so an unset `OLTP_DB_URL` gives a healthy API that returns 201 and loses every submission on restart. That is what the demo does if the box's `deploy/.env` omits it.

**Routing is the honest exception.** The router is wired inside `build_processor` (`router=DEFAULT_ROUTER`), which cannot run here, so the synthetic variant covers the loader and not the wire-up. The real-data E2E covers that. The docstring says so rather than implying otherwise.

**Roadmap.** Corrects the stated guarantee. "No un-redacted PII reaches the lake" is false and cannot be an acceptance criterion, because `complaints.grievance` is carried from the dump verbatim and has never met `pii_tagger`. The assertion is about page text; access controls the rest. This matches the correction already written into #49.

## Validation

- [x] `uv run ruff check .` — all checks passed
- [x] `uv run --extra serving --extra pipeline-core pytest` — 280 passed, 7 skipped (rebased onto `main` after #58/#29 merged)
- [x] `uv run --all-groups --extra serving pytest tests/test_e2e_synthetic.py tests/test_materialize.py` — green in the exact CI environment, no heavy extras
- [x] Mutation-tested the guarded properties by breaking production wiring (see above)
- [x] Notebooks have been stripped with `uv run nbstripout --install` or equivalent.
- [x] No proprietary data files are committed directly to Git.
- [x] DVC pointers / `dvc.lock` are updated — lake re-materialized and pushed, see below.

Every fixture in the new test is invented. No citizen text enters the test suite, which is what makes it runnable in CI.

## Review Expectations

- Keep this PR small enough to be reviewed by a human in a short sitting.
- Split unrelated changes into separate PRs before requesting review.
- Two-person review is required.
- Yashaswi is a mandatory reviewer.
- Add one additional reviewer who can assess the code, analysis, or domain impact.

The materialization change touches what leaves the trust boundary, so this wants the security-sensitive review tier.

## Data And Delivery Notes

- [ ] This PR does not modify data.
- [x] This PR ingests or versions data through DVC.
- [ ] This PR updates generated exhibits.
- [ ] This PR requires `make deliver` after merge.

Notes:

### DVC artifact re-materialized (Codex P1, resolved)

The code fix alone left the leak in circulation: `dvc.lock` still pointed at the pre-fix `pages.parquet`, so `dvc pull` on a fresh checkout kept receiving the Parquet containing `extracted_text`.

Re-materialized and pushed by the maintainer. The lock now records:

| | Before | After |
|---|---|---|
| dep `janasunani/olap/materialize.py` | `ea29e1c5…` (3,356 B) | `9bb2ff8d…` (5,273 B) |
| out `data/interim/pages.parquet` | `816be322…` (10,361 B) | `4ad7a178…` (3,925 B) |

The recorded dep hash matches the file carrying `LAKE_COLUMN_DENYLIST` byte for byte, so the recorded output is the one that code produced — not a re-run of the old stage. The other three tables are unchanged, as expected, since only `pages` has a denied column.

**On the pre-fix blob**, which stays in the remote under its old hash: no retraction needed. The DVC remote is IAM-scoped, and everyone who can reach it already has access to the raw dump — 1.37M grievances with names, mobiles and addresses. A few OCR'd pages from a 2-file sample add nothing to that. The exposure this PR closes was `dvc pull` at HEAD handing raw page text to anyone entitled to the *lake*, which is a wider group than the one entitled to the dump.

- Rebased onto `main` after #58 and #29 merged. Suite grew 230 → 280 as a result (#29's deploy tests).
- Roadmap now edits the rewritten version #29 brought to `main`. Two corrections there: §3.2's `pages.extracted_text` row claimed it "never leaves the pipeline artifact DB" (the exporter copies it to OLTP), and §5.1's E2E bullet asserted "no un-redacted PII reaches the lake", contradicting the precise guarantee stated in §3.2 of the same document.
