### PR TITLE
Deploy: CPU-only Torch for the api image (#48)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,8 +67,8 @@ jobs:
           # commits. The SHA tag is always both-or-neither (this job's push
           # either succeeds or the whole job — and thus the deploy — fails).
           tags: ${{ env.API_IMAGE }}:${{ github.sha }}
-          # Registry cache, not GHA cache: the `demo` extra resolves CUDA
-          # torch (~8-12 GB image) — well past the GHA cache size budget.
+          # Registry cache, not GHA cache: even on CPU-only torch the `demo`
+          # extra's layers run past the GHA cache size budget.
           # (This `buildcache` tag is BuildKit's layer cache, unrelated to
           # image tagging above — it's never pulled/deployed.)
           cache-from: type=registry,ref=${{ env.API_IMAGE }}:buildcache

--- a/deploy/api.Dockerfile
+++ b/deploy/api.Dockerfile
@@ -32,8 +32,12 @@ RUN mkdir -p -m 0700 /root/.ssh && ssh-keyscan github.com >> /root/.ssh/known_ho
 COPY pyproject.toml uv.lock ./
 # Dependency-only sync first (no project code yet) so this layer caches across
 # source-only changes; the registry cache (build-push-action cache-from/to
-# type=registry) makes this fast even on a cold CI runner given the ~8-12 GB
-# CUDA-torch resolve for `demo`.
+# type=registry) keeps this fast on a cold CI runner.
+#
+# `demo` resolves torch from PyTorch's CPU-only index (see [tool.uv.sources] in
+# pyproject.toml) — this box has no GPU. That drops ~2.5 GB of wheels versus the
+# default CUDA build: the nvidia-*/cuda-toolkit/triton payload entirely, plus
+# the torch wheel itself going 532 MB -> 192 MB.
 RUN --mount=type=ssh uv sync --locked --extra demo --no-dev --no-install-project
 COPY README.md alembic.ini ./
 COPY janasunani ./janasunani

--- a/deploy/api.Dockerfile
+++ b/deploy/api.Dockerfile
@@ -36,8 +36,13 @@ COPY pyproject.toml uv.lock ./
 #
 # `demo` resolves torch from PyTorch's CPU-only index (see [tool.uv.sources] in
 # pyproject.toml) — this box has no GPU. That drops ~2.5 GB of wheels versus the
-# default CUDA build: the nvidia-*/cuda-toolkit/triton payload entirely, plus
-# the torch wheel itself going 532 MB -> 192 MB.
+# default CUDA build: torch's whole cuda-toolkit/cuda-bindings/nvidia-*/triton
+# payload, plus the torch wheel itself going 532 MB -> 192 MB.
+#
+# One CUDA wheel survives: xgboost declares nvidia-nccl-cu12 unconditionally on
+# linux, and `demo` pulls xgboost via pipeline-core. The live processor never
+# loads the format classifier, so it is ~300 MB of dead weight here — tracked
+# separately, not fixed by the torch source.
 RUN --mount=type=ssh uv sync --locked --extra demo --no-dev --no-install-project
 COPY README.md alembic.ini ./
 COPY janasunani ./janasunani

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -389,8 +389,12 @@ policy itself prevents it.
   Dockerfile carefully; the first real signal is the CI build log / GHCR push.
   This is also where the CPU-torch switch (#48) gets confirmed: on darwin the
   `demo` extra still resolves the ordinary PyPI wheel, so the image-size drop
-  is not observable locally. Check the build log for
-  `torch-2.12.1+cpu-...manylinux_2_28_x86_64.whl` and no `nvidia-*` downloads.
+  is not observable locally. In the build log, expect
+  `torch-2.12.1+cpu-...manylinux_2_28_x86_64.whl`, and **exactly one**
+  `nvidia-*` download — `nvidia-nccl-cu12`, which xgboost declares
+  unconditionally on linux (~300 MB, tracked separately). Any other `nvidia-*`
+  or `cuda-*` wheel means the CPU source did not take effect and the image is
+  still carrying the CUDA runtime.
 - **On-box browser E2E** — submit a grievance → real pipeline output renders
   and persists to `live_grievances` → `/history` shows it → `basic_auth`
   actually gates access. Do this once after the first automated deploy.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -372,7 +372,10 @@ policy itself prevents it.
   Parquet lake, the HF cache, and the nightly `pg_dump` target — a
   disk-full here risks all of those, not just the deploy. `deploy.sh`
   refuses to even start pulling images if free space drops below ~20 GiB
-  (a few multiples of one ~8-12 GB api image), and after a successful
+  (deliberately several multiples of one api image; the threshold is kept
+  where it was after the CPU-torch switch shrank the image, since the point
+  is headroom for prod Postgres and the lake, not a tight fit), and after a
+  successful
   deploy prunes every SHA-tagged `janasunani-api`/`janasunani-frontend`
   image except the current and previous (the rollback target) — plus the
   usual `docker image prune -f` for dangling layers. If disk pressure still
@@ -381,10 +384,13 @@ policy itself prevents it.
 
 ### Known gaps — what this repo's automation does NOT verify for you
 
-- **The `linux/amd64` `api` build itself** — it resolves ~8–12 GB of CUDA
-  torch and can only be built for real on an amd64 runner (GitHub Actions),
-  never on an arm64 dev Mac. Review the Dockerfile carefully; the first real
-  signal is the CI build log / GHCR push.
+- **The `linux/amd64` `api` build itself** — it can only be built for real on
+  an amd64 runner (GitHub Actions), never on an arm64 dev Mac. Review the
+  Dockerfile carefully; the first real signal is the CI build log / GHCR push.
+  This is also where the CPU-torch switch (#48) gets confirmed: on darwin the
+  `demo` extra still resolves the ordinary PyPI wheel, so the image-size drop
+  is not observable locally. Check the build log for
+  `torch-2.12.1+cpu-...manylinux_2_28_x86_64.whl` and no `nvidia-*` downloads.
 - **On-box browser E2E** — submit a grievance → real pipeline output renders
   and persists to `live_grievances` → `/history` shows it → `basic_auth`
   actually gates access. Do this once after the first automated deploy.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -356,12 +356,21 @@ reaches OLTP through the exporter.
 
   Remaining: `terraform apply` of `ci.tf`, one-time box setup (GHCR login,
   `deploy/.env`), first real amd64 build + a live `workflow_dispatch` run, on-box
-  browser E2E (issue #30). Three hardening items before Phase 12 is done: a
-  **CPU-only Torch** API image (issue #48; the current 8–12 GB image bundles CUDA
-  Torch though the box is CPU-only), and two rollout gaps (issue #32): the workflow
-  can time out and kill the SSH session before the box script finishes its
-  health-wait/rollback, and a rollback run can ship the current compose/proxy
-  beside an old image SHA.
+  browser E2E (issue #30).
+
+  ✅ **CPU-only Torch image** (issue #48). The `demo` extra now resolves torch
+  from PyTorch's CPU index, dropping ~2.5 GB of wheels: the whole
+  nvidia-\*/cuda-toolkit/triton payload, plus the torch wheel itself going
+  532 MB → 192 MB. The box is CPU-only and DeepSeek is excluded from `demo`, so
+  none of it was ever reachable. Scoped to `demo` alone — `categorizer` and
+  `ocr-deepseek` keep CUDA wheels for the GPU-box batch jobs. The size drop is
+  only observable in the amd64 CI build; on darwin `demo` still resolves the
+  ordinary PyPI wheel.
+
+  Remaining hardening before Phase 12 is done: two rollout gaps (issue #32).
+  The workflow can time out and kill the SSH session before the box script
+  finishes its health-wait/rollback, and a rollback run can ship the current
+  compose/proxy beside an old image SHA.
 
 ### Model provenance & DSI baselines (hard rule)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -359,13 +359,18 @@ reaches OLTP through the exporter.
   browser E2E (issue #30).
 
   ✅ **CPU-only Torch image** (issue #48). The `demo` extra now resolves torch
-  from PyTorch's CPU index, dropping ~2.5 GB of wheels: the whole
-  nvidia-\*/cuda-toolkit/triton payload, plus the torch wheel itself going
-  532 MB → 192 MB. The box is CPU-only and DeepSeek is excluded from `demo`, so
-  none of it was ever reachable. Scoped to `demo` alone — `categorizer` and
-  `ocr-deepseek` keep CUDA wheels for the GPU-box batch jobs. The size drop is
-  only observable in the amd64 CI build; on darwin `demo` still resolves the
-  ordinary PyPI wheel.
+  from PyTorch's CPU index, dropping ~2.5 GB of wheels: torch's whole
+  cuda-toolkit / cuda-bindings / nvidia-\* / triton payload, plus the torch
+  wheel itself going 532 MB → 192 MB. The box is CPU-only and DeepSeek is
+  excluded from `demo`, so none of it was ever reachable. Scoped to `demo`
+  alone — `categorizer` and `ocr-deepseek` keep CUDA wheels for the GPU-box
+  batch jobs. The size drop is only observable in the amd64 CI build; on darwin
+  `demo` still resolves the ordinary PyPI wheel.
+
+  One CUDA wheel survives, and the torch source cannot remove it: `xgboost`
+  declares `nvidia-nccl-cu12` unconditionally on linux, and `demo` pulls
+  xgboost through `pipeline-core`. The live processor never loads the format
+  classifier, so it is ~300 MB of dead weight in the api image (issue #63).
 
   Remaining hardening before Phase 12 is done: two rollout gaps (issue #32).
   The workflow can time out and kill the SSH session before the box script

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,10 +101,20 @@ categorizer = [
 # with pipeline-core/categorizer, and it is deliberately excluded — DeepSeek OCR
 # runs out-of-process on the GPU box). Launch with:
 #   uv run --extra demo janasunani-api-live
+#
+# Torch resolves from the CPU-only index for this extra alone — see
+# [tool.uv.sources] below. The always-on box has no GPU.
 demo = [
     "janasunani[serving]",
     "janasunani[pipeline-core]",
     "janasunani[categorizer]",
+    # Listed directly, not just inherited, because uv binds a source's
+    # `extra = "demo"` marker only to packages declared on that extra.
+    # Pinned to the version already locked: this change is about *where* torch
+    # comes from, not which torch. Without the pin, adding the direct
+    # requirement re-resolves and drags torch 2.12.1 -> 2.13.0 and torchvision
+    # 0.27.1 -> 0.28.0 into the GPU path, which nothing here tests.
+    "torch==2.12.1",
 ]
 
 [project.scripts]
@@ -142,8 +152,27 @@ conflicts = [
     [{ extra = "ocr-deepseek" }, { extra = "demo" }],
 ]
 
+# PyTorch's CPU-only wheel index. `explicit = true` means nothing resolves from
+# here unless [tool.uv.sources] sends it — every other package still comes from
+# PyPI.
+[[tool.uv.index]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
+explicit = true
+
 [tool.uv.sources]
 dpic = { git = "ssh://git@github.com/Data-Policy-and-Innovation-Centre/dpic-org.git", rev = "main" }
+# CPU torch for the `demo` extra ONLY — the extra `deploy/api.Dockerfile`
+# builds. The always-on box is CPU-only and DeepSeek is deliberately excluded
+# from `demo`, so the CUDA runtime it was shipping (the linux x86_64 torch wheel
+# is 532 MB before the nvidia-* and cuda-toolkit deps) was pure weight on a
+# machine that also hosts the production Postgres.
+#
+# Deliberately NOT applied to `categorizer` or `pipeline-core`: the MuRIL
+# embedding pass is a corpus-scale GPU batch job on the GPU box (ROADMAP §5.3
+# S4), and `ocr-deepseek` is GPU-only by nature. Pinning those to CPU wheels
+# would quietly remove GPU acceleration from the backfills.
+torch = [{ index = "pytorch-cpu", extra = "demo" }]
 
 [dependency-groups]
 dev = [

--- a/tests/test_deploy_stack.py
+++ b/tests/test_deploy_stack.py
@@ -19,7 +19,9 @@ import shutil
 import stat
 import subprocess
 
+import pytest
 import yaml
+from packaging.markers import Marker
 
 from janasunani.config import ROOT_DIR
 
@@ -1005,9 +1007,6 @@ def test_rollback_restores_a_diverged_caddyfile(tmp_path):
 PYPROJECT_PATH = ROOT_DIR / "pyproject.toml"
 UV_LOCK_PATH = ROOT_DIR / "uv.lock"
 
-_CUDA_PACKAGE = re.compile(r"^name = \"((?:nvidia-|cuda-)[^\"]+|triton)\"", re.M)
-
-
 def _pyproject() -> dict:
     import tomllib
 
@@ -1042,35 +1041,77 @@ def test_gpu_extras_keep_cuda_torch():
         assert extra not in pinned, f"{extra} must keep the default CUDA torch"
 
 
-def test_no_cuda_payload_reaches_the_demo_extra_on_linux():
-    """The property that actually shrinks the image.
+def _demo_requirements_for_linux() -> dict[str, str]:
+    """The real resolved requirement set for `--extra demo` on linux.
 
-    Walks every dependency edge in the lock that points at an nvidia-*/cuda-*/
-    triton package and asserts none is reachable with `demo` enabled,
-    DeepSeek disabled, off darwin — i.e. the box.
+    Exports the actual lock via uv and evaluates each marker for the box's
+    platform, rather than inferring reachability from individual edges. An
+    edge's own marker is not enough: a CUDA package can be pulled by an
+    unconditional edge from a parent that `demo` selects, and inspecting
+    markers in isolation cannot see that (xgboost -> nvidia-nccl-cu12 is
+    exactly this shape).
     """
-    lock = UV_LOCK_PATH.read_text()
-    assert _CUDA_PACKAGE.search(lock), "no CUDA packages in the lock at all — "\
-        "the GPU extras should still pull them; this assertion is miscalibrated"
+    proc = subprocess.run(
+        ["uv", "export", "--frozen", "--extra", "demo", "--no-dev",
+         "--no-hashes", "--no-emit-project"],
+        cwd=ROOT_DIR, capture_output=True, text=True, check=True,
+    )
+    resolved: dict[str, str] = {}
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if not line or line.startswith(("#", "-")):
+            continue
+        requirement, _, marker = line.partition(";")
+        if marker.strip():
+            env = {
+                "sys_platform": "linux",
+                "platform_system": "Linux",
+                "os_name": "posix",
+                "platform_machine": "x86_64",
+                "python_version": "3.13",
+                "implementation_name": "cpython",
+                "platform_python_implementation": "CPython",
+            }
+            if not Marker(marker.strip()).evaluate(env):
+                continue
+        name, _, version = requirement.strip().partition("==")
+        resolved[re.split(r"[\[ ]", name)[0].lower()] = version.strip()
+    return resolved
 
-    edges = re.finditer(
-        r'\{ name = "((?:nvidia-|cuda-)[^"]+|triton)"[^}]*?marker = "([^"]*)"', lock
+
+@pytest.mark.skipif(shutil.which("uv") is None, reason="uv not on PATH")
+def test_demo_resolves_cpu_torch_on_linux():
+    """The api image gets the CPU build, not the CUDA one."""
+    resolved = _demo_requirements_for_linux()
+    assert resolved.get("torch") == "2.12.1+cpu", (
+        f"expected the CPU torch build on linux, got {resolved.get('torch')!r}"
     )
-    reachable = []
-    for edge in edges:
-        package, marker = edge.group(1), edge.group(2)
-        for clause in marker.split(" or "):
-            clause = clause.strip("() ")
-            if (
-                "extra == 'extra-10-janasunani-demo'" in clause
-                and "extra == 'extra-10-janasunani-ocr-deepseek'" not in clause
-                and "sys_platform == 'darwin'" not in clause
-            ):
-                reachable.append((package, clause))
-    assert not reachable, (
-        "CUDA packages reachable from the demo extra on linux: "
-        + ", ".join(sorted({p for p, _ in reachable}))
+
+
+@pytest.mark.skipif(shutil.which("uv") is None, reason="uv not on PATH")
+def test_demo_carries_no_cuda_payload_beyond_xgboosts_nccl():
+    """The property that shrinks the image, checked against a real resolution.
+
+    torch's CUDA payload (cuda-toolkit, cuda-bindings, nvidia-cublas, cudnn,
+    cusparselt, nccl-cu13, nvshmem, triton) must be gone entirely.
+
+    `nvidia-nccl-cu12` is the one documented exception: `xgboost` declares it
+    unconditionally on linux, and `demo` pulls xgboost via `pipeline-core`.
+    The live processor never uses the format classifier, so it is dead weight
+    in this image — tracked separately. Asserted explicitly rather than
+    excluded, so this fails if the CUDA surface grows again.
+    """
+    resolved = _demo_requirements_for_linux()
+    cuda = {
+        name for name in resolved
+        if name.startswith(("nvidia-", "cuda-")) or name == "triton"
+    }
+    assert cuda == {"nvidia-nccl-cu12"}, (
+        "CUDA packages in the linux demo resolution changed; expected only "
+        f"xgboost's nvidia-nccl-cu12, got {sorted(cuda)}"
     )
+    # and the specific thing this change removed really is absent
+    assert "nvidia-nccl-cu12" in resolved and "nvidia-nccl-cu13" not in resolved
 
 
 def test_locked_torch_resolves_to_a_cpu_wheel_for_linux():

--- a/tests/test_deploy_stack.py
+++ b/tests/test_deploy_stack.py
@@ -1079,6 +1079,35 @@ def _demo_requirements_for_linux() -> dict[str, str]:
     return resolved
 
 
+def test_only_torch_is_sourced_from_the_pytorch_index():
+    """`explicit = true` must actually hold across the whole lock.
+
+    download.pytorch.org is not a torch-only mirror — it also carries old
+    copies of common packages (certifi, requests, urllib3 among them). Without
+    `explicit`, uv treats it as a general index and will happily resolve those
+    from it, silently downgrading the TLS stack. That is not hypothetical: it
+    happened to this branch while mutation-testing the `explicit` assertion
+    itself, and shipped certifi 2022.12.7 before review caught it.
+
+    Asserted on the lock rather than on the pyproject flag, because the flag
+    being right does not prove the lock was generated with it right.
+    """
+    leaked = []
+    for block in UV_LOCK_PATH.read_text().split("[[package]]"):
+        name = re.search(r'^name = "([^"]+)"', block, re.M)
+        pytorch_sourced = re.search(
+            r'^source = \{ registry = "https://download\.pytorch\.org[^"]*" \}',
+            block,
+            re.M,
+        )
+        if name and pytorch_sourced and name.group(1) != "torch":
+            leaked.append(name.group(1))
+    assert not leaked, (
+        "packages resolved from the PyTorch index that should come from PyPI: "
+        f"{sorted(leaked)} — is `explicit = true` set on the index?"
+    )
+
+
 @pytest.mark.skipif(shutil.which("uv") is None, reason="uv not on PATH")
 def test_demo_resolves_cpu_torch_on_linux():
     """The api image gets the CPU build, not the CUDA one."""

--- a/tests/test_deploy_stack.py
+++ b/tests/test_deploy_stack.py
@@ -992,3 +992,92 @@ def test_rollback_restores_a_diverged_caddyfile(tmp_path):
     assert result.returncode == 1, combined
     assert "Restoring the last known-good Caddyfile" in combined
     assert (deploy_dir / "proxy" / "Caddyfile").read_text() == deployed_content
+
+
+# --- CPU-only torch for the api image (issue #48) ----------------------------
+#
+# The always-on box is CPU-only and hosts the production Postgres, so the api
+# image must not carry the CUDA runtime. This is a resolution property, not a
+# runtime one, so it is asserted against the real pyproject.toml and uv.lock —
+# and it cannot be caught by running the tests, because on darwin the `demo`
+# extra still resolves the ordinary PyPI wheel.
+
+PYPROJECT_PATH = ROOT_DIR / "pyproject.toml"
+UV_LOCK_PATH = ROOT_DIR / "uv.lock"
+
+_CUDA_PACKAGE = re.compile(r"^name = \"((?:nvidia-|cuda-)[^\"]+|triton)\"", re.M)
+
+
+def _pyproject() -> dict:
+    import tomllib
+
+    return tomllib.loads(PYPROJECT_PATH.read_text())
+
+
+def test_demo_extra_sources_torch_from_the_cpu_index():
+    """`deploy/api.Dockerfile` builds `--extra demo`; that extra must pin torch
+    to PyTorch's CPU wheel index."""
+    pyproject = _pyproject()
+    indexes = {i["name"]: i for i in pyproject["tool"]["uv"].get("index", [])}
+    assert "pytorch-cpu" in indexes, "the CPU wheel index is not declared"
+    assert indexes["pytorch-cpu"]["url"] == "https://download.pytorch.org/whl/cpu"
+    # explicit: nothing resolves from this index unless a source sends it there
+    assert indexes["pytorch-cpu"]["explicit"] is True
+
+    sources = pyproject["tool"]["uv"]["sources"]["torch"]
+    assert [s["extra"] for s in sources] == ["demo"], (
+        "torch's CPU source must apply to `demo` only — categorizer and "
+        "ocr-deepseek need CUDA wheels for the GPU-box batch jobs"
+    )
+    assert all(s["index"] == "pytorch-cpu" for s in sources)
+
+
+def test_gpu_extras_keep_cuda_torch():
+    """The counterpart: pinning the GPU extras to CPU wheels would silently
+    remove GPU acceleration from the DeepSeek OCR run and the MuRIL embedding
+    backfill (ROADMAP §5.3 S4)."""
+    torch_sources = _pyproject()["tool"]["uv"]["sources"]["torch"]
+    pinned = {s["extra"] for s in torch_sources}
+    for extra in ("categorizer", "pipeline-core", "ocr-deepseek"):
+        assert extra not in pinned, f"{extra} must keep the default CUDA torch"
+
+
+def test_no_cuda_payload_reaches_the_demo_extra_on_linux():
+    """The property that actually shrinks the image.
+
+    Walks every dependency edge in the lock that points at an nvidia-*/cuda-*/
+    triton package and asserts none is reachable with `demo` enabled,
+    DeepSeek disabled, off darwin — i.e. the box.
+    """
+    lock = UV_LOCK_PATH.read_text()
+    assert _CUDA_PACKAGE.search(lock), "no CUDA packages in the lock at all — "\
+        "the GPU extras should still pull them; this assertion is miscalibrated"
+
+    edges = re.finditer(
+        r'\{ name = "((?:nvidia-|cuda-)[^"]+|triton)"[^}]*?marker = "([^"]*)"', lock
+    )
+    reachable = []
+    for edge in edges:
+        package, marker = edge.group(1), edge.group(2)
+        for clause in marker.split(" or "):
+            clause = clause.strip("() ")
+            if (
+                "extra == 'extra-10-janasunani-demo'" in clause
+                and "extra == 'extra-10-janasunani-ocr-deepseek'" not in clause
+                and "sys_platform == 'darwin'" not in clause
+            ):
+                reachable.append((package, clause))
+    assert not reachable, (
+        "CUDA packages reachable from the demo extra on linux: "
+        + ", ".join(sorted({p for p, _ in reachable}))
+    )
+
+
+def test_locked_torch_resolves_to_a_cpu_wheel_for_linux():
+    """A `+cpu` build must actually be locked, with a linux x86_64 wheel —
+    the box's platform."""
+    lock = UV_LOCK_PATH.read_text()
+    assert 'version = "2.12.1+cpu"' in lock, "no CPU torch build in the lock"
+    assert "torch-2.12.1%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl" in lock, (
+        "the locked CPU torch has no linux x86_64 wheel"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -26,16 +26,20 @@ resolution-markers = [
     "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
     "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')",
     "(python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')",
-    "python_full_version >= '3.14' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and sys_platform != 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core')",
     "(python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core')",
-    "python_full_version >= '3.14' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "python_full_version < '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
@@ -504,7 +508,7 @@ name = "blis"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/d0/d8cc8c9a4488a787e7fa430f6055e5bd1ddb22c340a751d9e901b82e2efe/blis-1.3.3.tar.gz", hash = "sha256:034d4560ff3cc43e8aa37e188451b0440e3261d989bb8a42ceee865607715ecd", size = 2644873, upload-time = "2025-11-17T12:28:30.511Z" }
 wheels = [
@@ -592,11 +596,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2026.6.17"
+version = "2022.12.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/f7/2b1b0ec44fdc30a3d31dfebe52226be9ddc40cd6c0f34ffc8923ba423b69/certifi-2022.12.7.tar.gz", hash = "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3", size = 156897, upload-time = "2022-12-07T20:13:22.081Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+    { url = "https://files.pythonhosted.org/packages/71/4c/3db2b8021bd6f2f0ceb0e088d6b2d49147671f25832fb17970e9b583d742/certifi-2022.12.7-py3-none-any.whl", hash = "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18", size = 155255, upload-time = "2022-12-07T20:13:19.428Z" },
 ]
 
 [[package]]
@@ -646,59 +650,11 @@ wheels = [
 
 [[package]]
 name = "charset-normalizer"
-version = "3.4.7"
+version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/34/44964211e5410b051e4b8d2869c470ae8a68ae274953b1c7de6d98bbcf94/charset-normalizer-2.1.1.tar.gz", hash = "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845", size = 82360, upload-time = "2022-08-19T22:13:48.372Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
-    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
-    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
-    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
-    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
-    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
-    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
-    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
-    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
-    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
-    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
-    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
-    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
-    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
-    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
-    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
-    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
-    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
-    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
-    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+    { url = "https://files.pythonhosted.org/packages/db/51/a507c856293ab05cdc1db77ff4bc1268ddd39f29e7dc4919aa497f0adbec/charset_normalizer-2.1.1-py3-none-any.whl", hash = "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f", size = 39748, upload-time = "2022-08-19T22:13:46.702Z" },
 ]
 
 [[package]]
@@ -809,8 +765,7 @@ name = "contourpy"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-demo' or (extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-pipeline-core')" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-ocr-deepseek' or (extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -980,8 +935,16 @@ name = "cryptography"
 version = "48.0.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version < '3.14'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and sys_platform != 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version >= '3.14' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
 ]
 dependencies = [
     { name = "cffi", marker = "(platform_python_implementation != 'PyPy' and extra == 'extra-10-janasunani-ocr-deepseek') or (platform_python_implementation != 'PyPy' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core') or (extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
@@ -1037,7 +1000,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/6e/2394f8163360f8391f8f1b7e72d300a82724edb81a7b7084c799fbd4c91f/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9efb21c1ee64981e184b9e0ba5eb3179e5ba3d4b51665a6cb52b8ef3d01a7cbf", size = 5920504, upload-time = "2026-05-29T23:11:56.883Z" },
@@ -1053,10 +1016,10 @@ wheels = [
 
 [[package]]
 name = "cuda-pathfinder"
-version = "1.5.6"
+version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/53/8fc9b0cdc5b7f62746e6a01b85b6461e5ae27f871010a5fcf8fa6950766d/cuda_pathfinder-1.5.6-py3-none-any.whl", hash = "sha256:7e4c07c117b78ba1fb35dac4c444d21f3677b1b1ff56175c53a8e3025c5b43c0", size = 52972, upload-time = "2026-06-30T00:58:04.34Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b4/d088047afe39827556df21118cac9ffd20cc3f968c99a7681494d1eb333c/cuda_pathfinder-1.6.0-py3-none-any.whl", hash = "sha256:1503af579d8379c24bdd65528379bc57039b0455be9f5f9686cf8e473a1fce51", size = 54591, upload-time = "2026-07-21T15:03:56.224Z" },
 ]
 
 [[package]]
@@ -1283,36 +1246,19 @@ wheels = [
 
 [[package]]
 name = "dulwich"
-version = "1.2.6"
+version = "0.24.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/3d/7ea85d70d85f7d5ed5bf28dc742f106d8334e84286fbc852d983273dd890/dulwich-1.2.6.tar.gz", hash = "sha256:405cfd53a99374ff03aacdd7a86d6a07615feca072ed69721f49ae2ebaa3eab4", size = 1257895, upload-time = "2026-05-31T14:32:52.758Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f3/13a3425ddf04bd31f1caf3f4fa8de2352700c454cb0536ce3f4dbdc57a81/dulwich-0.24.1.tar.gz", hash = "sha256:e19fd864f10f02bb834bb86167d92dcca1c228451b04458761fc13dabd447758", size = 806136, upload-time = "2025-08-01T10:26:46.887Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/ea/f0d0aaf7c9e36f5490579a20ed37c85afd19e90177c2e270ff533d7fd533/dulwich-1.2.6-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:cdd15b8442b527575d733d90cfd6d3c4cbaebf989e2298b0cb57a7916c66254f", size = 1532486, upload-time = "2026-05-31T14:32:18.668Z" },
-    { url = "https://files.pythonhosted.org/packages/14/4e/5c212c2dcc2d8c06cafdcdc7893d9516cb861ec277f25a0f058f98512d22/dulwich-1.2.6-cp313-cp313-android_21_x86_64.whl", hash = "sha256:dd2783352917b7cb3ab12b7c3f7757210d93af6df0bd2d876a8e5b53b2feb3eb", size = 1525768, upload-time = "2026-05-31T14:32:20.174Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/84/7ff849d4fe769cb6439fc50322381b7eb3d6e5d64da9e5d8337c985a7748/dulwich-1.2.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:204d14692fb1dd850ab773690f7530f4065f405e9e7dd3f85bdf92e9330ffa2d", size = 1396354, upload-time = "2026-05-31T14:32:21.52Z" },
-    { url = "https://files.pythonhosted.org/packages/29/4d/2cb9662dd57417a11e5828f2b8f7607cfaccb42dcd9b6d69316755a5f5e0/dulwich-1.2.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:21e2e9b81ab04ad83f2d4101ac515ef56ee08d06fd853c1a7ac255f20bb49963", size = 1335031, upload-time = "2026-05-31T14:32:22.978Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/82/38ccfa7ee30c13d44734c5b1eb92ad0c95a96035319040e2c0b2011eee75/dulwich-1.2.6-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:7b4a2f497718bfe1a3b21f933ee27c111b9cea560c0b2d8a6d939e1b5f297f79", size = 1417366, upload-time = "2026-05-31T14:32:24.295Z" },
-    { url = "https://files.pythonhosted.org/packages/be/a1/239d52cbd94482c064821a0ccece888aac105a81f3f9719b9622c52fe6ec/dulwich-1.2.6-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5ff9f36c95deaf7eb5d6ccde4c68adbcb932a87e03c1b479a8d94d779e7cc5d2", size = 1442588, upload-time = "2026-05-31T14:32:25.731Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/92/739dc9e4d5da0b1c09b752f8aad94a518ff5eca7db2f5039ba7d5976b81f/dulwich-1.2.6-cp313-cp313-win32.whl", hash = "sha256:04252b107a1600325f5f0301dde8b5b62f5bb51a0467e360070baddbb4edcea7", size = 1018371, upload-time = "2026-05-31T14:32:27.147Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/28/626dc722ab20e0e5d0bf67e212494563f514790bc9c4b7c0133fdf491a5d/dulwich-1.2.6-cp313-cp313-win_amd64.whl", hash = "sha256:6fd9911fb57ee2d6eefaf895df65e1139fbc911fa560e959b38feabe5f15003f", size = 1032986, upload-time = "2026-05-31T14:32:28.66Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/b9/bb2f8b1d668b3959b8471c2af0fa2dbce66e81b2defab1fcfde4cd5a0ac1/dulwich-1.2.6-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:cb1f8d658f36b2ac3982715dc3e49f0d741a3e5a8c40136bebb6d8493968aa12", size = 1533055, upload-time = "2026-05-31T14:32:30.048Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/66/1a3b4580af650a40adb6ef1dce6f9153fa1096c723e1abff32959a0a2c76/dulwich-1.2.6-cp314-cp314-android_24_x86_64.whl", hash = "sha256:ad4b6114440f9cf72315b173532ee3284f27a288b8a24bc27e45b2e54593720d", size = 1478589, upload-time = "2026-05-31T14:32:31.368Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/34/55bc2440d1924710390ece68dc30496b0a0ef26228d9e02a60c82fc15ed1/dulwich-1.2.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:824b7f5b22b128c1e1ad7c655e9790e2d75c7ab1ba1e40a708024193f1dc47a3", size = 1351518, upload-time = "2026-05-31T14:32:32.644Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/31/befeb51ffd5047ea090ab18d2dc43525e6d528006eb7064135c2f1a1229a/dulwich-1.2.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7c187efaebb72146245ebcb872b89fdc99314fa37442119c5a5feb18af3f4b8a", size = 1335713, upload-time = "2026-05-31T14:32:33.995Z" },
-    { url = "https://files.pythonhosted.org/packages/72/8f/2913d2ab1cff9722383b88be0e34f8a277075c5b5ca3fc822ac2192476d8/dulwich-1.2.6-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:79728d98e0ec184856d71fd0d55abbf5ac7345b5baea9f2d1533a4de9064e13d", size = 1420343, upload-time = "2026-05-31T14:32:35.57Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/b7/53afa6cf1fb3bdf6669a73a6b1978f0adc2ac24f03fc414f45c5902e66e7/dulwich-1.2.6-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:c639a8c9fb7e745749f2dcbd5b63a82df2fc99cfe62e2c3654ec025a42d2e51f", size = 1442317, upload-time = "2026-05-31T14:32:37.216Z" },
-    { url = "https://files.pythonhosted.org/packages/23/34/4119559608dfc4b68427d8e9e3892db7a4b2dbf7b3e7c5b6a390e0af560f/dulwich-1.2.6-cp314-cp314-win32.whl", hash = "sha256:dd2b66c915f1b22ca6533b48e8ee435800b25f74f419c40e1a92271666d8b297", size = 1026443, upload-time = "2026-05-31T14:32:39.064Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/5f/4de7960cc39cfbd629ad60c1ef631ed32e4b303d4228ad8f92847aa87f3e/dulwich-1.2.6-cp314-cp314-win_amd64.whl", hash = "sha256:82e8810e57f9651a624116e3fede33276f89406cb910f517b944105e284e6755", size = 1041672, upload-time = "2026-05-31T14:32:41.008Z" },
-    { url = "https://files.pythonhosted.org/packages/72/19/01bcd25e4b2a8cf5f3507c4d02d6c999b70eb6d32eaff59c583e8e9c40c0/dulwich-1.2.6-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:794a85b8b9d4ad57d02c8cb455735419ac50c0f2e3d26d83873e34abee58cb1b", size = 1350601, upload-time = "2026-05-31T14:32:42.288Z" },
-    { url = "https://files.pythonhosted.org/packages/14/9c/517d858ee9af0678e5605397d1b5ca6c49210b64508c91486893c9fc0e56/dulwich-1.2.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:eb27a9ebe9029c872abadf4f9dcb18c9f6a4b7a4afe137f79a61df1ae59dc6bf", size = 1334723, upload-time = "2026-05-31T14:32:44.163Z" },
-    { url = "https://files.pythonhosted.org/packages/58/e9/d8dd703c6c581eacf109427472c1c02955b8de70fb8154ad2fe0cf2e0540/dulwich-1.2.6-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:1c35c294acfc5a0a88d01d5db1abeba550bf6274bcc3fddbf8b365e9eea280da", size = 1461300, upload-time = "2026-05-31T14:32:45.475Z" },
-    { url = "https://files.pythonhosted.org/packages/df/40/94c0d609206a770d3b4bc8dc30601e3c63642af637c5c12035e9645e0c85/dulwich-1.2.6-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:f682671a2e19b7b4caa572ff3073557de049a153946305e051a4f50bb0e5e1bd", size = 1491547, upload-time = "2026-05-31T14:32:47.12Z" },
-    { url = "https://files.pythonhosted.org/packages/04/97/c18ab70ec27eed02f6ba7b00b3d6236657df7cabbc7175533ff5b62f2147/dulwich-1.2.6-cp314-cp314t-win32.whl", hash = "sha256:27db364f2f3cf5b0dddd44d6c2ae9a20f6021e2bae8b1268fa689076f0192244", size = 1024467, upload-time = "2026-05-31T14:32:48.476Z" },
-    { url = "https://files.pythonhosted.org/packages/41/8c/7f49d256a813ab799fbce519a37857d75201c7c02b06b1a65fd989ec2ff2/dulwich-1.2.6-cp314-cp314t-win_amd64.whl", hash = "sha256:fae59c5e345f5ca234c85d157f1c7d5e0086126b45b5f7cfa66ffe41d049fdd6", size = 1083682, upload-time = "2026-05-31T14:32:49.881Z" },
-    { url = "https://files.pythonhosted.org/packages/24/15/61bd455d33979584f19d3a6e0b49b49e0d891bc680fc8cc7b028aea7360d/dulwich-1.2.6-py3-none-any.whl", hash = "sha256:8d8175dbe4feaf62bcafc8708448bfe223b4dfc71609be25c0cf2b0962abc36c", size = 688260, upload-time = "2026-05-31T14:32:51.285Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/a5/3f4760169fea1b90df7aea88172699807af6f4f667c878de6a9ee554170f/dulwich-0.24.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1a11ec69fc6604228804ddfc32c85b22bc627eca4cf4ff3f27dbe822e6f29477", size = 1080923, upload-time = "2025-08-01T10:26:28.011Z" },
+    { url = "https://files.pythonhosted.org/packages/71/d9/7aadd6318aed6f0e1242fa63bd61d80142716d13ea4e307c8b19fc61c9ae/dulwich-0.24.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a9800df7238b586b4c38c00432776781bc889cf02d756dcfb8dc0ecb8fc47a33", size = 1159246, upload-time = "2025-08-01T10:26:29.487Z" },
+    { url = "https://files.pythonhosted.org/packages/90/5d/df4256fe009c714e0392817df4fdc1748a901523504f58796d675fce755f/dulwich-0.24.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:3baab4a01aff890e2e6551ccbd33eb2a44173c897f0f027ad3aeab0fb057ec44", size = 1163646, upload-time = "2025-08-01T10:26:31.279Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/fe/850115d6fa7ad03756e20466ad5b72be54d1b59c1ff7d2b3c13bc4de965f/dulwich-0.24.1-cp313-cp313-win32.whl", hash = "sha256:b39689aa4d143ba1fb0a687a4eb93d2e630d2c8f940aaa6c6911e9c8dca16e6a", size = 762612, upload-time = "2025-08-01T10:26:33.223Z" },
+    { url = "https://files.pythonhosted.org/packages/47/7f/f79940e0773efda2ed0e666a0ca0ae7c734fdce4f04b5b60bc5ed268b7cb/dulwich-0.24.1-cp313-cp313-win_amd64.whl", hash = "sha256:8fca9b863b939b52c5f759d292499f0d21a7bf7f8cbb9fdeb8cdd9511c5bc973", size = 779168, upload-time = "2025-08-01T10:26:35.303Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/bc/a2557d1b0afa5bf1e140f42f8cbca1783e43d7fa17665859c63060957952/dulwich-0.24.1-py3-none-any.whl", hash = "sha256:57cc0dc5a21059698ffa4ed9a7272f1040ec48535193df84b0ee6b16bf615676", size = 440765, upload-time = "2025-08-01T10:26:45.415Z" },
 ]
 
 [[package]]
@@ -1546,11 +1492,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.29.4"
+version = "3.29.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e6/dc/be6cbe99670cd6e4ad387123647cb08e0c32975e223f82551e914c5568a6/filelock-3.29.4.tar.gz", hash = "sha256:10cdb3656fc44541cdf30652a93fb10ec6b05325620eb316bd26893e4201538a", size = 63028, upload-time = "2026-06-13T16:12:00.744Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/37/a065dc3bd6e49423a6532c642ca7378d3f467b1ef44c2800c937af7f9739/filelock-3.29.4-py3-none-any.whl", hash = "sha256:dac1648087d5115554850d113e7dd8c83ab2d38e3435dde2d4f163847e57b767", size = 42757, upload-time = "2026-06-13T16:11:59.582Z" },
+    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
 ]
 
 [[package]]
@@ -1722,11 +1668,11 @@ wheels = [
 
 [[package]]
 name = "fsspec"
-version = "2026.6.0"
+version = "2026.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/10/a1/ae4e3e5003468d6391d2c77b6fa1cd73bd5d13511d81c642d7b28ac90ed4/fsspec-2026.6.0.tar.gz", hash = "sha256:f5bac145310fe30e16e1471bd6840b2d990d609e872251d7e674241822abf01a", size = 313646, upload-time = "2026-06-16T01:57:28.105Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/8d/1c51c094345df128ca4a990d633fe1a0ff28726c9e6b3c41ba65087bba1d/fsspec-2026.4.0.tar.gz", hash = "sha256:301d8ac70ae90ef3ad05dcf94d6c3754a097f9b5fe4667d2787aa359ec7df7e4", size = 312760, upload-time = "2026-04-29T20:42:38.635Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/22/4222d7ddf3da30f363edaa98e329c2bce6c65497c9cb2810931c8b2c0fbc/fsspec-2026.6.0-py3-none-any.whl", hash = "sha256:02e0b71817df9b2169dc30a16832045764def1191b43dcff5bb85bdee212d2a1", size = 203949, upload-time = "2026-06-16T01:57:26.358Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl", hash = "sha256:11ef7bb35dab8a394fde6e608221d5cf3e8499401c249bebaeaad760a1a8dec2", size = 203402, upload-time = "2026-04-29T20:42:36.842Z" },
 ]
 
 [package.optional-dependencies]
@@ -2035,11 +1981,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.18"
+version = "3.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/e1/43beb3d38dba6cb420cefa297822eac205a277ab43e5ba5d5c46faf96438/idna-3.4.tar.gz", hash = "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4", size = 183077, upload-time = "2022-09-14T00:24:27.719Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/34/3030de6f1370931b9dbb4dad48f6ab1015ab1d32447850b9fc94e60097be/idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2", size = 61538, upload-time = "2022-09-14T00:24:23.22Z" },
 ]
 
 [[package]]
@@ -2047,7 +1993,7 @@ name = "imageio"
 version = "2.37.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy" },
     { name = "pillow" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b1/84/93bcd1300216ea50811cee96873b84a1bebf8d0489ffaf7f2a3756bab866/imageio-2.37.3.tar.gz", hash = "sha256:bbb37efbfc4c400fcd534b367b91fcd66d5da639aaa138034431a1c5e0a41451", size = 389673, upload-time = "2026-03-09T11:31:12.573Z" }
@@ -2057,14 +2003,14 @@ wheels = [
 
 [[package]]
 name = "importlib-metadata"
-version = "9.0.0"
+version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "zipp" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a0/fc/c4e6078d21fc4fa56300a241b87eae76766aa380a23fc450fc85bb7bf547/importlib_metadata-7.1.0.tar.gz", hash = "sha256:b78938b926ee8d5f020fc4772d487045805a55ddbad2ecf21c6d60938dc7fcd2", size = 52120, upload-time = "2024-03-20T19:51:32.429Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/0a/679461c511447ffaf176567d5c496d1de27cbe34a87df6677d7171b2fbd4/importlib_metadata-7.1.0-py3-none-any.whl", hash = "sha256:30962b96c0c223483ed6cc7280e7f0199feb01a0e40cfae4d4450fc6fab1f570", size = 24409, upload-time = "2024-03-20T19:51:30.241Z" },
 ]
 
 [[package]]
@@ -2221,7 +2167,9 @@ categorizer = [
     { name = "langdetect" },
     { name = "pandas" },
     { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "torch" },
+    { name = "torch", version = "2.12.1", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
+    { name = "torch", version = "2.12.1", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo') or (extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
+    { name = "torch", version = "2.12.1+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
     { name = "transformers", version = "4.57.6", source = { registry = "https://pypi.org/simple" } },
 ]
 demo = [
@@ -2230,7 +2178,7 @@ demo = [
     { name = "huggingface-hub" },
     { name = "langdetect" },
     { name = "nltk" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy" },
     { name = "opencv-python" },
     { name = "pandas" },
     { name = "pdf2image" },
@@ -2242,7 +2190,8 @@ demo = [
     { name = "scikit-image" },
     { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" } },
     { name = "spacy" },
-    { name = "torch" },
+    { name = "torch", version = "2.12.1", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-10-janasunani-demo') or (sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
+    { name = "torch", version = "2.12.1+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-10-janasunani-demo') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
     { name = "transformers", version = "4.57.6", source = { registry = "https://pypi.org/simple" } },
     { name = "uvicorn" },
     { name = "xgboost" },
@@ -2254,7 +2203,7 @@ ocr-deepseek = [
     { name = "pdf2image" },
     { name = "pillow" },
     { name = "tokenizers", version = "0.20.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "torch" },
+    { name = "torch", version = "2.12.1", source = { registry = "https://pypi.org/simple" } },
     { name = "torchvision" },
     { name = "transformers", version = "4.46.3", source = { registry = "https://pypi.org/simple" } },
 ]
@@ -2263,7 +2212,7 @@ pipeline-core = [
     { name = "huggingface-hub" },
     { name = "langdetect" },
     { name = "nltk" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy" },
     { name = "opencv-python" },
     { name = "pandas" },
     { name = "pdf2image" },
@@ -2274,7 +2223,9 @@ pipeline-core = [
     { name = "scikit-image" },
     { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" } },
     { name = "spacy" },
-    { name = "torch" },
+    { name = "torch", version = "2.12.1", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-pipeline-core') or (extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
+    { name = "torch", version = "2.12.1", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-pipeline-core')" },
+    { name = "torch", version = "2.12.1+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-pipeline-core') or (extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
     { name = "transformers", version = "4.57.6", source = { registry = "https://pypi.org/simple" } },
     { name = "xgboost" },
 ]
@@ -2351,6 +2302,7 @@ requires-dist = [
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },
     { name = "tokenizers", marker = "extra == 'ocr-deepseek'", specifier = "==0.20.3" },
     { name = "torch", marker = "extra == 'categorizer'" },
+    { name = "torch", marker = "extra == 'demo'", specifier = "==2.12.1", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "janasunani", extra = "demo" } },
     { name = "torch", marker = "extra == 'ocr-deepseek'" },
     { name = "torch", marker = "extra == 'pipeline-core'" },
     { name = "torchvision", marker = "extra == 'ocr-deepseek'" },
@@ -2494,19 +2446,6 @@ wheels = [
 ]
 
 [[package]]
-name = "jupyter-builder"
-version = "1.0.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jupyter-core" },
-    { name = "traitlets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/45/d0df8b43c10a61529c0f4a8af5e19ebe108f0c3af8f57e0fc358969907af/jupyter_builder-1.0.2.tar.gz", hash = "sha256:6155d78a5325010532a6419ffcba89eac643fd1aa56ea83115e661924d6f6aab", size = 968638, upload-time = "2026-06-12T02:33:25.767Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/b6/c418e0b3256f67c04933566b80bfce947350682db92c4b786a8653db32d6/jupyter_builder-1.0.2-py3-none-any.whl", hash = "sha256:b024f65d36e1d530542db597b00dd513261aa59842e0d0fbbb1015a9f1935e9c", size = 910789, upload-time = "2026-06-12T02:33:23.317Z" },
-]
-
-[[package]]
 name = "jupyter-client"
 version = "8.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2602,7 +2541,7 @@ dependencies = [
     { name = "nbformat" },
     { name = "packaging" },
     { name = "prometheus-client" },
-    { name = "pywinpty", marker = "(os_name == 'nt' and platform_machine != 'aarch64' and sys_platform == 'linux') or (os_name == 'nt' and sys_platform != 'darwin' and sys_platform != 'linux') or (os_name == 'nt' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name == 'nt' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core') or (os_name == 'nt' and sys_platform == 'linux' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name == 'nt' and sys_platform == 'linux' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core') or (os_name != 'nt' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name != 'nt' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name != 'nt' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek')" },
+    { name = "pywinpty", marker = "(os_name == 'nt' and platform_machine != 'aarch64' and sys_platform == 'linux') or (os_name == 'nt' and sys_platform != 'darwin' and sys_platform != 'linux') or (os_name == 'nt' and sys_platform == 'linux' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name == 'nt' and sys_platform == 'linux' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core') or (os_name == 'nt' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core') or (os_name != 'nt' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name != 'nt' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name != 'nt' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
     { name = "pyzmq" },
     { name = "send2trash" },
     { name = "terminado" },
@@ -2620,7 +2559,7 @@ name = "jupyter-server-terminals"
 version = "0.5.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pywinpty", marker = "(os_name == 'nt' and platform_machine != 'aarch64' and sys_platform == 'linux') or (os_name == 'nt' and sys_platform != 'darwin' and sys_platform != 'linux') or (os_name == 'nt' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name == 'nt' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core') or (os_name == 'nt' and sys_platform == 'linux' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name == 'nt' and sys_platform == 'linux' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core') or (os_name != 'nt' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name != 'nt' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name != 'nt' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek')" },
+    { name = "pywinpty", marker = "(os_name == 'nt' and platform_machine != 'aarch64' and sys_platform == 'linux') or (os_name == 'nt' and sys_platform != 'darwin' and sys_platform != 'linux') or (os_name == 'nt' and sys_platform == 'linux' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name == 'nt' and sys_platform == 'linux' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core') or (os_name == 'nt' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core') or (os_name != 'nt' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name != 'nt' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name != 'nt' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
     { name = "terminado" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f4/a7/bcd0a9b0cbba88986fe944aaaf91bfda603e5a50bda8ed15123f381a3b2f/jupyter_server_terminals-0.5.4.tar.gz", hash = "sha256:bbda128ed41d0be9020349f9f1f2a4ab9952a73ed5f5ac9f1419794761fb87f5", size = 31770, upload-time = "2026-01-14T16:53:20.213Z" }
@@ -2630,14 +2569,13 @@ wheels = [
 
 [[package]]
 name = "jupyterlab"
-version = "4.6.0"
+version = "4.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "async-lru" },
     { name = "httpx" },
     { name = "ipykernel" },
     { name = "jinja2" },
-    { name = "jupyter-builder" },
     { name = "jupyter-core" },
     { name = "jupyter-lsp" },
     { name = "jupyter-server" },
@@ -2647,9 +2585,9 @@ dependencies = [
     { name = "tornado" },
     { name = "traitlets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/3c/1ebd737b860cdbe61eed71536d06aab4e1781fbdcf07ecd5a1afe05b8adf/jupyterlab-4.6.0.tar.gz", hash = "sha256:6a8b88f2aae7ed4d012c634fc957c1a27f3aa217c32f0ced0175fac9ee17f9e5", size = 28181861, upload-time = "2026-06-18T13:52:56.039Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/42/c2/decb25538588ed104ada22c31d1845b1500f98806e3261b94f0333e8b099/jupyterlab-4.1.6.tar.gz", hash = "sha256:7935f36ba26eb615183a4f5c2bbca5791b5108ce2a00b5505f8cfd100d53648e", size = 21773628, upload-time = "2024-04-08T14:00:54.61Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/eb/aa48075d0aa3d0188db34ba2704f53791757743c0bb02e18c4eef989b6de/jupyterlab-4.6.0-py3-none-any.whl", hash = "sha256:b6938cb8a1ef3d43860ff4745a680c62cc0a9385f9672295bb56cd2e7cfeebe2", size = 17143447, upload-time = "2026-06-18T13:52:51.42Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/5a/e084a40e593329859926c5824cd47b32b2700732a179ca94b2c533c4dddf/jupyterlab-4.1.6-py3-none-any.whl", hash = "sha256:cf3e862bc10dbf4331e4eb37438634f813c238cfc62c71c640b3b3b2caa089a8", size = 11416049, upload-time = "2024-04-08T14:00:46.698Z" },
 ]
 
 [[package]]
@@ -2663,7 +2601,7 @@ wheels = [
 
 [[package]]
 name = "jupyterlab-server"
-version = "2.28.0"
+version = "2.24.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "babel" },
@@ -2674,9 +2612,9 @@ dependencies = [
     { name = "packaging" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d6/2c/90153f189e421e93c4bb4f9e3f59802a1f01abd2ac5cf40b152d7f735232/jupyterlab_server-2.28.0.tar.gz", hash = "sha256:35baa81898b15f93573e2deca50d11ac0ae407ebb688299d3a5213265033712c", size = 76996, upload-time = "2025-10-22T13:59:18.37Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/29/d867a88db915b54ff1025a9c0576b051687ac5baa5f7cd723e22069606de/jupyterlab_server-2.24.0.tar.gz", hash = "sha256:4e6f99e0a5579bbbc32e449c4dbb039561d4f1a7827d5733273ed56738f21f07", size = 72145, upload-time = "2023-07-24T08:07:24.605Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/07/a000fe835f76b7e1143242ab1122e6362ef1c03f23f83a045c38859c2ae0/jupyterlab_server-2.28.0-py3-none-any.whl", hash = "sha256:e4355b148fdcf34d312bbbc80f22467d6d20460e8b8736bf235577dd18506968", size = 59830, upload-time = "2025-10-22T13:59:16.767Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/0d/6d4eab0391bd4df1c43f308368d5e177b0fa8ac632267222a23b71317091/jupyterlab_server-2.24.0-py3-none-any.whl", hash = "sha256:5f077e142bb8dc9b843d960f940c513581bceca3793a0d80f9c67d9522c4e876", size = 57329, upload-time = "2023-07-24T08:07:22.09Z" },
 ]
 
 [[package]]
@@ -2960,8 +2898,7 @@ dependencies = [
     { name = "cycler" },
     { name = "fonttools" },
     { name = "kiwisolver" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-demo' or (extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-pipeline-core')" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-ocr-deepseek' or (extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
+    { name = "numpy" },
     { name = "packaging" },
     { name = "pillow" },
     { name = "pyparsing" },
@@ -3047,14 +2984,12 @@ dependencies = [
     { name = "matplotlib" },
     { name = "mlflow-skinny" },
     { name = "mlflow-tracing" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-demo' or (extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-pipeline-core')" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-ocr-deepseek' or (extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
+    { name = "numpy" },
     { name = "pandas" },
     { name = "pyarrow" },
     { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-categorizer' or extra == 'extra-10-janasunani-demo' or extra == 'extra-10-janasunani-pipeline-core'" },
     { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-ocr-deepseek' or (extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-demo' or (extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-pipeline-core')" },
-    { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-ocr-deepseek' or (extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
+    { name = "scipy" },
     { name = "skops" },
     { name = "sqlalchemy" },
     { name = "waitress", marker = "sys_platform == 'win32' or (extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
@@ -3280,11 +3215,11 @@ wheels = [
 
 [[package]]
 name = "mypy-extensions"
-version = "1.1.0"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/a4/1ab47638b92648243faf97a5aeb6ea83059cc3624972ab6b8d2316078d3f/mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782", size = 4433, upload-time = "2023-02-04T12:11:27.157Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/e2/5d3f6ada4297caebe1a2add3b126fe800c96f56dbe5d1988a2cbe0b267aa/mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d", size = 4695, upload-time = "2023-02-04T12:11:25.002Z" },
 ]
 
 [[package]]
@@ -3398,19 +3333,18 @@ wheels = [
 
 [[package]]
 name = "notebook"
-version = "7.6.0"
+version = "7.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jupyter-builder" },
     { name = "jupyter-server" },
     { name = "jupyterlab" },
     { name = "jupyterlab-server" },
     { name = "notebook-shim" },
     { name = "tornado" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0d/44/d5c65783f490298473bb1c05722e05ee2256231389559c2c5ae0a3e5d975/notebook-7.6.0.tar.gz", hash = "sha256:ea13e79e601bf273074895fdfb17dd3f2da916d3c045e0b9c47d18b16ab62481", size = 5497344, upload-time = "2026-06-18T16:18:55.202Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/38/f2c6cb06f3c4997980ad27713f23378616761fd8d36013c9cdd0d9c54ad2/notebook-7.1.3.tar.gz", hash = "sha256:41fcebff44cf7bb9377180808bcbae066629b55d8c7722f1ebbe75ca44f9cfc1", size = 4897695, upload-time = "2024-04-17T16:24:24.126Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/d1/e617c40db57ff40e75f43a7d4d1c305e3a54c053ab5cb0534a6c314664f9/notebook-7.6.0-py3-none-any.whl", hash = "sha256:98aa2811b54ac191321d5dfce12ca700f8a511a33a26e4de2fa106a357c43d6a", size = 5544575, upload-time = "2026-06-18T16:18:52.551Z" },
+    { url = "https://files.pythonhosted.org/packages/08/e6/e032f6a4d3da85c4bd38b6ff96de51347bfb0d932ea1d2ccfd89c6374c8a/notebook-7.1.3-py3-none-any.whl", hash = "sha256:919b911e59f41f6e3857ce93c9d93535ba66bb090059712770e5968c07e1004d", size = 4989396, upload-time = "2024-04-17T16:24:19.628Z" },
 ]
 
 [[package]]
@@ -3429,66 +3363,14 @@ wheels = [
 name = "numpy"
 version = "1.26.4"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform == 'darwin'",
-    "python_full_version < '3.14' and sys_platform == 'darwin'",
-    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux')",
-    "(python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux')",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010", size = 15786129, upload-time = "2024-02-06T00:26:44.495Z" }
-
-[[package]]
-name = "numpy"
-version = "2.5.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version < '3.14'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e7/05/3d27272d30698dc0ecb7fdfaa41ad70303b444f81722bb99bce1d818638a/numpy-2.5.0.tar.gz", hash = "sha256:5a129578019311b6e56bdd714250f19b518f7dceeeb8d1af5490f4942d3f891c", size = 20652461, upload-time = "2026-06-21T20:57:51.95Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/33/07675aaad7f26ea013d5e884d9a0d784b79c6bd7566c333f5a52fa3c610b/numpy-2.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:520e6b8be0a4b65840ac8090d4f51cef4bed66e2b0894d5a520f099adc24a9b2", size = 16784890, upload-time = "2026-06-21T20:56:40.799Z" },
-    { url = "https://files.pythonhosted.org/packages/85/4b/953118a730ee3b35e28645e0eb4cf9beec5bdbb954e1ac2f5fcefba6bbc3/numpy-2.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:146b81cdd3967fdb6beca8ba25f00c58741d8f3cbd797f55af0fbe0bfec3469c", size = 11754584, upload-time = "2026-06-21T20:56:43.094Z" },
-    { url = "https://files.pythonhosted.org/packages/44/9b/56dd530c367c74ae17411027cea4135ca57e1e0583bf5594cee18bd83217/numpy-2.5.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:126b88d95e8ff9b00c9e717aa540469f21d6180162f84c0caec51b16215d49cd", size = 5313904, upload-time = "2026-06-21T20:56:45.503Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/b0/bcd672edad27ecca7da1f7bb0ce72cd1706a4f2d79ae94990afc97c13e1c/numpy-2.5.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:d4313cef1594c5ce46c31b6e54e918338f63f16ee9322304e8c9114d6d81c8bd", size = 6648504, upload-time = "2026-06-21T20:56:47.567Z" },
-    { url = "https://files.pythonhosted.org/packages/80/9e/15cdfcbd30a1544a46c9e487a00df331c4672450216538705a9e51fa6710/numpy-2.5.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:750fb097caf26fa878746d9d119f6f9da12dedcbff1eea966c3e3447647c4a9e", size = 15150086, upload-time = "2026-06-21T20:56:49.352Z" },
-    { url = "https://files.pythonhosted.org/packages/32/4e/8d7656ccaab3e81e97258b8a9bc5f0c8502513a92fb4ceb0a2cbfebc17bf/numpy-2.5.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3893adc2dc7c0412ba76777db55a049215d99c9aa3113003be8f49f4f1290ab9", size = 16647250, upload-time = "2026-06-21T20:56:51.542Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/81/97060281b602ed07f21b12f4ec409eac1f75a2f91fbc829ed8b2becf3ad4/numpy-2.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:835e454dd99b238cdc5a3f63bce2371296f5ebc53ca1e0f8e6ddbb6d92a29aab", size = 16512864, upload-time = "2026-06-21T20:56:55.401Z" },
-    { url = "https://files.pythonhosted.org/packages/33/ab/4496208146911f8d8ddb54f68a972aafa6c8d44babcb2ea03b0e5cc87c9d/numpy-2.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f9836778081a0a3c02a6a21493f3e9f5b311f8d2541934f31f05583dc999ea4", size = 18408407, upload-time = "2026-06-21T20:56:57.75Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/9f/a4df67c181e4ee8b467aa3332dc2db10fd5c515136831302f3ca48bc0a01/numpy-2.5.0-cp313-cp313-win32.whl", hash = "sha256:0b525be4744b60bb0557ac872d53ef07d085b5f39622bc579c98d3809d05b988", size = 6054431, upload-time = "2026-06-21T20:57:00.016Z" },
-    { url = "https://files.pythonhosted.org/packages/30/53/491e1c47c55b62ccc6a63c1c5b8635c73fc2258dddeb9bda27cae4a0ae96/numpy-2.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:44353e2878930039db472b99dc353d749826e4010bd4d2a7f835e94a97a5c748", size = 12414420, upload-time = "2026-06-21T20:57:01.815Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/4a/25c2906f541e9d9f4c5769764db732e6627be91a13f4724fa10634d77db4/numpy-2.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:48f54b00711f83a5f796b70c518e8c2b3c5848dda03a54911f23eb68519b9b60", size = 10339533, upload-time = "2026-06-21T20:57:03.961Z" },
-    { url = "https://files.pythonhosted.org/packages/86/ad/abc44aaceaf7b17ee1edde2bbb4458da591bc79574cffff50c4bb35f00d1/numpy-2.5.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f27582c55ba4c750b7c58c8faf021d2cd9324a662b466229db8a417b41368af9", size = 16783807, upload-time = "2026-06-21T20:57:06.253Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/39/b72e168daf9c00fb20c9fc996d00437ccecdef3102387775d29d7a62576d/numpy-2.5.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:28e7137057d551e4a83c4ae414e3451f50568409db7569aacc7f9811ee06a446", size = 11765215, upload-time = "2026-06-21T20:57:08.547Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/a0/8400a9c0e3625182347593f5e1f57da9a617a534794805c8df5518154ddc/numpy-2.5.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:e1da54b53e75cd9fcfc23efcc7edab2c6aecf97b6037566d8a0fe804af8ec57c", size = 5324493, upload-time = "2026-06-21T20:57:11.012Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/8c/0d104deaa0401c93395a629ec902891618a2eff76d19229139cb5a887bfc/numpy-2.5.0-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:694d8f74e156f7fd01179f1aa8faa2f648ab6ae0f70b6c3fe57a03249aea2303", size = 6645211, upload-time = "2026-06-21T20:57:12.919Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/d9/4a4a628c812750363786afc3d33492709a5cd64b215469c16b0f6c7bb811/numpy-2.5.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1a7569a7b53c77716f036bb28cb1c91f166a26ec7d9502cd1e4bdfe502fdec22", size = 15166004, upload-time = "2026-06-21T20:57:14.717Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/5e/2a902317d7fc4aa93236e80c932662dadfc459b323d758329e01775125e1/numpy-2.5.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:39a0433bd4086ebd462960cf375e19195bb07b53dc1d87dd5fcf47ad78576f03", size = 16650797, upload-time = "2026-06-21T20:57:16.906Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/a0/a0090e6329f4ca5992c07847bb579c5259a19953dc57255bb08793142ffb/numpy-2.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:929f0c79ac38bcbd7154fe631dc907abfeddbcc5027a896bd1f7767323271e7a", size = 16524647, upload-time = "2026-06-21T20:57:19.165Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/7d/6caf27734c42b65837e7461ed0dbbd6b6fc835060c9714ec59d673bb383a/numpy-2.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cc4f247a47bbf070bfd70be53ccdcf47b800af563535e7bbe172322197c30e21", size = 18411841, upload-time = "2026-06-21T20:57:21.638Z" },
-    { url = "https://files.pythonhosted.org/packages/13/dc/26edadbd812536769a82c2e9e002234e33feb5da43061d47a044f6d309b7/numpy-2.5.0-cp314-cp314-win32.whl", hash = "sha256:5dc71423499fab3f46f7a7201155ade1669ea101f2f429d332df9e72f8161731", size = 6106361, upload-time = "2026-06-21T20:57:23.844Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/9e/4dd1459282229a72d92dece2ae9138e5cac94a72263a7ceb48f37434c925/numpy-2.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:ebb81d9d5443e0309d6c54894c3fbed74ad7da0714352a67b6d773cd189eae73", size = 12551749, upload-time = "2026-06-21T20:57:25.945Z" },
-    { url = "https://files.pythonhosted.org/packages/05/a7/6bc6384c080b86c7f6c85c5bc5b540b24f4f679cd144791d99574e90d462/numpy-2.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:3b94d0d0deceebfad3e67ae5c0e5eb87371e8f7a0581cd04a779928c2450cf1e", size = 10617072, upload-time = "2026-06-21T20:57:28.175Z" },
-    { url = "https://files.pythonhosted.org/packages/86/6b/4a2b71d66ada5608ae02b63f150dfad520f6940721cb7f029ad270befc0e/numpy-2.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:22f3d43e362d650bc39db1f17851302874a148ca95ba6981c1dfb5fa6862f35b", size = 11881067, upload-time = "2026-06-21T20:57:30.104Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/b2/d365eb40a20efb49d67e9feb90494ed8511282ee1f5fa16006675c65397d/numpy-2.5.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:243563efb4cd7528a264567e9fd206c87826457322521d06206a00bfa316c927", size = 5440290, upload-time = "2026-06-21T20:57:32.193Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/5e/e9c03188de5f9b767e46a8fe988bcfd3efad066a4a3fda8b9cb11a93f895/numpy-2.5.0-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:84881d825ca75249b189bbee875fcfe3238aa5c479e6100893cda566e8e86826", size = 6748371, upload-time = "2026-06-21T20:57:33.933Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/1d/68c186a38a5027bae2c4ddd5ea681fdaf8b4d30fb7301def6d8ad270390f/numpy-2.5.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cda12aa4779d42b8771180aba759c96f527d43446d8f380ab59e2b35e8489efd", size = 15214643, upload-time = "2026-06-21T20:57:35.677Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/67/73f67b7c7e20635baae9c4c3ead4ae7326a005900297a6110971abd62eb5/numpy-2.5.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c0121101093d2bd74981b10f8837d78e794a8ff57834eb27179f49e1ba11ac6", size = 16690128, upload-time = "2026-06-21T20:57:38.159Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/05/d4c1fb0c46d02a27d6b2b8b319a78c90937acec8631c1641874670b31e6f/numpy-2.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d371c92cfa09da00022f501ab67fafaea813d752eb30ac44336d45b1e5b0268a", size = 16577902, upload-time = "2026-06-21T20:57:40.447Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/1d/771c797d50fa26e4888989cccf1d50ee51f530d4e455ad2692dcb64fa711/numpy-2.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9990713e9c38154c6861e7547f1e3fc7a87e75ff09bab24ef1cc81d81c2835e9", size = 18452814, upload-time = "2026-06-21T20:57:42.875Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/46/52fc0d2a68d7643f0f149eeea5a5d8ea2a3507056ac8afa83c9212606e8b/numpy-2.5.0-cp314-cp314t-win32.whl", hash = "sha256:edadfbd4794b1086c0d822f81863e8a68fc129d132fd0bb9e31e955d7fbbbdb7", size = 6253168, upload-time = "2026-06-21T20:57:45.101Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/be/6c8d1118b5f13b2881dc095d5b345de19c6638b8959c17409b6eff84c8aa/numpy-2.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f7e5fa4382967ae6548bd2f174219afb908e294b0d5f625af01166edd5f7d9aa", size = 12736286, upload-time = "2026-06-21T20:57:46.935Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/6a/d3a169aaf8536cf228d56a09e04bcb713a2fe4410d4e2105b9419b5a9c89/numpy-2.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:016623417bb330d719d579daf2d6b9a01ddc52e41a9ed61a47f39fde46dcd865", size = 10686451, upload-time = "2026-06-21T20:57:49.313Z" },
-]
 
 [[package]]
 name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -3531,7 +3413,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -3544,7 +3426,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -3576,9 +3458,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'darwin'" },
+    { name = "nvidia-cusparse", marker = "sys_platform != 'darwin'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -3591,7 +3473,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -3611,11 +3493,11 @@ wheels = [
 
 [[package]]
 name = "nvidia-nccl-cu12"
-version = "2.30.7"
+version = "2.28.3"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/8c/554bb020501d6c04ad8127d83f728137f8f9123f991666efbdcf9095a221/nvidia_nccl_cu12-2.30.7-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:03ecd776fd1d58fd2c9a0a687dcf8db9ecd0057382dba646fa3d65786d4a9ea1", size = 303277471, upload-time = "2026-06-09T03:24:16.327Z" },
-    { url = "https://files.pythonhosted.org/packages/50/32/e7ffa9c324ae260e5dbb4af2cd557bf7a8d155c8ac7b79a785fe1796fb92/nvidia_nccl_cu12-2.30.7-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:8ce1b8213f61f2bfac132e6df890af6450b77cbd140c6ce4e98cb0c2d8e678c9", size = 303361239, upload-time = "2026-06-09T03:24:53.816Z" },
+    { url = "https://files.pythonhosted.org/packages/99/76/a87f70dc4544f76abf528c335a5c107130cca5c345725b1d2ad03bf2c2a2/nvidia_nccl_cu12-2.28.3-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:85144f2197e81148e18f3ffd28a30d78b5046844877630d2710a1b22669a6e46", size = 295887310, upload-time = "2025-09-06T00:31:43.228Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/24/11df42593d1a6d10b3ffef049cec064832f108e77bc5cac12726e4ec1cb2/nvidia_nccl_cu12-2.28.3-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:79cf0412094e4a552889e5cb7757d92c010ead557ec722c5eebe6a94b1d8681c", size = 295901337, upload-time = "2025-09-06T00:32:01.348Z" },
 ]
 
 [[package]]
@@ -3674,7 +3556,7 @@ name = "opencv-python"
 version = "4.11.0.86"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/17/06/68c27a523103dad5837dc5b87e71285280c4f098c60e4fe8a8db6486ab09/opencv-python-4.11.0.86.tar.gz", hash = "sha256:03d60ccae62304860d232272e4a4fda93c39d595780cb40b161b310244b736a4", size = 95171956, upload-time = "2025-01-16T13:52:24.737Z" }
 wheels = [
@@ -3777,11 +3659,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.2"
+version = "24.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/65/50db4dda066951078f0a96cf12f4b9ada6e4b811516bf0262c0f4f7064d4/packaging-24.1.tar.gz", hash = "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002", size = 148788, upload-time = "2024-06-09T23:19:24.956Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+    { url = "https://files.pythonhosted.org/packages/08/aa/cc0199a5f0ad350994d660967a8efb233fe0416e4639146c089643407ce6/packaging-24.1-py3-none-any.whl", hash = "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124", size = 53985, upload-time = "2024-06-09T23:19:21.909Z" },
 ]
 
 [[package]]
@@ -3789,8 +3671,7 @@ name = "pandas"
 version = "2.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-demo' or (extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-pipeline-core')" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-ocr-deepseek' or (extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
+    { name = "numpy" },
     { name = "python-dateutil" },
     { name = "pytz" },
     { name = "tzdata" },
@@ -4047,7 +3928,7 @@ version = "2.2.363"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy" },
     { name = "phonenumbers" },
     { name = "pydantic" },
     { name = "pyyaml" },
@@ -4851,7 +4732,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.34.2"
+version = "2.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -4859,9 +4740,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/61/a867851fd5ab77277495a8709ddda0861b28163c4613b011bc00228cc724/requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983", size = 109805, upload-time = "2022-06-29T15:13:42.715Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/91/6d9b8ccacd0412c08820f72cebaa4f0c0441b5cda699c90f618b6f8a1b42/requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349", size = 62843, upload-time = "2022-06-29T15:13:40.685Z" },
 ]
 
 [[package]]
@@ -4878,16 +4759,17 @@ wheels = [
 
 [[package]]
 name = "responses"
-version = "0.26.1"
+version = "0.23.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
+    { name = "types-pyyaml" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/58/1fb6de3503428196df78638f991ec8095274f1ee9723e272ee4d9ff0092b/responses-0.26.1.tar.gz", hash = "sha256:2eb3218553cc8f79b57d257bac23af5e1bf381f5b9390b1767816f0843e01dc2", size = 83088, upload-time = "2026-05-21T19:56:39.747Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/4f/5033bf66528c832e7fcc48e76f540bf401302c55041c7fb488b4fbaaec4a/responses-0.23.1.tar.gz", hash = "sha256:c4d9aa9fc888188f0c673eff79a8dadbe2e75b7fe879dc80a221a06e0a68138f", size = 72966, upload-time = "2023-03-10T21:27:35.193Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/31/6a620b4427d546b9e7cca8b3b8c5f0559d9cef2bb9eedcda7f73c1473c19/responses-0.26.1-py3-none-any.whl", hash = "sha256:8aacc4586eb08fb2208ef64a9eb4258d9b0c6e6f4260845f2f018ab847495345", size = 35502, upload-time = "2026-05-21T19:56:38.046Z" },
+    { url = "https://files.pythonhosted.org/packages/72/6a/64c85e69c6a7b02e828ed193b2fc15e3ff6581f87501666b98feabc54809/responses-0.23.1-py3-none-any.whl", hash = "sha256:8a3a5915713483bf353b6f4079ba8b2a29029d1d1090a503c70b0dc5d9d0c7bd", size = 52083, upload-time = "2023-03-10T21:27:35.187Z" },
 ]
 
 [[package]]
@@ -5079,16 +4961,16 @@ wheels = [
 
 [[package]]
 name = "s3fs"
-version = "2026.6.0"
+version = "2026.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiobotocore" },
     { name = "aiohttp" },
     { name = "fsspec" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/99/00/6677343dc919d6c072bb04d80210afdd22c16838a8d16b3315c122dc728f/s3fs-2026.6.0.tar.gz", hash = "sha256:b28de7082d0a4f72392884bdc497e34a4a1582f675d214c7da0acf6e950a0083", size = 87358, upload-time = "2026-06-16T02:05:48.719Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/d8/76f3dc1558bdf4494b117a9f7a9cc0a5d9d34edadc9e5d7ceabc5a6a7c37/s3fs-2026.4.0.tar.gz", hash = "sha256:5bdce0abb00b0435ee150807a45fea727451dbc22de4cbc116464f8504ab9d37", size = 85986, upload-time = "2026-04-29T20:52:51.748Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/0b/f68a968b49876eae0f2a515387093cebb2eb9451380a96741cc20efac0d0/s3fs-2026.6.0-py3-none-any.whl", hash = "sha256:60576e31bb31193c1f643f32b4c6439548720ea6918ac702e21cd757c80b5db8", size = 32573, upload-time = "2026-06-16T02:05:47.608Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/a4/9d1ea10ebc9e028a289a72fec84da170689549a8102c8aacfcad26bc5035/s3fs-2026.4.0-py3-none-any.whl", hash = "sha256:de0d2a1f33cdf03831fd2382d278c6e4e31fe57c3bf2f703c61f8aec6b703e2a", size = 32392, upload-time = "2026-04-29T20:52:50.295Z" },
 ]
 
 [[package]]
@@ -5135,10 +5017,10 @@ dependencies = [
     { name = "imageio" },
     { name = "lazy-loader" },
     { name = "networkx" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy" },
     { name = "packaging" },
     { name = "pillow" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy" },
     { name = "tifffile" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a1/b4/2528bb43c67d48053a7a649a9666432dc307d66ba02e3a6d5c40f46655df/scikit_image-0.26.0.tar.gz", hash = "sha256:f5f970ab04efad85c24714321fcc91613fcb64ef2a892a13167df2f3e59199fa", size = 22729739, upload-time = "2025-12-20T17:12:21.824Z" }
@@ -5212,8 +5094,10 @@ resolution-markers = [
     "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core')",
     "(python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core')",
-    "python_full_version >= '3.14' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "python_full_version < '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
@@ -5223,10 +5107,8 @@ resolution-markers = [
 ]
 dependencies = [
     { name = "joblib", marker = "extra == 'extra-10-janasunani-categorizer' or extra == 'extra-10-janasunani-demo' or extra == 'extra-10-janasunani-pipeline-core'" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-demo' or (extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-pipeline-core')" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-demo' or (extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-pipeline-core')" },
-    { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
+    { name = "numpy", marker = "extra == 'extra-10-janasunani-categorizer' or extra == 'extra-10-janasunani-demo' or extra == 'extra-10-janasunani-pipeline-core'" },
+    { name = "scipy", marker = "extra == 'extra-10-janasunani-categorizer' or extra == 'extra-10-janasunani-demo' or extra == 'extra-10-janasunani-pipeline-core'" },
     { name = "threadpoolctl", marker = "extra == 'extra-10-janasunani-categorizer' or extra == 'extra-10-janasunani-demo' or extra == 'extra-10-janasunani-pipeline-core'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
@@ -5262,14 +5144,18 @@ name = "scikit-learn"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version < '3.14'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and sys_platform != 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version >= '3.14' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
 ]
 dependencies = [
     { name = "joblib", marker = "extra == 'extra-10-janasunani-ocr-deepseek' or (extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
     { name = "narwhals", marker = "extra == 'extra-10-janasunani-ocr-deepseek' or (extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-ocr-deepseek' or (extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
-    { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-ocr-deepseek' or (extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
+    { name = "numpy", marker = "extra == 'extra-10-janasunani-ocr-deepseek' or (extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
+    { name = "scipy", marker = "extra == 'extra-10-janasunani-ocr-deepseek' or (extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
     { name = "threadpoolctl", marker = "extra == 'extra-10-janasunani-ocr-deepseek' or (extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fa/6f/37092bdb25f712817231799fc5674d8e704066a8a70c1d2d40517e18b4ab/scikit_learn-1.9.0.tar.gz", hash = "sha256:8833266989d3a5110178a9fae30783675460724d0e1efb13b14901d2c660c557", size = 7750767, upload-time = "2026-06-02T11:54:32.706Z" }
@@ -5298,16 +5184,8 @@ wheels = [
 name = "scipy"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform == 'darwin'",
-    "python_full_version < '3.14' and sys_platform == 'darwin'",
-    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux')",
-    "(python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux')",
-]
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-demo' or (extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-pipeline-core')" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -5354,68 +5232,24 @@ wheels = [
 ]
 
 [[package]]
-name = "scipy"
-version = "1.18.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version < '3.14'",
-]
-dependencies = [
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-ocr-deepseek' or (extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/52/9c0136c2de7ae0779b7b366447766cec6d9f0702c56bb8ffeb04c8fd3af4/scipy-1.18.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:09143f676d157d9f546d663504ef9c1becb819824f1afc018814176411942446", size = 31036107, upload-time = "2026-06-19T15:00:14.03Z" },
-    { url = "https://files.pythonhosted.org/packages/02/73/0291a64843270f4efb86cdcf2ee0f2048631b65ec6b405398b2b4dbf11bf/scipy-1.18.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5efe260f69417b97ddae455bfb5a95e8359f7f66ad7fa9522a60feb66f169520", size = 28663303, upload-time = "2026-06-19T15:00:16.819Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/0f/10ffa0b697a572f4e0d48b92a88895d366422f019f723e7e14a84c050dac/scipy-1.18.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:68363b7eaacd8b5dd426df56d782cc156468ac79a127a1b87ca597d6e2e82197", size = 20404960, upload-time = "2026-06-19T15:00:19.635Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/d2/e896cea21ba8edd6c81d4c55b1ffcc717e79698dcbebf9641b4cfb4c6622/scipy-1.18.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:c5557d8be5da8e41353fcd4d21491fdbab83b062fc579e94dc09a7c8ab4f669b", size = 23034074, upload-time = "2026-06-19T15:00:22.107Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/b2/e83ea34279a52c03374477c74006256ec78df65fc877baa4617d6de1d202/scipy-1.18.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0d13bca67c096d89fb95ced0d8921807300fce0275643aef9533cc63a0773468", size = 33942038, upload-time = "2026-06-19T15:00:24.964Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/af/e8fe5fb136f51e2b01678b92cb4106d10d8cd68ec147ead2e7cb0ac75398/scipy-1.18.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a46f9273dbd0eb1cefba61c9b8648b4dfe3cbc14a080176f9a73e44b8336dc7f", size = 35266390, upload-time = "2026-06-19T15:00:28.059Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/49/2c5cbb907b56695fc67517811d1db234dfd83381a84814ec220aded2794d/scipy-1.18.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5aba46108853ddfc77906b6557aac839d2b52e900c1d72a1180adaaab58d265f", size = 35551324, upload-time = "2026-06-19T15:00:31.014Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/73/eda39f7a2d306ff0ffc574afd13c0bbb6d10a603d9a413998ee269487a80/scipy-1.18.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b6f758e35f12757b5d95c00bc6de2438e229c2664b7a92e96f205959d9f2dfa4", size = 37404785, upload-time = "2026-06-19T15:00:34.072Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/d2/ae881ee28d014f38e0ccbfd974a06a919ba9af34f1f74bf42b5301891d63/scipy-1.18.0-cp313-cp313-win_amd64.whl", hash = "sha256:1afac4a847207c7ff8efd321734a50b06d0280b3b2a2c0fc2f413101747ad7c7", size = 36554943, upload-time = "2026-06-19T15:00:36.903Z" },
-    { url = "https://files.pythonhosted.org/packages/70/3a/21154e2d54eb3639c6bf4dbae2e531c68356bfe95990daa30df33b30d556/scipy-1.18.0-cp313-cp313-win_arm64.whl", hash = "sha256:c5dbddf60e58c2312316d097271a8e73d40eaf2eabfa4d95ed7d3695bbf2ce7b", size = 24350911, upload-time = "2026-06-19T15:00:40.062Z" },
-    { url = "https://files.pythonhosted.org/packages/78/b5/915a19b3de2f7430062b509653563db1633ddbb6f021b06731521115d4e2/scipy-1.18.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:4c256ee70c0d1a8a2ace807e199ccd4e3f57037433842abb3fb36bc17eaa9578", size = 31036253, upload-time = "2026-06-19T15:00:43.216Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/88/b72def7262e150d16be13fca37a96481138d624e700340bc3362a7588929/scipy-1.18.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:2ef3abc54a4ffc53765374b0d5728532dfdd2585ed23f6b11c206a1f0b1b9af8", size = 28673758, upload-time = "2026-06-19T15:00:46.663Z" },
-    { url = "https://files.pythonhosted.org/packages/91/02/2e636a61a525632c373cf6a9c24442a3ffb79e364d38e98b32042964ac32/scipy-1.18.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:f2a6af57bd9e4a75d70e4117e78a1bbee84f79ae3fbb6d0111005d6ebcc4cb8d", size = 20415514, upload-time = "2026-06-19T15:00:49.399Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/b6/2135974442f6aba159d9d39d774a1c8cb19947016725d69fecc685df45bf/scipy-1.18.0-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:3f1ac564d3bf6c03d861d2cd87a1bea0da2887136f7fb1bf519c05a8971452d6", size = 23034398, upload-time = "2026-06-19T15:00:51.941Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/e6/ba89ec5abf6ee9257c0d1ec985573f3ae32742c24bc03e016388a40b1b15/scipy-1.18.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40395a5fcd1abee49a5c7aaa98c29db393eedc835138560a588c47ec16156690", size = 33998032, upload-time = "2026-06-19T15:00:54.838Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/c4/bc41eb19b0fd0db868f4132920879019318d80cc522ad8f2bca4611af808/scipy-1.18.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ca01e8ae69f1b18e9a58d91afead31be3cef0dd905a10249dac559ee15460a0", size = 35283333, upload-time = "2026-06-19T15:00:58.152Z" },
-    { url = "https://files.pythonhosted.org/packages/53/a4/cbdeef6eb3830a8462a9d4ada814de5fc984345cc9ecf17cbec51a036f1e/scipy-1.18.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7a7f3b01647384dbc3a711e8c6778e0aabbe93959249fef5c7393396bcac0867", size = 35610216, upload-time = "2026-06-19T15:01:01.155Z" },
-    { url = "https://files.pythonhosted.org/packages/80/4d/b2b82502b65f661d1b789c1665dcdf315d5f12194e06fc0b37946294ebae/scipy-1.18.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6aa94e78ec192a30063a5e72e561c28af769dc311190b24fe91774eff1969709", size = 37418960, upload-time = "2026-06-19T15:01:04.155Z" },
-    { url = "https://files.pythonhosted.org/packages/93/3e/902d836831474b0ab5a37d16404f7bc5fafd9efba632890e271ba952635f/scipy-1.18.0-cp314-cp314-win_amd64.whl", hash = "sha256:2d8bbdc6c817f5b4006a54d799d4f5bab6f910193cbb9a1ff310833d4d270f61", size = 37288845, upload-time = "2026-06-19T15:01:07.822Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/43/8d73b337a3bdb14daa0314f0434210747c02d79d729ce1777574a817dcf6/scipy-1.18.0-cp314-cp314-win_arm64.whl", hash = "sha256:18e9575f1569b2c54174e6159d32942e03731177f63dce7975f0a0c88d102f5b", size = 24988971, upload-time = "2026-06-19T15:01:11.076Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/b4/f11918b0508a2787031a0499a03fbe3546f3bb5ca05d01038c45b278c09a/scipy-1.18.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:f351e0dd702687d12a402b867a1b4146a256923e1c38317cbc472f6372b94707", size = 31399325, upload-time = "2026-06-19T15:01:13.723Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/d1/1f287b57c0ff0ee5185dff3946d92c8017d39b0e431f0ae79a3ff1859512/scipy-1.18.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:7c7a51b33ce387193c97f228320cf8e87361daa1bba750638677729598b3e677", size = 29092110, upload-time = "2026-06-19T15:01:16.908Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/1a/7b74eb6c392fdcb27d414c0e7558a6d0231eb3b6d73571f479bb81ea8794/scipy-1.18.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:84031d7b052a54fae2f8632e0ec802073d385476eb9a63079bce6e23ef9283d4", size = 20833811, upload-time = "2026-06-19T15:01:20.488Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/ad/f3941716320a7b9cb4d68734a903b45fe16eff5fb7da7e16f2e619304979/scipy-1.18.0-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:56abf29a7c067dde59be8b9a22d606a4ea1b2f2a4b756d9d903c62818f5dacce", size = 23396644, upload-time = "2026-06-19T15:01:23.364Z" },
-    { url = "https://files.pythonhosted.org/packages/22/22/1446b62ffe07f9719b7d9b1b6a4e05a772833ae8f441fe4c22c34c9b250f/scipy-1.18.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ad44305cfa24b1ba5803cbbebf033590ccbac1aa5d612d727b785325ab408b0", size = 34079318, upload-time = "2026-06-19T15:01:26.002Z" },
-    { url = "https://files.pythonhosted.org/packages/56/3b/b87da667098bb470fa30c7011b0ba351ee976dd395c78798c66e941665a3/scipy-1.18.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:945c1761b93f38d7f99ae81ae80c63e621471608c7eeead563f6df025585cd58", size = 35324320, upload-time = "2026-06-19T15:01:28.881Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/a1/c7932f91909759b0267f75fdea34e91309f96b895757534b76a90b6b4344/scipy-1.18.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1a4441f15d620578772a49e5ab48c0ee1f7a0220e387110283062729136b2553", size = 35699541, upload-time = "2026-06-19T15:01:31.968Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/86/5185061a1fcc41d18c5dc2463969b3a3964b31d9ac67b2fb05d4c7ff7670/scipy-1.18.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9aac6192fac56bf2ca534389d24623f07b39ff83317d58287285e7fbd622ff76", size = 37472480, upload-time = "2026-06-19T15:01:35.136Z" },
-    { url = "https://files.pythonhosted.org/packages/31/8e/f04c68e39919a010d34f2ee1367fd705b0a25a02f609d755f0bfbc0a15fc/scipy-1.18.0-cp314-cp314t-win_amd64.whl", hash = "sha256:e40baea28ae7f5475c779741e2d90b1247c78531207b49c7030e698ff81cee3f", size = 37365390, upload-time = "2026-06-19T15:01:38.091Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/19/969dc072906c84dd0a3b05dcf57ea750936087d7873549e408b35cfc3f97/scipy-1.18.0-cp314-cp314t-win_arm64.whl", hash = "sha256:368e0a705903c466aa5f08eefb39e6b1b6b2d659e7352a31fd9e2438365be0f8", size = 25279661, upload-time = "2026-06-19T15:01:40.817Z" },
-]
-
-[[package]]
 name = "scmrepo"
-version = "3.6.2"
+version = "3.5.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp-retry" },
     { name = "asyncssh" },
     { name = "dulwich" },
     { name = "fsspec", extra = ["tqdm"] },
+    { name = "funcy" },
     { name = "gitpython" },
     { name = "pathspec" },
     { name = "pygit2" },
     { name = "pygtrie" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/90/d5/62ab01546616c42d05e11fe133ce80e1d5c5c601bfc391de41f52e32ce66/scmrepo-3.6.2.tar.gz", hash = "sha256:750741af151e4c602dbf1456b49c7a1d27844527ba94db1e0c580b167cbd9316", size = 97614, upload-time = "2026-03-31T05:05:12.452Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/e9/16538891e936c59434e9775cd213a248a040f6af2b8ac32506711c7b57a4/scmrepo-3.5.8.tar.gz", hash = "sha256:9970c6b5f8404ce3f7cced0cacf906a99509b3d2dad0c14bb391c0bc04006179", size = 97567, upload-time = "2025-12-02T07:45:57.658Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/42/f4bb5e4612681d28fb01335d5faa67e1478adc63077c86555776fe89e584/scmrepo-3.6.2-py3-none-any.whl", hash = "sha256:b6d2a904562d3fc8a1a375234ce6f9a3e47ce83cb67257381fa5dc43c6006d4a", size = 74242, upload-time = "2026-03-31T05:05:10.986Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/4f/8b7dba1749356cc36591776c0e840cf6dcf1a1840c6d5a07c0ddb732b3c0/scmrepo-3.5.8-py3-none-any.whl", hash = "sha256:24bef62d90f19a9ff2be70407805ca970b86363f1710c0ba169470225ae81aab", size = 74337, upload-time = "2025-12-02T07:45:55.423Z" },
 ]
 
 [[package]]
@@ -5438,66 +5272,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "81.0.0"
+version = "78.1.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
-    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
-    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')",
-    "(python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')",
-    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
-    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
-    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')",
-    "(python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')",
-    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
-    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
-    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')",
-    "(python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')",
-    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
-    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
-    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')",
-    "(python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')",
-    "python_full_version >= '3.14' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core')",
-    "(python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core')",
-    "python_full_version >= '3.14' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core')",
-    "(python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core')",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0d/1c/73e719955c59b8e424d015ab450f51c0af856ae46ea2da83eba51cc88de1/setuptools-81.0.0.tar.gz", hash = "sha256:487b53915f52501f0a79ccfd0c02c165ffe06631443a886740b91af4b7a5845a", size = 1198299, upload-time = "2026-02-06T21:10:39.601Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/5a/0db4da3bc908df06e5efae42b44e75c81dd52716e10192ff36d0c1c8e379/setuptools-78.1.0.tar.gz", hash = "sha256:18fd474d4a82a5f83dac888df697af65afa82dec7323d09c3e37d1f14288da54", size = 1367827, upload-time = "2025-03-25T22:49:35.332Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/e3/c164c88b2e5ce7b24d667b9bd83589cf4f3520d97cad01534cd3c4f55fdb/setuptools-81.0.0-py3-none-any.whl", hash = "sha256:fdd925d5c5d9f62e4b74b30d6dd7828ce236fd6ed998a08d81de62ce5a6310d6", size = 1062021, upload-time = "2026-02-06T21:10:37.175Z" },
-]
-
-[[package]]
-name = "setuptools"
-version = "82.0.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version < '3.14'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+    { url = "https://files.pythonhosted.org/packages/54/21/f43f0a1fa8b06b32812e0975981f4677d28e0f3271601dc88ac5a5b83220/setuptools-78.1.0-py3-none-any.whl", hash = "sha256:3e386e96793c8702ae83d17b853fb93d3e09ef82ec62722e61da5cd22376dcd8", size = 1256108, upload-time = "2025-03-25T22:49:33.13Z" },
 ]
 
 [[package]]
@@ -5541,14 +5320,12 @@ name = "skops"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-demo' or (extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-pipeline-core')" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-ocr-deepseek' or (extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
+    { name = "numpy" },
     { name = "packaging" },
     { name = "prettytable" },
     { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-categorizer' or extra == 'extra-10-janasunani-demo' or extra == 'extra-10-janasunani-pipeline-core'" },
     { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-ocr-deepseek' or (extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-demo' or (extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-pipeline-core')" },
-    { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-ocr-deepseek' or (extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
+    { name = "scipy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c8/9f/46448c4e41a4c5ee4bdb74b3758af48e5ff0faeffe40f4e301bfc7594894/skops-0.14.0.tar.gz", hash = "sha256:6c8c0e047f691a3a582c3258943eecafcbfd79c8c7eef66260f3703e363254f0", size = 608084, upload-time = "2026-04-20T18:23:55.336Z" }
 wheels = [
@@ -5595,12 +5372,12 @@ dependencies = [
     { name = "cymem" },
     { name = "jinja2" },
     { name = "murmurhash" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy" },
     { name = "packaging" },
     { name = "preshed" },
     { name = "pydantic" },
     { name = "requests" },
-    { name = "setuptools", version = "81.0.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "setuptools" },
     { name = "spacy-legacy" },
     { name = "spacy-loggers" },
     { name = "srsly" },
@@ -5798,7 +5575,7 @@ version = "0.18.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ptyprocess", marker = "os_name != 'nt' or (extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
-    { name = "pywinpty", marker = "(os_name == 'nt' and platform_machine != 'aarch64' and sys_platform == 'linux') or (os_name == 'nt' and sys_platform != 'darwin' and sys_platform != 'linux') or (os_name == 'nt' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name == 'nt' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core') or (os_name == 'nt' and sys_platform == 'linux' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name == 'nt' and sys_platform == 'linux' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core') or (os_name != 'nt' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name != 'nt' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name != 'nt' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek')" },
+    { name = "pywinpty", marker = "(os_name == 'nt' and platform_machine != 'aarch64' and sys_platform == 'linux') or (os_name == 'nt' and sys_platform != 'darwin' and sys_platform != 'linux') or (os_name == 'nt' and sys_platform == 'linux' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name == 'nt' and sys_platform == 'linux' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core') or (os_name == 'nt' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core') or (os_name != 'nt' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name != 'nt' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name != 'nt' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
     { name = "tornado" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8a/11/965c6fd8e5cc254f1fe142d547387da17a8ebfd75a3455f637c663fb38a0/terminado-0.18.1.tar.gz", hash = "sha256:de09f2c4b85de4765f7714688fff57d3e75bad1f909b589fde880460c753fd2e", size = 32701, upload-time = "2024-03-12T14:34:39.026Z" }
@@ -5816,11 +5593,11 @@ dependencies = [
     { name = "confection" },
     { name = "cymem" },
     { name = "murmurhash" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy" },
     { name = "packaging" },
     { name = "preshed" },
     { name = "pydantic" },
-    { name = "setuptools", version = "81.0.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "setuptools" },
     { name = "srsly" },
     { name = "wasabi" },
 ]
@@ -5858,7 +5635,7 @@ name = "tifffile"
 version = "2026.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c5/cb/2f6d79c7576e22c116352a801f4c3c8ace5957e9aced862012430b62e14f/tifffile-2026.3.3.tar.gz", hash = "sha256:d9a1266bed6f2ee1dd0abde2018a38b4f8b2935cb843df381d70ac4eac5458b7", size = 388745, upload-time = "2026-03-03T19:14:38.134Z" }
 wheels = [
@@ -5897,8 +5674,10 @@ name = "tokenizers"
 version = "0.20.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version < '3.14'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin'",
+    "python_full_version < '3.14' and sys_platform != 'darwin'",
+    "python_full_version < '3.14' and sys_platform == 'darwin'",
 ]
 dependencies = [
     { name = "huggingface-hub" },
@@ -5954,8 +5733,10 @@ resolution-markers = [
     "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core')",
     "(python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core')",
-    "python_full_version >= '3.14' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "python_full_version < '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
@@ -5997,10 +5778,55 @@ wheels = [
 [[package]]
 name = "torch"
 version = "2.12.1"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'darwin'",
+    "python_full_version < '3.14' and sys_platform == 'darwin'",
+]
+dependencies = [
+    { name = "filelock", marker = "(sys_platform == 'darwin' and extra == 'extra-10-janasunani-demo') or (sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
+    { name = "fsspec", marker = "(sys_platform == 'darwin' and extra == 'extra-10-janasunani-demo') or (sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
+    { name = "jinja2", marker = "(sys_platform == 'darwin' and extra == 'extra-10-janasunani-demo') or (sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
+    { name = "networkx", marker = "(sys_platform == 'darwin' and extra == 'extra-10-janasunani-demo') or (sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
+    { name = "setuptools", marker = "(sys_platform == 'darwin' and extra == 'extra-10-janasunani-demo') or (sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
+    { name = "sympy", marker = "(sys_platform == 'darwin' and extra == 'extra-10-janasunani-demo') or (sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
+    { name = "typing-extensions", marker = "(sys_platform == 'darwin' and extra == 'extra-10-janasunani-demo') or (sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
+]
+wheels = [
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:c75e93173c700bccd6bfcc4a9d19ce242ab6dacd1f1781483027a16239b9e650", upload-time = "2026-06-17T15:44:09Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:e9b6f7d2dd66ea87a3ae620069d31335d594c06effb1a383bdd21cfe61e44ece", upload-time = "2026-06-17T15:44:16Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:2afbb2bdaa8a95040e733f05492ddf133c3967c9b7ce0abd218d704b6cab437d", upload-time = "2026-06-17T15:44:24Z" },
+]
+
+[[package]]
+name = "torch"
+version = "2.12.1"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
+    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')",
+    "(python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
+    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')",
+    "(python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and sys_platform != 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+]
 dependencies = [
     { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
-    { name = "cuda-toolkit", extra = ["cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "(sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer') or (sys_platform == 'linux' and extra == 'extra-10-janasunani-demo') or (sys_platform == 'linux' and extra == 'extra-10-janasunani-ocr-deepseek') or (sys_platform == 'linux' and extra == 'extra-10-janasunani-pipeline-core') or (extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
+    { name = "cuda-toolkit", extra = ["cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "(sys_platform == 'linux' and extra == 'extra-10-janasunani-ocr-deepseek') or (sys_platform != 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo') or (sys_platform == 'linux' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-pipeline-core') or (extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
     { name = "filelock" },
     { name = "fsspec" },
     { name = "jinja2" },
@@ -6010,7 +5836,7 @@ dependencies = [
     { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
     { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
     { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
-    { name = "setuptools", version = "81.0.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "setuptools" },
     { name = "sympy" },
     { name = "triton", marker = "sys_platform == 'linux'" },
     { name = "typing-extensions" },
@@ -6031,13 +5857,47 @@ wheels = [
 ]
 
 [[package]]
+name = "torch"
+version = "2.12.1+cpu"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+resolution-markers = [
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "(python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux')",
+]
+dependencies = [
+    { name = "filelock", marker = "(sys_platform != 'darwin' and extra == 'extra-10-janasunani-demo') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
+    { name = "fsspec", marker = "(sys_platform != 'darwin' and extra == 'extra-10-janasunani-demo') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
+    { name = "jinja2", marker = "(sys_platform != 'darwin' and extra == 'extra-10-janasunani-demo') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
+    { name = "networkx", marker = "(sys_platform != 'darwin' and extra == 'extra-10-janasunani-demo') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
+    { name = "setuptools", marker = "(sys_platform != 'darwin' and extra == 'extra-10-janasunani-demo') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
+    { name = "sympy", marker = "(sys_platform != 'darwin' and extra == 'extra-10-janasunani-demo') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
+    { name = "typing-extensions", marker = "(sys_platform != 'darwin' and extra == 'extra-10-janasunani-demo') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
+]
+wheels = [
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp313-cp313-linux_s390x.whl", hash = "sha256:4ca206a35f2aeba7da944a69ef857103358e8d4bc6b06b49b9e554dcfa57777d", upload-time = "2026-06-18T01:57:47Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:8d47e0cfc59679d4e367646c3df4cf433c7d1595b31307e0e7b2391c58ca2160", upload-time = "2026-06-18T01:57:52Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:77d049968c7817456dbdebf0aadcac0813e302218b0e857a8723463331339d55", upload-time = "2026-06-18T01:57:59Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp313-cp313-win_amd64.whl", hash = "sha256:06d13c354df07953ae0d150da22a071496cbbedd22d1b644961813c0f0fc3b23", upload-time = "2026-06-18T01:58:05Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp314-cp314-linux_s390x.whl", hash = "sha256:ef228ec70f5e73762c213f145c0fdb672e5770a6de760801c58b933b0d5b6957", upload-time = "2026-06-18T01:58:09Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:1b9ad70d0a300d6bd883fffc153a6c0f9bc64bf4190519aeeed0373807bffbcc", upload-time = "2026-06-18T01:58:15Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:618120d79360688595e61162147d37e1d69fc3f2e13d60584a1eb6a74c74735a", upload-time = "2026-06-18T01:58:22Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp314-cp314-win_amd64.whl", hash = "sha256:6354069774ce2d9c26d6d8612fc252586428467b7e4ced7c8bbbfb961fafb783", upload-time = "2026-06-18T01:58:29Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp314-cp314t-linux_s390x.whl", hash = "sha256:0706eb7b53c4b1381b2acc418f6d89d6ed18a308677125ced7ca30519c57dc42", upload-time = "2026-06-18T01:58:33Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:21ed774c10a0fd24ab2cfaabfa98a9260fc28d518946c98c0151b6e447730250", upload-time = "2026-06-18T01:58:39Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:e3c3b5c275dd57cff1aa34a0ab8f84beab8976c63c8dc1d84f29430eac0590ea", upload-time = "2026-06-18T01:58:46Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp314-cp314t-win_amd64.whl", hash = "sha256:03094411b20e85a221125a332211d59c099dc556afb1423e04193fcf1b4c1cbd", upload-time = "2026-06-18T01:58:52Z" },
+]
+
+[[package]]
 name = "torchvision"
 version = "0.27.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy" },
     { name = "pillow" },
-    { name = "torch" },
+    { name = "torch", version = "2.12.1", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/bb/b21e0f598ca191bb2a9e9fda2fee37c06ad113313b43c6769dbefa0e921d/torchvision-0.27.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:d60311a6d08df905f9656a3a312f0a8f55f0d46321bc737bad30a8dec9644309", size = 1852110, upload-time = "2026-06-17T21:09:22.577Z" },
@@ -6073,14 +5933,14 @@ wheels = [
 
 [[package]]
 name = "tqdm"
-version = "4.68.3"
+version = "4.66.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/87/d7/0535a28b1f5f24f6612fb3ff1e89fb1a8d160fee0f976e0aa6803862134b/tqdm-4.68.3.tar.gz", hash = "sha256:00dfa48452b6b6cfae3dd9885636c23d3422d1ec97c66d96818cbd5e0821d482", size = 170596, upload-time = "2026-06-17T07:36:52.105Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/83/6ba9844a41128c62e810fddddd72473201f3eacde02046066142a2d96cc5/tqdm-4.66.5.tar.gz", hash = "sha256:e1020aef2e5096702d8a025ac7d16b1577279c9d63f8375b63083e9a5f0fcbad", size = 169504, upload-time = "2024-08-03T22:35:40.339Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/8e/bb97bb0c71802080bfc8952937d174e49cfc50de5c951dd47b2496f0dcdb/tqdm-4.68.3-py3-none-any.whl", hash = "sha256:39832cc2def2789a6f29df83f172db7416cea70052c0907a57801c5f2fdccb03", size = 78337, upload-time = "2026-06-17T07:36:50.132Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5d/acf5905c36149bbaec41ccf7f2b68814647347b72075ac0b1fe3022fdc73/tqdm-4.66.5-py3-none-any.whl", hash = "sha256:90279a3770753eafc9194a0364852159802111925aa30eb3f9d85b0e805ac7cd", size = 78351, upload-time = "2024-08-03T22:35:36.644Z" },
 ]
 
 [[package]]
@@ -6097,13 +5957,15 @@ name = "transformers"
 version = "4.46.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version < '3.14'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin'",
+    "python_full_version < '3.14' and sys_platform != 'darwin'",
+    "python_full_version < '3.14' and sys_platform == 'darwin'",
 ]
 dependencies = [
     { name = "filelock" },
     { name = "huggingface-hub" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy" },
     { name = "packaging" },
     { name = "pyyaml" },
     { name = "regex" },
@@ -6152,8 +6014,10 @@ resolution-markers = [
     "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core')",
     "(python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core')",
-    "python_full_version >= '3.14' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "python_full_version < '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
@@ -6164,8 +6028,7 @@ resolution-markers = [
 dependencies = [
     { name = "filelock" },
     { name = "huggingface-hub" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-demo' or (extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-pipeline-core')" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
+    { name = "numpy" },
     { name = "packaging" },
     { name = "pyyaml" },
     { name = "regex" },
@@ -6217,6 +6080,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/ed/ef06584ccdd5c410df0837951ecd7e15d9a6144ea1bd4c73cecab1a89891/typer-0.26.7.tar.gz", hash = "sha256:e314a34c617e419c091b2830dda3ea1f257134ff593061a8f5b9717ab8dddb3a", size = 201709, upload-time = "2026-06-03T07:18:06.843Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/25/2201973529af2c954de0bb725323c3aaed6d7f0ceee8f550dec9185df013/typer-0.26.7-py3-none-any.whl", hash = "sha256:5c87cfbc5d34491c5346ebf49c23e18d56ccb863268d3a8d592b26087c2f5e58", size = 122456, upload-time = "2026-06-03T07:18:05.732Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260724"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/6f/a28f44bcd56bebed42b028a2894c79853e2f5e6b5279e633cb3f287a05e7/types_pyyaml-6.0.12.20260724.tar.gz", hash = "sha256:3c1ce1bb73cd5ec02e90390c2b1f00e810d241d8825fd73ff359696839271b6b", size = 17893, upload-time = "2026-07-24T04:58:43.453Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/42/0337fefc615e20ee55d1c8f71b774a9b2b734a04669139c20753b27a2a3a/types_pyyaml-6.0.12.20260724-py3-none-any.whl", hash = "sha256:d57db930a4b2efbc57cf430ec8882765d246929432fa253092f383902329a453", size = 20312, upload-time = "2026-07-24T04:58:42.486Z" },
 ]
 
 [[package]]
@@ -6285,11 +6157,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.7.0"
+version = "1.26.13"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/51/32da03cf19d17d46cce5c731967bf58de9bd71db3a379932f53b094deda4/urllib3-1.26.13.tar.gz", hash = "sha256:c083dd0dce68dbfbe1129d5271cb90f9447dea7d52097c6e0126120c521ddea8", size = 300476, upload-time = "2022-11-23T22:34:32.145Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+    { url = "https://files.pythonhosted.org/packages/65/0c/cc6644eaa594585e5875f46f3c83ee8762b647b51fc5b0fb253a242df2dc/urllib3-1.26.13-py2.py3-none-any.whl", hash = "sha256:47cc05d99aaa09c9e72ed5809b60e7ba354e64b59c9c173ac3018642d8bb41fc", size = 140572, upload-time = "2022-11-23T22:34:29.785Z" },
 ]
 
 [[package]]
@@ -6488,9 +6360,9 @@ name = "xgboost"
 version = "3.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy" },
     { name = "nvidia-nccl-cu12", marker = "sys_platform == 'linux'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fd/41/846d4de2b8fc694073fd3ac5052caf68caa1ea11cb7fa32d7ad9c049b232/xgboost-3.3.0.tar.gz", hash = "sha256:58bcb8a4cace648cdab7b94fa4f16d2c9ff26d90dd4d26907168106fa06d8746", size = 1224702, upload-time = "2026-06-17T21:26:50.846Z" }
 wheels = [
@@ -6589,8 +6461,7 @@ name = "zc-lockfile"
 version = "4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "setuptools", version = "81.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-categorizer' or extra == 'extra-10-janasunani-demo' or extra == 'extra-10-janasunani-ocr-deepseek' or extra == 'extra-10-janasunani-pipeline-core'" },
-    { name = "setuptools", version = "82.0.1", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core')" },
+    { name = "setuptools" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/10/9a/2fef89272d98b799e4daa50201c5582ec76bdd4e92a1a7e3deb74c52b7fa/zc_lockfile-4.0.tar.gz", hash = "sha256:d3ab0f53974296a806db3219b9191ba0e6d5cbbd1daa2e0d17208cb9b29d2102", size = 10956, upload-time = "2025-09-18T07:32:34.412Z" }
 wheels = [
@@ -6599,9 +6470,9 @@ wheels = [
 
 [[package]]
 name = "zipp"
-version = "4.1.0"
+version = "3.19.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/20/b48f58857d98dcb78f9e30ed2cfe533025e2e9827bbd36ea0a64cc00cbc1/zipp-3.19.2.tar.gz", hash = "sha256:bf1dcf6450f873a13e952a29504887c89e6de7506209e5b1bcc3460135d4de19", size = 22922, upload-time = "2024-06-04T17:21:09.042Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
+    { url = "https://files.pythonhosted.org/packages/20/38/f5c473fe9b90c8debdd29ea68d5add0289f1936d6f923b6b9cc0b931194c/zipp-3.19.2-py3-none-any.whl", hash = "sha256:f091755f667055f2d02b32c53771a7a6c8b47e1fdbc4b72a8b9072b3eef8015c", size = 9039, upload-time = "2024-06-04T17:21:07.146Z" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -26,20 +26,16 @@ resolution-markers = [
     "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
     "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')",
     "(python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')",
-    "python_full_version >= '3.14' and sys_platform != 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and sys_platform != 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version >= '3.14' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core')",
     "(python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core')",
-    "python_full_version >= '3.14' and sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version >= '3.14' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "python_full_version < '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
@@ -508,7 +504,7 @@ name = "blis"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/d0/d8cc8c9a4488a787e7fa430f6055e5bd1ddb22c340a751d9e901b82e2efe/blis-1.3.3.tar.gz", hash = "sha256:034d4560ff3cc43e8aa37e188451b0440e3261d989bb8a42ceee865607715ecd", size = 2644873, upload-time = "2025-11-17T12:28:30.511Z" }
 wheels = [
@@ -596,11 +592,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2022.12.7"
+version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/37/f7/2b1b0ec44fdc30a3d31dfebe52226be9ddc40cd6c0f34ffc8923ba423b69/certifi-2022.12.7.tar.gz", hash = "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3", size = 156897, upload-time = "2022-12-07T20:13:22.081Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/4c/3db2b8021bd6f2f0ceb0e088d6b2d49147671f25832fb17970e9b583d742/certifi-2022.12.7-py3-none-any.whl", hash = "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18", size = 155255, upload-time = "2022-12-07T20:13:19.428Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
 ]
 
 [[package]]
@@ -650,11 +646,59 @@ wheels = [
 
 [[package]]
 name = "charset-normalizer"
-version = "2.1.1"
+version = "3.4.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a1/34/44964211e5410b051e4b8d2869c470ae8a68ae274953b1c7de6d98bbcf94/charset-normalizer-2.1.1.tar.gz", hash = "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845", size = 82360, upload-time = "2022-08-19T22:13:48.372Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/51/a507c856293ab05cdc1db77ff4bc1268ddd39f29e7dc4919aa497f0adbec/charset_normalizer-2.1.1-py3-none-any.whl", hash = "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f", size = 39748, upload-time = "2022-08-19T22:13:46.702Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
 ]
 
 [[package]]
@@ -765,7 +809,8 @@ name = "contourpy"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-demo' or (extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-pipeline-core')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-ocr-deepseek' or (extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -935,16 +980,8 @@ name = "cryptography"
 version = "48.0.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform != 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and sys_platform != 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version >= '3.14' and sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version >= '3.14' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
 ]
 dependencies = [
     { name = "cffi", marker = "(platform_python_implementation != 'PyPy' and extra == 'extra-10-janasunani-ocr-deepseek') or (platform_python_implementation != 'PyPy' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core') or (extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
@@ -1016,10 +1053,10 @@ wheels = [
 
 [[package]]
 name = "cuda-pathfinder"
-version = "1.6.0"
+version = "1.5.6"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/b4/d088047afe39827556df21118cac9ffd20cc3f968c99a7681494d1eb333c/cuda_pathfinder-1.6.0-py3-none-any.whl", hash = "sha256:1503af579d8379c24bdd65528379bc57039b0455be9f5f9686cf8e473a1fce51", size = 54591, upload-time = "2026-07-21T15:03:56.224Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/53/8fc9b0cdc5b7f62746e6a01b85b6461e5ae27f871010a5fcf8fa6950766d/cuda_pathfinder-1.5.6-py3-none-any.whl", hash = "sha256:7e4c07c117b78ba1fb35dac4c444d21f3677b1b1ff56175c53a8e3025c5b43c0", size = 52972, upload-time = "2026-06-30T00:58:04.34Z" },
 ]
 
 [[package]]
@@ -1246,19 +1283,36 @@ wheels = [
 
 [[package]]
 name = "dulwich"
-version = "0.24.1"
+version = "1.2.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2b/f3/13a3425ddf04bd31f1caf3f4fa8de2352700c454cb0536ce3f4dbdc57a81/dulwich-0.24.1.tar.gz", hash = "sha256:e19fd864f10f02bb834bb86167d92dcca1c228451b04458761fc13dabd447758", size = 806136, upload-time = "2025-08-01T10:26:46.887Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/3d/7ea85d70d85f7d5ed5bf28dc742f106d8334e84286fbc852d983273dd890/dulwich-1.2.6.tar.gz", hash = "sha256:405cfd53a99374ff03aacdd7a86d6a07615feca072ed69721f49ae2ebaa3eab4", size = 1257895, upload-time = "2026-05-31T14:32:52.758Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/a5/3f4760169fea1b90df7aea88172699807af6f4f667c878de6a9ee554170f/dulwich-0.24.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1a11ec69fc6604228804ddfc32c85b22bc627eca4cf4ff3f27dbe822e6f29477", size = 1080923, upload-time = "2025-08-01T10:26:28.011Z" },
-    { url = "https://files.pythonhosted.org/packages/71/d9/7aadd6318aed6f0e1242fa63bd61d80142716d13ea4e307c8b19fc61c9ae/dulwich-0.24.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a9800df7238b586b4c38c00432776781bc889cf02d756dcfb8dc0ecb8fc47a33", size = 1159246, upload-time = "2025-08-01T10:26:29.487Z" },
-    { url = "https://files.pythonhosted.org/packages/90/5d/df4256fe009c714e0392817df4fdc1748a901523504f58796d675fce755f/dulwich-0.24.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:3baab4a01aff890e2e6551ccbd33eb2a44173c897f0f027ad3aeab0fb057ec44", size = 1163646, upload-time = "2025-08-01T10:26:31.279Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/fe/850115d6fa7ad03756e20466ad5b72be54d1b59c1ff7d2b3c13bc4de965f/dulwich-0.24.1-cp313-cp313-win32.whl", hash = "sha256:b39689aa4d143ba1fb0a687a4eb93d2e630d2c8f940aaa6c6911e9c8dca16e6a", size = 762612, upload-time = "2025-08-01T10:26:33.223Z" },
-    { url = "https://files.pythonhosted.org/packages/47/7f/f79940e0773efda2ed0e666a0ca0ae7c734fdce4f04b5b60bc5ed268b7cb/dulwich-0.24.1-cp313-cp313-win_amd64.whl", hash = "sha256:8fca9b863b939b52c5f759d292499f0d21a7bf7f8cbb9fdeb8cdd9511c5bc973", size = 779168, upload-time = "2025-08-01T10:26:35.303Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/bc/a2557d1b0afa5bf1e140f42f8cbca1783e43d7fa17665859c63060957952/dulwich-0.24.1-py3-none-any.whl", hash = "sha256:57cc0dc5a21059698ffa4ed9a7272f1040ec48535193df84b0ee6b16bf615676", size = 440765, upload-time = "2025-08-01T10:26:45.415Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/ea/f0d0aaf7c9e36f5490579a20ed37c85afd19e90177c2e270ff533d7fd533/dulwich-1.2.6-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:cdd15b8442b527575d733d90cfd6d3c4cbaebf989e2298b0cb57a7916c66254f", size = 1532486, upload-time = "2026-05-31T14:32:18.668Z" },
+    { url = "https://files.pythonhosted.org/packages/14/4e/5c212c2dcc2d8c06cafdcdc7893d9516cb861ec277f25a0f058f98512d22/dulwich-1.2.6-cp313-cp313-android_21_x86_64.whl", hash = "sha256:dd2783352917b7cb3ab12b7c3f7757210d93af6df0bd2d876a8e5b53b2feb3eb", size = 1525768, upload-time = "2026-05-31T14:32:20.174Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/84/7ff849d4fe769cb6439fc50322381b7eb3d6e5d64da9e5d8337c985a7748/dulwich-1.2.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:204d14692fb1dd850ab773690f7530f4065f405e9e7dd3f85bdf92e9330ffa2d", size = 1396354, upload-time = "2026-05-31T14:32:21.52Z" },
+    { url = "https://files.pythonhosted.org/packages/29/4d/2cb9662dd57417a11e5828f2b8f7607cfaccb42dcd9b6d69316755a5f5e0/dulwich-1.2.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:21e2e9b81ab04ad83f2d4101ac515ef56ee08d06fd853c1a7ac255f20bb49963", size = 1335031, upload-time = "2026-05-31T14:32:22.978Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/82/38ccfa7ee30c13d44734c5b1eb92ad0c95a96035319040e2c0b2011eee75/dulwich-1.2.6-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:7b4a2f497718bfe1a3b21f933ee27c111b9cea560c0b2d8a6d939e1b5f297f79", size = 1417366, upload-time = "2026-05-31T14:32:24.295Z" },
+    { url = "https://files.pythonhosted.org/packages/be/a1/239d52cbd94482c064821a0ccece888aac105a81f3f9719b9622c52fe6ec/dulwich-1.2.6-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5ff9f36c95deaf7eb5d6ccde4c68adbcb932a87e03c1b479a8d94d779e7cc5d2", size = 1442588, upload-time = "2026-05-31T14:32:25.731Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/92/739dc9e4d5da0b1c09b752f8aad94a518ff5eca7db2f5039ba7d5976b81f/dulwich-1.2.6-cp313-cp313-win32.whl", hash = "sha256:04252b107a1600325f5f0301dde8b5b62f5bb51a0467e360070baddbb4edcea7", size = 1018371, upload-time = "2026-05-31T14:32:27.147Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/28/626dc722ab20e0e5d0bf67e212494563f514790bc9c4b7c0133fdf491a5d/dulwich-1.2.6-cp313-cp313-win_amd64.whl", hash = "sha256:6fd9911fb57ee2d6eefaf895df65e1139fbc911fa560e959b38feabe5f15003f", size = 1032986, upload-time = "2026-05-31T14:32:28.66Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/b9/bb2f8b1d668b3959b8471c2af0fa2dbce66e81b2defab1fcfde4cd5a0ac1/dulwich-1.2.6-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:cb1f8d658f36b2ac3982715dc3e49f0d741a3e5a8c40136bebb6d8493968aa12", size = 1533055, upload-time = "2026-05-31T14:32:30.048Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/66/1a3b4580af650a40adb6ef1dce6f9153fa1096c723e1abff32959a0a2c76/dulwich-1.2.6-cp314-cp314-android_24_x86_64.whl", hash = "sha256:ad4b6114440f9cf72315b173532ee3284f27a288b8a24bc27e45b2e54593720d", size = 1478589, upload-time = "2026-05-31T14:32:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/34/55bc2440d1924710390ece68dc30496b0a0ef26228d9e02a60c82fc15ed1/dulwich-1.2.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:824b7f5b22b128c1e1ad7c655e9790e2d75c7ab1ba1e40a708024193f1dc47a3", size = 1351518, upload-time = "2026-05-31T14:32:32.644Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/31/befeb51ffd5047ea090ab18d2dc43525e6d528006eb7064135c2f1a1229a/dulwich-1.2.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7c187efaebb72146245ebcb872b89fdc99314fa37442119c5a5feb18af3f4b8a", size = 1335713, upload-time = "2026-05-31T14:32:33.995Z" },
+    { url = "https://files.pythonhosted.org/packages/72/8f/2913d2ab1cff9722383b88be0e34f8a277075c5b5ca3fc822ac2192476d8/dulwich-1.2.6-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:79728d98e0ec184856d71fd0d55abbf5ac7345b5baea9f2d1533a4de9064e13d", size = 1420343, upload-time = "2026-05-31T14:32:35.57Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b7/53afa6cf1fb3bdf6669a73a6b1978f0adc2ac24f03fc414f45c5902e66e7/dulwich-1.2.6-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:c639a8c9fb7e745749f2dcbd5b63a82df2fc99cfe62e2c3654ec025a42d2e51f", size = 1442317, upload-time = "2026-05-31T14:32:37.216Z" },
+    { url = "https://files.pythonhosted.org/packages/23/34/4119559608dfc4b68427d8e9e3892db7a4b2dbf7b3e7c5b6a390e0af560f/dulwich-1.2.6-cp314-cp314-win32.whl", hash = "sha256:dd2b66c915f1b22ca6533b48e8ee435800b25f74f419c40e1a92271666d8b297", size = 1026443, upload-time = "2026-05-31T14:32:39.064Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5f/4de7960cc39cfbd629ad60c1ef631ed32e4b303d4228ad8f92847aa87f3e/dulwich-1.2.6-cp314-cp314-win_amd64.whl", hash = "sha256:82e8810e57f9651a624116e3fede33276f89406cb910f517b944105e284e6755", size = 1041672, upload-time = "2026-05-31T14:32:41.008Z" },
+    { url = "https://files.pythonhosted.org/packages/72/19/01bcd25e4b2a8cf5f3507c4d02d6c999b70eb6d32eaff59c583e8e9c40c0/dulwich-1.2.6-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:794a85b8b9d4ad57d02c8cb455735419ac50c0f2e3d26d83873e34abee58cb1b", size = 1350601, upload-time = "2026-05-31T14:32:42.288Z" },
+    { url = "https://files.pythonhosted.org/packages/14/9c/517d858ee9af0678e5605397d1b5ca6c49210b64508c91486893c9fc0e56/dulwich-1.2.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:eb27a9ebe9029c872abadf4f9dcb18c9f6a4b7a4afe137f79a61df1ae59dc6bf", size = 1334723, upload-time = "2026-05-31T14:32:44.163Z" },
+    { url = "https://files.pythonhosted.org/packages/58/e9/d8dd703c6c581eacf109427472c1c02955b8de70fb8154ad2fe0cf2e0540/dulwich-1.2.6-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:1c35c294acfc5a0a88d01d5db1abeba550bf6274bcc3fddbf8b365e9eea280da", size = 1461300, upload-time = "2026-05-31T14:32:45.475Z" },
+    { url = "https://files.pythonhosted.org/packages/df/40/94c0d609206a770d3b4bc8dc30601e3c63642af637c5c12035e9645e0c85/dulwich-1.2.6-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:f682671a2e19b7b4caa572ff3073557de049a153946305e051a4f50bb0e5e1bd", size = 1491547, upload-time = "2026-05-31T14:32:47.12Z" },
+    { url = "https://files.pythonhosted.org/packages/04/97/c18ab70ec27eed02f6ba7b00b3d6236657df7cabbc7175533ff5b62f2147/dulwich-1.2.6-cp314-cp314t-win32.whl", hash = "sha256:27db364f2f3cf5b0dddd44d6c2ae9a20f6021e2bae8b1268fa689076f0192244", size = 1024467, upload-time = "2026-05-31T14:32:48.476Z" },
+    { url = "https://files.pythonhosted.org/packages/41/8c/7f49d256a813ab799fbce519a37857d75201c7c02b06b1a65fd989ec2ff2/dulwich-1.2.6-cp314-cp314t-win_amd64.whl", hash = "sha256:fae59c5e345f5ca234c85d157f1c7d5e0086126b45b5f7cfa66ffe41d049fdd6", size = 1083682, upload-time = "2026-05-31T14:32:49.881Z" },
+    { url = "https://files.pythonhosted.org/packages/24/15/61bd455d33979584f19d3a6e0b49b49e0d891bc680fc8cc7b028aea7360d/dulwich-1.2.6-py3-none-any.whl", hash = "sha256:8d8175dbe4feaf62bcafc8708448bfe223b4dfc71609be25c0cf2b0962abc36c", size = 688260, upload-time = "2026-05-31T14:32:51.285Z" },
 ]
 
 [[package]]
@@ -1492,11 +1546,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.29.0"
+version = "3.29.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/dc/be6cbe99670cd6e4ad387123647cb08e0c32975e223f82551e914c5568a6/filelock-3.29.4.tar.gz", hash = "sha256:10cdb3656fc44541cdf30652a93fb10ec6b05325620eb316bd26893e4201538a", size = 63028, upload-time = "2026-06-13T16:12:00.744Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+    { url = "https://files.pythonhosted.org/packages/13/37/a065dc3bd6e49423a6532c642ca7378d3f467b1ef44c2800c937af7f9739/filelock-3.29.4-py3-none-any.whl", hash = "sha256:dac1648087d5115554850d113e7dd8c83ab2d38e3435dde2d4f163847e57b767", size = 42757, upload-time = "2026-06-13T16:11:59.582Z" },
 ]
 
 [[package]]
@@ -1668,11 +1722,11 @@ wheels = [
 
 [[package]]
 name = "fsspec"
-version = "2026.4.0"
+version = "2026.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d5/8d/1c51c094345df128ca4a990d633fe1a0ff28726c9e6b3c41ba65087bba1d/fsspec-2026.4.0.tar.gz", hash = "sha256:301d8ac70ae90ef3ad05dcf94d6c3754a097f9b5fe4667d2787aa359ec7df7e4", size = 312760, upload-time = "2026-04-29T20:42:38.635Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/a1/ae4e3e5003468d6391d2c77b6fa1cd73bd5d13511d81c642d7b28ac90ed4/fsspec-2026.6.0.tar.gz", hash = "sha256:f5bac145310fe30e16e1471bd6840b2d990d609e872251d7e674241822abf01a", size = 313646, upload-time = "2026-06-16T01:57:28.105Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl", hash = "sha256:11ef7bb35dab8a394fde6e608221d5cf3e8499401c249bebaeaad760a1a8dec2", size = 203402, upload-time = "2026-04-29T20:42:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/22/4222d7ddf3da30f363edaa98e329c2bce6c65497c9cb2810931c8b2c0fbc/fsspec-2026.6.0-py3-none-any.whl", hash = "sha256:02e0b71817df9b2169dc30a16832045764def1191b43dcff5bb85bdee212d2a1", size = 203949, upload-time = "2026-06-16T01:57:26.358Z" },
 ]
 
 [package.optional-dependencies]
@@ -1981,11 +2035,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.4"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8b/e1/43beb3d38dba6cb420cefa297822eac205a277ab43e5ba5d5c46faf96438/idna-3.4.tar.gz", hash = "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4", size = 183077, upload-time = "2022-09-14T00:24:27.719Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/34/3030de6f1370931b9dbb4dad48f6ab1015ab1d32447850b9fc94e60097be/idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2", size = 61538, upload-time = "2022-09-14T00:24:23.22Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -1993,7 +2047,7 @@ name = "imageio"
 version = "2.37.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" } },
     { name = "pillow" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b1/84/93bcd1300216ea50811cee96873b84a1bebf8d0489ffaf7f2a3756bab866/imageio-2.37.3.tar.gz", hash = "sha256:bbb37efbfc4c400fcd534b367b91fcd66d5da639aaa138034431a1c5e0a41451", size = 389673, upload-time = "2026-03-09T11:31:12.573Z" }
@@ -2003,14 +2057,14 @@ wheels = [
 
 [[package]]
 name = "importlib-metadata"
-version = "7.1.0"
+version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "zipp" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a0/fc/c4e6078d21fc4fa56300a241b87eae76766aa380a23fc450fc85bb7bf547/importlib_metadata-7.1.0.tar.gz", hash = "sha256:b78938b926ee8d5f020fc4772d487045805a55ddbad2ecf21c6d60938dc7fcd2", size = 52120, upload-time = "2024-03-20T19:51:32.429Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/0a/679461c511447ffaf176567d5c496d1de27cbe34a87df6677d7171b2fbd4/importlib_metadata-7.1.0-py3-none-any.whl", hash = "sha256:30962b96c0c223483ed6cc7280e7f0199feb01a0e40cfae4d4450fc6fab1f570", size = 24409, upload-time = "2024-03-20T19:51:30.241Z" },
+    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
 ]
 
 [[package]]
@@ -2178,7 +2232,7 @@ demo = [
     { name = "huggingface-hub" },
     { name = "langdetect" },
     { name = "nltk" },
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" } },
     { name = "opencv-python" },
     { name = "pandas" },
     { name = "pdf2image" },
@@ -2212,7 +2266,7 @@ pipeline-core = [
     { name = "huggingface-hub" },
     { name = "langdetect" },
     { name = "nltk" },
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" } },
     { name = "opencv-python" },
     { name = "pandas" },
     { name = "pdf2image" },
@@ -2446,6 +2500,19 @@ wheels = [
 ]
 
 [[package]]
+name = "jupyter-builder"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-core" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/45/d0df8b43c10a61529c0f4a8af5e19ebe108f0c3af8f57e0fc358969907af/jupyter_builder-1.0.2.tar.gz", hash = "sha256:6155d78a5325010532a6419ffcba89eac643fd1aa56ea83115e661924d6f6aab", size = 968638, upload-time = "2026-06-12T02:33:25.767Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/b6/c418e0b3256f67c04933566b80bfce947350682db92c4b786a8653db32d6/jupyter_builder-1.0.2-py3-none-any.whl", hash = "sha256:b024f65d36e1d530542db597b00dd513261aa59842e0d0fbbb1015a9f1935e9c", size = 910789, upload-time = "2026-06-12T02:33:23.317Z" },
+]
+
+[[package]]
 name = "jupyter-client"
 version = "8.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2541,7 +2608,7 @@ dependencies = [
     { name = "nbformat" },
     { name = "packaging" },
     { name = "prometheus-client" },
-    { name = "pywinpty", marker = "(os_name == 'nt' and platform_machine != 'aarch64' and sys_platform == 'linux') or (os_name == 'nt' and sys_platform != 'darwin' and sys_platform != 'linux') or (os_name == 'nt' and sys_platform == 'linux' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name == 'nt' and sys_platform == 'linux' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core') or (os_name == 'nt' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core') or (os_name != 'nt' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name != 'nt' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name != 'nt' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
+    { name = "pywinpty", marker = "(os_name == 'nt' and platform_machine != 'aarch64' and sys_platform == 'linux') or (os_name == 'nt' and sys_platform != 'darwin' and sys_platform != 'linux') or (os_name == 'nt' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name == 'nt' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core') or (os_name == 'nt' and sys_platform == 'linux' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name == 'nt' and sys_platform == 'linux' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core') or (os_name != 'nt' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name != 'nt' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name != 'nt' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek')" },
     { name = "pyzmq" },
     { name = "send2trash" },
     { name = "terminado" },
@@ -2559,7 +2626,7 @@ name = "jupyter-server-terminals"
 version = "0.5.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pywinpty", marker = "(os_name == 'nt' and platform_machine != 'aarch64' and sys_platform == 'linux') or (os_name == 'nt' and sys_platform != 'darwin' and sys_platform != 'linux') or (os_name == 'nt' and sys_platform == 'linux' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name == 'nt' and sys_platform == 'linux' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core') or (os_name == 'nt' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core') or (os_name != 'nt' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name != 'nt' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name != 'nt' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
+    { name = "pywinpty", marker = "(os_name == 'nt' and platform_machine != 'aarch64' and sys_platform == 'linux') or (os_name == 'nt' and sys_platform != 'darwin' and sys_platform != 'linux') or (os_name == 'nt' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name == 'nt' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core') or (os_name == 'nt' and sys_platform == 'linux' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name == 'nt' and sys_platform == 'linux' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core') or (os_name != 'nt' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name != 'nt' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name != 'nt' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek')" },
     { name = "terminado" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f4/a7/bcd0a9b0cbba88986fe944aaaf91bfda603e5a50bda8ed15123f381a3b2f/jupyter_server_terminals-0.5.4.tar.gz", hash = "sha256:bbda128ed41d0be9020349f9f1f2a4ab9952a73ed5f5ac9f1419794761fb87f5", size = 31770, upload-time = "2026-01-14T16:53:20.213Z" }
@@ -2569,13 +2636,14 @@ wheels = [
 
 [[package]]
 name = "jupyterlab"
-version = "4.1.6"
+version = "4.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "async-lru" },
     { name = "httpx" },
     { name = "ipykernel" },
     { name = "jinja2" },
+    { name = "jupyter-builder" },
     { name = "jupyter-core" },
     { name = "jupyter-lsp" },
     { name = "jupyter-server" },
@@ -2585,9 +2653,9 @@ dependencies = [
     { name = "tornado" },
     { name = "traitlets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/c2/decb25538588ed104ada22c31d1845b1500f98806e3261b94f0333e8b099/jupyterlab-4.1.6.tar.gz", hash = "sha256:7935f36ba26eb615183a4f5c2bbca5791b5108ce2a00b5505f8cfd100d53648e", size = 21773628, upload-time = "2024-04-08T14:00:54.61Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/3c/1ebd737b860cdbe61eed71536d06aab4e1781fbdcf07ecd5a1afe05b8adf/jupyterlab-4.6.0.tar.gz", hash = "sha256:6a8b88f2aae7ed4d012c634fc957c1a27f3aa217c32f0ced0175fac9ee17f9e5", size = 28181861, upload-time = "2026-06-18T13:52:56.039Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/5a/e084a40e593329859926c5824cd47b32b2700732a179ca94b2c533c4dddf/jupyterlab-4.1.6-py3-none-any.whl", hash = "sha256:cf3e862bc10dbf4331e4eb37438634f813c238cfc62c71c640b3b3b2caa089a8", size = 11416049, upload-time = "2024-04-08T14:00:46.698Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/eb/aa48075d0aa3d0188db34ba2704f53791757743c0bb02e18c4eef989b6de/jupyterlab-4.6.0-py3-none-any.whl", hash = "sha256:b6938cb8a1ef3d43860ff4745a680c62cc0a9385f9672295bb56cd2e7cfeebe2", size = 17143447, upload-time = "2026-06-18T13:52:51.42Z" },
 ]
 
 [[package]]
@@ -2601,7 +2669,7 @@ wheels = [
 
 [[package]]
 name = "jupyterlab-server"
-version = "2.24.0"
+version = "2.28.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "babel" },
@@ -2612,9 +2680,9 @@ dependencies = [
     { name = "packaging" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1e/29/d867a88db915b54ff1025a9c0576b051687ac5baa5f7cd723e22069606de/jupyterlab_server-2.24.0.tar.gz", hash = "sha256:4e6f99e0a5579bbbc32e449c4dbb039561d4f1a7827d5733273ed56738f21f07", size = 72145, upload-time = "2023-07-24T08:07:24.605Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/2c/90153f189e421e93c4bb4f9e3f59802a1f01abd2ac5cf40b152d7f735232/jupyterlab_server-2.28.0.tar.gz", hash = "sha256:35baa81898b15f93573e2deca50d11ac0ae407ebb688299d3a5213265033712c", size = 76996, upload-time = "2025-10-22T13:59:18.37Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/0d/6d4eab0391bd4df1c43f308368d5e177b0fa8ac632267222a23b71317091/jupyterlab_server-2.24.0-py3-none-any.whl", hash = "sha256:5f077e142bb8dc9b843d960f940c513581bceca3793a0d80f9c67d9522c4e876", size = 57329, upload-time = "2023-07-24T08:07:22.09Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/07/a000fe835f76b7e1143242ab1122e6362ef1c03f23f83a045c38859c2ae0/jupyterlab_server-2.28.0-py3-none-any.whl", hash = "sha256:e4355b148fdcf34d312bbbc80f22467d6d20460e8b8736bf235577dd18506968", size = 59830, upload-time = "2025-10-22T13:59:16.767Z" },
 ]
 
 [[package]]
@@ -2898,7 +2966,8 @@ dependencies = [
     { name = "cycler" },
     { name = "fonttools" },
     { name = "kiwisolver" },
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-demo' or (extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-pipeline-core')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-ocr-deepseek' or (extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
     { name = "packaging" },
     { name = "pillow" },
     { name = "pyparsing" },
@@ -2984,12 +3053,14 @@ dependencies = [
     { name = "matplotlib" },
     { name = "mlflow-skinny" },
     { name = "mlflow-tracing" },
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-demo' or (extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-pipeline-core')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-ocr-deepseek' or (extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
     { name = "pandas" },
     { name = "pyarrow" },
     { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-categorizer' or extra == 'extra-10-janasunani-demo' or extra == 'extra-10-janasunani-pipeline-core'" },
     { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-ocr-deepseek' or (extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
-    { name = "scipy" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-demo' or (extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-pipeline-core')" },
+    { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-ocr-deepseek' or (extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
     { name = "skops" },
     { name = "sqlalchemy" },
     { name = "waitress", marker = "sys_platform == 'win32' or (extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
@@ -3215,11 +3286,11 @@ wheels = [
 
 [[package]]
 name = "mypy-extensions"
-version = "1.0.0"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/98/a4/1ab47638b92648243faf97a5aeb6ea83059cc3624972ab6b8d2316078d3f/mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782", size = 4433, upload-time = "2023-02-04T12:11:27.157Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/e2/5d3f6ada4297caebe1a2add3b126fe800c96f56dbe5d1988a2cbe0b267aa/mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d", size = 4695, upload-time = "2023-02-04T12:11:25.002Z" },
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
 ]
 
 [[package]]
@@ -3333,18 +3404,19 @@ wheels = [
 
 [[package]]
 name = "notebook"
-version = "7.1.3"
+version = "7.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "jupyter-builder" },
     { name = "jupyter-server" },
     { name = "jupyterlab" },
     { name = "jupyterlab-server" },
     { name = "notebook-shim" },
     { name = "tornado" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/65/38/f2c6cb06f3c4997980ad27713f23378616761fd8d36013c9cdd0d9c54ad2/notebook-7.1.3.tar.gz", hash = "sha256:41fcebff44cf7bb9377180808bcbae066629b55d8c7722f1ebbe75ca44f9cfc1", size = 4897695, upload-time = "2024-04-17T16:24:24.126Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/44/d5c65783f490298473bb1c05722e05ee2256231389559c2c5ae0a3e5d975/notebook-7.6.0.tar.gz", hash = "sha256:ea13e79e601bf273074895fdfb17dd3f2da916d3c045e0b9c47d18b16ab62481", size = 5497344, upload-time = "2026-06-18T16:18:55.202Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/e6/e032f6a4d3da85c4bd38b6ff96de51347bfb0d932ea1d2ccfd89c6374c8a/notebook-7.1.3-py3-none-any.whl", hash = "sha256:919b911e59f41f6e3857ce93c9d93535ba66bb090059712770e5968c07e1004d", size = 4989396, upload-time = "2024-04-17T16:24:19.628Z" },
+    { url = "https://files.pythonhosted.org/packages/93/d1/e617c40db57ff40e75f43a7d4d1c305e3a54c053ab5cb0534a6c314664f9/notebook-7.6.0-py3-none-any.whl", hash = "sha256:98aa2811b54ac191321d5dfce12ca700f8a511a33a26e4de2fa106a357c43d6a", size = 5544575, upload-time = "2026-06-18T16:18:52.551Z" },
 ]
 
 [[package]]
@@ -3363,7 +3435,59 @@ wheels = [
 name = "numpy"
 version = "1.26.4"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'darwin'",
+    "python_full_version < '3.14' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "(python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux')",
+]
 sdist = { url = "https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010", size = 15786129, upload-time = "2024-02-06T00:26:44.495Z" }
+
+[[package]]
+name = "numpy"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/05/3d27272d30698dc0ecb7fdfaa41ad70303b444f81722bb99bce1d818638a/numpy-2.5.0.tar.gz", hash = "sha256:5a129578019311b6e56bdd714250f19b518f7dceeeb8d1af5490f4942d3f891c", size = 20652461, upload-time = "2026-06-21T20:57:51.95Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/33/07675aaad7f26ea013d5e884d9a0d784b79c6bd7566c333f5a52fa3c610b/numpy-2.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:520e6b8be0a4b65840ac8090d4f51cef4bed66e2b0894d5a520f099adc24a9b2", size = 16784890, upload-time = "2026-06-21T20:56:40.799Z" },
+    { url = "https://files.pythonhosted.org/packages/85/4b/953118a730ee3b35e28645e0eb4cf9beec5bdbb954e1ac2f5fcefba6bbc3/numpy-2.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:146b81cdd3967fdb6beca8ba25f00c58741d8f3cbd797f55af0fbe0bfec3469c", size = 11754584, upload-time = "2026-06-21T20:56:43.094Z" },
+    { url = "https://files.pythonhosted.org/packages/44/9b/56dd530c367c74ae17411027cea4135ca57e1e0583bf5594cee18bd83217/numpy-2.5.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:126b88d95e8ff9b00c9e717aa540469f21d6180162f84c0caec51b16215d49cd", size = 5313904, upload-time = "2026-06-21T20:56:45.503Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/b0/bcd672edad27ecca7da1f7bb0ce72cd1706a4f2d79ae94990afc97c13e1c/numpy-2.5.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:d4313cef1594c5ce46c31b6e54e918338f63f16ee9322304e8c9114d6d81c8bd", size = 6648504, upload-time = "2026-06-21T20:56:47.567Z" },
+    { url = "https://files.pythonhosted.org/packages/80/9e/15cdfcbd30a1544a46c9e487a00df331c4672450216538705a9e51fa6710/numpy-2.5.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:750fb097caf26fa878746d9d119f6f9da12dedcbff1eea966c3e3447647c4a9e", size = 15150086, upload-time = "2026-06-21T20:56:49.352Z" },
+    { url = "https://files.pythonhosted.org/packages/32/4e/8d7656ccaab3e81e97258b8a9bc5f0c8502513a92fb4ceb0a2cbfebc17bf/numpy-2.5.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3893adc2dc7c0412ba76777db55a049215d99c9aa3113003be8f49f4f1290ab9", size = 16647250, upload-time = "2026-06-21T20:56:51.542Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/81/97060281b602ed07f21b12f4ec409eac1f75a2f91fbc829ed8b2becf3ad4/numpy-2.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:835e454dd99b238cdc5a3f63bce2371296f5ebc53ca1e0f8e6ddbb6d92a29aab", size = 16512864, upload-time = "2026-06-21T20:56:55.401Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ab/4496208146911f8d8ddb54f68a972aafa6c8d44babcb2ea03b0e5cc87c9d/numpy-2.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f9836778081a0a3c02a6a21493f3e9f5b311f8d2541934f31f05583dc999ea4", size = 18408407, upload-time = "2026-06-21T20:56:57.75Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/9f/a4df67c181e4ee8b467aa3332dc2db10fd5c515136831302f3ca48bc0a01/numpy-2.5.0-cp313-cp313-win32.whl", hash = "sha256:0b525be4744b60bb0557ac872d53ef07d085b5f39622bc579c98d3809d05b988", size = 6054431, upload-time = "2026-06-21T20:57:00.016Z" },
+    { url = "https://files.pythonhosted.org/packages/30/53/491e1c47c55b62ccc6a63c1c5b8635c73fc2258dddeb9bda27cae4a0ae96/numpy-2.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:44353e2878930039db472b99dc353d749826e4010bd4d2a7f835e94a97a5c748", size = 12414420, upload-time = "2026-06-21T20:57:01.815Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/4a/25c2906f541e9d9f4c5769764db732e6627be91a13f4724fa10634d77db4/numpy-2.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:48f54b00711f83a5f796b70c518e8c2b3c5848dda03a54911f23eb68519b9b60", size = 10339533, upload-time = "2026-06-21T20:57:03.961Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ad/abc44aaceaf7b17ee1edde2bbb4458da591bc79574cffff50c4bb35f00d1/numpy-2.5.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f27582c55ba4c750b7c58c8faf021d2cd9324a662b466229db8a417b41368af9", size = 16783807, upload-time = "2026-06-21T20:57:06.253Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/39/b72e168daf9c00fb20c9fc996d00437ccecdef3102387775d29d7a62576d/numpy-2.5.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:28e7137057d551e4a83c4ae414e3451f50568409db7569aacc7f9811ee06a446", size = 11765215, upload-time = "2026-06-21T20:57:08.547Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a0/8400a9c0e3625182347593f5e1f57da9a617a534794805c8df5518154ddc/numpy-2.5.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:e1da54b53e75cd9fcfc23efcc7edab2c6aecf97b6037566d8a0fe804af8ec57c", size = 5324493, upload-time = "2026-06-21T20:57:11.012Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/8c/0d104deaa0401c93395a629ec902891618a2eff76d19229139cb5a887bfc/numpy-2.5.0-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:694d8f74e156f7fd01179f1aa8faa2f648ab6ae0f70b6c3fe57a03249aea2303", size = 6645211, upload-time = "2026-06-21T20:57:12.919Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/d9/4a4a628c812750363786afc3d33492709a5cd64b215469c16b0f6c7bb811/numpy-2.5.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1a7569a7b53c77716f036bb28cb1c91f166a26ec7d9502cd1e4bdfe502fdec22", size = 15166004, upload-time = "2026-06-21T20:57:14.717Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/5e/2a902317d7fc4aa93236e80c932662dadfc459b323d758329e01775125e1/numpy-2.5.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:39a0433bd4086ebd462960cf375e19195bb07b53dc1d87dd5fcf47ad78576f03", size = 16650797, upload-time = "2026-06-21T20:57:16.906Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a0/a0090e6329f4ca5992c07847bb579c5259a19953dc57255bb08793142ffb/numpy-2.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:929f0c79ac38bcbd7154fe631dc907abfeddbcc5027a896bd1f7767323271e7a", size = 16524647, upload-time = "2026-06-21T20:57:19.165Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/7d/6caf27734c42b65837e7461ed0dbbd6b6fc835060c9714ec59d673bb383a/numpy-2.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cc4f247a47bbf070bfd70be53ccdcf47b800af563535e7bbe172322197c30e21", size = 18411841, upload-time = "2026-06-21T20:57:21.638Z" },
+    { url = "https://files.pythonhosted.org/packages/13/dc/26edadbd812536769a82c2e9e002234e33feb5da43061d47a044f6d309b7/numpy-2.5.0-cp314-cp314-win32.whl", hash = "sha256:5dc71423499fab3f46f7a7201155ade1669ea101f2f429d332df9e72f8161731", size = 6106361, upload-time = "2026-06-21T20:57:23.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/9e/4dd1459282229a72d92dece2ae9138e5cac94a72263a7ceb48f37434c925/numpy-2.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:ebb81d9d5443e0309d6c54894c3fbed74ad7da0714352a67b6d773cd189eae73", size = 12551749, upload-time = "2026-06-21T20:57:25.945Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a7/6bc6384c080b86c7f6c85c5bc5b540b24f4f679cd144791d99574e90d462/numpy-2.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:3b94d0d0deceebfad3e67ae5c0e5eb87371e8f7a0581cd04a779928c2450cf1e", size = 10617072, upload-time = "2026-06-21T20:57:28.175Z" },
+    { url = "https://files.pythonhosted.org/packages/86/6b/4a2b71d66ada5608ae02b63f150dfad520f6940721cb7f029ad270befc0e/numpy-2.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:22f3d43e362d650bc39db1f17851302874a148ca95ba6981c1dfb5fa6862f35b", size = 11881067, upload-time = "2026-06-21T20:57:30.104Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b2/d365eb40a20efb49d67e9feb90494ed8511282ee1f5fa16006675c65397d/numpy-2.5.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:243563efb4cd7528a264567e9fd206c87826457322521d06206a00bfa316c927", size = 5440290, upload-time = "2026-06-21T20:57:32.193Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/5e/e9c03188de5f9b767e46a8fe988bcfd3efad066a4a3fda8b9cb11a93f895/numpy-2.5.0-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:84881d825ca75249b189bbee875fcfe3238aa5c479e6100893cda566e8e86826", size = 6748371, upload-time = "2026-06-21T20:57:33.933Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/1d/68c186a38a5027bae2c4ddd5ea681fdaf8b4d30fb7301def6d8ad270390f/numpy-2.5.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cda12aa4779d42b8771180aba759c96f527d43446d8f380ab59e2b35e8489efd", size = 15214643, upload-time = "2026-06-21T20:57:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/67/73f67b7c7e20635baae9c4c3ead4ae7326a005900297a6110971abd62eb5/numpy-2.5.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c0121101093d2bd74981b10f8837d78e794a8ff57834eb27179f49e1ba11ac6", size = 16690128, upload-time = "2026-06-21T20:57:38.159Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/05/d4c1fb0c46d02a27d6b2b8b319a78c90937acec8631c1641874670b31e6f/numpy-2.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d371c92cfa09da00022f501ab67fafaea813d752eb30ac44336d45b1e5b0268a", size = 16577902, upload-time = "2026-06-21T20:57:40.447Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/1d/771c797d50fa26e4888989cccf1d50ee51f530d4e455ad2692dcb64fa711/numpy-2.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9990713e9c38154c6861e7547f1e3fc7a87e75ff09bab24ef1cc81d81c2835e9", size = 18452814, upload-time = "2026-06-21T20:57:42.875Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/46/52fc0d2a68d7643f0f149eeea5a5d8ea2a3507056ac8afa83c9212606e8b/numpy-2.5.0-cp314-cp314t-win32.whl", hash = "sha256:edadfbd4794b1086c0d822f81863e8a68fc129d132fd0bb9e31e955d7fbbbdb7", size = 6253168, upload-time = "2026-06-21T20:57:45.101Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/be/6c8d1118b5f13b2881dc095d5b345de19c6638b8959c17409b6eff84c8aa/numpy-2.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f7e5fa4382967ae6548bd2f174219afb908e294b0d5f625af01166edd5f7d9aa", size = 12736286, upload-time = "2026-06-21T20:57:46.935Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/6a/d3a169aaf8536cf228d56a09e04bcb713a2fe4410d4e2105b9419b5a9c89/numpy-2.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:016623417bb330d719d579daf2d6b9a01ddc52e41a9ed61a47f39fde46dcd865", size = 10686451, upload-time = "2026-06-21T20:57:49.313Z" },
+]
 
 [[package]]
 name = "nvidia-cublas"
@@ -3493,11 +3617,11 @@ wheels = [
 
 [[package]]
 name = "nvidia-nccl-cu12"
-version = "2.28.3"
+version = "2.30.7"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/76/a87f70dc4544f76abf528c335a5c107130cca5c345725b1d2ad03bf2c2a2/nvidia_nccl_cu12-2.28.3-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:85144f2197e81148e18f3ffd28a30d78b5046844877630d2710a1b22669a6e46", size = 295887310, upload-time = "2025-09-06T00:31:43.228Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/24/11df42593d1a6d10b3ffef049cec064832f108e77bc5cac12726e4ec1cb2/nvidia_nccl_cu12-2.28.3-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:79cf0412094e4a552889e5cb7757d92c010ead557ec722c5eebe6a94b1d8681c", size = 295901337, upload-time = "2025-09-06T00:32:01.348Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/8c/554bb020501d6c04ad8127d83f728137f8f9123f991666efbdcf9095a221/nvidia_nccl_cu12-2.30.7-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:03ecd776fd1d58fd2c9a0a687dcf8db9ecd0057382dba646fa3d65786d4a9ea1", size = 303277471, upload-time = "2026-06-09T03:24:16.327Z" },
+    { url = "https://files.pythonhosted.org/packages/50/32/e7ffa9c324ae260e5dbb4af2cd557bf7a8d155c8ac7b79a785fe1796fb92/nvidia_nccl_cu12-2.30.7-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:8ce1b8213f61f2bfac132e6df890af6450b77cbd140c6ce4e98cb0c2d8e678c9", size = 303361239, upload-time = "2026-06-09T03:24:53.816Z" },
 ]
 
 [[package]]
@@ -3556,7 +3680,7 @@ name = "opencv-python"
 version = "4.11.0.86"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/17/06/68c27a523103dad5837dc5b87e71285280c4f098c60e4fe8a8db6486ab09/opencv-python-4.11.0.86.tar.gz", hash = "sha256:03d60ccae62304860d232272e4a4fda93c39d595780cb40b161b310244b736a4", size = 95171956, upload-time = "2025-01-16T13:52:24.737Z" }
 wheels = [
@@ -3659,11 +3783,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "24.1"
+version = "26.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/51/65/50db4dda066951078f0a96cf12f4b9ada6e4b811516bf0262c0f4f7064d4/packaging-24.1.tar.gz", hash = "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002", size = 148788, upload-time = "2024-06-09T23:19:24.956Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/aa/cc0199a5f0ad350994d660967a8efb233fe0416e4639146c089643407ce6/packaging-24.1-py3-none-any.whl", hash = "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124", size = 53985, upload-time = "2024-06-09T23:19:21.909Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
 ]
 
 [[package]]
@@ -3671,7 +3795,8 @@ name = "pandas"
 version = "2.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-demo' or (extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-pipeline-core')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-ocr-deepseek' or (extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
     { name = "python-dateutil" },
     { name = "pytz" },
     { name = "tzdata" },
@@ -3928,7 +4053,7 @@ version = "2.2.363"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" } },
     { name = "phonenumbers" },
     { name = "pydantic" },
     { name = "pyyaml" },
@@ -4732,7 +4857,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.28.1"
+version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -4740,9 +4865,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/61/a867851fd5ab77277495a8709ddda0861b28163c4613b011bc00228cc724/requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983", size = 109805, upload-time = "2022-06-29T15:13:42.715Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/91/6d9b8ccacd0412c08820f72cebaa4f0c0441b5cda699c90f618b6f8a1b42/requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349", size = 62843, upload-time = "2022-06-29T15:13:40.685Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]
@@ -4759,17 +4884,16 @@ wheels = [
 
 [[package]]
 name = "responses"
-version = "0.23.1"
+version = "0.26.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
-    { name = "types-pyyaml" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fa/4f/5033bf66528c832e7fcc48e76f540bf401302c55041c7fb488b4fbaaec4a/responses-0.23.1.tar.gz", hash = "sha256:c4d9aa9fc888188f0c673eff79a8dadbe2e75b7fe879dc80a221a06e0a68138f", size = 72966, upload-time = "2023-03-10T21:27:35.193Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/58/1fb6de3503428196df78638f991ec8095274f1ee9723e272ee4d9ff0092b/responses-0.26.1.tar.gz", hash = "sha256:2eb3218553cc8f79b57d257bac23af5e1bf381f5b9390b1767816f0843e01dc2", size = 83088, upload-time = "2026-05-21T19:56:39.747Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/6a/64c85e69c6a7b02e828ed193b2fc15e3ff6581f87501666b98feabc54809/responses-0.23.1-py3-none-any.whl", hash = "sha256:8a3a5915713483bf353b6f4079ba8b2a29029d1d1090a503c70b0dc5d9d0c7bd", size = 52083, upload-time = "2023-03-10T21:27:35.187Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/31/6a620b4427d546b9e7cca8b3b8c5f0559d9cef2bb9eedcda7f73c1473c19/responses-0.26.1-py3-none-any.whl", hash = "sha256:8aacc4586eb08fb2208ef64a9eb4258d9b0c6e6f4260845f2f018ab847495345", size = 35502, upload-time = "2026-05-21T19:56:38.046Z" },
 ]
 
 [[package]]
@@ -4961,16 +5085,16 @@ wheels = [
 
 [[package]]
 name = "s3fs"
-version = "2026.4.0"
+version = "2026.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiobotocore" },
     { name = "aiohttp" },
     { name = "fsspec" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cb/d8/76f3dc1558bdf4494b117a9f7a9cc0a5d9d34edadc9e5d7ceabc5a6a7c37/s3fs-2026.4.0.tar.gz", hash = "sha256:5bdce0abb00b0435ee150807a45fea727451dbc22de4cbc116464f8504ab9d37", size = 85986, upload-time = "2026-04-29T20:52:51.748Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/00/6677343dc919d6c072bb04d80210afdd22c16838a8d16b3315c122dc728f/s3fs-2026.6.0.tar.gz", hash = "sha256:b28de7082d0a4f72392884bdc497e34a4a1582f675d214c7da0acf6e950a0083", size = 87358, upload-time = "2026-06-16T02:05:48.719Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a4/9d1ea10ebc9e028a289a72fec84da170689549a8102c8aacfcad26bc5035/s3fs-2026.4.0-py3-none-any.whl", hash = "sha256:de0d2a1f33cdf03831fd2382d278c6e4e31fe57c3bf2f703c61f8aec6b703e2a", size = 32392, upload-time = "2026-04-29T20:52:50.295Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/0b/f68a968b49876eae0f2a515387093cebb2eb9451380a96741cc20efac0d0/s3fs-2026.6.0-py3-none-any.whl", hash = "sha256:60576e31bb31193c1f643f32b4c6439548720ea6918ac702e21cd757c80b5db8", size = 32573, upload-time = "2026-06-16T02:05:47.608Z" },
 ]
 
 [[package]]
@@ -5017,10 +5141,10 @@ dependencies = [
     { name = "imageio" },
     { name = "lazy-loader" },
     { name = "networkx" },
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" } },
     { name = "packaging" },
     { name = "pillow" },
-    { name = "scipy" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" } },
     { name = "tifffile" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a1/b4/2528bb43c67d48053a7a649a9666432dc307d66ba02e3a6d5c40f46655df/scikit_image-0.26.0.tar.gz", hash = "sha256:f5f970ab04efad85c24714321fcc91613fcb64ef2a892a13167df2f3e59199fa", size = 22729739, upload-time = "2025-12-20T17:12:21.824Z" }
@@ -5094,10 +5218,8 @@ resolution-markers = [
     "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core')",
     "(python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core')",
-    "python_full_version >= '3.14' and sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version >= '3.14' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "python_full_version < '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
@@ -5107,8 +5229,10 @@ resolution-markers = [
 ]
 dependencies = [
     { name = "joblib", marker = "extra == 'extra-10-janasunani-categorizer' or extra == 'extra-10-janasunani-demo' or extra == 'extra-10-janasunani-pipeline-core'" },
-    { name = "numpy", marker = "extra == 'extra-10-janasunani-categorizer' or extra == 'extra-10-janasunani-demo' or extra == 'extra-10-janasunani-pipeline-core'" },
-    { name = "scipy", marker = "extra == 'extra-10-janasunani-categorizer' or extra == 'extra-10-janasunani-demo' or extra == 'extra-10-janasunani-pipeline-core'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-demo' or (extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-pipeline-core')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-demo' or (extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-pipeline-core')" },
+    { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
     { name = "threadpoolctl", marker = "extra == 'extra-10-janasunani-categorizer' or extra == 'extra-10-janasunani-demo' or extra == 'extra-10-janasunani-pipeline-core'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
@@ -5144,18 +5268,14 @@ name = "scikit-learn"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform != 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and sys_platform != 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version >= '3.14' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
 ]
 dependencies = [
     { name = "joblib", marker = "extra == 'extra-10-janasunani-ocr-deepseek' or (extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
     { name = "narwhals", marker = "extra == 'extra-10-janasunani-ocr-deepseek' or (extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
-    { name = "numpy", marker = "extra == 'extra-10-janasunani-ocr-deepseek' or (extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
-    { name = "scipy", marker = "extra == 'extra-10-janasunani-ocr-deepseek' or (extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-ocr-deepseek' or (extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
+    { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-ocr-deepseek' or (extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
     { name = "threadpoolctl", marker = "extra == 'extra-10-janasunani-ocr-deepseek' or (extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fa/6f/37092bdb25f712817231799fc5674d8e704066a8a70c1d2d40517e18b4ab/scikit_learn-1.9.0.tar.gz", hash = "sha256:8833266989d3a5110178a9fae30783675460724d0e1efb13b14901d2c660c557", size = 7750767, upload-time = "2026-06-02T11:54:32.706Z" }
@@ -5184,8 +5304,16 @@ wheels = [
 name = "scipy"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'darwin'",
+    "python_full_version < '3.14' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "(python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux')",
+]
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-demo' or (extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-pipeline-core')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -5232,24 +5360,68 @@ wheels = [
 ]
 
 [[package]]
+name = "scipy"
+version = "1.18.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
+]
+dependencies = [
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-ocr-deepseek' or (extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/52/9c0136c2de7ae0779b7b366447766cec6d9f0702c56bb8ffeb04c8fd3af4/scipy-1.18.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:09143f676d157d9f546d663504ef9c1becb819824f1afc018814176411942446", size = 31036107, upload-time = "2026-06-19T15:00:14.03Z" },
+    { url = "https://files.pythonhosted.org/packages/02/73/0291a64843270f4efb86cdcf2ee0f2048631b65ec6b405398b2b4dbf11bf/scipy-1.18.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5efe260f69417b97ddae455bfb5a95e8359f7f66ad7fa9522a60feb66f169520", size = 28663303, upload-time = "2026-06-19T15:00:16.819Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/0f/10ffa0b697a572f4e0d48b92a88895d366422f019f723e7e14a84c050dac/scipy-1.18.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:68363b7eaacd8b5dd426df56d782cc156468ac79a127a1b87ca597d6e2e82197", size = 20404960, upload-time = "2026-06-19T15:00:19.635Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/d2/e896cea21ba8edd6c81d4c55b1ffcc717e79698dcbebf9641b4cfb4c6622/scipy-1.18.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:c5557d8be5da8e41353fcd4d21491fdbab83b062fc579e94dc09a7c8ab4f669b", size = 23034074, upload-time = "2026-06-19T15:00:22.107Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/b2/e83ea34279a52c03374477c74006256ec78df65fc877baa4617d6de1d202/scipy-1.18.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0d13bca67c096d89fb95ced0d8921807300fce0275643aef9533cc63a0773468", size = 33942038, upload-time = "2026-06-19T15:00:24.964Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/af/e8fe5fb136f51e2b01678b92cb4106d10d8cd68ec147ead2e7cb0ac75398/scipy-1.18.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a46f9273dbd0eb1cefba61c9b8648b4dfe3cbc14a080176f9a73e44b8336dc7f", size = 35266390, upload-time = "2026-06-19T15:00:28.059Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/49/2c5cbb907b56695fc67517811d1db234dfd83381a84814ec220aded2794d/scipy-1.18.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5aba46108853ddfc77906b6557aac839d2b52e900c1d72a1180adaaab58d265f", size = 35551324, upload-time = "2026-06-19T15:00:31.014Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/73/eda39f7a2d306ff0ffc574afd13c0bbb6d10a603d9a413998ee269487a80/scipy-1.18.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b6f758e35f12757b5d95c00bc6de2438e229c2664b7a92e96f205959d9f2dfa4", size = 37404785, upload-time = "2026-06-19T15:00:34.072Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/d2/ae881ee28d014f38e0ccbfd974a06a919ba9af34f1f74bf42b5301891d63/scipy-1.18.0-cp313-cp313-win_amd64.whl", hash = "sha256:1afac4a847207c7ff8efd321734a50b06d0280b3b2a2c0fc2f413101747ad7c7", size = 36554943, upload-time = "2026-06-19T15:00:36.903Z" },
+    { url = "https://files.pythonhosted.org/packages/70/3a/21154e2d54eb3639c6bf4dbae2e531c68356bfe95990daa30df33b30d556/scipy-1.18.0-cp313-cp313-win_arm64.whl", hash = "sha256:c5dbddf60e58c2312316d097271a8e73d40eaf2eabfa4d95ed7d3695bbf2ce7b", size = 24350911, upload-time = "2026-06-19T15:00:40.062Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b5/915a19b3de2f7430062b509653563db1633ddbb6f021b06731521115d4e2/scipy-1.18.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:4c256ee70c0d1a8a2ace807e199ccd4e3f57037433842abb3fb36bc17eaa9578", size = 31036253, upload-time = "2026-06-19T15:00:43.216Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/88/b72def7262e150d16be13fca37a96481138d624e700340bc3362a7588929/scipy-1.18.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:2ef3abc54a4ffc53765374b0d5728532dfdd2585ed23f6b11c206a1f0b1b9af8", size = 28673758, upload-time = "2026-06-19T15:00:46.663Z" },
+    { url = "https://files.pythonhosted.org/packages/91/02/2e636a61a525632c373cf6a9c24442a3ffb79e364d38e98b32042964ac32/scipy-1.18.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:f2a6af57bd9e4a75d70e4117e78a1bbee84f79ae3fbb6d0111005d6ebcc4cb8d", size = 20415514, upload-time = "2026-06-19T15:00:49.399Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b6/2135974442f6aba159d9d39d774a1c8cb19947016725d69fecc685df45bf/scipy-1.18.0-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:3f1ac564d3bf6c03d861d2cd87a1bea0da2887136f7fb1bf519c05a8971452d6", size = 23034398, upload-time = "2026-06-19T15:00:51.941Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/e6/ba89ec5abf6ee9257c0d1ec985573f3ae32742c24bc03e016388a40b1b15/scipy-1.18.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40395a5fcd1abee49a5c7aaa98c29db393eedc835138560a588c47ec16156690", size = 33998032, upload-time = "2026-06-19T15:00:54.838Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c4/bc41eb19b0fd0db868f4132920879019318d80cc522ad8f2bca4611af808/scipy-1.18.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ca01e8ae69f1b18e9a58d91afead31be3cef0dd905a10249dac559ee15460a0", size = 35283333, upload-time = "2026-06-19T15:00:58.152Z" },
+    { url = "https://files.pythonhosted.org/packages/53/a4/cbdeef6eb3830a8462a9d4ada814de5fc984345cc9ecf17cbec51a036f1e/scipy-1.18.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7a7f3b01647384dbc3a711e8c6778e0aabbe93959249fef5c7393396bcac0867", size = 35610216, upload-time = "2026-06-19T15:01:01.155Z" },
+    { url = "https://files.pythonhosted.org/packages/80/4d/b2b82502b65f661d1b789c1665dcdf315d5f12194e06fc0b37946294ebae/scipy-1.18.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6aa94e78ec192a30063a5e72e561c28af769dc311190b24fe91774eff1969709", size = 37418960, upload-time = "2026-06-19T15:01:04.155Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3e/902d836831474b0ab5a37d16404f7bc5fafd9efba632890e271ba952635f/scipy-1.18.0-cp314-cp314-win_amd64.whl", hash = "sha256:2d8bbdc6c817f5b4006a54d799d4f5bab6f910193cbb9a1ff310833d4d270f61", size = 37288845, upload-time = "2026-06-19T15:01:07.822Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/43/8d73b337a3bdb14daa0314f0434210747c02d79d729ce1777574a817dcf6/scipy-1.18.0-cp314-cp314-win_arm64.whl", hash = "sha256:18e9575f1569b2c54174e6159d32942e03731177f63dce7975f0a0c88d102f5b", size = 24988971, upload-time = "2026-06-19T15:01:11.076Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/b4/f11918b0508a2787031a0499a03fbe3546f3bb5ca05d01038c45b278c09a/scipy-1.18.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:f351e0dd702687d12a402b867a1b4146a256923e1c38317cbc472f6372b94707", size = 31399325, upload-time = "2026-06-19T15:01:13.723Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d1/1f287b57c0ff0ee5185dff3946d92c8017d39b0e431f0ae79a3ff1859512/scipy-1.18.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:7c7a51b33ce387193c97f228320cf8e87361daa1bba750638677729598b3e677", size = 29092110, upload-time = "2026-06-19T15:01:16.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1a/7b74eb6c392fdcb27d414c0e7558a6d0231eb3b6d73571f479bb81ea8794/scipy-1.18.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:84031d7b052a54fae2f8632e0ec802073d385476eb9a63079bce6e23ef9283d4", size = 20833811, upload-time = "2026-06-19T15:01:20.488Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ad/f3941716320a7b9cb4d68734a903b45fe16eff5fb7da7e16f2e619304979/scipy-1.18.0-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:56abf29a7c067dde59be8b9a22d606a4ea1b2f2a4b756d9d903c62818f5dacce", size = 23396644, upload-time = "2026-06-19T15:01:23.364Z" },
+    { url = "https://files.pythonhosted.org/packages/22/22/1446b62ffe07f9719b7d9b1b6a4e05a772833ae8f441fe4c22c34c9b250f/scipy-1.18.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ad44305cfa24b1ba5803cbbebf033590ccbac1aa5d612d727b785325ab408b0", size = 34079318, upload-time = "2026-06-19T15:01:26.002Z" },
+    { url = "https://files.pythonhosted.org/packages/56/3b/b87da667098bb470fa30c7011b0ba351ee976dd395c78798c66e941665a3/scipy-1.18.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:945c1761b93f38d7f99ae81ae80c63e621471608c7eeead563f6df025585cd58", size = 35324320, upload-time = "2026-06-19T15:01:28.881Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/a1/c7932f91909759b0267f75fdea34e91309f96b895757534b76a90b6b4344/scipy-1.18.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1a4441f15d620578772a49e5ab48c0ee1f7a0220e387110283062729136b2553", size = 35699541, upload-time = "2026-06-19T15:01:31.968Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/86/5185061a1fcc41d18c5dc2463969b3a3964b31d9ac67b2fb05d4c7ff7670/scipy-1.18.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9aac6192fac56bf2ca534389d24623f07b39ff83317d58287285e7fbd622ff76", size = 37472480, upload-time = "2026-06-19T15:01:35.136Z" },
+    { url = "https://files.pythonhosted.org/packages/31/8e/f04c68e39919a010d34f2ee1367fd705b0a25a02f609d755f0bfbc0a15fc/scipy-1.18.0-cp314-cp314t-win_amd64.whl", hash = "sha256:e40baea28ae7f5475c779741e2d90b1247c78531207b49c7030e698ff81cee3f", size = 37365390, upload-time = "2026-06-19T15:01:38.091Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/19/969dc072906c84dd0a3b05dcf57ea750936087d7873549e408b35cfc3f97/scipy-1.18.0-cp314-cp314t-win_arm64.whl", hash = "sha256:368e0a705903c466aa5f08eefb39e6b1b6b2d659e7352a31fd9e2438365be0f8", size = 25279661, upload-time = "2026-06-19T15:01:40.817Z" },
+]
+
+[[package]]
 name = "scmrepo"
-version = "3.5.8"
+version = "3.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp-retry" },
     { name = "asyncssh" },
     { name = "dulwich" },
     { name = "fsspec", extra = ["tqdm"] },
-    { name = "funcy" },
     { name = "gitpython" },
     { name = "pathspec" },
     { name = "pygit2" },
     { name = "pygtrie" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/e9/16538891e936c59434e9775cd213a248a040f6af2b8ac32506711c7b57a4/scmrepo-3.5.8.tar.gz", hash = "sha256:9970c6b5f8404ce3f7cced0cacf906a99509b3d2dad0c14bb391c0bc04006179", size = 97567, upload-time = "2025-12-02T07:45:57.658Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/d5/62ab01546616c42d05e11fe133ce80e1d5c5c601bfc391de41f52e32ce66/scmrepo-3.6.2.tar.gz", hash = "sha256:750741af151e4c602dbf1456b49c7a1d27844527ba94db1e0c580b167cbd9316", size = 97614, upload-time = "2026-03-31T05:05:12.452Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/4f/8b7dba1749356cc36591776c0e840cf6dcf1a1840c6d5a07c0ddb732b3c0/scmrepo-3.5.8-py3-none-any.whl", hash = "sha256:24bef62d90f19a9ff2be70407805ca970b86363f1710c0ba169470225ae81aab", size = 74337, upload-time = "2025-12-02T07:45:55.423Z" },
+    { url = "https://files.pythonhosted.org/packages/16/42/f4bb5e4612681d28fb01335d5faa67e1478adc63077c86555776fe89e584/scmrepo-3.6.2-py3-none-any.whl", hash = "sha256:b6d2a904562d3fc8a1a375234ce6f9a3e47ce83cb67257381fa5dc43c6006d4a", size = 74242, upload-time = "2026-03-31T05:05:10.986Z" },
 ]
 
 [[package]]
@@ -5272,11 +5444,66 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "78.1.0"
+version = "81.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a9/5a/0db4da3bc908df06e5efae42b44e75c81dd52716e10192ff36d0c1c8e379/setuptools-78.1.0.tar.gz", hash = "sha256:18fd474d4a82a5f83dac888df697af65afa82dec7323d09c3e37d1f14288da54", size = 1367827, upload-time = "2025-03-25T22:49:35.332Z" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
+    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')",
+    "(python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
+    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')",
+    "(python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
+    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')",
+    "(python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
+    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')",
+    "(python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')",
+    "python_full_version >= '3.14' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core')",
+    "(python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core')",
+    "python_full_version >= '3.14' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core')",
+    "(python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core')",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/1c/73e719955c59b8e424d015ab450f51c0af856ae46ea2da83eba51cc88de1/setuptools-81.0.0.tar.gz", hash = "sha256:487b53915f52501f0a79ccfd0c02c165ffe06631443a886740b91af4b7a5845a", size = 1198299, upload-time = "2026-02-06T21:10:39.601Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/21/f43f0a1fa8b06b32812e0975981f4677d28e0f3271601dc88ac5a5b83220/setuptools-78.1.0-py3-none-any.whl", hash = "sha256:3e386e96793c8702ae83d17b853fb93d3e09ef82ec62722e61da5cd22376dcd8", size = 1256108, upload-time = "2025-03-25T22:49:33.13Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/e3/c164c88b2e5ce7b24d667b9bd83589cf4f3520d97cad01534cd3c4f55fdb/setuptools-81.0.0-py3-none-any.whl", hash = "sha256:fdd925d5c5d9f62e4b74b30d6dd7828ce236fd6ed998a08d81de62ce5a6310d6", size = 1062021, upload-time = "2026-02-06T21:10:37.175Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
 ]
 
 [[package]]
@@ -5320,12 +5547,14 @@ name = "skops"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-demo' or (extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-pipeline-core')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-ocr-deepseek' or (extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
     { name = "packaging" },
     { name = "prettytable" },
     { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-categorizer' or extra == 'extra-10-janasunani-demo' or extra == 'extra-10-janasunani-pipeline-core'" },
     { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-ocr-deepseek' or (extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
-    { name = "scipy" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-demo' or (extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-pipeline-core')" },
+    { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-ocr-deepseek' or (extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c8/9f/46448c4e41a4c5ee4bdb74b3758af48e5ff0faeffe40f4e301bfc7594894/skops-0.14.0.tar.gz", hash = "sha256:6c8c0e047f691a3a582c3258943eecafcbfd79c8c7eef66260f3703e363254f0", size = 608084, upload-time = "2026-04-20T18:23:55.336Z" }
 wheels = [
@@ -5372,12 +5601,12 @@ dependencies = [
     { name = "cymem" },
     { name = "jinja2" },
     { name = "murmurhash" },
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" } },
     { name = "packaging" },
     { name = "preshed" },
     { name = "pydantic" },
     { name = "requests" },
-    { name = "setuptools" },
+    { name = "setuptools", version = "81.0.0", source = { registry = "https://pypi.org/simple" } },
     { name = "spacy-legacy" },
     { name = "spacy-loggers" },
     { name = "srsly" },
@@ -5575,7 +5804,7 @@ version = "0.18.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ptyprocess", marker = "os_name != 'nt' or (extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
-    { name = "pywinpty", marker = "(os_name == 'nt' and platform_machine != 'aarch64' and sys_platform == 'linux') or (os_name == 'nt' and sys_platform != 'darwin' and sys_platform != 'linux') or (os_name == 'nt' and sys_platform == 'linux' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name == 'nt' and sys_platform == 'linux' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core') or (os_name == 'nt' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core') or (os_name != 'nt' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name != 'nt' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name != 'nt' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
+    { name = "pywinpty", marker = "(os_name == 'nt' and platform_machine != 'aarch64' and sys_platform == 'linux') or (os_name == 'nt' and sys_platform != 'darwin' and sys_platform != 'linux') or (os_name == 'nt' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name == 'nt' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core') or (os_name == 'nt' and sys_platform == 'linux' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name == 'nt' and sys_platform == 'linux' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core') or (os_name != 'nt' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name != 'nt' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (os_name != 'nt' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek')" },
     { name = "tornado" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8a/11/965c6fd8e5cc254f1fe142d547387da17a8ebfd75a3455f637c663fb38a0/terminado-0.18.1.tar.gz", hash = "sha256:de09f2c4b85de4765f7714688fff57d3e75bad1f909b589fde880460c753fd2e", size = 32701, upload-time = "2024-03-12T14:34:39.026Z" }
@@ -5593,11 +5822,11 @@ dependencies = [
     { name = "confection" },
     { name = "cymem" },
     { name = "murmurhash" },
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" } },
     { name = "packaging" },
     { name = "preshed" },
     { name = "pydantic" },
-    { name = "setuptools" },
+    { name = "setuptools", version = "81.0.0", source = { registry = "https://pypi.org/simple" } },
     { name = "srsly" },
     { name = "wasabi" },
 ]
@@ -5635,7 +5864,7 @@ name = "tifffile"
 version = "2026.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c5/cb/2f6d79c7576e22c116352a801f4c3c8ace5957e9aced862012430b62e14f/tifffile-2026.3.3.tar.gz", hash = "sha256:d9a1266bed6f2ee1dd0abde2018a38b4f8b2935cb843df381d70ac4eac5458b7", size = 388745, upload-time = "2026-03-03T19:14:38.134Z" }
 wheels = [
@@ -5674,10 +5903,8 @@ name = "tokenizers"
 version = "0.20.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform != 'darwin'",
-    "python_full_version >= '3.14' and sys_platform == 'darwin'",
-    "python_full_version < '3.14' and sys_platform != 'darwin'",
-    "python_full_version < '3.14' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
 ]
 dependencies = [
     { name = "huggingface-hub" },
@@ -5733,10 +5960,8 @@ resolution-markers = [
     "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core')",
     "(python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core')",
-    "python_full_version >= '3.14' and sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version >= '3.14' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "python_full_version < '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
@@ -5788,7 +6013,7 @@ dependencies = [
     { name = "fsspec", marker = "(sys_platform == 'darwin' and extra == 'extra-10-janasunani-demo') or (sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
     { name = "jinja2", marker = "(sys_platform == 'darwin' and extra == 'extra-10-janasunani-demo') or (sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
     { name = "networkx", marker = "(sys_platform == 'darwin' and extra == 'extra-10-janasunani-demo') or (sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
-    { name = "setuptools", marker = "(sys_platform == 'darwin' and extra == 'extra-10-janasunani-demo') or (sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
+    { name = "setuptools", version = "81.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'darwin' and extra == 'extra-10-janasunani-demo') or (sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
     { name = "sympy", marker = "(sys_platform == 'darwin' and extra == 'extra-10-janasunani-demo') or (sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
     { name = "typing-extensions", marker = "(sys_platform == 'darwin' and extra == 'extra-10-janasunani-demo') or (sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
 ]
@@ -5815,14 +6040,10 @@ resolution-markers = [
     "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core'",
     "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')",
     "(python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')",
-    "python_full_version >= '3.14' and sys_platform != 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and sys_platform != 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version >= '3.14' and sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version >= '3.14' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version >= '3.14' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
 ]
 dependencies = [
     { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
@@ -5836,7 +6057,7 @@ dependencies = [
     { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
     { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
     { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
-    { name = "setuptools" },
+    { name = "setuptools", version = "81.0.0", source = { registry = "https://pypi.org/simple" } },
     { name = "sympy" },
     { name = "triton", marker = "sys_platform == 'linux'" },
     { name = "typing-extensions" },
@@ -5871,7 +6092,7 @@ dependencies = [
     { name = "fsspec", marker = "(sys_platform != 'darwin' and extra == 'extra-10-janasunani-demo') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
     { name = "jinja2", marker = "(sys_platform != 'darwin' and extra == 'extra-10-janasunani-demo') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
     { name = "networkx", marker = "(sys_platform != 'darwin' and extra == 'extra-10-janasunani-demo') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
-    { name = "setuptools", marker = "(sys_platform != 'darwin' and extra == 'extra-10-janasunani-demo') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
+    { name = "setuptools", version = "81.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'darwin' and extra == 'extra-10-janasunani-demo') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
     { name = "sympy", marker = "(sys_platform != 'darwin' and extra == 'extra-10-janasunani-demo') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
     { name = "typing-extensions", marker = "(sys_platform != 'darwin' and extra == 'extra-10-janasunani-demo') or (sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core')" },
 ]
@@ -5895,7 +6116,7 @@ name = "torchvision"
 version = "0.27.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" } },
     { name = "pillow" },
     { name = "torch", version = "2.12.1", source = { registry = "https://pypi.org/simple" } },
 ]
@@ -5933,14 +6154,14 @@ wheels = [
 
 [[package]]
 name = "tqdm"
-version = "4.66.5"
+version = "4.68.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/58/83/6ba9844a41128c62e810fddddd72473201f3eacde02046066142a2d96cc5/tqdm-4.66.5.tar.gz", hash = "sha256:e1020aef2e5096702d8a025ac7d16b1577279c9d63f8375b63083e9a5f0fcbad", size = 169504, upload-time = "2024-08-03T22:35:40.339Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/87/d7/0535a28b1f5f24f6612fb3ff1e89fb1a8d160fee0f976e0aa6803862134b/tqdm-4.68.3.tar.gz", hash = "sha256:00dfa48452b6b6cfae3dd9885636c23d3422d1ec97c66d96818cbd5e0821d482", size = 170596, upload-time = "2026-06-17T07:36:52.105Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/5d/acf5905c36149bbaec41ccf7f2b68814647347b72075ac0b1fe3022fdc73/tqdm-4.66.5-py3-none-any.whl", hash = "sha256:90279a3770753eafc9194a0364852159802111925aa30eb3f9d85b0e805ac7cd", size = 78351, upload-time = "2024-08-03T22:35:36.644Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/8e/bb97bb0c71802080bfc8952937d174e49cfc50de5c951dd47b2496f0dcdb/tqdm-4.68.3-py3-none-any.whl", hash = "sha256:39832cc2def2789a6f29df83f172db7416cea70052c0907a57801c5f2fdccb03", size = 78337, upload-time = "2026-06-17T07:36:50.132Z" },
 ]
 
 [[package]]
@@ -5957,15 +6178,13 @@ name = "transformers"
 version = "4.46.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform != 'darwin'",
-    "python_full_version >= '3.14' and sys_platform == 'darwin'",
-    "python_full_version < '3.14' and sys_platform != 'darwin'",
-    "python_full_version < '3.14' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
 ]
 dependencies = [
     { name = "filelock" },
     { name = "huggingface-hub" },
-    { name = "numpy" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" } },
     { name = "packaging" },
     { name = "pyyaml" },
     { name = "regex" },
@@ -6014,10 +6233,8 @@ resolution-markers = [
     "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core')",
     "(python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core')",
-    "python_full_version >= '3.14' and sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and sys_platform != 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
-    "python_full_version < '3.14' and sys_platform == 'darwin' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version >= '3.14' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
+    "python_full_version < '3.14' and extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "python_full_version < '3.14' and sys_platform == 'darwin' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
     "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core'",
@@ -6028,7 +6245,8 @@ resolution-markers = [
 dependencies = [
     { name = "filelock" },
     { name = "huggingface-hub" },
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-demo' or (extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra != 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra != 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-pipeline-core')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra == 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-pipeline-core')" },
     { name = "packaging" },
     { name = "pyyaml" },
     { name = "regex" },
@@ -6080,15 +6298,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/ed/ef06584ccdd5c410df0837951ecd7e15d9a6144ea1bd4c73cecab1a89891/typer-0.26.7.tar.gz", hash = "sha256:e314a34c617e419c091b2830dda3ea1f257134ff593061a8f5b9717ab8dddb3a", size = 201709, upload-time = "2026-06-03T07:18:06.843Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/25/2201973529af2c954de0bb725323c3aaed6d7f0ceee8f550dec9185df013/typer-0.26.7-py3-none-any.whl", hash = "sha256:5c87cfbc5d34491c5346ebf49c23e18d56ccb863268d3a8d592b26087c2f5e58", size = 122456, upload-time = "2026-06-03T07:18:05.732Z" },
-]
-
-[[package]]
-name = "types-pyyaml"
-version = "6.0.12.20260724"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3f/6f/a28f44bcd56bebed42b028a2894c79853e2f5e6b5279e633cb3f287a05e7/types_pyyaml-6.0.12.20260724.tar.gz", hash = "sha256:3c1ce1bb73cd5ec02e90390c2b1f00e810d241d8825fd73ff359696839271b6b", size = 17893, upload-time = "2026-07-24T04:58:43.453Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/42/0337fefc615e20ee55d1c8f71b774a9b2b734a04669139c20753b27a2a3a/types_pyyaml-6.0.12.20260724-py3-none-any.whl", hash = "sha256:d57db930a4b2efbc57cf430ec8882765d246929432fa253092f383902329a453", size = 20312, upload-time = "2026-07-24T04:58:42.486Z" },
 ]
 
 [[package]]
@@ -6157,11 +6366,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "1.26.13"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/51/32da03cf19d17d46cce5c731967bf58de9bd71db3a379932f53b094deda4/urllib3-1.26.13.tar.gz", hash = "sha256:c083dd0dce68dbfbe1129d5271cb90f9447dea7d52097c6e0126120c521ddea8", size = 300476, upload-time = "2022-11-23T22:34:32.145Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/0c/cc6644eaa594585e5875f46f3c83ee8762b647b51fc5b0fb253a242df2dc/urllib3-1.26.13-py2.py3-none-any.whl", hash = "sha256:47cc05d99aaa09c9e72ed5809b60e7ba354e64b59c9c173ac3018642d8bb41fc", size = 140572, upload-time = "2022-11-23T22:34:29.785Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]
@@ -6360,9 +6569,9 @@ name = "xgboost"
 version = "3.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" } },
     { name = "nvidia-nccl-cu12", marker = "sys_platform == 'linux'" },
-    { name = "scipy" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fd/41/846d4de2b8fc694073fd3ac5052caf68caa1ea11cb7fa32d7ad9c049b232/xgboost-3.3.0.tar.gz", hash = "sha256:58bcb8a4cace648cdab7b94fa4f16d2c9ff26d90dd4d26907168106fa06d8746", size = 1224702, upload-time = "2026-06-17T21:26:50.846Z" }
 wheels = [
@@ -6461,7 +6670,8 @@ name = "zc-lockfile"
 version = "4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "setuptools" },
+    { name = "setuptools", version = "81.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-10-janasunani-categorizer' or extra == 'extra-10-janasunani-demo' or extra == 'extra-10-janasunani-ocr-deepseek' or extra == 'extra-10-janasunani-pipeline-core'" },
+    { name = "setuptools", version = "82.0.1", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-10-janasunani-categorizer' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-demo' and extra == 'extra-10-janasunani-ocr-deepseek') or (extra == 'extra-10-janasunani-ocr-deepseek' and extra == 'extra-10-janasunani-pipeline-core') or (extra != 'extra-10-janasunani-categorizer' and extra != 'extra-10-janasunani-demo' and extra != 'extra-10-janasunani-ocr-deepseek' and extra != 'extra-10-janasunani-pipeline-core')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/10/9a/2fef89272d98b799e4daa50201c5582ec76bdd4e92a1a7e3deb74c52b7fa/zc_lockfile-4.0.tar.gz", hash = "sha256:d3ab0f53974296a806db3219b9191ba0e6d5cbbd1daa2e0d17208cb9b29d2102", size = 10956, upload-time = "2025-09-18T07:32:34.412Z" }
 wheels = [
@@ -6470,9 +6680,9 @@ wheels = [
 
 [[package]]
 name = "zipp"
-version = "3.19.2"
+version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d3/20/b48f58857d98dcb78f9e30ed2cfe533025e2e9827bbd36ea0a64cc00cbc1/zipp-3.19.2.tar.gz", hash = "sha256:bf1dcf6450f873a13e952a29504887c89e6de7506209e5b1bcc3460135d4de19", size = 22922, upload-time = "2024-06-04T17:21:09.042Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/38/f5c473fe9b90c8debdd29ea68d5add0289f1936d6f923b6b9cc0b931194c/zipp-3.19.2-py3-none-any.whl", hash = "sha256:f091755f667055f2d02b32c53771a7a6c8b47e1fdbc4b72a8b9072b3eef8015c", size = 9039, upload-time = "2024-06-04T17:21:07.146Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
 ]


### PR DESCRIPTION
## Summary

Closes #48. The always-on box is CPU-only and hosts the production Postgres, but the api image was shipping the full CUDA runtime.

On `linux/amd64` the `demo` extra pulled `cuda-bindings`, `cuda-toolkit` (cudart, cufft, cufile, cupti, curand, cusolver, cusparse, nvjitlink, nvrtc, nvtx), `nvidia-cublas`, `nvidia-cudnn-cu13`, `nvidia-cusparselt-cu13`, `nvidia-nccl-cu13`, `nvidia-nvshmem-cu13` and `triton` — behind a torch wheel that is 532 MB on its own.

None of it was ever reachable. DeepSeek OCR is deliberately excluded from `demo`, so nothing in that image can use a GPU.

## What Changed

`demo` now resolves torch from PyTorch's CPU-only index.

| | Before | After |
|---|---|---|
| torch wheel (linux x86_64) | 532.3 MB | 192.3 MB |
| torch's CUDA payload | ~2,196 MB across 17 packages | none |
| **Total wheels removed** | | **~2.5 GB** (more once unpacked) |

**One CUDA wheel survives and the torch source cannot remove it.** `xgboost` declares `nvidia-nccl-cu12` unconditionally on linux, and `demo` pulls xgboost through `pipeline-core`, so ~300 MB remains. Verified against the real lock:

```
$ uv export --frozen --extra demo --no-dev --no-hashes --no-emit-project | grep -iE '^(nvidia|torch|xgboost)'
nvidia-nccl-cu12==2.28.3 ; sys_platform == 'linux'
torch==2.12.1 ; sys_platform == 'darwin'
torch==2.12.1+cpu ; sys_platform != 'darwin'
xgboost==3.3.0
```

`build_processor` never loads the format classifier, xgboost's only consumer, so it is dead weight in this image — filed as #63. Removing it changes what `demo` includes, a different decision from where torch comes from, so it is not in this PR.

**Scoped to `demo` alone, deliberately.** `categorizer` and `pipeline-core` keep CUDA wheels, because the MuRIL embedding pass is a corpus-scale GPU batch job on the GPU box (ROADMAP §5.3 S4), and `ocr-deepseek` is GPU-only by nature. Pinning those would have removed GPU acceleration from the backfills to save space in an image they are not built into. There is a test asserting they stay unpinned.

Two implementation notes worth flagging in review:

- `torch` is listed **directly** on `demo`, not only inherited via `janasunani[pipeline-core]`. uv binds a source's `extra =` marker only to packages declared on that extra, and errors out otherwise.
- It is pinned to the already-locked `2.12.1`. Without the pin, adding the direct requirement re-resolves and drags torch to 2.13.0 and **torchvision to 0.28.0 in the GPU path**, which nothing in this repo can test. With it, the lock diff is exactly one added version.

Also updated the four places describing the image as CUDA-bearing: `deploy/api.Dockerfile`, `.github/workflows/deploy.yml`, `docs/DEPLOY.md` (×2), `docs/ROADMAP.md` §Phase 12. The `deploy.sh` ~20 GiB free-space guard is **left where it is** — the point is headroom for prod Postgres and the lake, not a tight fit around the image.

## Validation

- [x] `uv run ruff check .` — all checks passed
- [x] `uv run --extra serving --extra pipeline-core pytest` — 285 passed, 7 skipped (5 new)
- [x] `uv lock --check` — consistent, so the Dockerfile's `uv sync --locked` still works
- [x] `uv sync --extra demo` + import smoke — torch 2.12.1, transformers 4.57.6, loads clean
- [x] Verified against a **real resolution** (`uv export --frozen --extra demo`, markers evaluated for linux) that torch is `2.12.1+cpu` and `nvidia-nccl-cu12` is the only remaining CUDA package
- [x] Verified the GPU path is untouched: `torchvision` still 0.27.1, the PyPI torch entry still carries its 7 CUDA deps
- [x] Mutation-tested every new assertion (removed the source and re-locked; made the index non-explicit; wrongly pinned `categorizer`) — all fail correctly
- [x] Notebooks have been stripped with `uv run nbstripout --install` or equivalent.
- [x] No proprietary data files are committed directly to Git.
- [x] DVC pointers / `dvc.lock` are updated when approved data or pipeline outputs changed.

### ⚠️ What is NOT verified here

**The image-size drop itself.** On darwin the `demo` extra still resolves the ordinary PyPI wheel — the CPU source is markered `sys_platform != 'darwin'` — so the win is invisible on an arm64 dev Mac by construction. The `linux/amd64` build is CI's job.

First real signal, in the build log:

- `torch-2.12.1+cpu-...-manylinux_2_28_x86_64.whl` downloaded
- **exactly one** `nvidia-*` download (`nvidia-nccl-cu12`, #63). Any other `nvidia-*`/`cuda-*` wheel means the CPU source did not take effect
- the pushed image materially smaller than the previous ~8–12 GB

Also unverified: that the live processor (page-type ViT, MuRIL, BART, Presidio) loads on CPU torch on amd64. It loads fine on darwin CPU torch here, which is the same code path minus the platform, but the box is the real test. That is #30's on-box browser E2E.

## Review Expectations

- Keep this PR small enough to be reviewed by a human in a short sitting.
- Split unrelated changes into separate PRs before requesting review.
- Two-person review is required.
- Yashaswi is a mandatory reviewer.
- Add one additional reviewer who can assess the code, analysis, or domain impact.

The dependency-resolution change is the substance; the rest is comments and docs catching up. `uv.lock` is +95/-14 and mostly marker churn.

## Data And Delivery Notes

- [x] This PR does not modify data.
- [ ] This PR ingests or versions data through DVC.
- [ ] This PR updates generated exhibits.
- [ ] This PR requires `make deliver` after merge.

Notes:

- Lands before the first deploy on purpose. Doing the first-ever `workflow_dispatch` with the oversized image is the version of #30 with the most downside, since a disk-full on that box risks prod Postgres, the lake and the nightly `pg_dump` target, not just the deploy.
- The GHCR registry cache will miss on the first build after this, since the dependency layer changes. Expect one slow build.
