### PR TITLE
ops: land infra preflight + read-only infra-status pass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,7 @@ API_URL        ?= http://127.0.0.1:$(API_PORT)
 # the rest of the line); a stray `$(` with no matching `)` is worse — it is a
 # hard parse error that aborts `make` for every target, not just this one, so
 # a single unlucky character in a generated password can brick the Makefile
-# entirely. Only OLTP_DB_URL needs the safe path here: it is the one dotenv
-# value this Makefile actually consumes (grep confirms no other `?=`
-# variable's name collides with a .env.example key).
+# entirely.
 #
 # Two earlier attempts at this extraction (`grep`/`sed` for the key, then for
 # one layer of matching quotes) each closed one character class and left
@@ -48,7 +46,7 @@ API_URL        ?= http://127.0.0.1:$(API_PORT)
 # (`KEY=value # note`, which `sed`'s quote-stripping never accounted for --
 # `Settings` strips it via python-dotenv, so the Make wrapper silently kept it
 # and passed a corrupted DSN). Patching one more character each round is how
-# this stayed a live bug through three reviews. This now shells out to
+# this stayed a live bug through three reviews. This shells out to
 # `python-dotenv` itself -- the exact parser `Settings` uses
 # (janasunani/config.py) -- instead of re-deriving its quoting/comment rules
 # by hand, so the two can no longer drift: whatever `.env` value `Settings`
@@ -56,39 +54,96 @@ API_URL        ?= http://127.0.0.1:$(API_PORT)
 # (the `ifneq` below), so a checkout with no `.env` (CI, a fresh clone) pays
 # nothing.
 #
-# `:=` (not `?=`), so a value here overrides both this demo default and a
-# shell-exported OLTP_DB_URL, matching the precedence documented above. A
-# `make OLTP_DB_URL=...` command-line value still wins regardless: Make locks
-# in command-line variables before reading any of the makefile, and no plain
-# assignment (only `override`, unused here) can replace them -- verified with
-# `make OLTP_DB_URL=... db` against a conflicting `.env` (see PR description).
+# `:=` (not `?=`), so a value here overrides both the `?=` default and a
+# shell-exported value, matching the OLTP_DB_URL precedence documented above
+# (the same precedence applies to every key below). A `make KEY=...`
+# command-line value still wins regardless: Make locks in command-line
+# variables before reading any of the makefile, and no plain assignment
+# (only `override`, unused here) can replace them -- verified for OLTP_DB_URL
+# with `make OLTP_DB_URL=... db` against a conflicting `.env` (see PR
+# description).
 #
-# Two things fixed here (#103, a regression this extraction itself
-# introduced): first, `uv` is looked up with PATH widened by $(USER_BIN)
-# directly on *this* command, not via the `export PATH` line below -- that
-# only reaches recipe subprocesses, not a $(shell ...) call evaluated here
-# at Make-parse time (confirmed directly: an `export`ed PATH change does not
-# reach an immediately-following $(shell ...) in GNU Make). Without this, a
-# `uv` installed only under $(USER_BIN) -- the repo's own documented install
-# location -- would not resolve here even though every recipe below finds it
-# fine. Second, the python one-liner always prints a `DOTENV_OK:` prefix on
-# success, even with an empty value, so a genuine parse failure (uv still
-# not found, python-dotenv missing, any other error) is distinguishable from
-# ".env exists but doesn't set OLTP_DB_URL" by that prefix's *absence* --
-# never by empty output alone. A failure here is a hard `$(error ...)`, not
-# a silent fallback: silently keeping the throwaway demo default while an
-# operator's .env names a real database is exactly the wrong outcome `make
-# OLTP_DB_URL=... db`'s guard exists to prevent, reached by a different
-# route.
+# Two things fixed for OLTP_DB_URL (#103, a regression this extraction
+# itself introduced): first, `uv` is looked up with PATH widened by
+# $(USER_BIN) directly on *this* command, not via the `export PATH` line
+# below -- that only reaches recipe subprocesses, not a $(shell ...) call
+# evaluated here at Make-parse time (confirmed directly: an `export`ed PATH
+# change does not reach an immediately-following $(shell ...) in GNU Make).
+# Without this, a `uv` installed only under $(USER_BIN) -- the repo's own
+# documented install location -- would not resolve here even though every
+# recipe below finds it fine. Second, dotenv_get below always prints a
+# `DOTENV_OK:` prefix on success, even with an empty value, so a genuine
+# parse failure (uv still not found, python-dotenv missing, any other error)
+# is distinguishable from "this key is not set in .env" by that prefix's
+# *absence* -- never by empty output alone. A failure is a hard
+# `$(error ...)`, not a silent fallback: for OLTP_DB_URL specifically,
+# silently keeping the throwaway demo default while an operator's .env names
+# a real database is exactly the wrong outcome `make OLTP_DB_URL=... db`'s
+# guard exists to prevent, reached by a different route.
+#
+# OLTP_DB_URL was the only key extracted here until #104: the audit done
+# when this extraction landed (17bad32) checked that no other `?=`
+# variable's *name* collided with a .env.example key -- the wrong direction.
+# The actual question is which variables README.md's "Box paths and data
+# ops" section tells operators to persist in .env: BOX_REMOTE,
+# BOX_PROJECT_ROOT, INCOMING_REMOTE and EXHIBITS_REMOTE, none of which
+# collide with a .env.example key but all of which `-include .env` used to
+# supply before #60. Dropping them silently turned `make ingest`/`make
+# deliver` into reading from or publishing to the wrong Box folder with no
+# indication the operator's own .env was ignored -- the same "silently wrong
+# instead of loudly wrong" shape as #103, just for these four keys instead
+# of the database URL. They are not secrets (unlike OLTP_DB_URL, never
+# printed and read via `sh_quote`/OLTP_DB_URL_RAW below), so they get the
+# same safe *parsing* but no additional quoting machinery beyond what
+# `ingest`/`publish-raw`/`deliver`/`box-paths` already did before #60.
+define dotenv_get
+$(shell PATH="$(USER_BIN):$$PATH" uv run python -c "from dotenv import dotenv_values; import sys; v = dotenv_values('.env').get('$(1)'); sys.stdout.write('DOTENV_OK:' + (v if v is not None else ''))" 2>$(_DOTENV_STDERR))
+endef
 _DOTENV_STDERR := /tmp/.janasunani-makefile-dotenv-stderr-$(shell whoami 2>/dev/null)
 ifneq (,$(wildcard .env))
-_DOTENV_RAW_OLTP_DB_URL := $(shell PATH="$(USER_BIN):$$PATH" uv run python -c "from dotenv import dotenv_values; import sys; v = dotenv_values('.env').get('OLTP_DB_URL'); sys.stdout.write('DOTENV_OK:' + (v if v is not None else ''))" 2>$(_DOTENV_STDERR))
+_DOTENV_RAW_OLTP_DB_URL := $(call dotenv_get,OLTP_DB_URL)
 ifeq ($(findstring DOTENV_OK:,$(_DOTENV_RAW_OLTP_DB_URL)),)
 $(error .env exists but OLTP_DB_URL could not be parsed from it (#103) -- refusing to silently fall back to the throwaway demo default. 'uv run python' stderr: $(shell cat $(_DOTENV_STDERR) 2>/dev/null))
 endif
 _DOTENV_OLTP_DB_URL := $(subst DOTENV_OK:,,$(_DOTENV_RAW_OLTP_DB_URL))
 ifneq (,$(_DOTENV_OLTP_DB_URL))
 OLTP_DB_URL := $(_DOTENV_OLTP_DB_URL)
+endif
+
+_DOTENV_RAW_BOX_REMOTE := $(call dotenv_get,BOX_REMOTE)
+ifeq ($(findstring DOTENV_OK:,$(_DOTENV_RAW_BOX_REMOTE)),)
+$(error .env exists but BOX_REMOTE could not be parsed from it (#104) -- refusing to silently fall back to the default. 'uv run python' stderr: $(shell cat $(_DOTENV_STDERR) 2>/dev/null))
+endif
+_DOTENV_BOX_REMOTE := $(subst DOTENV_OK:,,$(_DOTENV_RAW_BOX_REMOTE))
+ifneq (,$(_DOTENV_BOX_REMOTE))
+BOX_REMOTE := $(_DOTENV_BOX_REMOTE)
+endif
+
+_DOTENV_RAW_BOX_PROJECT_ROOT := $(call dotenv_get,BOX_PROJECT_ROOT)
+ifeq ($(findstring DOTENV_OK:,$(_DOTENV_RAW_BOX_PROJECT_ROOT)),)
+$(error .env exists but BOX_PROJECT_ROOT could not be parsed from it (#104) -- refusing to silently fall back to the default. 'uv run python' stderr: $(shell cat $(_DOTENV_STDERR) 2>/dev/null))
+endif
+_DOTENV_BOX_PROJECT_ROOT := $(subst DOTENV_OK:,,$(_DOTENV_RAW_BOX_PROJECT_ROOT))
+ifneq (,$(_DOTENV_BOX_PROJECT_ROOT))
+BOX_PROJECT_ROOT := $(_DOTENV_BOX_PROJECT_ROOT)
+endif
+
+_DOTENV_RAW_INCOMING_REMOTE := $(call dotenv_get,INCOMING_REMOTE)
+ifeq ($(findstring DOTENV_OK:,$(_DOTENV_RAW_INCOMING_REMOTE)),)
+$(error .env exists but INCOMING_REMOTE could not be parsed from it (#104) -- refusing to silently fall back to the default. 'uv run python' stderr: $(shell cat $(_DOTENV_STDERR) 2>/dev/null))
+endif
+_DOTENV_INCOMING_REMOTE := $(subst DOTENV_OK:,,$(_DOTENV_RAW_INCOMING_REMOTE))
+ifneq (,$(_DOTENV_INCOMING_REMOTE))
+INCOMING_REMOTE := $(_DOTENV_INCOMING_REMOTE)
+endif
+
+_DOTENV_RAW_EXHIBITS_REMOTE := $(call dotenv_get,EXHIBITS_REMOTE)
+ifeq ($(findstring DOTENV_OK:,$(_DOTENV_RAW_EXHIBITS_REMOTE)),)
+$(error .env exists but EXHIBITS_REMOTE could not be parsed from it (#104) -- refusing to silently fall back to the default. 'uv run python' stderr: $(shell cat $(_DOTENV_STDERR) 2>/dev/null))
+endif
+_DOTENV_EXHIBITS_REMOTE := $(subst DOTENV_OK:,,$(_DOTENV_RAW_EXHIBITS_REMOTE))
+ifneq (,$(_DOTENV_EXHIBITS_REMOTE))
+EXHIBITS_REMOTE := $(_DOTENV_EXHIBITS_REMOTE)
 endif
 endif
 # A fourth instance of the same bug class, in the one place the .env fix

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,15 @@ ifneq (,$(_DOTENV_OLTP_DB_URL))
 OLTP_DB_URL := $(_DOTENV_OLTP_DB_URL)
 endif
 endif
+# Embeds an arbitrary value (e.g. $(OLTP_DB_URL)) as a single shell word safe
+# from further expansion: single-quoted, with each embedded `'` replaced by
+# `'\''` (close the quote, an escaped literal quote outside it, reopen the
+# quote) -- the standard POSIX idiom for putting a quote inside a quoted
+# string. Plain single-quoting handles `$`/`#` (#60) but a DSN containing a
+# literal `'` would otherwise still break the recipe's shell string; this
+# closes that gap. Use as `$(call sh_quote,$(OLTP_DB_URL))` -- already quoted,
+# so call sites do not wrap it in quotes themselves.
+sh_quote = '$(subst ','\'',$(1))'
 SHELL          := /bin/bash
 .SHELLFLAGS    := -euo pipefail -c
 export PATH    := $(USER_BIN):$(PATH)
@@ -218,12 +227,14 @@ models:
 	uv run dvc pull models/categorizer.dvc models/page_type_classifier/vit_type_classifier.dvc
 
 # `@` so the OLTP DSN (may carry a password) is not echoed into terminal logs.
-# Single-quoted: double quotes would hand a `$` in the password to *this*
-# shell to re-expand (the same class of bug as #60, one layer down, since
-# Make's own textual substitution here does not re-parse the value it pastes
-# in -- only the shell that receives it would).
+# $(call sh_quote,...): double quotes would hand a `$` in the password to
+# *this* shell to re-expand (the same class of bug as #60, one layer down,
+# since Make's own textual substitution here does not re-parse the value it
+# pastes in -- only the shell that receives it would); a bare single-quoted
+# `'$(OLTP_DB_URL)'` fixes that but then breaks on an embedded `'` instead.
+# sh_quote handles both.
 preflight:
-	@OLTP_DB_URL='$(OLTP_DB_URL)' uv run --extra demo janasunani-demo-preflight
+	@OLTP_DB_URL=$(call sh_quote,$(OLTP_DB_URL)) uv run --extra demo janasunani-demo-preflight
 
 # Idempotent: create the throwaway Postgres only if missing, start it if stopped,
 # always (re-)apply migrations (alembic upgrade head is a no-op when current).
@@ -232,7 +243,7 @@ preflight:
 # another, and never provisions/migrates an operator's own (local or off-box) DB.
 db:
 	@set -e; \
-	if [ '$(OLTP_DB_URL)' != '$(DEMO_OLTP_URL)' ]; then \
+	if [ $(call sh_quote,$(OLTP_DB_URL)) != $(call sh_quote,$(DEMO_OLTP_URL)) ]; then \
 	  echo "OLTP_DB_URL is not the throwaway demo default; skipping provisioning — create and migrate that database yourself."; \
 	  exit 0; \
 	fi; \
@@ -251,13 +262,13 @@ db:
 	  docker exec $(PG_CONTAINER) pg_isready -U postgres -d janasunani >/dev/null 2>&1 && break; \
 	  sleep 1; \
 	done; \
-	OLTP_DB_URL='$(OLTP_DB_URL)' uv run alembic upgrade head; \
+	OLTP_DB_URL=$(call sh_quote,$(OLTP_DB_URL)) uv run alembic upgrade head; \
 	echo "Demo DB ready."
 
 # `@` so the OLTP DSN is not echoed. API_HOST=0.0.0.0 to serve off-box.
-# OLTP_DB_URL single-quoted for the same reason as `preflight` above.
+# OLTP_DB_URL quoted via sh_quote for the same reason as `preflight` above.
 api: preflight db
-	@OLTP_DB_URL='$(OLTP_DB_URL)' JANASUNANI_API_HOST="$(API_HOST)" \
+	@OLTP_DB_URL=$(call sh_quote,$(OLTP_DB_URL)) JANASUNANI_API_HOST="$(API_HOST)" \
 	  JANASUNANI_API_PORT="$(API_PORT)" uv run --extra demo janasunani-api-live
 
 frontend:
@@ -273,7 +284,7 @@ frontend:
 up: preflight db
 	@set -e; \
 	echo "Starting live API (:$(API_PORT)) in the background..."; \
-	OLTP_DB_URL='$(OLTP_DB_URL)' JANASUNANI_API_HOST="$(API_HOST)" \
+	OLTP_DB_URL=$(call sh_quote,$(OLTP_DB_URL)) JANASUNANI_API_HOST="$(API_HOST)" \
 	  JANASUNANI_API_PORT="$(API_PORT)" uv run --extra demo janasunani-api-live & \
 	API_PID=$$!; \
 	trap 'pkill -P $$API_PID 2>/dev/null; kill $$API_PID 2>/dev/null || true' EXIT INT TERM; \

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ help:
 	@echo "  make docs            Render docs/*.md to DPIC-branded Word files"
 	@echo "  make box-paths       Show resolved local and Box paths"
 	@echo "  make status          Show what has changed"
+	@echo "  make infra           Read-only health pass over the cloud infra"
 	@echo ""
 	@echo "  Live demo (real-inference API — see docs/DEMO.md):"
 	@echo "  make models          DVC-pull ONLY the demo model artifacts"
@@ -121,7 +122,7 @@ deliver:
 	rclone copy $(EXHIBITS_LOCAL) $(EXHIBITS_REMOTE) --progress
 	@echo "Exhibits delivered. Existing Box files were not deleted."
 
-.PHONY: docs docs-clean
+.PHONY: docs docs-clean infra status
 
 # Word renders of the planning docs, for circulation outside the repo.
 # Outputs are gitignored (docs/*.docx): the Markdown is the source of truth.
@@ -144,6 +145,24 @@ box-paths:
 	@echo "EXHIBITS_LOCAL=$(EXHIBITS_LOCAL)"
 	@echo "INCOMING_REMOTE=$(INCOMING_REMOTE)"
 	@echo "EXHIBITS_REMOTE=$(EXHIBITS_REMOTE)"
+
+
+# Read-only pass over the cloud infra (EC2 boxes, SSH exposure, disk,
+# containers, backups, demo health). Nothing here mutates; see
+# scripts/infra_status.py.
+#
+# CPU_BOX_SSH is the EC2 instance, NOT `BOX_REMOTE` above — that one is the
+# rclone Box.com remote. Two unrelated things both called "box"; do not wire
+# one to the other.
+#
+#   make infra
+#   make infra SITE=52-66-116-80.nip.io SG_ID=sg-0abc123
+#   make infra ARGS="--no-ssh"
+CPU_BOX_SSH    ?= ubuntu@52.66.116.80
+
+infra:
+	@uv run python scripts/infra_status.py --host "$(CPU_BOX_SSH)" \
+	  $(if $(SITE),--site "$(SITE)") $(if $(SG_ID),--sg-id "$(SG_ID)") $(ARGS)
 
 status:
 	@echo "=== Git ==="

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ help:
 	@echo ""
 	@echo "  Live demo (real-inference API — see docs/DEMO.md):"
 	@echo "  make models          DVC-pull ONLY the demo model artifacts"
-	@echo "  make preflight       Fast readiness check (models + OCR binaries)"
+	@echo "  make preflight       Fast readiness check (models, OCR binaries, mappings/lake/OLTP)"
 	@echo "  make db              Start throwaway Postgres + run migrations"
 	@echo "  make api             Run the live real-inference API"
 	@echo "  make frontend        Run the Next.js UI against the live API"

--- a/Makefile
+++ b/Makefile
@@ -68,14 +68,52 @@ ifneq (,$(_DOTENV_OLTP_DB_URL))
 OLTP_DB_URL := $(_DOTENV_OLTP_DB_URL)
 endif
 endif
-# Embeds an arbitrary value (e.g. $(OLTP_DB_URL)) as a single shell word safe
-# from further expansion: single-quoted, with each embedded `'` replaced by
-# `'\''` (close the quote, an escaped literal quote outside it, reopen the
+# A fourth instance of the same bug class, in the one place the .env fix
+# above does not reach: OLTP_DB_URL from `make OLTP_DB_URL=...` (command
+# line) or a shell-exported OLTP_DB_URL is stored by Make as a *recursively*
+# expanded value -- the raw text, re-scanned for `$`/`$(...)` on every
+# reference, not just once. Referencing plain $(OLTP_DB_URL) below (even
+# inside sh_quote's $(subst ...)) re-triggers that scan, so `pa$word` loses
+# `word` the same way an un-fixed `.env` value once did -- this is exactly
+# #60's bug, just arriving through the command-line/environment tier instead
+# of the .env tier, and it is precisely the tier `make OLTP_DB_URL=... db`
+# depends on to force a database for one run (the guard #60's own precedence
+# note above exists to protect).
+#
+# $(value OLTP_DB_URL) reads the raw stored text without expanding it, which
+# is exactly right for a command-line/environment value (a literal string,
+# never intended as a nested Make macro) but wrong for anything else: the
+# untouched default chain's raw text is the literal, unexpanded macro
+# reference `$(DEMO_OLTP_URL)`, and $(value ...) on that returns exactly
+# that string -- not the demo URL -- which would hand the shell a bare
+# `$(DEMO_OLTP_URL)` (itself a *shell* command-substitution token). So
+# $(value ...) is used only when $(origin OLTP_DB_URL) says the value came
+# from the command line or the environment; every other origin (the plain
+# `?=` default, or our own `:=` reassignment from .env above, already a
+# fully-resolved simply-expanded string) goes through normal `$(OLTP_DB_URL)`
+# expansion instead. Command-line values lock their origin regardless of
+# this file's later `:=` attempt (Make ignores plain reassignment of a
+# command-line variable), so this still resolves to "command line" even
+# after the .env block above runs.
+ifeq ($(origin OLTP_DB_URL),command line)
+OLTP_DB_URL_RAW := $(value OLTP_DB_URL)
+else ifeq ($(origin OLTP_DB_URL),environment)
+OLTP_DB_URL_RAW := $(value OLTP_DB_URL)
+else ifeq ($(origin OLTP_DB_URL),environment override)
+OLTP_DB_URL_RAW := $(value OLTP_DB_URL)
+else
+OLTP_DB_URL_RAW := $(OLTP_DB_URL)
+endif
+# Embeds an arbitrary value (e.g. $(OLTP_DB_URL_RAW)) as a single shell word
+# safe from further expansion: single-quoted, with each embedded `'` replaced
+# by `'\''` (close the quote, an escaped literal quote outside it, reopen the
 # quote) -- the standard POSIX idiom for putting a quote inside a quoted
 # string. Plain single-quoting handles `$`/`#` (#60) but a DSN containing a
 # literal `'` would otherwise still break the recipe's shell string; this
-# closes that gap. Use as `$(call sh_quote,$(OLTP_DB_URL))` -- already quoted,
-# so call sites do not wrap it in quotes themselves.
+# closes that gap. Use as `$(call sh_quote,$(OLTP_DB_URL_RAW))` -- already
+# quoted, so call sites do not wrap it in quotes themselves, and always via
+# OLTP_DB_URL_RAW, never the plain $(OLTP_DB_URL) reference, per the origin
+# note above.
 sh_quote = '$(subst ','\'',$(1))'
 SHELL          := /bin/bash
 .SHELLFLAGS    := -euo pipefail -c
@@ -239,7 +277,7 @@ models:
 # `'$(OLTP_DB_URL)'` fixes that but then breaks on an embedded `'` instead.
 # sh_quote handles both.
 preflight:
-	@OLTP_DB_URL=$(call sh_quote,$(OLTP_DB_URL)) uv run --extra demo janasunani-demo-preflight
+	@OLTP_DB_URL=$(call sh_quote,$(OLTP_DB_URL_RAW)) uv run --extra demo janasunani-demo-preflight
 
 # Idempotent: create the throwaway Postgres only if missing, start it if stopped,
 # always (re-)apply migrations (alembic upgrade head is a no-op when current).
@@ -248,7 +286,7 @@ preflight:
 # another, and never provisions/migrates an operator's own (local or off-box) DB.
 db:
 	@set -e; \
-	if [ $(call sh_quote,$(OLTP_DB_URL)) != $(call sh_quote,$(DEMO_OLTP_URL)) ]; then \
+	if [ $(call sh_quote,$(OLTP_DB_URL_RAW)) != $(call sh_quote,$(DEMO_OLTP_URL)) ]; then \
 	  echo "OLTP_DB_URL is not the throwaway demo default; skipping provisioning — create and migrate that database yourself."; \
 	  exit 0; \
 	fi; \
@@ -267,7 +305,7 @@ db:
 	  docker exec $(PG_CONTAINER) pg_isready -U postgres -d janasunani >/dev/null 2>&1 && break; \
 	  sleep 1; \
 	done; \
-	OLTP_DB_URL=$(call sh_quote,$(OLTP_DB_URL)) uv run alembic upgrade head; \
+	OLTP_DB_URL=$(call sh_quote,$(OLTP_DB_URL_RAW)) uv run alembic upgrade head; \
 	echo "Demo DB ready."
 
 # `@` so the OLTP DSN is not echoed. API_HOST=0.0.0.0 to serve off-box.
@@ -280,7 +318,7 @@ db:
 # in this order rather than `db preflight` so the cheap model/OCR-binary
 # checks still fail fast ahead of provisioning a container.
 api: preflight db
-	@OLTP_DB_URL=$(call sh_quote,$(OLTP_DB_URL)) JANASUNANI_API_HOST="$(API_HOST)" \
+	@OLTP_DB_URL=$(call sh_quote,$(OLTP_DB_URL_RAW)) JANASUNANI_API_HOST="$(API_HOST)" \
 	  JANASUNANI_API_PORT="$(API_PORT)" uv run --extra demo janasunani-api-live
 
 frontend:
@@ -299,7 +337,7 @@ frontend:
 up: preflight db
 	@set -e; \
 	echo "Starting live API (:$(API_PORT)) in the background..."; \
-	OLTP_DB_URL=$(call sh_quote,$(OLTP_DB_URL)) JANASUNANI_API_HOST="$(API_HOST)" \
+	OLTP_DB_URL=$(call sh_quote,$(OLTP_DB_URL_RAW)) JANASUNANI_API_HOST="$(API_HOST)" \
 	  JANASUNANI_API_PORT="$(API_PORT)" uv run --extra demo janasunani-api-live & \
 	API_PID=$$!; \
 	trap 'pkill -P $$API_PID 2>/dev/null; kill $$API_PID 2>/dev/null || true' EXIT INT TERM; \

--- a/Makefile
+++ b/Makefile
@@ -272,6 +272,13 @@ db:
 
 # `@` so the OLTP DSN is not echoed. API_HOST=0.0.0.0 to serve off-box.
 # OLTP_DB_URL quoted via sh_quote for the same reason as `preflight` above.
+# Note: `preflight` now opens a real, timeout-bounded connection to
+# OLTP_DB_URL when one is set (janasunani/inference/service.py's
+# _oltp_check). On a fresh box that means it can WARN "unreachable" here,
+# before `db` (next) has started the throwaway Postgres it is pointed at --
+# non-fatal (advisory, not --strict) and self-resolving once `db` runs, kept
+# in this order rather than `db preflight` so the cheap model/OCR-binary
+# checks still fail fast ahead of provisioning a container.
 api: preflight db
 	@OLTP_DB_URL=$(call sh_quote,$(OLTP_DB_URL)) JANASUNANI_API_HOST="$(API_HOST)" \
 	  JANASUNANI_API_PORT="$(API_PORT)" uv run --extra demo janasunani-api-live
@@ -286,6 +293,9 @@ frontend:
 # a UI against a dead backend. The trap reaps only the API process we launched
 # (its PID + children) -- never a global `pkill` that could hit an unrelated
 # live API on the same box. A single Ctrl-C on the frontend stops both.
+# See `api`'s comment above re: preflight's OLTP connectivity probe possibly
+# WARNing here on a fresh box, before `db` (next) has started the throwaway
+# Postgres -- non-fatal and self-resolving.
 up: preflight db
 	@set -e; \
 	echo "Starting live API (:$(API_PORT)) in the background..."; \

--- a/Makefile
+++ b/Makefile
@@ -38,17 +38,23 @@ API_URL        ?= http://127.0.0.1:$(API_PORT)
 # the rest of the line); a stray `$(` with no matching `)` is worse — it is a
 # hard parse error that aborts `make` for every target, not just this one, so
 # a single unlucky character in a generated password can brick the Makefile
-# entirely. `Settings` reads the same file correctly via python-dotenv
-# (janasunani/config.py), so only OLTP_DB_URL needs the safe path here: it is
-# the one dotenv value this Makefile actually consumes (grep confirms no
-# other `?=` variable's name collides with a .env.example key).
+# entirely. Only OLTP_DB_URL needs the safe path here: it is the one dotenv
+# value this Makefile actually consumes (grep confirms no other `?=`
+# variable's name collides with a .env.example key).
 #
-# Extracted by `grep`/`sed`, never by letting Make or a shell evaluate the
-# line -- so a `$` or `#` in the value is just a character, and an unbalanced
-# `$(` cannot blow up the parse. `tail -n1` matches dotenv's own last-key-wins
-# rule for a repeated key; the two `sed` passes strip one layer of matching
-# quotes so a quoted .env value (`OLTP_DB_URL='...'`) parses the same way here
-# as it does for Settings.
+# Two earlier attempts at this extraction (`grep`/`sed` for the key, then for
+# one layer of matching quotes) each closed one character class and left
+# another: `$`/`#`, then an embedded `'`, then a valid dotenv inline comment
+# (`KEY=value # note`, which `sed`'s quote-stripping never accounted for --
+# `Settings` strips it via python-dotenv, so the Make wrapper silently kept it
+# and passed a corrupted DSN). Patching one more character each round is how
+# this stayed a live bug through three reviews. This now shells out to
+# `python-dotenv` itself -- the exact parser `Settings` uses
+# (janasunani/config.py) -- instead of re-deriving its quoting/comment rules
+# by hand, so the two can no longer drift: whatever `.env` value `Settings`
+# resolves is what Make resolves too. `uv run` only runs when `.env` exists
+# (the `ifneq` below), so a checkout with no `.env` (CI, a fresh clone) pays
+# nothing.
 #
 # `:=` (not `?=`), so a value here overrides both this demo default and a
 # shell-exported OLTP_DB_URL, matching the precedence documented above. A
@@ -57,8 +63,7 @@ API_URL        ?= http://127.0.0.1:$(API_PORT)
 # assignment (only `override`, unused here) can replace them -- verified with
 # `make OLTP_DB_URL=... db` against a conflicting `.env` (see PR description).
 ifneq (,$(wildcard .env))
-_DOTENV_OLTP_DB_URL := $(shell grep '^OLTP_DB_URL=' .env 2>/dev/null | tail -n1 | \
-  sed -e 's/^OLTP_DB_URL=//' -e 's/^"\(.*\)"$$/\1/' -e "s/^'\(.*\)'$$/\1/")
+_DOTENV_OLTP_DB_URL := $(shell uv run python -c "from dotenv import dotenv_values; import sys; v = dotenv_values('.env').get('OLTP_DB_URL'); sys.stdout.write(v if v is not None else '')" 2>/dev/null)
 ifneq (,$(_DOTENV_OLTP_DB_URL))
 OLTP_DB_URL := $(_DOTENV_OLTP_DB_URL)
 endif

--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,31 @@ API_URL        ?= http://127.0.0.1:$(API_PORT)
 # in command-line variables before reading any of the makefile, and no plain
 # assignment (only `override`, unused here) can replace them -- verified with
 # `make OLTP_DB_URL=... db` against a conflicting `.env` (see PR description).
+#
+# Two things fixed here (#103, a regression this extraction itself
+# introduced): first, `uv` is looked up with PATH widened by $(USER_BIN)
+# directly on *this* command, not via the `export PATH` line below -- that
+# only reaches recipe subprocesses, not a $(shell ...) call evaluated here
+# at Make-parse time (confirmed directly: an `export`ed PATH change does not
+# reach an immediately-following $(shell ...) in GNU Make). Without this, a
+# `uv` installed only under $(USER_BIN) -- the repo's own documented install
+# location -- would not resolve here even though every recipe below finds it
+# fine. Second, the python one-liner always prints a `DOTENV_OK:` prefix on
+# success, even with an empty value, so a genuine parse failure (uv still
+# not found, python-dotenv missing, any other error) is distinguishable from
+# ".env exists but doesn't set OLTP_DB_URL" by that prefix's *absence* --
+# never by empty output alone. A failure here is a hard `$(error ...)`, not
+# a silent fallback: silently keeping the throwaway demo default while an
+# operator's .env names a real database is exactly the wrong outcome `make
+# OLTP_DB_URL=... db`'s guard exists to prevent, reached by a different
+# route.
+_DOTENV_STDERR := /tmp/.janasunani-makefile-dotenv-stderr-$(shell whoami 2>/dev/null)
 ifneq (,$(wildcard .env))
-_DOTENV_OLTP_DB_URL := $(shell uv run python -c "from dotenv import dotenv_values; import sys; v = dotenv_values('.env').get('OLTP_DB_URL'); sys.stdout.write(v if v is not None else '')" 2>/dev/null)
+_DOTENV_RAW_OLTP_DB_URL := $(shell PATH="$(USER_BIN):$$PATH" uv run python -c "from dotenv import dotenv_values; import sys; v = dotenv_values('.env').get('OLTP_DB_URL'); sys.stdout.write('DOTENV_OK:' + (v if v is not None else ''))" 2>$(_DOTENV_STDERR))
+ifeq ($(findstring DOTENV_OK:,$(_DOTENV_RAW_OLTP_DB_URL)),)
+$(error .env exists but OLTP_DB_URL could not be parsed from it (#103) -- refusing to silently fall back to the throwaway demo default. 'uv run python' stderr: $(shell cat $(_DOTENV_STDERR) 2>/dev/null))
+endif
+_DOTENV_OLTP_DB_URL := $(subst DOTENV_OK:,,$(_DOTENV_RAW_OLTP_DB_URL))
 ifneq (,$(_DOTENV_OLTP_DB_URL))
 OLTP_DB_URL := $(_DOTENV_OLTP_DB_URL)
 endif

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,37 @@ OLTP_DB_URL    ?= $(DEMO_OLTP_URL)
 #   ssh -L $(FRONTEND_PORT):127.0.0.1:$(FRONTEND_PORT) -L $(API_PORT):127.0.0.1:$(API_PORT) <box>
 # API_URL/API_HOST remain overridable for advanced setups.
 API_URL        ?= http://127.0.0.1:$(API_PORT)
--include .env
+# Deliberately NOT `-include .env`: that makes GNU Make parse the file as
+# Makefile syntax, not key=value (#60). `$` starts a variable reference (a
+# password's `pa$word` silently loses `word`) and `#` starts a comment (drops
+# the rest of the line); a stray `$(` with no matching `)` is worse — it is a
+# hard parse error that aborts `make` for every target, not just this one, so
+# a single unlucky character in a generated password can brick the Makefile
+# entirely. `Settings` reads the same file correctly via python-dotenv
+# (janasunani/config.py), so only OLTP_DB_URL needs the safe path here: it is
+# the one dotenv value this Makefile actually consumes (grep confirms no
+# other `?=` variable's name collides with a .env.example key).
+#
+# Extracted by `grep`/`sed`, never by letting Make or a shell evaluate the
+# line -- so a `$` or `#` in the value is just a character, and an unbalanced
+# `$(` cannot blow up the parse. `tail -n1` matches dotenv's own last-key-wins
+# rule for a repeated key; the two `sed` passes strip one layer of matching
+# quotes so a quoted .env value (`OLTP_DB_URL='...'`) parses the same way here
+# as it does for Settings.
+#
+# `:=` (not `?=`), so a value here overrides both this demo default and a
+# shell-exported OLTP_DB_URL, matching the precedence documented above. A
+# `make OLTP_DB_URL=...` command-line value still wins regardless: Make locks
+# in command-line variables before reading any of the makefile, and no plain
+# assignment (only `override`, unused here) can replace them -- verified with
+# `make OLTP_DB_URL=... db` against a conflicting `.env` (see PR description).
+ifneq (,$(wildcard .env))
+_DOTENV_OLTP_DB_URL := $(shell grep '^OLTP_DB_URL=' .env 2>/dev/null | tail -n1 | \
+  sed -e 's/^OLTP_DB_URL=//' -e 's/^"\(.*\)"$$/\1/' -e "s/^'\(.*\)'$$/\1/")
+ifneq (,$(_DOTENV_OLTP_DB_URL))
+OLTP_DB_URL := $(_DOTENV_OLTP_DB_URL)
+endif
+endif
 SHELL          := /bin/bash
 .SHELLFLAGS    := -euo pipefail -c
 export PATH    := $(USER_BIN):$(PATH)
@@ -188,8 +218,12 @@ models:
 	uv run dvc pull models/categorizer.dvc models/page_type_classifier/vit_type_classifier.dvc
 
 # `@` so the OLTP DSN (may carry a password) is not echoed into terminal logs.
+# Single-quoted: double quotes would hand a `$` in the password to *this*
+# shell to re-expand (the same class of bug as #60, one layer down, since
+# Make's own textual substitution here does not re-parse the value it pastes
+# in -- only the shell that receives it would).
 preflight:
-	@OLTP_DB_URL="$(OLTP_DB_URL)" uv run --extra demo janasunani-demo-preflight
+	@OLTP_DB_URL='$(OLTP_DB_URL)' uv run --extra demo janasunani-demo-preflight
 
 # Idempotent: create the throwaway Postgres only if missing, start it if stopped,
 # always (re-)apply migrations (alembic upgrade head is a no-op when current).
@@ -198,7 +232,7 @@ preflight:
 # another, and never provisions/migrates an operator's own (local or off-box) DB.
 db:
 	@set -e; \
-	if [ "$(OLTP_DB_URL)" != "$(DEMO_OLTP_URL)" ]; then \
+	if [ '$(OLTP_DB_URL)' != '$(DEMO_OLTP_URL)' ]; then \
 	  echo "OLTP_DB_URL is not the throwaway demo default; skipping provisioning — create and migrate that database yourself."; \
 	  exit 0; \
 	fi; \
@@ -217,12 +251,13 @@ db:
 	  docker exec $(PG_CONTAINER) pg_isready -U postgres -d janasunani >/dev/null 2>&1 && break; \
 	  sleep 1; \
 	done; \
-	OLTP_DB_URL="$(OLTP_DB_URL)" uv run alembic upgrade head; \
+	OLTP_DB_URL='$(OLTP_DB_URL)' uv run alembic upgrade head; \
 	echo "Demo DB ready."
 
 # `@` so the OLTP DSN is not echoed. API_HOST=0.0.0.0 to serve off-box.
+# OLTP_DB_URL single-quoted for the same reason as `preflight` above.
 api: preflight db
-	@OLTP_DB_URL="$(OLTP_DB_URL)" JANASUNANI_API_HOST="$(API_HOST)" \
+	@OLTP_DB_URL='$(OLTP_DB_URL)' JANASUNANI_API_HOST="$(API_HOST)" \
 	  JANASUNANI_API_PORT="$(API_PORT)" uv run --extra demo janasunani-api-live
 
 frontend:
@@ -238,7 +273,7 @@ frontend:
 up: preflight db
 	@set -e; \
 	echo "Starting live API (:$(API_PORT)) in the background..."; \
-	OLTP_DB_URL="$(OLTP_DB_URL)" JANASUNANI_API_HOST="$(API_HOST)" \
+	OLTP_DB_URL='$(OLTP_DB_URL)' JANASUNANI_API_HOST="$(API_HOST)" \
 	  JANASUNANI_API_PORT="$(API_PORT)" uv run --extra demo janasunani-api-live & \
 	API_PID=$$!; \
 	trap 'pkill -P $$API_PID 2>/dev/null; kill $$API_PID 2>/dev/null || true' EXIT INT TERM; \

--- a/README.md
+++ b/README.md
@@ -223,14 +223,18 @@ history.
 You can create an optional local `.env` file in the repo root to configure
 machine-specific Box/rclone paths:
 
-```make
+```dotenv
 BOX_REMOTE=box
 BOX_PROJECT_ROOT=2. Projects/21. Governance/
 ```
 
 `.env` is ignored by Git and should be used only for local path or remote-name
-settings, not credentials or data files. Use Make-style assignments, do not use
-shell `export` lines, and do not wrap values with spaces in shell quotes.
+settings, not credentials or data files. It uses the same dotenv syntax
+`Settings` reads (`janasunani/config.py`) — plain `KEY=value` per line, an
+optional `export ` prefix, and optional quotes around the value — not Make
+syntax: the Makefile parses it with python-dotenv rather than including it as
+Makefile text, specifically so a value containing `$`, `#`, or a quote
+character is read literally instead of being misread as Make syntax.
 
 Most users only need to set `BOX_REMOTE` and `BOX_PROJECT_ROOT`; the Makefile
 derives the full remotes from those values. Collaborators may see the same

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -234,13 +234,23 @@ docker run --rm caddy:2-alpine caddy hash-password --plaintext '<a real password
 
 ```bash
 cd ~/janasunani
-OLTP_DB_URL="<the same URL compose gives the api>" \
+OLTP_DB_URL="postgresql+asyncpg://postgres:<PW>@127.0.0.1:5432/janasunani" \
   uv run --extra demo janasunani-demo-preflight --strict
 ```
 
-Loads no model weights, so it answers in milliseconds. Without `--strict`
-three checks report `WARN` rather than failing, because each one leaves the
-demo *running* — which is exactly why they are easy to miss:
+Host-visible, not the compose-internal DSN: this command runs on the host,
+not inside a container, so it needs the same `127.0.0.1:5432` form §2 used
+for `alembic upgrade head` above — not the `oltp:5432` service hostname
+`deploy/docker-compose.yml` gives the `api` container, which the compose
+network resolves and the host does not. `<PW>` is the same
+`POSTGRES_PASSWORD` from `deploy/.env`.
+
+Loads no model weights, so it answers in milliseconds — except the `oltp
+store` check as of #88, which opens a real, timeout-bounded connection when
+OLTP_DB_URL is set, so a wrong password/host/port here fails this command
+directly rather than passing quietly. Without `--strict` three checks report
+`WARN` rather than failing, because each one leaves the demo *running* —
+which is exactly why they are easy to miss:
 
 | Check | What you get if it is not OK |
 |---|---|

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -230,6 +230,28 @@ cp proxy.env.example proxy.env && chmod 600 proxy.env
 docker run --rm caddy:2-alpine caddy hash-password --plaintext '<a real password>'
 ```
 
+**Verify the box before the first deploy**, with `--strict`:
+
+```bash
+cd ~/janasunani
+OLTP_DB_URL="<the same URL compose gives the api>" \
+  uv run --extra demo janasunani-demo-preflight --strict
+```
+
+Loads no model weights, so it answers in milliseconds. Without `--strict`
+three checks report `WARN` rather than failing, because each one leaves the
+demo *running* — which is exactly why they are easy to miss:
+
+| Check | What you get if it is not OK |
+|---|---|
+| `routing mappings` | every response carries `method:"fallback"`; departments are illustrative, not real |
+| `history lake` | `/history` returns an empty page, indistinguishable from "no results" |
+| `oltp store` | `InMemoryResultStore`: submissions return 201 and vanish on restart |
+
+`--strict` makes all three fatal. Use it here and after any `dvc pull`, so a
+box that is merely *up* is not mistaken for a box that is *ready*. Local
+`make up` deliberately runs without it.
+
 Then the maintainer (not CI, not this file's author) creates a GitHub
 Actions **environment** and provisions CI's AWS access and repo
 secrets/vars — **run each of these yourself; nothing here does it for you:**

--- a/janasunani/inference/serve.py
+++ b/janasunani/inference/serve.py
@@ -20,33 +20,16 @@ if sys.platform == "darwin":
     # to plain HTTPS locally; the Linux CPU box (where Xet works) is untouched.
     os.environ.setdefault("HF_HUB_DISABLE_XET", "1")
 
-from janasunani.config import DEFAULT_OLTP_DB_URL, Settings  # noqa: E402
-from janasunani.inference.service import build_processor  # noqa: E402
+from janasunani.inference.service import (  # noqa: E402
+    build_processor,
+    resolve_explicit_oltp_url as _resolve_explicit_oltp_url,
+)
 from janasunani.serving.api import create_app  # noqa: E402
 from janasunani.serving.history import LakeHistory  # noqa: E402
 from janasunani.serving.store import (  # noqa: E402
     DatabaseResultStore,
     InMemoryResultStore,
 )
-
-
-def _resolve_explicit_oltp_url() -> str | None:
-    """Resolve `OLTP_DB_URL` through the same `Settings` layer the rest of the
-    app uses, so a value set in the project `.env` (not just a shell-exported
-    env var) is honored -- a raw `os.environ` read misses it and store
-    selection silently falls back to `InMemoryResultStore`.
-
-    Re-instantiates `Settings()` (rather than importing the module-level
-    singleton) so this always reflects the current process environment and
-    `.env` file at call time.
-
-    Returns None unless OLTP is *explicitly* configured: a value equal to
-    `DEFAULT_OLTP_DB_URL` (the built-in local-SQLite fallback `Settings`
-    itself falls back to) is treated as "not configured", matching Phase 8C's
-    contract of using `DatabaseResultStore` only for an explicit OLTP URL.
-    """
-    resolved = Settings().OLTP_DB_URL
-    return resolved if resolved != DEFAULT_OLTP_DB_URL else None
 
 
 def create_live_app():
@@ -68,26 +51,55 @@ def preflight_main() -> None:
 
     A fast, weight-free pre-check to run before the multi-minute warm start:
     it surfaces a missing model artifact or OCR binary in milliseconds instead
-    of minutes into `build_processor`. Also reports which OLTP store `main`
-    would select, so an operator can confirm the DB URL is wired before boot.
+    of minutes into `build_processor`.
+
+    Two severities. Required checks are things `build_processor` cannot start
+    without, and always fail the run. Advisory checks (`WARN`) are the ones
+    that let the demo start and then quietly show less than expected: routing
+    silently on `method:"fallback"`, `/history` empty because the lake was
+    never materialized, submissions dropped because OLTP was never configured.
+
+    `--strict` promotes advisory failures to fatal. That is the mode for a
+    box bring-up, where "starts but shows nothing" is not success.
     """
+    import argparse
+
     from janasunani.inference.service import preflight
 
+    parser = argparse.ArgumentParser(
+        description="Report demo readiness without loading model weights."
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help=(
+            "Treat advisory checks as failures. Use for a box bring-up: "
+            "routing mappings, the history lake and the OLTP store all fail "
+            "silently at runtime."
+        ),
+    )
+    args = parser.parse_args()
+
     checks = preflight()
-    all_ok = True
+    fatal = False
+    degraded = False
     for check in checks:
-        mark = "OK  " if check.ok else "FAIL"
+        if check.ok:
+            mark = "OK  "
+        elif check.required or args.strict:
+            mark = "FAIL"
+            fatal = True
+        else:
+            mark = "WARN"
+            degraded = True
         print(f"[{mark}] {check.name}: {check.detail}")
-        all_ok = all_ok and check.ok
 
-    oltp_url = _resolve_explicit_oltp_url()
-    if oltp_url:
-        # Do not print the URL: it can carry a DB password.
-        print("[INFO] OLTP: explicit URL set -> DatabaseResultStore (persistent)")
-    else:
-        print("[INFO] OLTP: not set -> InMemoryResultStore (results lost on restart)")
-
-    raise SystemExit(0 if all_ok else 1)
+    if degraded and not args.strict:
+        print(
+            "[INFO] WARN items do not stop startup; the demo will run degraded. "
+            "Re-run with --strict to treat them as failures."
+        )
+    raise SystemExit(1 if fatal else 0)
 
 
 def main() -> None:

--- a/janasunani/inference/service.py
+++ b/janasunani/inference/service.py
@@ -585,22 +585,73 @@ def _lake_check() -> DependencyCheck:
     )
 
 
+_OLTP_PROBE_TIMEOUT_S = 5.0
+
+
+def _probe_oltp_connection(url: str, timeout: float = _OLTP_PROBE_TIMEOUT_S) -> None:
+    """Open a real connection and run a harmless query; raises on failure.
+
+    Separated from `_oltp_check` so tests can stub this out rather than
+    touching a real database or the network -- the same collection/judgement
+    split `scripts/infra_status.py` uses for its own AWS/SSH/HTTP calls, for
+    the same reason: a test suite must never depend on real infrastructure
+    being reachable, and preflight tests must never point at a real database.
+    Bounded by `timeout` so an unreachable host degrades this one check
+    within a few seconds rather than hanging preflight indefinitely.
+    """
+    import asyncio
+
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    async def _probe() -> None:
+        engine = create_async_engine(url)
+        try:
+            async with engine.connect() as conn:
+                await conn.execute(text("SELECT 1"))
+        finally:
+            await engine.dispose()
+
+    asyncio.run(asyncio.wait_for(_probe(), timeout=timeout))
+
+
 def _oltp_check() -> DependencyCheck:
-    """Whether live submissions will survive a restart."""
-    # Never include the URL itself: it can carry a DB password.
+    """Whether live submissions will survive a restart -- verified with a
+    real connection, not just an explicit URL. `DatabaseResultStore`
+    (janasunani/serving/store.py) only creates its async engine at startup
+    and never actually connects until the first save, so a wrong password,
+    host, database, or a migration that never ran would otherwise pass
+    preflight clean and only surface when a citizen's submission fails to
+    save.
+    """
     # `required` is a property of the check, not of this run's outcome, so it
-    # stays False on the passing branch too.
-    if resolve_explicit_oltp_url():
+    # stays False on both branches below.
+    url = resolve_explicit_oltp_url()
+    if not url:
         return DependencyCheck(
             "oltp store",
-            True,
-            "explicit OLTP_DB_URL -> DatabaseResultStore",
+            False,
+            "OLTP_DB_URL not set -> InMemoryResultStore, submissions lost on restart",
+            required=False,
+        )
+    try:
+        _probe_oltp_connection(url)
+    except Exception as exc:
+        # Never str(exc): some DBAPI errors embed the DSN -- and its
+        # password -- in their own message. The exception's type name is
+        # actionable (auth vs. host vs. timeout look different) without that
+        # risk; never the URL itself, which is what resolve_explicit_oltp_url
+        # returns and must not appear here either.
+        return DependencyCheck(
+            "oltp store",
+            False,
+            f"explicit OLTP_DB_URL set but unreachable ({type(exc).__name__})",
             required=False,
         )
     return DependencyCheck(
         "oltp store",
-        False,
-        "OLTP_DB_URL not set -> InMemoryResultStore, submissions lost on restart",
+        True,
+        "explicit OLTP_DB_URL -> DatabaseResultStore, connection verified",
         required=False,
     )
 
@@ -639,6 +690,9 @@ def preflight(models_dir: str | Path | None = None) -> list[DependencyCheck]:
 
     # Advisory checks: none of these stop `build_processor`, and all three fail
     # in ways the running demo does not surface. See DependencyCheck.required.
+    # _oltp_check is the one exception to "milliseconds" above when
+    # OLTP_DB_URL is explicitly set: it opens a real, timeout-bounded
+    # connection (_OLTP_PROBE_TIMEOUT_S) rather than just checking presence.
     checks.append(_routing_mappings_check())
     checks.append(_lake_check())
     checks.append(_oltp_check())

--- a/janasunani/inference/service.py
+++ b/janasunani/inference/service.py
@@ -525,12 +525,37 @@ def _routing_mappings_check() -> DependencyCheck:
     return DependencyCheck("routing mappings", True, detail, required=False)
 
 
+# The exact columns janasunani/serving/history.py's LakeHistory.search()
+# selects. Duplicated here (not imported) rather than sharing a constant with
+# janasunani.serving.history: preflight lives in this module specifically so
+# it does not need the `serving` extra (see resolve_explicit_oltp_url's
+# docstring), and importing from janasunani.serving would reintroduce exactly
+# that dependency. Keep in sync with history.py's `columns` if either drifts.
+_HISTORY_COLUMNS = (
+    "ticket_no",
+    "created_on",
+    "district",
+    "category",
+    "subcategory",
+    "dept",
+    "status",
+    "office",
+    "grievance",
+)
+
+
 def _lake_check() -> DependencyCheck:
     """The Parquet lake behind ``GET /history``.
 
     ``LakeHistory`` returns an empty page when ``complaints.parquet`` is
     missing, so an unmaterialized lake looks identical to "no results" in the
-    UI.
+    UI. A present-but-malformed lake is a quieter version of the same
+    failure: a row count alone can pass while a column
+    ``LakeHistory.search()`` actually selects is missing, stale, or renamed,
+    which only surfaces once a real ``/history`` request hits it. The
+    ``LIMIT 0`` select below asks DuckDB to bind every one of those columns
+    without materializing any rows, so a schema mismatch fails preflight
+    instead of a request.
     """
     try:
         from janasunani.olap import lake
@@ -545,9 +570,14 @@ def _lake_check() -> DependencyCheck:
             )
         import duckdb
 
-        rows = duckdb.connect().execute(
+        conn = duckdb.connect()
+        rows = conn.execute(
             f"SELECT count(*) FROM read_parquet('{path.as_posix()}')"
         ).fetchone()[0]
+        conn.execute(
+            f"SELECT {', '.join(_HISTORY_COLUMNS)} "
+            f"FROM read_parquet('{path.as_posix()}') LIMIT 0"
+        )
     except Exception as exc:  # pragma: no cover - defensive; never raise
         return DependencyCheck("history lake", False, f"unreadable: {exc}", required=False)
     return DependencyCheck(

--- a/janasunani/inference/service.py
+++ b/janasunani/inference/service.py
@@ -14,7 +14,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Callable, Optional, Protocol
 
-from janasunani.config import MODELS_DIR
+from janasunani.config import DEFAULT_OLTP_DB_URL, MODELS_DIR, Settings
 from janasunani.inference.ocr import OcrQualityError, OcrResult
 from janasunani.pipeline.stages.page_type_classifier import PAGE_TYPE_CLASS_BY_LABEL
 from janasunani.serving.schemas import (
@@ -436,15 +436,132 @@ def _required_model_files(root: Path) -> list[tuple[tuple[Path, ...], str]]:
 
 
 class DependencyCheck:
-    """One demo-readiness dependency and whether it is satisfied."""
+    """One demo-readiness dependency and whether it is satisfied.
 
-    def __init__(self, name: str, ok: bool, detail: str) -> None:
+    ``required`` separates "the processor cannot start" from "the demo will
+    start and quietly show you less than you think". A missing model artifact
+    is the first kind; an unmaterialized lake is the second — `/history`
+    returns an empty page rather than an error, so nothing surfaces it. The
+    second kind is advisory by default and fatal under ``--strict``, which is
+    what the box runbook uses.
+    """
+
+    def __init__(
+        self, name: str, ok: bool, detail: str, *, required: bool = True
+    ) -> None:
         self.name = name
         self.ok = ok
         self.detail = detail
+        self.required = required
 
     def __repr__(self) -> str:  # pragma: no cover - debug aid
         return f"DependencyCheck(name={self.name!r}, ok={self.ok!r})"
+
+
+def resolve_explicit_oltp_url() -> Optional[str]:
+    """Resolve ``OLTP_DB_URL`` through the same ``Settings`` layer the rest of
+    the app uses, so a value set in the project ``.env`` (not just a
+    shell-exported env var) is honored -- a raw ``os.environ`` read misses it
+    and store selection silently falls back to ``InMemoryResultStore``.
+
+    Re-instantiates ``Settings()`` (rather than importing the module-level
+    singleton) so this always reflects the current process environment and
+    ``.env`` file at call time.
+
+    Returns None unless OLTP is *explicitly* configured: a value equal to
+    ``DEFAULT_OLTP_DB_URL`` (the built-in local-SQLite fallback ``Settings``
+    itself falls back to) is treated as "not configured", matching Phase 8C's
+    contract of using ``DatabaseResultStore`` only for an explicit OLTP URL.
+
+    Lives here rather than in ``serve`` so ``preflight`` can report the same
+    answer ``create_live_app`` will act on, without importing the serving
+    stack (which needs the ``serving`` extra).
+    """
+    resolved = Settings().OLTP_DB_URL
+    return resolved if resolved != DEFAULT_OLTP_DB_URL else None
+
+
+def _routing_mappings_check() -> DependencyCheck:
+    """The ORTPSA master tables the router needs to produce real departments.
+
+    ``load_mapping_tables`` returns None rather than raising when the CSVs are
+    absent, and ``MappingRouter`` then falls back to the illustrative rule set.
+    The API stays healthy and every response carries ``method:"fallback"``.
+    On a box that has not run the scoped ``dvc pull``, that is the default.
+    """
+    try:
+        from janasunani.routing.mappings import DEFAULT_MAPPING_DIR, load_mapping_tables
+
+        tables = load_mapping_tables()
+    except Exception as exc:  # pragma: no cover - defensive; never raise
+        return DependencyCheck(
+            "routing mappings", False, f"unavailable: {exc}", required=False
+        )
+    if tables is None:
+        return DependencyCheck(
+            "routing mappings",
+            False,
+            f"absent at {DEFAULT_MAPPING_DIR} -> routing degrades to "
+            'method:"fallback" (run the scoped dvc pull)',
+            required=False,
+        )
+    return DependencyCheck(
+        "routing mappings",
+        True,
+        f"{len(tables.categories)} categories, "
+        f"{len(tables.category_to_department)} with a derivable department",
+        required=False,
+    )
+
+
+def _lake_check() -> DependencyCheck:
+    """The Parquet lake behind ``GET /history``.
+
+    ``LakeHistory`` returns an empty page when ``complaints.parquet`` is
+    missing, so an unmaterialized lake looks identical to "no results" in the
+    UI.
+    """
+    try:
+        from janasunani.olap import lake
+
+        path = lake.lake_path("complaints")
+        if not path.is_file():
+            return DependencyCheck(
+                "history lake",
+                False,
+                f"{path} absent -> /history returns an empty page, not an error",
+                required=False,
+            )
+        import duckdb
+
+        rows = duckdb.connect().execute(
+            f"SELECT count(*) FROM read_parquet('{path.as_posix()}')"
+        ).fetchone()[0]
+    except Exception as exc:  # pragma: no cover - defensive; never raise
+        return DependencyCheck("history lake", False, f"unreadable: {exc}", required=False)
+    return DependencyCheck(
+        "history lake", rows > 0, f"{rows:,} complaints in {path}", required=False
+    )
+
+
+def _oltp_check() -> DependencyCheck:
+    """Whether live submissions will survive a restart."""
+    # Never include the URL itself: it can carry a DB password.
+    # `required` is a property of the check, not of this run's outcome, so it
+    # stays False on the passing branch too.
+    if resolve_explicit_oltp_url():
+        return DependencyCheck(
+            "oltp store",
+            True,
+            "explicit OLTP_DB_URL -> DatabaseResultStore",
+            required=False,
+        )
+    return DependencyCheck(
+        "oltp store",
+        False,
+        "OLTP_DB_URL not set -> InMemoryResultStore, submissions lost on restart",
+        required=False,
+    )
 
 
 def preflight(models_dir: str | Path | None = None) -> list[DependencyCheck]:
@@ -478,6 +595,12 @@ def preflight(models_dir: str | Path | None = None) -> list[DependencyCheck]:
     _binary_check(
         "pdfinfo/pdftoppm", _poppler_available, "PDF page renderer (poppler)"
     )
+
+    # Advisory checks: none of these stop `build_processor`, and all three fail
+    # in ways the running demo does not surface. See DependencyCheck.required.
+    checks.append(_routing_mappings_check())
+    checks.append(_lake_check())
+    checks.append(_oltp_check())
     return checks
 
 

--- a/janasunani/inference/service.py
+++ b/janasunani/inference/service.py
@@ -589,7 +589,8 @@ _OLTP_PROBE_TIMEOUT_S = 5.0
 
 
 def _probe_oltp_connection(url: str, timeout: float = _OLTP_PROBE_TIMEOUT_S) -> None:
-    """Open a real connection and run a harmless query; raises on failure.
+    """Open a real connection, then confirm `live_grievances` exists; raises
+    on failure of either.
 
     Separated from `_oltp_check` so tests can stub this out rather than
     touching a real database or the network -- the same collection/judgement
@@ -598,17 +599,29 @@ def _probe_oltp_connection(url: str, timeout: float = _OLTP_PROBE_TIMEOUT_S) -> 
     being reachable, and preflight tests must never point at a real database.
     Bounded by `timeout` so an unreachable host degrades this one check
     within a few seconds rather than hanging preflight indefinitely.
+
+    The table check is existence only, not a migration-head check: `SELECT`
+    against `LiveGrievance.__table__` (janasunani/db/models.py, exactly what
+    `DatabaseResultStore.save` writes to) with `LIMIT 0`, so it raises the
+    same way an unreadable connection does if the table is absent, without
+    reading any row. Deliberately does not run or verify Alembic migrations
+    -- no migration is authored by this check, and none should be; this only
+    confirms the one table `DatabaseResultStore` needs is there, the same way
+    `SELECT 1` above only confirms the connection is there.
     """
     import asyncio
 
-    from sqlalchemy import text
+    from sqlalchemy import select, text
     from sqlalchemy.ext.asyncio import create_async_engine
+
+    from janasunani.db.models import LiveGrievance
 
     async def _probe() -> None:
         engine = create_async_engine(url)
         try:
             async with engine.connect() as conn:
                 await conn.execute(text("SELECT 1"))
+                await conn.execute(select(LiveGrievance.id).limit(0))
         finally:
             await engine.dispose()
 
@@ -617,12 +630,12 @@ def _probe_oltp_connection(url: str, timeout: float = _OLTP_PROBE_TIMEOUT_S) -> 
 
 def _oltp_check() -> DependencyCheck:
     """Whether live submissions will survive a restart -- verified with a
-    real connection, not just an explicit URL. `DatabaseResultStore`
-    (janasunani/serving/store.py) only creates its async engine at startup
-    and never actually connects until the first save, so a wrong password,
-    host, database, or a migration that never ran would otherwise pass
-    preflight clean and only surface when a citizen's submission fails to
-    save.
+    real connection and the `live_grievances` table's existence, not just an
+    explicit URL. `DatabaseResultStore` (janasunani/serving/store.py) only
+    creates its async engine at startup and never actually connects until
+    the first save, so a wrong password, host, database, or a migration that
+    never ran would otherwise pass preflight clean and only surface when a
+    citizen's submission fails to save.
     """
     # `required` is a property of the check, not of this run's outcome, so it
     # stays False on both branches below.
@@ -639,19 +652,22 @@ def _oltp_check() -> DependencyCheck:
     except Exception as exc:
         # Never str(exc): some DBAPI errors embed the DSN -- and its
         # password -- in their own message. The exception's type name is
-        # actionable (auth vs. host vs. timeout look different) without that
-        # risk; never the URL itself, which is what resolve_explicit_oltp_url
-        # returns and must not appear here either.
+        # actionable (a connection failure and a missing table raise
+        # different exception types) without that risk; never the URL
+        # itself, which is what resolve_explicit_oltp_url returns and must
+        # not appear here either.
         return DependencyCheck(
             "oltp store",
             False,
-            f"explicit OLTP_DB_URL set but unreachable ({type(exc).__name__})",
+            f"explicit OLTP_DB_URL set but not usable ({type(exc).__name__}: "
+            "unreachable, or live_grievances is missing -- run the Alembic migration)",
             required=False,
         )
     return DependencyCheck(
         "oltp store",
         True,
-        "explicit OLTP_DB_URL -> DatabaseResultStore, connection verified",
+        "explicit OLTP_DB_URL -> DatabaseResultStore, connection and "
+        "live_grievances both verified",
         required=False,
     )
 

--- a/janasunani/inference/service.py
+++ b/janasunani/inference/service.py
@@ -505,13 +505,24 @@ def _routing_mappings_check() -> DependencyCheck:
             'method:"fallback" (run the scoped dvc pull)',
             required=False,
         )
-    return DependencyCheck(
-        "routing mappings",
-        True,
+    detail = (
         f"{len(tables.categories)} categories, "
-        f"{len(tables.category_to_department)} with a derivable department",
-        required=False,
+        f"{len(tables.category_to_department)} with a derivable department"
     )
+    if not tables.categories or not tables.category_to_department:
+        # Present but empty is the same runtime failure as absent: a
+        # header-only or truncated CSV pull parses without error, but
+        # MappingRouter has nothing to route with and falls back the same
+        # way it would with no tables at all. A corrupt pull should not read
+        # as a healthy strict preflight just because the files exist.
+        return DependencyCheck(
+            "routing mappings",
+            False,
+            detail + ' -> effectively empty, routing degrades to method:"fallback" '
+            "(mapping pull looks truncated or corrupt)",
+            required=False,
+        )
+    return DependencyCheck("routing mappings", True, detail, required=False)
 
 
 def _lake_check() -> DependencyCheck:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -40,7 +40,9 @@ Thresholds come from the repo, not from taste:
 |---|---|---|
 | Disk free | CRIT < 20 GiB | `deploy.sh`'s own `MIN_FREE_KIB`; that volume also holds prod Postgres |
 | Backup age | WARN > 26 h, CRIT > 48 h | nightly cadence, §5 of [DEPLOY.md](../docs/DEPLOY.md). The cron lives only on the box (#31), so a rebuilt box loses it silently |
-| Port 22 ingress | WARN on any, CRIT on `0.0.0.0/0`/`::/0` or a rule covering all ports/protocols; OK on the standing maintainer rule | the deploy opens 22 to the runner's /32 and revokes it; a leftover rule is #32. Covers `IpProtocol="-1"`, wide TCP port ranges and IPv6 sources, not just a literal `FromPort==22` |
+| Port 22 ingress | WARN on any, CRIT on `0.0.0.0/0`/`::/0` or a rule covering all ports/protocols; OK on the standing maintainer rule *if it is a single host* | the deploy opens 22 to the runner's /32 and revokes it; a leftover rule is #32. Covers `IpProtocol="-1"`, wide TCP port ranges and IPv6 sources, not just a literal `FromPort==22`. The maintainer-rule description alone is not trusted — `admin_cidr`'s terraform validation only rejects `0.0.0.0/0`, so a `/24` keeping that description still gets WARN |
+| Container health | CRIT if failing its HEALTHCHECK, WARN if still in `start_period` | oltp/api/frontend all define one (deploy/docker-compose.yml); a name-only `docker ps` can't tell "running" from "running but unhealthy" or "running but not confirmed healthy yet" (the api's warm-up can take minutes) |
+| Instance identity | exact `Name` tag + `Project=janasunani` | deploy/terraform's provider `default_tags` plus each instance's own `Name`; a substring match could let an unrelated instance in a shared account stand in for a missing box |
 | GPU box running | WARN | on-demand and billed hourly |
 | `processor` not `pipeline` | WARN | `mock` is up but serving canned results; anything else isn't a value the app produces at all — deploy.sh's own smoke gate greps for `"processor":"pipeline"` and would still be waiting on either |
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,6 +11,44 @@ as scripts rather than DVC stages. Each is safe to re-run.
 | `bootstrap_pii_gold.py` | OCR a bundle + pre-annotate with the production analyzer → draft gold JSONL for the PII eval (below). |
 | `evaluate_pii_redaction.py` | Thin wrapper over `janasunani-evaluate-pii` (the PII gold-JSONL gate). |
 | `setup.sh` | Workspace setup backing `make setup` (uv, rclone, AWS CLI, hooks). |
+| `infra_status.py` | Read-only health pass over the cloud infra, behind `make infra` (below). |
+
+## infra_status.py
+
+One pass answering "is anything wrong right now" across the CPU box (which
+holds production Postgres, the models, the lake and the `pg_dump` target), the
+on-demand GPU box, the deployed stack, and the backups.
+
+```bash
+make infra                                          # AWS + box over SSH
+make infra SITE=52-66-116-80.nip.io SG_ID=sg-0abc    # + health + SSH exposure
+make infra ARGS="--no-ssh"                          # AWS only
+make infra ARGS="--json"                            # machine-readable
+```
+
+**Read-only by construction.** Every command is a query (`aws ec2 describe-*`,
+`aws s3api list-objects-v2`, `df`, `docker ps`, an unauthenticated
+`GET /api/health`). It never starts, stops, deploys or prunes anything, and a
+test asserts no mutating invocation appears in the source. This points at the
+box holding real citizen data, so a status tool that *can* mutate is one that
+eventually will, at the worst moment. It also never prints the OLTP URL, which
+carries a password.
+
+Thresholds come from the repo, not from taste:
+
+| Check | Threshold | Source |
+|---|---|---|
+| Disk free | CRIT < 20 GiB | `deploy.sh`'s own `MIN_FREE_KIB`; that volume also holds prod Postgres |
+| Backup age | WARN > 26 h, CRIT > 48 h | nightly cadence, §5 of [DEPLOY.md](../docs/DEPLOY.md). The cron lives only on the box (#31), so a rebuilt box loses it silently |
+| Port 22 ingress | WARN on any, CRIT on `0.0.0.0/0` | the deploy opens 22 to the runner's /32 and revokes it; a leftover rule is #32 |
+| GPU box running | WARN | on-demand and billed hourly |
+| `processor=mock` | WARN | site is up and serving canned results, not the real pipeline |
+
+Exit code is 0 unless something is CRIT, so it is cron-safe. Two deliberate
+behaviours: skipped or unreachable checks report as `--`, never as healthy, and
+a run where *nothing* was checked prints `NOTHING CHECKED` rather than
+`all clear`. AWS and SSH failures degrade to "not checked" instead of aborting
+the run, so one missing credential does not hide the checks that did work.
 
 ## sample_english_complaints.py
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -42,7 +42,7 @@ Thresholds come from the repo, not from taste:
 | Backup age | WARN > 26 h, CRIT > 48 h | nightly cadence, §5 of [DEPLOY.md](../docs/DEPLOY.md). The cron lives only on the box (#31), so a rebuilt box loses it silently |
 | Port 22 ingress | WARN on any, CRIT on `0.0.0.0/0`/`::/0` or a rule covering all ports/protocols; OK on the standing maintainer rule | the deploy opens 22 to the runner's /32 and revokes it; a leftover rule is #32. Covers `IpProtocol="-1"`, wide TCP port ranges and IPv6 sources, not just a literal `FromPort==22` |
 | GPU box running | WARN | on-demand and billed hourly |
-| `processor=mock` | WARN | site is up and serving canned results, not the real pipeline |
+| `processor` not `pipeline` | WARN | `mock` is up but serving canned results; anything else isn't a value the app produces at all — deploy.sh's own smoke gate greps for `"processor":"pipeline"` and would still be waiting on either |
 
 Exit code is 0 unless something is CRIT, so it is cron-safe. Two deliberate
 behaviours: skipped or unreachable checks report as `--`, never as healthy, and

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -40,7 +40,7 @@ Thresholds come from the repo, not from taste:
 |---|---|---|
 | Disk free | CRIT < 20 GiB | `deploy.sh`'s own `MIN_FREE_KIB`; that volume also holds prod Postgres |
 | Backup age | WARN > 26 h, CRIT > 48 h | nightly cadence, §5 of [DEPLOY.md](../docs/DEPLOY.md). The cron lives only on the box (#31), so a rebuilt box loses it silently |
-| Port 22 ingress | WARN on any, CRIT on `0.0.0.0/0` | the deploy opens 22 to the runner's /32 and revokes it; a leftover rule is #32 |
+| Port 22 ingress | WARN on any, CRIT on `0.0.0.0/0`/`::/0` or a rule covering all ports/protocols; OK on the standing maintainer rule | the deploy opens 22 to the runner's /32 and revokes it; a leftover rule is #32. Covers `IpProtocol="-1"`, wide TCP port ranges and IPv6 sources, not just a literal `FromPort==22` |
 | GPU box running | WARN | on-demand and billed hourly |
 | `processor=mock` | WARN | site is up and serving canned results, not the real pipeline |
 
@@ -48,7 +48,14 @@ Exit code is 0 unless something is CRIT, so it is cron-safe. Two deliberate
 behaviours: skipped or unreachable checks report as `--`, never as healthy, and
 a run where *nothing* was checked prints `NOTHING CHECKED` rather than
 `all clear`. AWS and SSH failures degrade to "not checked" instead of aborting
-the run, so one missing credential does not hide the checks that did work.
+the run, so one missing credential does not hide the checks that did work; this
+applies to the `describe-instances`/`describe-security-groups`/
+`list-objects-v2` calls failing outright, not just to being skipped by a flag.
+
+AWS queries are pinned to `--region ap-south-1` (`--region` to override) rather
+than left to the caller's default CLI profile — a profile pointed at another
+region gets a successful, *empty* response, which otherwise reads as "the CPU
+box is gone" rather than "wrong region".
 
 ## sample_english_complaints.py
 

--- a/scripts/infra_status.py
+++ b/scripts/infra_status.py
@@ -320,6 +320,7 @@ def evaluate_containers(
     running: Optional[list[str]],
     unhealthy: Optional[frozenset[str]] = None,
     starting: Optional[frozenset[str]] = None,
+    all_seen: Optional[list[str]] = None,
 ) -> list[Finding]:
     """``unhealthy`` are containers Docker itself has marked failing their
     HEALTHCHECK (oltp/api/frontend all define one) despite still running --
@@ -329,16 +330,32 @@ def evaluate_containers(
     multi-minute model warm-up) -- not yet *confirmed* healthy, so `make
     infra` running mid-warm-up must not call that OK either, even though it
     is an expected, transient state rather than a failure.
+
+    ``all_seen`` is every janasunani container `docker ps -a` sees,
+    regardless of state -- collected so an *empty* ``running`` can be told
+    apart from "never deployed": if every previously-deployed container has
+    exited, `running` is empty exactly the same as a box that was never
+    deployed at all, and reading that as "not deployed yet" would mask a
+    full outage as a non-event. Only when `all_seen` is *also* empty is
+    nothing running the pre-deploy state.
     """
     if running is None:
         return [Finding("box", "stack", INFO, "not checked")]
     if not running:
-        return [
-            Finding(
-                "box", "stack", INFO, "no janasunani containers — stack not deployed yet"
-            )
-        ]
-    if set(running) == PRE_DEPLOY_CONTAINERS:
+        if not all_seen:
+            return [
+                Finding(
+                    "box",
+                    "stack",
+                    INFO,
+                    "no janasunani containers — stack not deployed yet",
+                )
+            ]
+        # Containers exist (docker ps -a saw them) but none are running --
+        # a full outage, not a pre-deploy box. Falls through to the
+        # per-container loop below, which CRITs every STACK_CONTAINERS
+        # member exactly because none of them are in the (empty) `running`.
+    elif set(running) == PRE_DEPLOY_CONTAINERS:
         # docs/DEPLOY.md's documented first-time bring-up: oltp only, up
         # before the app images are ever deployed. Scoring that against the
         # full STACK_CONTAINERS list below would CRIT three containers
@@ -547,22 +564,24 @@ def collect_box(host: str) -> tuple[
     Optional[list[str]],
     Optional[frozenset[str]],
     Optional[frozenset[str]],
+    Optional[list[str]],
 ]:
     """Disk free (GiB), running janasunani containers, which of those Docker
-    considers unhealthy, and which are still inside their HEALTHCHECK's
-    start_period, over SSH.
+    considers unhealthy, which are still inside their HEALTHCHECK's
+    start_period, and every janasunani container that exists regardless of
+    state, over SSH.
 
-    `docker ps` (no `-a`) already excludes exited containers, so a stopped
-    container correctly falls out of the `containers` list. The gap this
-    closes is the other direction: a container that is running but whose
-    HEALTHCHECK (oltp/api/frontend all define one, deploy/docker-compose.yml)
-    is failing, or has not finished its `start_period` yet (Docker's
-    `(health: starting)` -- the api's warm-up can take minutes) -- a
-    name-only list can't distinguish either from a genuinely healthy one, so
-    it still says OK.
+    Uses `docker ps -a`, not plain `docker ps`: without `-a`, an exited
+    container is indistinguishable from one that was never created at all --
+    both are simply absent from the output -- so a box where the whole stack
+    has crashed would read exactly like a box nothing has ever been deployed
+    to. `-a`'s Status field always starts with "Up" for a running container
+    (e.g. "Up 5 minutes (healthy)") and something else for anything not
+    running ("Exited (1) 2 hours ago", "Created", ...), which is what
+    separates `running` from the last return value below.
     """
     if shutil.which("ssh") is None:
-        return None, None, None, None
+        return None, None, None, None, None
     ssh = ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=10", host]
 
     free_gib = None
@@ -570,26 +589,31 @@ def collect_box(host: str) -> tuple[
     if raw and raw.strip().isdigit():
         free_gib = int(raw.strip()) / (1024 * 1024)
 
-    containers = None
+    running = None
     unhealthy = None
     starting = None
-    raw = _run([*ssh, "docker ps --format '{{.Names}}\t{{.Status}}'"], timeout=30)
+    all_seen = None
+    raw = _run([*ssh, "docker ps -a --format '{{.Names}}\t{{.Status}}'"], timeout=30)
     if raw is not None:
-        containers = []
+        running = []
+        all_seen = []
         unhealthy_set = set()
         starting_set = set()
         for line in raw.splitlines():
             name, _, status = line.strip().partition("\t")
             if not name.startswith("janasunani"):
                 continue
-            containers.append(name)
+            all_seen.append(name)
+            if not status.startswith("Up"):
+                continue
+            running.append(name)
             if "(unhealthy)" in status:
                 unhealthy_set.add(name)
             elif "(health: starting)" in status:
                 starting_set.add(name)
         unhealthy = frozenset(unhealthy_set)
         starting = frozenset(starting_set)
-    return free_gib, containers, unhealthy, starting
+    return free_gib, running, unhealthy, starting, all_seen
 
 
 def collect_health(site: Optional[str]) -> tuple[Optional[dict], Optional[str]]:
@@ -730,12 +754,14 @@ def main() -> int:
     if args.no_ssh:
         report.add("box", "ssh", INFO, "skipped (--no-ssh)")
     else:
-        free_gib, containers, unhealthy, starting = collect_box(args.host)
+        free_gib, containers, unhealthy, starting, all_seen = collect_box(args.host)
         if free_gib is None and containers is None:
             report.add("box", "ssh", INFO, f"{args.host} unreachable — box checks skipped")
         else:
             report.findings.append(evaluate_disk(free_gib))
-            report.findings.extend(evaluate_containers(containers, unhealthy, starting))
+            report.findings.extend(
+                evaluate_containers(containers, unhealthy, starting, all_seen)
+            )
 
     payload, error = collect_health(args.site)
     if args.site:

--- a/scripts/infra_status.py
+++ b/scripts/infra_status.py
@@ -188,6 +188,23 @@ def evaluate_instance(name: str, instance: Optional[dict], *, always_on: bool) -
     return Finding(section, name, OK, f"{state} ({itype})")
 
 
+def _attached_security_group_ids(instance: Optional[dict]) -> Optional[list[str]]:
+    """Every security group ID actually attached to an instance, straight out
+    of `describe-instances`' own `SecurityGroups` field on the instance dict
+    `collect_instances` already returns -- no extra AWS call needed.
+
+    A box can have more than one group attached, and any one of them can
+    expose SSH; checking only a single operator-supplied `--sg-id` missed
+    that. None (not an empty list) when there is no instance to read from, or
+    it has no groups -- both cases the caller must treat as "nothing to
+    check from this," not as "checked and found zero groups."
+    """
+    if not instance:
+        return None
+    ids = [g["GroupId"] for g in instance.get("SecurityGroups", []) if g.get("GroupId")]
+    return ids or None
+
+
 def _rule_covers_ssh(rule: dict) -> bool:
     """Whether an IpPermission's protocol/port coverage includes TCP/22.
 
@@ -225,13 +242,22 @@ def _is_single_host(cidr: str) -> bool:
 def evaluate_ssh_exposure(permissions: list[dict]) -> list[Finding]:
     """Port 22 ingress. See issue #32.
 
-    Checks both `IpRanges` (IPv4) and `Ipv6Ranges` (IPv6) — an IPv6-only
-    source is exposure this tool would otherwise never see. The standing
-    maintainer rule (`MAINTAINER_SSH_DESCRIPTION`) is recognized as intended
-    access, not a leftover; anything else is either a deploy authorizing 22 to
-    the runner's /32 (expected only for the duration of that deploy, revoked
-    after — a leftover means a runner died mid-deploy) or, open to the world,
-    something badly wrong.
+    Checks all four source types AWS's `IpPermission` can carry on a rule
+    covering SSH: `IpRanges` (IPv4), `Ipv6Ranges` (IPv6), `UserIdGroupPairs`
+    (a referenced security group -- membership not resolvable without
+    another AWS call this read-only pass does not make) and `PrefixListIds`
+    (a managed prefix list -- likewise opaque without resolving it). The
+    latter two cannot be scored CRIT/OK the way a CIDR can (their contents
+    are unknown here), but skipping them silently is exactly the earlier bug
+    (#102): a rule granting 22 through a referenced group or prefix list
+    added no finding, so the "no findings -> OK" fallback below printed a
+    clean all-clear regardless. They now always WARN, so a real exposure
+    through either can never be absorbed into that fallback.
+    The standing maintainer rule (`MAINTAINER_SSH_DESCRIPTION`) is recognized
+    as intended access, not a leftover; a plain CIDR source is either a
+    deploy authorizing 22 to the runner's /32 (expected only for the
+    duration of that deploy, revoked after — a leftover means a runner died
+    mid-deploy) or, open to the world, something badly wrong.
     """
     findings: list[Finding] = []
     for rule in permissions:
@@ -289,6 +315,33 @@ def evaluate_ssh_exposure(permissions: list[dict]) -> list[Finding]:
                         " — expected only during a deploy; a leftover rule is issue #32",
                     )
                 )
+        for group in rule.get("UserIdGroupPairs", []):
+            group_id = group.get("GroupId", "?")
+            description = group.get("Description")
+            findings.append(
+                Finding(
+                    "network",
+                    "ssh exposure",
+                    WARN,
+                    f"port 22 open to security group {group_id}"
+                    f"{f' ({description})' if description else ''}"
+                    " — membership not resolved by this tool; check which instances "
+                    "belong to that group",
+                )
+            )
+        for prefix in rule.get("PrefixListIds", []):
+            prefix_id = prefix.get("PrefixListId", "?")
+            description = prefix.get("Description")
+            findings.append(
+                Finding(
+                    "network",
+                    "ssh exposure",
+                    WARN,
+                    f"port 22 open to prefix list {prefix_id}"
+                    f"{f' ({description})' if description else ''}"
+                    " — contents not resolved by this tool; check what CIDRs it expands to",
+                )
+            )
     if not findings:
         findings.append(Finding("network", "ssh exposure", OK, "no port-22 ingress"))
     return findings
@@ -702,6 +755,7 @@ def main() -> int:
         report.add("compute", "aws", INFO, "aws CLI not installed — AWS checks skipped")
     else:
         instances = collect_instances(INSTANCE_NAME_TAGS, args.region)
+        cpu_box = None
         if instances is None:
             report.add(
                 "compute",
@@ -711,21 +765,56 @@ def main() -> int:
                 "network) — not checked",
             )
         else:
-            report.findings.append(
-                evaluate_instance("cpu box", instances["cpu box"], always_on=True)
-            )
+            cpu_box = instances["cpu box"]
+            report.findings.append(evaluate_instance("cpu box", cpu_box, always_on=True))
             report.findings.append(
                 evaluate_instance("gpu box", instances["gpu box"], always_on=False)
             )
 
-        if not args.sg_id:
-            report.add(
-                "network",
-                "ssh exposure",
-                INFO,
-                "not checked (pass --sg-id, from `terraform output cpu_box_security_group_id`)",
-            )
-        else:
+        # Every security group actually attached to the CPU box, not just the
+        # one named by --sg-id: describe-instances (above, already fetched)
+        # returns each instance's SecurityGroups for free, no extra AWS call.
+        # A box can have more than one group attached, and any one of them
+        # can expose 22 -- checking only the group an operator happened to
+        # pass would print "OK no port-22 ingress" while a *different*
+        # attached group leaves it open. This is preferred over the weaker
+        # "refuse an all-clear on a --sg-id mismatch" fallback because it
+        # does not depend on the operator supplying --sg-id at all, or
+        # supplying the right one.
+        attached_group_ids = _attached_security_group_ids(cpu_box)
+        if attached_group_ids:
+            if args.sg_id and args.sg_id not in attached_group_ids:
+                report.add(
+                    "network",
+                    "ssh exposure",
+                    WARN,
+                    f"--sg-id {args.sg_id} is not among the CPU box's attached groups "
+                    f"({', '.join(attached_group_ids)}) — checking the attached groups "
+                    "instead, not the one supplied",
+                )
+            all_permissions: list[dict] = []
+            collection_failed = False
+            for group_id in attached_group_ids:
+                permissions = collect_security_group(group_id, args.region)
+                if permissions is None:
+                    collection_failed = True
+                    break
+                all_permissions.extend(permissions)
+            if collection_failed:
+                report.add(
+                    "network",
+                    "ssh exposure",
+                    INFO,
+                    "describe-security-groups failed for one or more of the CPU box's "
+                    f"attached groups ({', '.join(attached_group_ids)}, "
+                    f"region={args.region}) — not checked",
+                )
+            else:
+                report.findings.extend(evaluate_ssh_exposure(all_permissions))
+        elif args.sg_id:
+            # Instance lookup unavailable (AWS collection failed above, or no
+            # instance tagged "cpu box" was found) -- fall back to whatever
+            # group the operator supplied, the best available check.
             permissions = collect_security_group(args.sg_id, args.region)
             if permissions is None:
                 report.add(
@@ -737,6 +826,14 @@ def main() -> int:
                 )
             else:
                 report.findings.extend(evaluate_ssh_exposure(permissions))
+        else:
+            report.add(
+                "network",
+                "ssh exposure",
+                INFO,
+                "not checked (CPU box not found and no --sg-id given; from `terraform "
+                "output cpu_box_security_group_id`)",
+            )
 
         backup = collect_backup(args.region)
         if backup is None:

--- a/scripts/infra_status.py
+++ b/scripts/infra_status.py
@@ -1,0 +1,475 @@
+"""One read-only status pass over the janasunani infrastructure.
+
+Answers "is anything wrong right now" for the CPU box (which holds the
+production Postgres, the models, the Parquet lake and the nightly `pg_dump`
+target), the on-demand GPU box, the deployed demo stack, and the backups.
+
+**Strictly read-only by construction.** Every command it runs is a query:
+`aws ec2 describe-*`, `aws s3api list-objects-v2`, `df`, `docker ps`, and an
+unauthenticated GET of `/api/health`. It never starts, stops, deploys, prunes
+or writes anything. That is deliberate: this points at the box holding real
+citizen data, and a status tool that can mutate is a status tool that will
+eventually mutate at the wrong moment.
+
+It also never prints a secret. The OLTP URL, the demo password and the DB
+password are all out of scope for every check below.
+
+Thresholds are taken from the repo, not invented:
+
+* 20 GiB free disk is `deploy.sh`'s own `MIN_FREE_KIB` floor, below which it
+  refuses to pull images (docs/DEPLOY.md §"Disk hygiene").
+* Backups are nightly to `s3://grievance-database-backups-main/janasunani/`
+  (docs/DEPLOY.md §5). That script lives only on the box and is **not**
+  reproducible from code (issue #31), so a rebuilt box loses it silently —
+  which is exactly why staleness is checked here.
+* Port 22 exposure is issue #32's rule-leakage gap: the deploy workflow opens
+  22 to the runner's /32 and revokes it after, and a runner that dies between
+  the two leaves the rule behind.
+
+Usage:
+
+    uv run python scripts/infra_status.py
+    uv run python scripts/infra_status.py --no-ssh        # AWS + HTTP only
+    uv run python scripts/infra_status.py --json          # machine-readable
+
+Exit code is 0 unless something is CRIT, so it is safe to put in a cron.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Optional
+
+# --- grounded constants ------------------------------------------------------
+
+BACKUP_BUCKET = "grievance-database-backups-main"
+BACKUP_PREFIX = "janasunani/"
+# deploy.sh: min_free_kib="${MIN_FREE_KIB:-$((20 * 1024 * 1024))}"
+DISK_CRIT_GIB = 20
+DISK_WARN_GIB = 40
+# nightly cadence, so one missed run is a warning and two is a failure
+BACKUP_WARN_HOURS = 26
+BACKUP_CRIT_HOURS = 48
+STACK_CONTAINERS = (
+    "janasunani-oltp",
+    "janasunani-api",
+    "janasunani-frontend",
+    "janasunani-proxy",
+)
+
+OK, WARN, CRIT, INFO = "OK", "WARN", "CRIT", "INFO"
+_RANK = {OK: 0, INFO: 0, WARN: 1, CRIT: 2}
+
+
+@dataclass
+class Finding:
+    section: str
+    name: str
+    status: str
+    detail: str
+
+
+@dataclass
+class Report:
+    findings: list[Finding] = field(default_factory=list)
+
+    def add(self, section: str, name: str, status: str, detail: str) -> None:
+        self.findings.append(Finding(section, name, status, detail))
+
+    @property
+    def worst(self) -> str:
+        """Highest severity present. INFO ranks with OK: "not checked" is not a
+        problem, it is an absence of one, and must not read as degraded."""
+        rank = max((_RANK[f.status] for f in self.findings), default=0)
+        return {0: OK, 1: WARN, 2: CRIT}[rank]
+
+    def exit_code(self) -> int:
+        return 1 if self.worst == CRIT else 0
+
+
+# --- evaluation (pure; this is what the tests drive) -------------------------
+
+
+def evaluate_instance(name: str, instance: Optional[dict], *, always_on: bool) -> Finding:
+    """One EC2 instance's state.
+
+    The CPU box is always-on and holds production data, so anything but
+    `running` is critical. The GPU box is on-demand and billed by the hour, so
+    *running* is the noteworthy state.
+    """
+    section = "compute"
+    if instance is None:
+        if always_on:
+            return Finding(section, name, CRIT, "not found (expected an always-on box)")
+        return Finding(section, name, OK, "not provisioned (gpu_box_count = 0)")
+
+    state = instance.get("State", {}).get("Name", "unknown")
+    itype = instance.get("InstanceType", "?")
+    if always_on:
+        status = OK if state == "running" else CRIT
+        return Finding(section, name, status, f"{state} ({itype})")
+
+    if state == "running":
+        launched = instance.get("LaunchTime")
+        age = ""
+        if launched:
+            hours = _hours_since(launched)
+            if hours is not None:
+                age = f", up {hours:.1f}h"
+        return Finding(
+            section, name, WARN, f"running ({itype}{age}) — on-demand, still billing"
+        )
+    return Finding(section, name, OK, f"{state} ({itype})")
+
+
+def evaluate_ssh_exposure(permissions: list[dict]) -> list[Finding]:
+    """Port 22 ingress. See issue #32.
+
+    A deploy authorizes 22 to the runner's /32 and revokes it afterwards. A
+    leftover rule means a runner died mid-deploy; an open-to-the-world rule
+    means something is badly wrong.
+    """
+    findings: list[Finding] = []
+    for rule in permissions:
+        if rule.get("FromPort") != 22:
+            continue
+        for cidr in rule.get("IpRanges", []):
+            block = cidr.get("CidrIp", "?")
+            if block in ("0.0.0.0/0", "::/0"):
+                findings.append(
+                    Finding(
+                        "network",
+                        "ssh exposure",
+                        CRIT,
+                        f"port 22 open to {block} — the box holds production PII",
+                    )
+                )
+            else:
+                findings.append(
+                    Finding(
+                        "network",
+                        "ssh exposure",
+                        WARN,
+                        f"port 22 open to {block}"
+                        f"{' (' + cidr['Description'] + ')' if cidr.get('Description') else ''}"
+                        " — expected only during a deploy; a leftover rule is issue #32",
+                    )
+                )
+    if not findings:
+        findings.append(Finding("network", "ssh exposure", OK, "no port-22 ingress"))
+    return findings
+
+
+def evaluate_disk(free_gib: Optional[float]) -> Finding:
+    """Free space on the box's root volume.
+
+    That one volume carries prod Postgres, the models, the lake, the HF cache
+    and the pg_dump target, so filling it takes all of them down together, not
+    just the next deploy.
+    """
+    if free_gib is None:
+        return Finding("box", "disk", INFO, "not checked")
+    if free_gib < DISK_CRIT_GIB:
+        return Finding(
+            "box",
+            "disk",
+            CRIT,
+            f"{free_gib:.1f} GiB free — below deploy.sh's {DISK_CRIT_GIB} GiB floor; "
+            "prod Postgres shares this volume",
+        )
+    if free_gib < DISK_WARN_GIB:
+        return Finding("box", "disk", WARN, f"{free_gib:.1f} GiB free")
+    return Finding("box", "disk", OK, f"{free_gib:.1f} GiB free")
+
+
+def evaluate_containers(running: Optional[list[str]]) -> list[Finding]:
+    if running is None:
+        return [Finding("box", "stack", INFO, "not checked")]
+    if not running:
+        return [
+            Finding(
+                "box", "stack", INFO, "no janasunani containers — stack not deployed yet"
+            )
+        ]
+    findings = []
+    for name in STACK_CONTAINERS:
+        up = name in running
+        findings.append(
+            Finding("box", name, OK if up else CRIT, "running" if up else "not running")
+        )
+    return findings
+
+
+def evaluate_backup(last_modified: Optional[str], size_bytes: Optional[int]) -> Finding:
+    """Freshness of the newest nightly pg_dump in S3."""
+    if last_modified is None:
+        return Finding(
+            "backups",
+            "pg_dump",
+            CRIT,
+            f"no objects under s3://{BACKUP_BUCKET}/{BACKUP_PREFIX} — "
+            "the cron lives only on the box and is not in code (issue #31)",
+        )
+    hours = _hours_since(last_modified)
+    if hours is None:
+        return Finding("backups", "pg_dump", WARN, f"unparseable timestamp {last_modified!r}")
+    size = f", {size_bytes / 1e9:.2f} GB" if size_bytes else ""
+    detail = f"newest {hours:.1f}h old{size}"
+    if hours > BACKUP_CRIT_HOURS:
+        return Finding("backups", "pg_dump", CRIT, detail + " — two nightly runs missed")
+    if hours > BACKUP_WARN_HOURS:
+        return Finding("backups", "pg_dump", WARN, detail + " — a nightly run was missed")
+    return Finding("backups", "pg_dump", OK, detail)
+
+
+def evaluate_health(payload: Optional[dict], error: Optional[str]) -> Finding:
+    """`GET /api/health`, which the Caddyfile exempts from basic_auth.
+
+    A `mock` processor here means the site is serving canned results: healthy,
+    responsive, and not the real pipeline.
+    """
+    if error:
+        return Finding("demo", "health", CRIT, error)
+    if not payload:
+        return Finding("demo", "health", INFO, "not checked")
+    processor = payload.get("processor", "?")
+    if processor == "mock":
+        return Finding(
+            "demo",
+            "health",
+            WARN,
+            "up, but processor=mock — serving canned results, not the real pipeline",
+        )
+    return Finding("demo", "health", OK, f"up, processor={processor}")
+
+
+def _hours_since(timestamp: Any) -> Optional[float]:
+    if isinstance(timestamp, datetime):
+        moment = timestamp
+    else:
+        try:
+            moment = datetime.fromisoformat(str(timestamp).replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=UTC)
+    return (datetime.now(UTC) - moment).total_seconds() / 3600
+
+
+# --- collection (shells out; every command is a query) -----------------------
+
+
+def _run(command: list[str], timeout: int = 30) -> Optional[str]:
+    try:
+        proc = subprocess.run(command, capture_output=True, text=True, timeout=timeout)
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    return proc.stdout if proc.returncode == 0 else None
+
+
+def _aws_json(args: list[str]) -> Optional[dict]:
+    raw = _run(["aws", *args, "--output", "json"], timeout=60)
+    if raw is None:
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+
+
+def collect_instances(tag_names: dict[str, str]) -> dict[str, Optional[dict]]:
+    found: dict[str, Optional[dict]] = {label: None for label in tag_names}
+    payload = _aws_json(["ec2", "describe-instances"])
+    if payload is None:
+        return found
+    for reservation in payload.get("Reservations", []):
+        for instance in reservation.get("Instances", []):
+            if instance.get("State", {}).get("Name") == "terminated":
+                continue
+            tags = {t["Key"]: t["Value"] for t in instance.get("Tags", [])}
+            name = tags.get("Name", "")
+            for label, wanted in tag_names.items():
+                if wanted in name:
+                    found[label] = instance
+    return found
+
+
+def collect_security_group(group_id: Optional[str]) -> Optional[list[dict]]:
+    if not group_id:
+        return None
+    payload = _aws_json(["ec2", "describe-security-groups", "--group-ids", group_id])
+    if not payload or not payload.get("SecurityGroups"):
+        return None
+    return payload["SecurityGroups"][0].get("IpPermissions", [])
+
+
+def collect_backup() -> tuple[Optional[str], Optional[int]]:
+    payload = _aws_json(
+        [
+            "s3api",
+            "list-objects-v2",
+            "--bucket",
+            BACKUP_BUCKET,
+            "--prefix",
+            BACKUP_PREFIX,
+        ]
+    )
+    if not payload or not payload.get("Contents"):
+        return None, None
+    newest = max(payload["Contents"], key=lambda o: o["LastModified"])
+    return newest["LastModified"], newest.get("Size")
+
+
+def collect_box(host: str) -> tuple[Optional[float], Optional[list[str]]]:
+    """Disk free (GiB) and running janasunani containers, over SSH."""
+    if shutil.which("ssh") is None:
+        return None, None
+    ssh = ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=10", host]
+
+    free_gib = None
+    raw = _run([*ssh, "df -Pk ~ | tail -1 | awk '{print $4}'"], timeout=30)
+    if raw and raw.strip().isdigit():
+        free_gib = int(raw.strip()) / (1024 * 1024)
+
+    containers = None
+    raw = _run([*ssh, "docker ps --format '{{.Names}}'"], timeout=30)
+    if raw is not None:
+        containers = [
+            line.strip() for line in raw.splitlines() if line.strip().startswith("janasunani")
+        ]
+    return free_gib, containers
+
+
+def collect_health(site: Optional[str]) -> tuple[Optional[dict], Optional[str]]:
+    if not site:
+        return None, None
+    url = f"https://{site}/api/health"
+    raw = _run(["curl", "-fsS", "--max-time", "15", url], timeout=30)
+    if raw is None:
+        return None, f"{url} unreachable or non-200"
+    try:
+        return json.loads(raw), None
+    except json.JSONDecodeError:
+        return None, f"{url} returned non-JSON"
+
+
+# --- reporting ---------------------------------------------------------------
+
+
+def render(report: Report) -> str:
+    marks = {OK: "OK  ", WARN: "WARN", CRIT: "CRIT", INFO: "--  "}
+    lines: list[str] = []
+    section = None
+    for finding in report.findings:
+        if finding.section != section:
+            section = finding.section
+            lines.append(f"\n=== {section} ===")
+        lines.append(f"[{marks[finding.status]}] {finding.name}: {finding.detail}")
+    lines.append("")
+    counts = {
+        level: sum(1 for f in report.findings if f.status == level)
+        for level in (CRIT, WARN, INFO)
+    }
+    checked = len(report.findings) - counts[INFO]
+    skipped = f" ({counts[INFO]} not checked)" if counts[INFO] else ""
+
+    if counts[CRIT]:
+        lines.append(f"{counts[CRIT]} critical, {counts[WARN]} warning{skipped}")
+    elif counts[WARN]:
+        lines.append(f"no critical issues, {counts[WARN]} warning{skipped}")
+    elif checked == 0:
+        # Never say "all clear" when nothing ran. Unreachable AWS, an
+        # unreachable box and --no-aws --no-ssh all land here, and reading that
+        # as healthy is the exact mistake this tool exists to prevent.
+        lines.append("NOTHING CHECKED — this is not a clean bill of health")
+    else:
+        lines.append(f"all clear ({checked} checks){skipped}")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__.split("\n")[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--host", default="ubuntu@52.66.116.80", help="SSH target for the CPU box.")
+    parser.add_argument(
+        "--site", default=None, help="Public site for the health check (e.g. 52-66-116-80.nip.io)."
+    )
+    parser.add_argument("--sg-id", default=None, help="CPU box security group id.")
+    parser.add_argument("--no-ssh", action="store_true", help="Skip the box-side checks.")
+    parser.add_argument("--no-aws", action="store_true", help="Skip the AWS API checks.")
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of text.")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    report = Report()
+
+    if args.no_aws:
+        report.add("compute", "aws", INFO, "skipped (--no-aws)")
+    elif shutil.which("aws") is None:
+        report.add("compute", "aws", INFO, "aws CLI not installed — AWS checks skipped")
+    else:
+        instances = collect_instances({"cpu box": "cpu", "gpu box": "gpu"})
+        report.findings.append(
+            evaluate_instance("cpu box", instances["cpu box"], always_on=True)
+        )
+        report.findings.append(
+            evaluate_instance("gpu box", instances["gpu box"], always_on=False)
+        )
+
+        permissions = collect_security_group(args.sg_id)
+        if permissions is None:
+            report.add(
+                "network",
+                "ssh exposure",
+                INFO,
+                "not checked (pass --sg-id, from `terraform output cpu_box_security_group_id`)",
+            )
+        else:
+            report.findings.extend(evaluate_ssh_exposure(permissions))
+
+        last_modified, size = collect_backup()
+        report.findings.append(evaluate_backup(last_modified, size))
+
+    if args.no_ssh:
+        report.add("box", "ssh", INFO, "skipped (--no-ssh)")
+    else:
+        free_gib, containers = collect_box(args.host)
+        if free_gib is None and containers is None:
+            report.add("box", "ssh", INFO, f"{args.host} unreachable — box checks skipped")
+        else:
+            report.findings.append(evaluate_disk(free_gib))
+            report.findings.extend(evaluate_containers(containers))
+
+    payload, error = collect_health(args.site)
+    if args.site:
+        report.findings.append(evaluate_health(payload, error))
+    else:
+        report.add("demo", "health", INFO, "not checked (pass --site)")
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "worst": report.worst,
+                    "findings": [vars(f) for f in report.findings],
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(render(report))
+    return report.exit_code()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/infra_status.py
+++ b/scripts/infra_status.py
@@ -273,7 +273,12 @@ def evaluate_disk(free_gib: Optional[float]) -> Finding:
     return Finding("box", "disk", OK, f"{free_gib:.1f} GiB free")
 
 
-def evaluate_containers(running: Optional[list[str]]) -> list[Finding]:
+def evaluate_containers(
+    running: Optional[list[str]], unhealthy: Optional[frozenset[str]] = None
+) -> list[Finding]:
+    """``unhealthy`` are containers Docker itself has marked failing their
+    HEALTHCHECK (oltp/api/frontend all define one) despite still running --
+    distinct from ``running`` not containing the name at all (stopped)."""
     if running is None:
         return [Finding("box", "stack", INFO, "not checked")]
     if not running:
@@ -295,12 +300,17 @@ def evaluate_containers(running: Optional[list[str]]) -> list[Finding]:
                 "only oltp up — app stack (api/frontend/proxy) not deployed yet",
             )
         ]
+    unhealthy = unhealthy or frozenset()
     findings = []
     for name in STACK_CONTAINERS:
-        up = name in running
-        findings.append(
-            Finding("box", name, OK if up else CRIT, "running" if up else "not running")
-        )
+        if name not in running:
+            findings.append(Finding("box", name, CRIT, "not running"))
+        elif name in unhealthy:
+            findings.append(
+                Finding("box", name, CRIT, "running but failing its HEALTHCHECK")
+            )
+        else:
+            findings.append(Finding("box", name, OK, "running"))
     return findings
 
 
@@ -466,10 +476,21 @@ def collect_backup(region: str) -> Optional[tuple[Optional[str], Optional[int]]]
     return newest["LastModified"], newest.get("Size")
 
 
-def collect_box(host: str) -> tuple[Optional[float], Optional[list[str]]]:
-    """Disk free (GiB) and running janasunani containers, over SSH."""
+def collect_box(
+    host: str,
+) -> tuple[Optional[float], Optional[list[str]], Optional[frozenset[str]]]:
+    """Disk free (GiB), running janasunani containers, and which of those
+    Docker itself considers unhealthy, over SSH.
+
+    `docker ps` (no `-a`) already excludes exited containers, so a stopped
+    container correctly falls out of the `containers` list. The gap this
+    closes is the other direction: a container that is running but whose
+    HEALTHCHECK (oltp/api/frontend all define one, deploy/docker-compose.yml)
+    is failing -- `docker ps --format '{{.Names}}'` alone can't distinguish
+    that from a genuinely healthy one, so a name-only list still says OK.
+    """
     if shutil.which("ssh") is None:
-        return None, None
+        return None, None, None
     ssh = ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=10", host]
 
     free_gib = None
@@ -478,12 +499,20 @@ def collect_box(host: str) -> tuple[Optional[float], Optional[list[str]]]:
         free_gib = int(raw.strip()) / (1024 * 1024)
 
     containers = None
-    raw = _run([*ssh, "docker ps --format '{{.Names}}'"], timeout=30)
+    unhealthy = None
+    raw = _run([*ssh, "docker ps --format '{{.Names}}\t{{.Status}}'"], timeout=30)
     if raw is not None:
-        containers = [
-            line.strip() for line in raw.splitlines() if line.strip().startswith("janasunani")
-        ]
-    return free_gib, containers
+        containers = []
+        unhealthy_set = set()
+        for line in raw.splitlines():
+            name, _, status = line.strip().partition("\t")
+            if not name.startswith("janasunani"):
+                continue
+            containers.append(name)
+            if "(unhealthy)" in status:
+                unhealthy_set.add(name)
+        unhealthy = frozenset(unhealthy_set)
+    return free_gib, containers, unhealthy
 
 
 def collect_health(site: Optional[str]) -> tuple[Optional[dict], Optional[str]]:
@@ -624,12 +653,12 @@ def main() -> int:
     if args.no_ssh:
         report.add("box", "ssh", INFO, "skipped (--no-ssh)")
     else:
-        free_gib, containers = collect_box(args.host)
+        free_gib, containers, unhealthy = collect_box(args.host)
         if free_gib is None and containers is None:
             report.add("box", "ssh", INFO, f"{args.host} unreachable — box checks skipped")
         else:
             report.findings.append(evaluate_disk(free_gib))
-            report.findings.extend(evaluate_containers(containers))
+            report.findings.extend(evaluate_containers(containers, unhealthy))
 
     payload, error = collect_health(args.site)
     if args.site:

--- a/scripts/infra_status.py
+++ b/scripts/infra_status.py
@@ -38,6 +38,7 @@ Exit code is 0 unless something is CRIT, so it is safe to put in a cron.
 from __future__ import annotations
 
 import argparse
+import ipaddress
 import json
 import shutil
 import subprocess
@@ -56,6 +57,14 @@ BACKUP_PREFIX = "janasunani/"
 # elsewhere gets a successful, empty response, not an error, and that reads
 # as "the box is gone" (see collect_instances).
 AWS_REGION_DEFAULT = "ap-south-1"
+# deploy/terraform/main.tf and gpu.tf: the exact `Name` tag each instance
+# resource sets. `Project` comes from the provider's own `default_tags` block
+# (main.tf), applied to every resource it manages, not just these two --
+# required alongside Name so an unrelated instance in a shared account (e.g.
+# a substring match on "cpu" hitting a "batch-cpu-worker") cannot stand in
+# for a missing production box.
+INSTANCE_NAME_TAGS = {"cpu box": "janasunani-cpu-box", "gpu box": "janasunani-gpu-box"}
+PROJECT_TAG_VALUE = "janasunani"
 # deploy.sh: min_free_kib="${MIN_FREE_KIB:-$((20 * 1024 * 1024))}"
 DISK_CRIT_GIB = 20
 DISK_WARN_GIB = 40
@@ -84,6 +93,13 @@ PRE_DEPLOY_CONTAINERS = frozenset({"janasunani-oltp"})
 # IpPermission, so a rule carrying this exact text is the intended permanent
 # access, not a leftover deploy-runner /32 (issue #32) -- distinguished here
 # so a healthy box can still render all clear.
+#
+# The description alone is not proof of scope: deploy/terraform/variables.tf's
+# `admin_cidr` validation only rejects 0.0.0.0/0, so a `/24` (or wider) still
+# passes terraform and keeps this exact description, and trusting the text
+# would then bless SSH from every address in that block. evaluate_ssh_exposure
+# also requires the CIDR itself to be a single host (see `_is_single_host`)
+# before treating it as the intended maintainer-only rule.
 MAINTAINER_SSH_DESCRIPTION = "SSH from the maintainer IP only"
 
 OK, WARN, CRIT, INFO = "OK", "WARN", "CRIT", "INFO"
@@ -194,6 +210,18 @@ def _rule_covers_ssh(rule: dict) -> bool:
     return from_port <= 22 <= to_port
 
 
+def _is_single_host(cidr: str) -> bool:
+    """Whether a CIDR block is exactly one address (a `/32` for IPv4, a
+    `/128` for IPv6) -- what "the maintainer IP only" actually means.
+    `admin_cidr`'s terraform validation only rejects `0.0.0.0/0`, so this
+    cannot be assumed from the variable's description or its name.
+    """
+    try:
+        return ipaddress.ip_network(cidr, strict=False).num_addresses == 1
+    except ValueError:
+        return False
+
+
 def evaluate_ssh_exposure(permissions: list[dict]) -> list[Finding]:
     """Port 22 ingress. See issue #32.
 
@@ -226,13 +254,28 @@ def evaluate_ssh_exposure(permissions: list[dict]) -> list[Finding]:
                         f"port 22 open to {block} — the box holds production PII",
                     )
                 )
-            elif description == MAINTAINER_SSH_DESCRIPTION:
+            elif description == MAINTAINER_SSH_DESCRIPTION and _is_single_host(block):
                 findings.append(
                     Finding(
                         "network",
                         "ssh exposure",
                         OK,
                         f"port 22 open to {block} ({description}) — standing maintainer access",
+                    )
+                )
+            elif description == MAINTAINER_SSH_DESCRIPTION:
+                # Carries the admin rule's description but is not a single
+                # host -- admin_cidr's terraform validation only rejects
+                # 0.0.0.0/0, so this is not hypothetical. Trusting the label
+                # here would bless SSH from the whole block.
+                findings.append(
+                    Finding(
+                        "network",
+                        "ssh exposure",
+                        WARN,
+                        f"port 22 open to {block} ({description}) — labeled as the "
+                        "maintainer rule but not a single host; check admin_cidr in "
+                        "deploy/terraform",
                     )
                 )
             else:
@@ -274,11 +317,19 @@ def evaluate_disk(free_gib: Optional[float]) -> Finding:
 
 
 def evaluate_containers(
-    running: Optional[list[str]], unhealthy: Optional[frozenset[str]] = None
+    running: Optional[list[str]],
+    unhealthy: Optional[frozenset[str]] = None,
+    starting: Optional[frozenset[str]] = None,
 ) -> list[Finding]:
     """``unhealthy`` are containers Docker itself has marked failing their
     HEALTHCHECK (oltp/api/frontend all define one) despite still running --
-    distinct from ``running`` not containing the name at all (stopped)."""
+    distinct from ``running`` not containing the name at all (stopped).
+    ``starting`` are containers still inside their HEALTHCHECK's
+    ``start_period`` (Docker's `(health: starting)`, e.g. the api's
+    multi-minute model warm-up) -- not yet *confirmed* healthy, so `make
+    infra` running mid-warm-up must not call that OK either, even though it
+    is an expected, transient state rather than a failure.
+    """
     if running is None:
         return [Finding("box", "stack", INFO, "not checked")]
     if not running:
@@ -301,6 +352,7 @@ def evaluate_containers(
             )
         ]
     unhealthy = unhealthy or frozenset()
+    starting = starting or frozenset()
     findings = []
     for name in STACK_CONTAINERS:
         if name not in running:
@@ -308,6 +360,10 @@ def evaluate_containers(
         elif name in unhealthy:
             findings.append(
                 Finding("box", name, CRIT, "running but failing its HEALTHCHECK")
+            )
+        elif name in starting:
+            findings.append(
+                Finding("box", name, WARN, "running, HEALTHCHECK still starting (warm-up)")
             )
         else:
             findings.append(Finding("box", name, OK, "running"))
@@ -423,7 +479,15 @@ def _aws_json(args: list[str], region: str) -> Optional[dict]:
 def collect_instances(
     tag_names: dict[str, str], region: str
 ) -> Optional[dict[str, Optional[dict]]]:
-    """None means the `describe-instances` call itself failed (credentials,
+    """`tag_names` maps a report label to the exact `Name` tag to match (see
+    `INSTANCE_NAME_TAGS`) -- an instance must also carry
+    `Project=PROJECT_TAG_VALUE` to qualify, so an unrelated instance sharing
+    part of the name (or the name outright, in a shared account) cannot stand
+    in for a missing production box. An exact match also means at most one
+    instance can satisfy a given label, so there is no "later matches
+    overwrite earlier ones" ambiguity left to depend on response order for.
+
+    None means the `describe-instances` call itself failed (credentials,
     region, IAM, network) -- distinct from a successful call that simply found
     no matching instance. Conflating the two turns "AWS is unreachable" into
     "the box is gone", which is a false production alarm, not a status check.
@@ -437,9 +501,11 @@ def collect_instances(
             if instance.get("State", {}).get("Name") == "terminated":
                 continue
             tags = {t["Key"]: t["Value"] for t in instance.get("Tags", [])}
+            if tags.get("Project") != PROJECT_TAG_VALUE:
+                continue
             name = tags.get("Name", "")
             for label, wanted in tag_names.items():
-                if wanted in name:
+                if name == wanted:
                     found[label] = instance
     return found
 
@@ -476,21 +542,27 @@ def collect_backup(region: str) -> Optional[tuple[Optional[str], Optional[int]]]
     return newest["LastModified"], newest.get("Size")
 
 
-def collect_box(
-    host: str,
-) -> tuple[Optional[float], Optional[list[str]], Optional[frozenset[str]]]:
-    """Disk free (GiB), running janasunani containers, and which of those
-    Docker itself considers unhealthy, over SSH.
+def collect_box(host: str) -> tuple[
+    Optional[float],
+    Optional[list[str]],
+    Optional[frozenset[str]],
+    Optional[frozenset[str]],
+]:
+    """Disk free (GiB), running janasunani containers, which of those Docker
+    considers unhealthy, and which are still inside their HEALTHCHECK's
+    start_period, over SSH.
 
     `docker ps` (no `-a`) already excludes exited containers, so a stopped
     container correctly falls out of the `containers` list. The gap this
     closes is the other direction: a container that is running but whose
     HEALTHCHECK (oltp/api/frontend all define one, deploy/docker-compose.yml)
-    is failing -- `docker ps --format '{{.Names}}'` alone can't distinguish
-    that from a genuinely healthy one, so a name-only list still says OK.
+    is failing, or has not finished its `start_period` yet (Docker's
+    `(health: starting)` -- the api's warm-up can take minutes) -- a
+    name-only list can't distinguish either from a genuinely healthy one, so
+    it still says OK.
     """
     if shutil.which("ssh") is None:
-        return None, None, None
+        return None, None, None, None
     ssh = ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=10", host]
 
     free_gib = None
@@ -500,10 +572,12 @@ def collect_box(
 
     containers = None
     unhealthy = None
+    starting = None
     raw = _run([*ssh, "docker ps --format '{{.Names}}\t{{.Status}}'"], timeout=30)
     if raw is not None:
         containers = []
         unhealthy_set = set()
+        starting_set = set()
         for line in raw.splitlines():
             name, _, status = line.strip().partition("\t")
             if not name.startswith("janasunani"):
@@ -511,8 +585,11 @@ def collect_box(
             containers.append(name)
             if "(unhealthy)" in status:
                 unhealthy_set.add(name)
+            elif "(health: starting)" in status:
+                starting_set.add(name)
         unhealthy = frozenset(unhealthy_set)
-    return free_gib, containers, unhealthy
+        starting = frozenset(starting_set)
+    return free_gib, containers, unhealthy, starting
 
 
 def collect_health(site: Optional[str]) -> tuple[Optional[dict], Optional[str]]:
@@ -600,7 +677,7 @@ def main() -> int:
     elif shutil.which("aws") is None:
         report.add("compute", "aws", INFO, "aws CLI not installed — AWS checks skipped")
     else:
-        instances = collect_instances({"cpu box": "cpu", "gpu box": "gpu"}, args.region)
+        instances = collect_instances(INSTANCE_NAME_TAGS, args.region)
         if instances is None:
             report.add(
                 "compute",
@@ -653,12 +730,12 @@ def main() -> int:
     if args.no_ssh:
         report.add("box", "ssh", INFO, "skipped (--no-ssh)")
     else:
-        free_gib, containers, unhealthy = collect_box(args.host)
+        free_gib, containers, unhealthy, starting = collect_box(args.host)
         if free_gib is None and containers is None:
             report.add("box", "ssh", INFO, f"{args.host} unreachable — box checks skipped")
         else:
             report.findings.append(evaluate_disk(free_gib))
-            report.findings.extend(evaluate_containers(containers, unhealthy))
+            report.findings.extend(evaluate_containers(containers, unhealthy, starting))
 
     payload, error = collect_health(args.site)
     if args.site:

--- a/scripts/infra_status.py
+++ b/scripts/infra_status.py
@@ -384,10 +384,17 @@ def render(report: Report) -> str:
     elif counts[WARN]:
         lines.append(f"no critical issues, {counts[WARN]} warning{skipped}")
     elif checked == 0:
-        # Never say "all clear" when nothing ran. Unreachable AWS, an
-        # unreachable box and --no-aws --no-ssh all land here, and reading that
-        # as healthy is the exact mistake this tool exists to prevent.
+        # Must precede the partial-pass branch below: with nothing checked,
+        # every finding is INFO and this would otherwise read "all clear on 0
+        # checks". Unreachable AWS, an unreachable box and --no-aws --no-ssh
+        # all land here, and reading that as healthy is the exact mistake this
+        # tool exists to prevent.
         lines.append("NOTHING CHECKED — this is not a clean bill of health")
+    elif counts[INFO]:
+        lines.append(
+            f"all clear on {checked} checks, but {counts[INFO]} were not run — "
+            "see the '--' lines above"
+        )
     else:
         lines.append(f"all clear ({checked} checks){skipped}")
     return "\n".join(lines)

--- a/scripts/infra_status.py
+++ b/scripts/infra_status.py
@@ -50,6 +50,12 @@ from typing import Any, Optional
 
 BACKUP_BUCKET = "grievance-database-backups-main"
 BACKUP_PREFIX = "janasunani/"
+# deploy/terraform/variables.tf's aws_region default, also config.py's
+# Settings.AWS_REGION default. Pinned explicitly on every `aws` call rather
+# than left to the caller's default CLI profile/region: a profile pointed
+# elsewhere gets a successful, empty response, not an error, and that reads
+# as "the box is gone" (see collect_instances).
+AWS_REGION_DEFAULT = "ap-south-1"
 # deploy.sh: min_free_kib="${MIN_FREE_KIB:-$((20 * 1024 * 1024))}"
 DISK_CRIT_GIB = 20
 DISK_WARN_GIB = 40
@@ -62,6 +68,17 @@ STACK_CONTAINERS = (
     "janasunani-frontend",
     "janasunani-proxy",
 )
+# docs/DEPLOY.md's documented first-time state: only the oltp container up
+# (`up -d oltp`, deploy/docker-compose.yml: container_name janasunani-oltp),
+# before the app images are deployed at all.
+PRE_DEPLOY_CONTAINERS = frozenset({"janasunani-oltp"})
+# deploy/terraform/main.tf: the cpu_box security group's standing ingress
+# rule, `description = "SSH from the maintainer IP only"`. Terraform attaches
+# an ingress block's `description` to that CIDR's entry in the resulting
+# IpPermission, so a rule carrying this exact text is the intended permanent
+# access, not a leftover deploy-runner /32 (issue #32) -- distinguished here
+# so a healthy box can still render all clear.
+MAINTAINER_SSH_DESCRIPTION = "SSH from the maintainer IP only"
 
 OK, WARN, CRIT, INFO = "OK", "WARN", "CRIT", "INFO"
 _RANK = {OK: 0, INFO: 0, WARN: 1, CRIT: 2}
@@ -85,12 +102,33 @@ class Report:
     @property
     def worst(self) -> str:
         """Highest severity present. INFO ranks with OK: "not checked" is not a
-        problem, it is an absence of one, and must not read as degraded."""
+        problem, it is an absence of one, and must not read as degraded.
+
+        This is deliberately blind to *how many* checks ran (a cron job must
+        not fail just because some checks were skipped) -- `nothing_checked`
+        below is the separate signal for "no real check happened here"."""
         rank = max((_RANK[f.status] for f in self.findings), default=0)
         return {0: OK, 1: WARN, 2: CRIT}[rank]
 
     def exit_code(self) -> int:
         return 1 if self.worst == CRIT else 0
+
+    @property
+    def checked_count(self) -> int:
+        return sum(1 for f in self.findings if f.status != INFO)
+
+    @property
+    def skipped_count(self) -> int:
+        return sum(1 for f in self.findings if f.status == INFO)
+
+    @property
+    def nothing_checked(self) -> bool:
+        """True iff every finding is INFO -- `--no-aws --no-ssh`, an
+        unreachable box, or unreachable AWS all land here. `worst` alone
+        reads `OK` in this case (by design, see above), so a machine
+        consumer of `--json` needs this to avoid the exact false-all-clear
+        the text renderer's `NOTHING CHECKED` line exists to prevent."""
+        return self.checked_count == 0
 
 
 # --- evaluation (pure; this is what the tests drive) -------------------------
@@ -128,19 +166,51 @@ def evaluate_instance(name: str, instance: Optional[dict], *, always_on: bool) -
     return Finding(section, name, OK, f"{state} ({itype})")
 
 
+def _rule_covers_ssh(rule: dict) -> bool:
+    """Whether an IpPermission's protocol/port coverage includes TCP/22.
+
+    Two ways a rule can expose 22 without literally saying `FromPort: 22`:
+    `IpProtocol: "-1"` is AWS's "all protocols, all ports" wildcard (no
+    meaningful FromPort/ToPort), and a real TCP rule specifies an *inclusive
+    range* -- `FromPort=0, ToPort=65535` covers 22 exactly as much as
+    `FromPort=22, ToPort=22` does. Missing either means a wide-open box scores
+    the same as a locked-down one.
+    """
+    protocol = rule.get("IpProtocol")
+    if protocol in ("-1", -1):
+        return True
+    if protocol not in ("tcp", 6, "6"):
+        return False
+    from_port = rule.get("FromPort")
+    to_port = rule.get("ToPort")
+    if from_port is None or to_port is None:
+        return False
+    return from_port <= 22 <= to_port
+
+
 def evaluate_ssh_exposure(permissions: list[dict]) -> list[Finding]:
     """Port 22 ingress. See issue #32.
 
-    A deploy authorizes 22 to the runner's /32 and revokes it afterwards. A
-    leftover rule means a runner died mid-deploy; an open-to-the-world rule
-    means something is badly wrong.
+    Checks both `IpRanges` (IPv4) and `Ipv6Ranges` (IPv6) — an IPv6-only
+    source is exposure this tool would otherwise never see. The standing
+    maintainer rule (`MAINTAINER_SSH_DESCRIPTION`) is recognized as intended
+    access, not a leftover; anything else is either a deploy authorizing 22 to
+    the runner's /32 (expected only for the duration of that deploy, revoked
+    after — a leftover means a runner died mid-deploy) or, open to the world,
+    something badly wrong.
     """
     findings: list[Finding] = []
     for rule in permissions:
-        if rule.get("FromPort") != 22:
+        if not _rule_covers_ssh(rule):
             continue
-        for cidr in rule.get("IpRanges", []):
-            block = cidr.get("CidrIp", "?")
+        sources = [
+            (cidr.get("CidrIp", "?"), cidr.get("Description"))
+            for cidr in rule.get("IpRanges", [])
+        ] + [
+            (cidr.get("CidrIpv6", "?"), cidr.get("Description"))
+            for cidr in rule.get("Ipv6Ranges", [])
+        ]
+        for block, description in sources:
             if block in ("0.0.0.0/0", "::/0"):
                 findings.append(
                     Finding(
@@ -150,6 +220,15 @@ def evaluate_ssh_exposure(permissions: list[dict]) -> list[Finding]:
                         f"port 22 open to {block} — the box holds production PII",
                     )
                 )
+            elif description == MAINTAINER_SSH_DESCRIPTION:
+                findings.append(
+                    Finding(
+                        "network",
+                        "ssh exposure",
+                        OK,
+                        f"port 22 open to {block} ({description}) — standing maintainer access",
+                    )
+                )
             else:
                 findings.append(
                     Finding(
@@ -157,7 +236,7 @@ def evaluate_ssh_exposure(permissions: list[dict]) -> list[Finding]:
                         "ssh exposure",
                         WARN,
                         f"port 22 open to {block}"
-                        f"{' (' + cidr['Description'] + ')' if cidr.get('Description') else ''}"
+                        f"{f' ({description})' if description else ''}"
                         " — expected only during a deploy; a leftover rule is issue #32",
                     )
                 )
@@ -195,6 +274,19 @@ def evaluate_containers(running: Optional[list[str]]) -> list[Finding]:
         return [
             Finding(
                 "box", "stack", INFO, "no janasunani containers — stack not deployed yet"
+            )
+        ]
+    if set(running) == PRE_DEPLOY_CONTAINERS:
+        # docs/DEPLOY.md's documented first-time bring-up: oltp only, up
+        # before the app images are ever deployed. Scoring that against the
+        # full STACK_CONTAINERS list below would CRIT three containers
+        # nothing has tried to start yet, on every fresh box.
+        return [
+            Finding(
+                "box",
+                "stack",
+                INFO,
+                "only oltp up — app stack (api/frontend/proxy) not deployed yet",
             )
         ]
     findings = []
@@ -273,8 +365,12 @@ def _run(command: list[str], timeout: int = 30) -> Optional[str]:
     return proc.stdout if proc.returncode == 0 else None
 
 
-def _aws_json(args: list[str]) -> Optional[dict]:
-    raw = _run(["aws", *args, "--output", "json"], timeout=60)
+def _aws_json(args: list[str], region: str) -> Optional[dict]:
+    # Pinned rather than left to the caller's default profile/region
+    # (AWS_REGION_DEFAULT below): an operator whose default profile points
+    # elsewhere gets a *successful, empty* describe-instances response, which
+    # is indistinguishable from the box actually being gone.
+    raw = _run(["aws", *args, "--region", region, "--output", "json"], timeout=60)
     if raw is None:
         return None
     try:
@@ -283,11 +379,18 @@ def _aws_json(args: list[str]) -> Optional[dict]:
         return None
 
 
-def collect_instances(tag_names: dict[str, str]) -> dict[str, Optional[dict]]:
-    found: dict[str, Optional[dict]] = {label: None for label in tag_names}
-    payload = _aws_json(["ec2", "describe-instances"])
+def collect_instances(
+    tag_names: dict[str, str], region: str
+) -> Optional[dict[str, Optional[dict]]]:
+    """None means the `describe-instances` call itself failed (credentials,
+    region, IAM, network) -- distinct from a successful call that simply found
+    no matching instance. Conflating the two turns "AWS is unreachable" into
+    "the box is gone", which is a false production alarm, not a status check.
+    """
+    payload = _aws_json(["ec2", "describe-instances"], region)
     if payload is None:
-        return found
+        return None
+    found: dict[str, Optional[dict]] = {label: None for label in tag_names}
     for reservation in payload.get("Reservations", []):
         for instance in reservation.get("Instances", []):
             if instance.get("State", {}).get("Name") == "terminated":
@@ -300,16 +403,19 @@ def collect_instances(tag_names: dict[str, str]) -> dict[str, Optional[dict]]:
     return found
 
 
-def collect_security_group(group_id: Optional[str]) -> Optional[list[dict]]:
+def collect_security_group(group_id: Optional[str], region: str) -> Optional[list[dict]]:
     if not group_id:
         return None
-    payload = _aws_json(["ec2", "describe-security-groups", "--group-ids", group_id])
+    payload = _aws_json(["ec2", "describe-security-groups", "--group-ids", group_id], region)
     if not payload or not payload.get("SecurityGroups"):
         return None
     return payload["SecurityGroups"][0].get("IpPermissions", [])
 
 
-def collect_backup() -> tuple[Optional[str], Optional[int]]:
+def collect_backup(region: str) -> Optional[tuple[Optional[str], Optional[int]]]:
+    """Outer None means `list-objects-v2` itself failed; ``(None, None)``
+    means it succeeded and found nothing under the backup prefix -- the two
+    read very differently (see `collect_instances`)."""
     payload = _aws_json(
         [
             "s3api",
@@ -318,9 +424,12 @@ def collect_backup() -> tuple[Optional[str], Optional[int]]:
             BACKUP_BUCKET,
             "--prefix",
             BACKUP_PREFIX,
-        ]
+        ],
+        region,
     )
-    if not payload or not payload.get("Contents"):
+    if payload is None:
+        return None
+    if not payload.get("Contents"):
         return None, None
     newest = max(payload["Contents"], key=lambda o: o["LastModified"])
     return newest["LastModified"], newest.get("Size")
@@ -376,14 +485,14 @@ def render(report: Report) -> str:
         level: sum(1 for f in report.findings if f.status == level)
         for level in (CRIT, WARN, INFO)
     }
-    checked = len(report.findings) - counts[INFO]
+    checked = report.checked_count
     skipped = f" ({counts[INFO]} not checked)" if counts[INFO] else ""
 
     if counts[CRIT]:
         lines.append(f"{counts[CRIT]} critical, {counts[WARN]} warning{skipped}")
     elif counts[WARN]:
         lines.append(f"no critical issues, {counts[WARN]} warning{skipped}")
-    elif checked == 0:
+    elif report.nothing_checked:
         # Must precede the partial-pass branch below: with nothing checked,
         # every finding is INFO and this would otherwise read "all clear on 0
         # checks". Unreachable AWS, an unreachable box and --no-aws --no-ssh
@@ -410,6 +519,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--site", default=None, help="Public site for the health check (e.g. 52-66-116-80.nip.io)."
     )
     parser.add_argument("--sg-id", default=None, help="CPU box security group id.")
+    parser.add_argument(
+        "--region",
+        default=AWS_REGION_DEFAULT,
+        help=f"AWS region for every query (default: {AWS_REGION_DEFAULT}, matching "
+        "deploy/terraform).",
+    )
     parser.add_argument("--no-ssh", action="store_true", help="Skip the box-side checks.")
     parser.add_argument("--no-aws", action="store_true", help="Skip the AWS API checks.")
     parser.add_argument("--json", action="store_true", help="Emit JSON instead of text.")
@@ -425,16 +540,24 @@ def main() -> int:
     elif shutil.which("aws") is None:
         report.add("compute", "aws", INFO, "aws CLI not installed — AWS checks skipped")
     else:
-        instances = collect_instances({"cpu box": "cpu", "gpu box": "gpu"})
-        report.findings.append(
-            evaluate_instance("cpu box", instances["cpu box"], always_on=True)
-        )
-        report.findings.append(
-            evaluate_instance("gpu box", instances["gpu box"], always_on=False)
-        )
+        instances = collect_instances({"cpu box": "cpu", "gpu box": "gpu"}, args.region)
+        if instances is None:
+            report.add(
+                "compute",
+                "aws",
+                INFO,
+                f"describe-instances failed (region={args.region}; check credentials/IAM/"
+                "network) — not checked",
+            )
+        else:
+            report.findings.append(
+                evaluate_instance("cpu box", instances["cpu box"], always_on=True)
+            )
+            report.findings.append(
+                evaluate_instance("gpu box", instances["gpu box"], always_on=False)
+            )
 
-        permissions = collect_security_group(args.sg_id)
-        if permissions is None:
+        if not args.sg_id:
             report.add(
                 "network",
                 "ssh exposure",
@@ -442,10 +565,30 @@ def main() -> int:
                 "not checked (pass --sg-id, from `terraform output cpu_box_security_group_id`)",
             )
         else:
-            report.findings.extend(evaluate_ssh_exposure(permissions))
+            permissions = collect_security_group(args.sg_id, args.region)
+            if permissions is None:
+                report.add(
+                    "network",
+                    "ssh exposure",
+                    INFO,
+                    f"describe-security-groups for {args.sg_id} failed (region={args.region}) "
+                    "— not checked",
+                )
+            else:
+                report.findings.extend(evaluate_ssh_exposure(permissions))
 
-        last_modified, size = collect_backup()
-        report.findings.append(evaluate_backup(last_modified, size))
+        backup = collect_backup(args.region)
+        if backup is None:
+            report.add(
+                "backups",
+                "pg_dump",
+                INFO,
+                f"list-objects-v2 failed (region={args.region}; check credentials/network) "
+                "— not checked",
+            )
+        else:
+            last_modified, size = backup
+            report.findings.append(evaluate_backup(last_modified, size))
 
     if args.no_ssh:
         report.add("box", "ssh", INFO, "skipped (--no-ssh)")
@@ -468,6 +611,13 @@ def main() -> int:
             json.dumps(
                 {
                     "worst": report.worst,
+                    # `worst` alone can read "OK" when nothing was actually
+                    # checked (--no-aws --no-ssh, unreachable AWS/box) --
+                    # deliberately, see Report.worst -- so a machine consumer
+                    # needs this to not treat a fully-skipped run as healthy.
+                    "nothing_checked": report.nothing_checked,
+                    "checked": report.checked_count,
+                    "skipped": report.skipped_count,
                     "findings": [vars(f) for f in report.findings],
                 },
                 indent=2,

--- a/scripts/infra_status.py
+++ b/scripts/infra_status.py
@@ -62,6 +62,12 @@ DISK_WARN_GIB = 40
 # nightly cadence, so one missed run is a warning and two is a failure
 BACKUP_WARN_HOURS = 26
 BACKUP_CRIT_HOURS = 48
+# Not a target size -- just a floor low enough that only a truly empty or
+# near-empty object (a 0-byte or header-only upload after a failed `pg_dump`)
+# can fail it. The prod DB holds 1.37M complaints / 6.56M action-history rows
+# (docs/ROADMAP.md); a real dump, even compressed, is orders of magnitude
+# above this, so there is no meaningful risk of flagging a genuine backup.
+BACKUP_MIN_SIZE_BYTES = 1024 * 1024  # 1 MiB
 STACK_CONTAINERS = (
     "janasunani-oltp",
     "janasunani-api",
@@ -311,8 +317,19 @@ def evaluate_backup(last_modified: Optional[str], size_bytes: Optional[int]) -> 
     hours = _hours_since(last_modified)
     if hours is None:
         return Finding("backups", "pg_dump", WARN, f"unparseable timestamp {last_modified!r}")
-    size = f", {size_bytes / 1e9:.2f} GB" if size_bytes else ""
+    size = f", {size_bytes / 1e9:.2f} GB" if size_bytes is not None else ""
     detail = f"newest {hours:.1f}h old{size}"
+    if size_bytes is not None and size_bytes < BACKUP_MIN_SIZE_BYTES:
+        # Fresh but empty is worse than stale: a 0-byte object after a failed
+        # dump-and-upload masks the last *good* backup and would otherwise
+        # read as healthy on freshness alone.
+        return Finding(
+            "backups",
+            "pg_dump",
+            CRIT,
+            detail + f" — under {BACKUP_MIN_SIZE_BYTES:,} bytes, looks like a failed "
+            "dump, not a restorable backup",
+        )
     if hours > BACKUP_CRIT_HOURS:
         return Finding("backups", "pg_dump", CRIT, detail + " — two nightly runs missed")
     if hours > BACKUP_WARN_HOURS:
@@ -323,14 +340,22 @@ def evaluate_backup(last_modified: Optional[str], size_bytes: Optional[int]) -> 
 def evaluate_health(payload: Optional[dict], error: Optional[str]) -> Finding:
     """`GET /api/health`, which the Caddyfile exempts from basic_auth.
 
-    A `mock` processor here means the site is serving canned results: healthy,
-    responsive, and not the real pipeline.
+    Only `processor="pipeline"` (`PipelineGrievanceProcessor.name`) is OK --
+    matching `deploy.sh`'s own smoke gate, which greps for that exact string
+    and would still be waiting on anything else. `mock`
+    (`MockGrievanceProcessor.name`) is the one other value the codebase can
+    actually produce: healthy and responsive, but serving canned results.
+    Anything besides those two -- missing, malformed, or a value neither
+    processor uses -- is not something the deploy would ever consider ready,
+    so it is not OK either.
     """
     if error:
         return Finding("demo", "health", CRIT, error)
     if not payload:
         return Finding("demo", "health", INFO, "not checked")
     processor = payload.get("processor", "?")
+    if processor == "pipeline":
+        return Finding("demo", "health", OK, f"up, processor={processor}")
     if processor == "mock":
         return Finding(
             "demo",
@@ -338,7 +363,13 @@ def evaluate_health(payload: Optional[dict], error: Optional[str]) -> Finding:
             WARN,
             "up, but processor=mock — serving canned results, not the real pipeline",
         )
-    return Finding("demo", "health", OK, f"up, processor={processor}")
+    return Finding(
+        "demo",
+        "health",
+        WARN,
+        f"up, but processor={processor!r} — not the expected pipeline "
+        "(deploy.sh's own smoke gate would still be waiting on this)",
+    )
 
 
 def _hours_since(timestamp: Any) -> Optional[float]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,5 +10,70 @@ classifier) before spaCy (PII), which does not crash.
 import os
 import sys
 
+import pytest
+
 if sys.platform == "darwin":
     os.environ.setdefault("OMP_NUM_THREADS", "1")
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers",
+        "real_oltp_probe: exempt this test from the autouse "
+        "_no_ambient_oltp_probe neutralization below, for tests that "
+        "genuinely exercise the real _probe_oltp_connection (#119)",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_oltp_probe(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch):
+    """Neutralizes `janasunani.inference.service._probe_oltp_connection` for
+    every test, so `preflight()` never opens a real database connection.
+
+    `_oltp_check()` (aab4d8e/c97bdb6) calls the real, timeout-bounded
+    `_probe_oltp_connection` whenever `OLTP_DB_URL` resolves to something
+    explicit -- a shell-exported env var, or a root `.env` via `Settings`.
+    That live probe is the CLI's intended behavior (`janasunani-demo-
+    preflight`), not pytest's: AGENTS.md/tests/README.md are explicit that
+    this suite must never point at production Postgres, and most tests that
+    call `preflight()` are exercising something unrelated (model artifacts,
+    OCR binaries) and never stub the probe themselves. The probe is
+    read-only, so this is not the table-dropping hazard those docs warn
+    about elsewhere -- the actual problem is narrower: a routine `pytest`
+    run silently following whatever `OLTP_DB_URL` a developer's own `.env`
+    happens to name, connecting to it (or eating the 5s timeout) for tests
+    that have nothing to do with OLTP, with no signal that it happened.
+
+    Autouse, here in the top-level conftest, rather than patched only at
+    today's call sites: a new test written next month that calls
+    `preflight()` inherits this by construction, without needing to know to
+    stub the probe itself. `test_preflight_never_opens_a_real_connection_
+    even_with_ambient_oltp_db_url` (tests/test_inference_live_builder.py)
+    proves this holds even when OLTP_DB_URL is set in the environment.
+
+    Tests that genuinely want the real `_probe_oltp_connection` -- its own
+    direct tests, exercising a throwaway sqlite file or a deliberately
+    refused loopback connection -- opt out with `@pytest.mark.real_oltp_probe`.
+    A test's own explicit `monkeypatch.setattr(service,
+    "_probe_oltp_connection", ...)` for a specific fake outcome (success or
+    a chosen failure) does not need the marker: it runs after this fixture's
+    setup and overrides it the same way any later `monkeypatch.setattr` call
+    on the same target does.
+    """
+    if request.node.get_closest_marker("real_oltp_probe"):
+        yield
+        return
+    try:
+        from janasunani.inference import service
+    except Exception:
+        # service (or an optional dependency of it) is not importable in
+        # this test environment -- nothing to neutralize, and nothing that
+        # could reach a real database either.
+        yield
+        return
+    monkeypatch.setattr(
+        service,
+        "_probe_oltp_connection",
+        lambda url, timeout=service._OLTP_PROBE_TIMEOUT_S: None,
+    )
+    yield

--- a/tests/test_deploy_stack.py
+++ b/tests/test_deploy_stack.py
@@ -731,6 +731,27 @@ def test_caddyfile_deployed_snapshot_is_gitignored_and_versioned():
     assert rollback_fn_start < caddyfile_restore < tag_decision
 
 
+def test_deploy_doc_preflight_uses_the_host_visible_oltp_dsn():
+    """The strict-preflight command in docs/DEPLOY.md's box bring-up runs on
+    the host, not inside a container, so it needs the 127.0.0.1:5432 form
+    the oltp service publishes to the host (its own ports comment says so)
+    -- not the oltp:5432 compose-internal hostname the api container's own
+    OLTP_DB_URL uses, which only the compose network resolves. Codex review
+    on #88: following the doc as written pointed the new strict connectivity
+    probe (#88, _oltp_check) at a hostname the host can't reach, failing
+    against an otherwise-healthy database."""
+    doc_text = DEPLOY_DOC_PATH.read_text()
+    anchor = doc_text.index("Verify the box before the first deploy")
+    fence_start = doc_text.index("```bash", anchor)
+    fence_end = doc_text.index("```", fence_start + len("```bash"))
+    command_block = doc_text[fence_start:fence_end]
+    assert "127.0.0.1:5432" in command_block
+    assert "oltp:5432" not in command_block
+
+    api_dsn = _compose()["services"]["api"]["environment"]["OLTP_DB_URL"]
+    assert "oltp:5432" in api_dsn, "sanity: the compose-internal DSN really is oltp:5432"
+
+
 def test_migration_policy_is_documented():
     """A rollback re-deploys the previous image unchanged and never runs
     `alembic downgrade` -- every migration must be expand-only/backward-

--- a/tests/test_inference_live_builder.py
+++ b/tests/test_inference_live_builder.py
@@ -13,8 +13,10 @@ pytest.importorskip("pytesseract")
 
 import pytesseract  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
+from sqlalchemy import create_engine  # noqa: E402
 
 from janasunani.config import Settings  # noqa: E402
+from janasunani.db.models import Base  # noqa: E402
 from janasunani.inference import serve  # noqa: E402
 from janasunani.inference import service  # noqa: E402
 from janasunani.inference.service import (  # noqa: E402
@@ -654,7 +656,8 @@ def test_preflight_verifies_oltp_connectivity_not_just_presence(tmp_path, monkey
     monkeypatch.setattr(service, "_probe_oltp_connection", lambda url, timeout=5.0: None)
     check = _advisory(preflight(tmp_path), "oltp store")
     assert check.ok is True
-    assert "connection verified" in check.detail
+    assert "live_grievances" in check.detail
+    assert "verified" in check.detail
 
 
 def test_preflight_flags_an_explicit_but_unreachable_oltp(tmp_path, monkeypatch):
@@ -703,12 +706,36 @@ def test_preflight_never_leaks_the_oltp_url_on_connection_failure(tmp_path, monk
     assert secret not in check.detail
 
 
-def test_probe_oltp_connection_succeeds_against_a_real_sqlite_db(tmp_path):
+def _sqlite_url_with_live_grievances(tmp_path) -> str:
+    """A throwaway sqlite file with the real schema (Base.metadata, same as
+    tests/test_serving_persistence.py's _make_oltp) -- test setup, not an
+    Alembic migration; no migration is authored or run anywhere in this
+    file."""
+    url = f"sqlite+aiosqlite:///{tmp_path}/probe.db"
+    sync = create_engine(url.replace("+aiosqlite", ""))
+    Base.metadata.create_all(sync)
+    sync.dispose()
+    return url
+
+
+def test_probe_oltp_connection_succeeds_when_live_grievances_exists(tmp_path):
     """Exercises the real probe (not the preflight wiring above, which stubs
-    it) against an actual database, so the SELECT 1 round trip is proven to
-    work end to end without needing network or a real Postgres."""
-    db_path = tmp_path / "probe.db"
-    service._probe_oltp_connection(f"sqlite+aiosqlite:///{db_path}")
+    it) against an actual database with the real schema, so both the
+    SELECT 1 round trip and the live_grievances existence check are proven
+    to work end to end without needing network or a real Postgres."""
+    service._probe_oltp_connection(_sqlite_url_with_live_grievances(tmp_path))
+
+
+def test_probe_oltp_connection_raises_when_live_grievances_is_missing(tmp_path):
+    """A reachable database whose Alembic migration never ran must fail this
+    probe, not just a connection failure -- otherwise --strict passes clean
+    and the first real DatabaseResultStore.save() is what discovers the
+    missing table, against a citizen's actual submission. Codex re-review on
+    #88; deliberately existence-only (SELECT ... LIMIT 0), no migration is
+    run or authored here."""
+    db_path = tmp_path / "empty.db"  # no Base.metadata.create_all -- no tables at all
+    with pytest.raises(Exception):
+        service._probe_oltp_connection(f"sqlite+aiosqlite:///{db_path}")
 
 
 def test_probe_oltp_connection_raises_for_an_unreachable_target():

--- a/tests/test_inference_live_builder.py
+++ b/tests/test_inference_live_builder.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from pathlib import Path
 
 import pytest
@@ -706,6 +707,42 @@ def test_preflight_never_leaks_the_oltp_url_on_connection_failure(tmp_path, monk
     assert secret not in check.detail
 
 
+def test_preflight_never_opens_a_real_connection_even_with_ambient_oltp_db_url(
+    tmp_path, monkeypatch
+):
+    """#119: preflight() must not silently follow whatever OLTP_DB_URL the
+    ambient environment (a shell-exported var, or a root .env via Settings)
+    happens to name. AGENTS.md/tests/README.md are explicit pytest must
+    never point at production Postgres; the live probe added in aab4d8e/
+    c97bdb6 is read-only, so this is not that table-dropping hazard, but a
+    routine `pytest` run should still never attempt to reach whatever
+    database a developer's own .env happens to configure, silently, while
+    testing something unrelated.
+
+    Deliberately does NOT stub `resolve_explicit_oltp_url` or
+    `_probe_oltp_connection` itself -- doing either would test this file's
+    own mocking, not whether the autouse `_no_ambient_oltp_probe` fixture in
+    conftest.py actually neutralizes the real code path. Sets OLTP_DB_URL to
+    a host confirmed (empirically, in this environment) to hang rather than
+    fail fast, so a real connection attempt would consume the probe's own
+    5s internal timeout (_OLTP_PROBE_TIMEOUT_S) -- comfortably distinguishing
+    "the neutralized probe returned instantly" from "a real attempt was
+    made" without depending on exactly how a given network path fails.
+    """
+    monkeypatch.setenv(
+        "OLTP_DB_URL", "postgresql+asyncpg://nope:nope@10.255.255.1:5432/nope"
+    )
+    started = time.monotonic()
+    checks = preflight(tmp_path)
+    elapsed = time.monotonic() - started
+    check = _advisory(checks, "oltp store")
+    assert check.ok is True, "the neutralized probe should report success, not attempt IO"
+    assert elapsed < 2.0, (
+        f"preflight() took {elapsed:.1f}s -- long enough to suggest a real "
+        "connection was attempted despite the autouse neutralization"
+    )
+
+
 def _sqlite_url_with_live_grievances(tmp_path) -> str:
     """A throwaway sqlite file with the real schema (Base.metadata, same as
     tests/test_serving_persistence.py's _make_oltp) -- test setup, not an
@@ -718,14 +755,21 @@ def _sqlite_url_with_live_grievances(tmp_path) -> str:
     return url
 
 
+@pytest.mark.real_oltp_probe
 def test_probe_oltp_connection_succeeds_when_live_grievances_exists(tmp_path):
     """Exercises the real probe (not the preflight wiring above, which stubs
     it) against an actual database with the real schema, so both the
     SELECT 1 round trip and the live_grievances existence check are proven
-    to work end to end without needing network or a real Postgres."""
+    to work end to end without needing network or a real Postgres.
+
+    Marked real_oltp_probe (#119) to opt out of conftest.py's autouse
+    neutralization of `service._probe_oltp_connection` -- this test's entire
+    point is calling the real implementation, against a throwaway sqlite
+    file it builds itself, never a real/ambient database."""
     service._probe_oltp_connection(_sqlite_url_with_live_grievances(tmp_path))
 
 
+@pytest.mark.real_oltp_probe
 def test_probe_oltp_connection_raises_when_live_grievances_is_missing(tmp_path):
     """A reachable database whose Alembic migration never ran must fail this
     probe, not just a connection failure -- otherwise --strict passes clean
@@ -738,6 +782,7 @@ def test_probe_oltp_connection_raises_when_live_grievances_is_missing(tmp_path):
         service._probe_oltp_connection(f"sqlite+aiosqlite:///{db_path}")
 
 
+@pytest.mark.real_oltp_probe
 def test_probe_oltp_connection_raises_for_an_unreachable_target():
     """127.0.0.1 loopback on a closed port refuses instantly -- no DNS, no
     real network needed -- which is what _oltp_check's except clause and the

--- a/tests/test_inference_live_builder.py
+++ b/tests/test_inference_live_builder.py
@@ -539,6 +539,39 @@ def test_preflight_passes_when_routing_mappings_load(tmp_path, monkeypatch):
     assert "3 categories" in check.detail
 
 
+def test_preflight_flags_mapping_tables_that_load_empty(tmp_path, monkeypatch):
+    """A header-only or truncated CSV pull parses without error -- `tables` is
+    not None -- but MappingRouter has nothing to route with and falls back
+    exactly as it would with no tables at all. Present-but-empty must not
+    read as a healthy strict preflight (Codex review on #88)."""
+
+    class _EmptyTables:
+        categories = ()
+        category_to_department = {}
+
+    monkeypatch.setattr(
+        "janasunani.routing.mappings.load_mapping_tables", lambda *a, **k: _EmptyTables()
+    )
+    check = _advisory(preflight(tmp_path), "routing mappings")
+    assert check.ok is False
+    assert "fallback" in check.detail
+
+
+def test_preflight_flags_mapping_tables_with_no_derivable_department(tmp_path, monkeypatch):
+    """Categories present but every one lacking a department is the same
+    dead end for routing as no categories at all."""
+
+    class _NoDepartments:
+        categories = ("a", "b", "c")
+        category_to_department = {}
+
+    monkeypatch.setattr(
+        "janasunani.routing.mappings.load_mapping_tables", lambda *a, **k: _NoDepartments()
+    )
+    check = _advisory(preflight(tmp_path), "routing mappings")
+    assert check.ok is False
+
+
 def test_preflight_flags_unmaterialized_lake(tmp_path, monkeypatch):
     """`LakeHistory` returns an empty page for a missing lake, so the UI shows
     'no results' rather than an error. Preflight must say which it is."""

--- a/tests/test_inference_live_builder.py
+++ b/tests/test_inference_live_builder.py
@@ -232,7 +232,10 @@ def test_preflight_all_ok_when_dependencies_present(tmp_path, monkeypatch):
     checks = preflight(tmp_path)
 
     assert checks, "preflight must report at least one dependency"
-    assert all(check.ok for check in checks)
+    # Only the required checks: the advisory ones (routing mappings, history
+    # lake, OLTP store) depend on DVC data and environment, not on this
+    # fixture, and are exercised separately below.
+    assert all(check.ok for check in checks if check.required)
 
 
 def test_preflight_reports_missing_artifacts_without_raising(tmp_path, monkeypatch):
@@ -244,7 +247,11 @@ def test_preflight_reports_missing_artifacts_without_raising(tmp_path, monkeypat
 
     checks = preflight(tmp_path)  # empty models dir -> artifacts absent
 
-    model_checks = [c for c in checks if c.name != "tesseract" and "pdf" not in c.name]
+    model_checks = [
+        c
+        for c in checks
+        if c.required and c.name != "tesseract" and "pdf" not in c.name
+    ]
     assert model_checks and all(not c.ok for c in model_checks)
 
 
@@ -288,10 +295,11 @@ def test_preflight_reports_every_shared_required_model_file(tmp_path):
     guards preflight's *use* of the shared list; the companion test below
     guards `build_processor`'s use of it -- together they close the
     green-preflight-then-failed-startup drift gap."""
-    reported = {c.detail for c in preflight(tmp_path) if c.name not in {
-        "tesseract",
-        "pdfinfo/pdftoppm",
-    }}
+    reported = {
+        c.detail
+        for c in preflight(tmp_path)
+        if c.required and c.name not in {"tesseract", "pdfinfo/pdftoppm"}
+    }
     required = {
         " | ".join(str(path) for path in candidates)
         for candidates, _ in _required_model_files(Path(tmp_path))
@@ -433,7 +441,9 @@ def test_live_app_uses_database_store_for_dotenv_only_oltp(tmp_path, monkeypatch
     env_file.write_text("OLTP_DB_URL=postgresql+asyncpg://user:pass@db/janasunani\n")
 
     monkeypatch.delenv("OLTP_DB_URL", raising=False)  # never exported in the shell
-    monkeypatch.setattr(serve, "Settings", lambda: Settings(_env_file=env_file))
+    # `create_live_app` resolves the URL through `service.resolve_explicit_oltp_url`,
+    # which is also what preflight reports — one definition, so the two cannot drift.
+    monkeypatch.setattr(service, "Settings", lambda: Settings(_env_file=env_file))
     monkeypatch.setattr(serve, "build_processor", object)
     monkeypatch.setattr(serve, "LakeHistory", object)
     monkeypatch.setattr(
@@ -480,3 +490,117 @@ def test_live_app_always_uses_lake_history_regardless_of_real_history_flag(
     monkeypatch.setenv("JANASUNANI_REAL_HISTORY", "0")
     serve.create_live_app()
     assert captured["history"] is history
+
+
+# --- advisory readiness checks (#30 bring-up) --------------------------------
+#
+# These three fail in ways the running demo does not surface: routing quietly
+# on method:"fallback", /history empty rather than erroring, submissions kept
+# in memory and lost on restart. They are advisory by default so local
+# `make up` still works, and fatal under --strict for a box bring-up.
+#
+# Each is exercised in both directions with the environment stubbed, so the
+# result does not depend on whether this machine has run `dvc pull`.
+
+
+def _advisory(checks, name):
+    by_name = {c.name: c for c in checks}
+    assert name in by_name, f"{name} missing from preflight; got {sorted(by_name)}"
+    check = by_name[name]
+    assert not check.required, f"{name} must be advisory, not required"
+    return check
+
+
+def test_preflight_flags_absent_routing_mappings(tmp_path, monkeypatch):
+    """Without the master CSVs the router silently answers `method:"fallback"`
+    while the API stays healthy — the exact state #30 warns about for a box
+    that skipped the scoped `dvc pull`."""
+    monkeypatch.setattr(
+        service, "_routing_mappings_check", service._routing_mappings_check
+    )
+    monkeypatch.setattr(
+        "janasunani.routing.mappings.load_mapping_tables", lambda *a, **k: None
+    )
+    check = _advisory(preflight(tmp_path), "routing mappings")
+    assert check.ok is False
+    assert "fallback" in check.detail
+
+
+def test_preflight_passes_when_routing_mappings_load(tmp_path, monkeypatch):
+    class _Tables:
+        categories = ("a", "b", "c")
+        category_to_department = {"1": "5"}
+
+    monkeypatch.setattr(
+        "janasunani.routing.mappings.load_mapping_tables", lambda *a, **k: _Tables()
+    )
+    check = _advisory(preflight(tmp_path), "routing mappings")
+    assert check.ok is True
+    assert "3 categories" in check.detail
+
+
+def test_preflight_flags_unmaterialized_lake(tmp_path, monkeypatch):
+    """`LakeHistory` returns an empty page for a missing lake, so the UI shows
+    'no results' rather than an error. Preflight must say which it is."""
+    monkeypatch.setattr(
+        "janasunani.olap.lake.lake_path",
+        lambda table, lake_dir=None: tmp_path / f"{table}.parquet",
+    )
+    check = _advisory(preflight(tmp_path), "history lake")
+    assert check.ok is False
+    assert "empty page" in check.detail
+
+
+def test_preflight_reports_lake_row_count(tmp_path, monkeypatch):
+    """A materialized lake reports its size, so an operator can tell a real
+    lake from an empty-but-present Parquet."""
+    pytest.importorskip("duckdb")
+    import duckdb
+
+    parquet = tmp_path / "complaints.parquet"
+    duckdb.connect().execute(
+        f"COPY (SELECT 'T1' AS ticket_no UNION ALL SELECT 'T2') "
+        f"TO '{parquet.as_posix()}' (FORMAT parquet)"
+    )
+    monkeypatch.setattr(
+        "janasunani.olap.lake.lake_path", lambda table, lake_dir=None: parquet
+    )
+    check = _advisory(preflight(tmp_path), "history lake")
+    assert check.ok is True
+    assert "2 complaints" in check.detail
+
+
+def test_preflight_flags_unconfigured_oltp(tmp_path, monkeypatch):
+    """No explicit OLTP_DB_URL means InMemoryResultStore: the demo accepts
+    submissions, returns 201, and loses them on restart."""
+    monkeypatch.setattr(service, "resolve_explicit_oltp_url", lambda: None)
+    check = _advisory(preflight(tmp_path), "oltp store")
+    assert check.ok is False
+    assert "lost on restart" in check.detail
+
+
+def test_preflight_never_leaks_the_oltp_url(tmp_path, monkeypatch):
+    """The URL carries a DB password; the report must never print it."""
+    secret = "postgresql+asyncpg://user:hunter2@db.internal/janasunani"
+    monkeypatch.setattr(service, "resolve_explicit_oltp_url", lambda: secret)
+    check = _advisory(preflight(tmp_path), "oltp store")
+    assert check.ok is True
+    assert "hunter2" not in check.detail
+    assert secret not in check.detail
+
+
+def test_advisory_failures_do_not_fail_preflight_by_default(tmp_path, monkeypatch):
+    """`make up` must keep working on a dev box with no DVC data."""
+    _write_dummy_model_artifacts(tmp_path)
+    monkeypatch.setattr(service.shutil, "which", lambda _binary: "/usr/bin/fake")
+    monkeypatch.setattr(page_renderer, "POPPLER_PATH", None)
+    monkeypatch.setattr(service, "resolve_explicit_oltp_url", lambda: None)
+    monkeypatch.setattr(
+        "janasunani.routing.mappings.load_mapping_tables", lambda *a, **k: None
+    )
+
+    checks = preflight(tmp_path)
+    assert any(not c.ok for c in checks), "test setup should produce advisory failures"
+    assert all(c.ok for c in checks if c.required), (
+        "no required check may fail here — only advisory ones"
+    )

--- a/tests/test_inference_live_builder.py
+++ b/tests/test_inference_live_builder.py
@@ -640,14 +640,85 @@ def test_preflight_flags_unconfigured_oltp(tmp_path, monkeypatch):
     assert "lost on restart" in check.detail
 
 
-def test_preflight_never_leaks_the_oltp_url(tmp_path, monkeypatch):
+def test_preflight_verifies_oltp_connectivity_not_just_presence(tmp_path, monkeypatch):
+    """DatabaseResultStore (janasunani/serving/store.py) only creates its
+    async engine at startup and never actually connects until the first
+    save, so a wrong password/host/database/migration would otherwise pass
+    preflight and only fail on a citizen's first submission. Stubs
+    `_probe_oltp_connection` rather than touching a real database or the
+    network -- the same split infra_status.py's AWS/SSH tests use. Codex
+    review on #88."""
+    monkeypatch.setattr(
+        service, "resolve_explicit_oltp_url", lambda: "postgresql+asyncpg://u:p@h/db"
+    )
+    monkeypatch.setattr(service, "_probe_oltp_connection", lambda url, timeout=5.0: None)
+    check = _advisory(preflight(tmp_path), "oltp store")
+    assert check.ok is True
+    assert "connection verified" in check.detail
+
+
+def test_preflight_flags_an_explicit_but_unreachable_oltp(tmp_path, monkeypatch):
+    """A configured OLTP_DB_URL that cannot actually be connected to must not
+    read as ready -- exactly the gap that lets /health report
+    processor=pipeline while the first submission fails on save."""
+    monkeypatch.setattr(
+        service, "resolve_explicit_oltp_url", lambda: "postgresql+asyncpg://u:p@h/db"
+    )
+
+    def _boom(url, timeout=5.0):
+        raise ConnectionRefusedError("nope")
+
+    monkeypatch.setattr(service, "_probe_oltp_connection", _boom)
+    check = _advisory(preflight(tmp_path), "oltp store")
+    assert check.ok is False
+    assert "unreachable" in check.detail
+    assert "ConnectionRefusedError" in check.detail
+
+
+def test_preflight_never_leaks_the_oltp_url_on_success(tmp_path, monkeypatch):
     """The URL carries a DB password; the report must never print it."""
     secret = "postgresql+asyncpg://user:hunter2@db.internal/janasunani"
     monkeypatch.setattr(service, "resolve_explicit_oltp_url", lambda: secret)
+    monkeypatch.setattr(service, "_probe_oltp_connection", lambda url, timeout=5.0: None)
     check = _advisory(preflight(tmp_path), "oltp store")
     assert check.ok is True
     assert "hunter2" not in check.detail
     assert secret not in check.detail
+
+
+def test_preflight_never_leaks_the_oltp_url_on_connection_failure(tmp_path, monkeypatch):
+    """The likelier leak vector: some DBAPI errors embed the DSN -- and its
+    password -- in their own exception message. Only the exception's type
+    name may be reported, never str(exc)."""
+    secret = "postgresql+asyncpg://user:hunter2@db.internal/janasunani"
+    monkeypatch.setattr(service, "resolve_explicit_oltp_url", lambda: secret)
+
+    def _boom(url, timeout=5.0):
+        raise RuntimeError(f"could not connect to {secret}")
+
+    monkeypatch.setattr(service, "_probe_oltp_connection", _boom)
+    check = _advisory(preflight(tmp_path), "oltp store")
+    assert check.ok is False
+    assert "hunter2" not in check.detail
+    assert secret not in check.detail
+
+
+def test_probe_oltp_connection_succeeds_against_a_real_sqlite_db(tmp_path):
+    """Exercises the real probe (not the preflight wiring above, which stubs
+    it) against an actual database, so the SELECT 1 round trip is proven to
+    work end to end without needing network or a real Postgres."""
+    db_path = tmp_path / "probe.db"
+    service._probe_oltp_connection(f"sqlite+aiosqlite:///{db_path}")
+
+
+def test_probe_oltp_connection_raises_for_an_unreachable_target():
+    """127.0.0.1 loopback on a closed port refuses instantly -- no DNS, no
+    real network needed -- which is what _oltp_check's except clause and the
+    timeout bound both depend on being a real `raise`, not a hang."""
+    with pytest.raises(Exception):
+        service._probe_oltp_connection(
+            "postgresql+asyncpg://u:p@127.0.0.1:1/nonexistent", timeout=2.0
+        )
 
 
 def test_advisory_failures_do_not_fail_preflight_by_default(tmp_path, monkeypatch):

--- a/tests/test_inference_live_builder.py
+++ b/tests/test_inference_live_builder.py
@@ -584,9 +584,37 @@ def test_preflight_flags_unmaterialized_lake(tmp_path, monkeypatch):
     assert "empty page" in check.detail
 
 
+_HISTORY_ROW_SQL = (
+    "SELECT 'T1' AS ticket_no, DATE '2024-01-01' AS created_on, 'Khordha' AS district, "
+    "'Roads' AS category, 'Pothole' AS subcategory, 'Works' AS dept, 'Pending' AS status, "
+    "'Collector Office' AS office, 'A pothole' AS grievance "
+    "UNION ALL "
+    "SELECT 'T2', DATE '2024-01-02', 'Cuttack', 'Water', 'Leak', 'RWSS', 'Resolved', "
+    "'Collector Office', 'A leak'"
+)
+
+
 def test_preflight_reports_lake_row_count(tmp_path, monkeypatch):
     """A materialized lake reports its size, so an operator can tell a real
     lake from an empty-but-present Parquet."""
+    pytest.importorskip("duckdb")
+    import duckdb
+
+    parquet = tmp_path / "complaints.parquet"
+    duckdb.connect().execute(f"COPY ({_HISTORY_ROW_SQL}) TO '{parquet.as_posix()}' (FORMAT parquet)")
+    monkeypatch.setattr(
+        "janasunani.olap.lake.lake_path", lambda table, lake_dir=None: parquet
+    )
+    check = _advisory(preflight(tmp_path), "history lake")
+    assert check.ok is True
+    assert "2 complaints" in check.detail
+
+
+def test_preflight_flags_lake_missing_a_column_history_selects(tmp_path, monkeypatch):
+    """Rows present but a column `LakeHistory.search()` actually selects is
+    missing -- a stale or malformed lake -- must not pass strict preflight
+    just because the row count is nonzero; it would only surface once a real
+    `/history` request hit the missing column. Codex review on #88."""
     pytest.importorskip("duckdb")
     import duckdb
 
@@ -599,8 +627,8 @@ def test_preflight_reports_lake_row_count(tmp_path, monkeypatch):
         "janasunani.olap.lake.lake_path", lambda table, lake_dir=None: parquet
     )
     check = _advisory(preflight(tmp_path), "history lake")
-    assert check.ok is True
-    assert "2 complaints" in check.detail
+    assert check.ok is False
+    assert "unreadable" in check.detail
 
 
 def test_preflight_flags_unconfigured_oltp(tmp_path, monkeypatch):

--- a/tests/test_infra_status.py
+++ b/tests/test_infra_status.py
@@ -263,6 +263,28 @@ def test_no_containers_reads_as_not_deployed_not_as_broken():
     assert "not deployed" in findings[0].detail
 
 
+def test_all_containers_exited_is_a_full_outage_not_a_pre_deploy_box():
+    """`running=[]` alone is ambiguous: it means both "never deployed" and
+    "deployed, then every container crashed". `docker ps` (no -a) can't tell
+    them apart -- collect_box now uses `-a` and passes `all_seen` so this
+    function can. Codex re-review on #88."""
+    findings = infra_status.evaluate_containers(
+        [], all_seen=list(infra_status.STACK_CONTAINERS)
+    )
+    assert [f.status for f in findings] == [CRIT] * len(infra_status.STACK_CONTAINERS)
+    assert all("not running" in f.detail for f in findings)
+
+
+def test_all_seen_defaults_to_none_and_keeps_old_not_deployed_behavior():
+    """A caller that doesn't pass all_seen (e.g. a stub in an older test)
+    must not suddenly read a full outage as a pre-deploy box, or vice versa
+    -- default is "unknown", which still reads as not-deployed, matching the
+    pre-`-a` behavior exactly."""
+    findings = infra_status.evaluate_containers([])
+    assert [f.status for f in findings] == [INFO]
+    assert "not deployed" in findings[0].detail
+
+
 def test_oltp_only_reads_as_pre_deploy_not_as_three_missing_containers():
     """docs/DEPLOY.md's documented first-time state (`up -d oltp` only,
     before the app images are deployed) must not CRIT api/frontend/proxy --
@@ -588,6 +610,38 @@ def test_aws_json_pins_the_region(monkeypatch):
     infra_status._aws_json(["ec2", "describe-instances"], "ap-south-1")
     assert "--region" in captured["command"]
     assert "ap-south-1" in captured["command"]
+
+
+def test_collect_box_uses_docker_ps_dash_a_and_splits_running_from_all_seen(monkeypatch):
+    """`docker ps -a`'s Status field starts with "Up" only for a genuinely
+    running container ("Exited (1) 2 hours ago", "Created", ... otherwise).
+    Mixed output must split into `running` (Up only, further checked for
+    unhealthy/starting) and `all_seen` (every janasunani container,
+    regardless of state) -- the distinction evaluate_containers needs to
+    tell a full outage (all_seen non-empty, running empty) apart from a
+    pre-deploy box (both empty). Codex re-review on #88 flagged the
+    pre-`-a` version of this collector for exactly this gap."""
+    docker_output = (
+        "janasunani-oltp\tUp 5 minutes (healthy)\n"
+        "janasunani-api\tExited (1) 2 hours ago\n"
+        "janasunani-frontend\tUp 2 minutes (health: starting)\n"
+        "unrelated-container\tUp 10 minutes\n"
+    )
+    captured_docker_command: list = []
+
+    def fake_run(command, timeout=30):
+        if "docker ps" in command[-1]:
+            captured_docker_command.extend(command)
+            return docker_output
+        return "1048576"  # df -Pk: 1 GiB free, in KiB
+
+    monkeypatch.setattr(infra_status, "_run", fake_run)
+    _free_gib, running, unhealthy, starting, all_seen = infra_status.collect_box("fake-host")
+    assert "-a" in captured_docker_command[-1], captured_docker_command
+    assert set(running) == {"janasunani-oltp", "janasunani-frontend"}
+    assert set(all_seen) == {"janasunani-oltp", "janasunani-api", "janasunani-frontend"}
+    assert starting == frozenset({"janasunani-frontend"})
+    assert not unhealthy
 
 
 # --- the read-only guarantee --------------------------------------------------

--- a/tests/test_infra_status.py
+++ b/tests/test_infra_status.py
@@ -248,13 +248,15 @@ def test_render_never_says_all_clear_when_nothing_was_checked():
     assert "NOTHING CHECKED" in text
 
 
-def test_render_counts_skips_alongside_real_results():
+def test_render_qualifies_all_clear_when_some_checks_did_not_run():
+    """A partial pass is not a pass. "all clear" alone would invite reading an
+    unreachable box as a healthy one."""
     report = infra_status.Report()
     report.add("compute", "cpu box", OK, "running")
     report.add("box", "ssh", INFO, "unreachable")
     text = infra_status.render(report)
-    assert "all clear (1 checks)" in text
-    assert "1 not checked" in text
+    assert "were not run" in text
+    assert "all clear on 1 checks" in text
 
 
 # --- the read-only guarantee --------------------------------------------------

--- a/tests/test_infra_status.py
+++ b/tests/test_infra_status.py
@@ -181,6 +181,47 @@ def test_maintainer_rule_reads_ok_not_as_a_leftover():
     assert "maintainer" in findings[0].detail
 
 
+def test_maintainer_description_on_a_wide_cidr_is_not_whitelisted():
+    """admin_cidr's terraform validation only rejects 0.0.0.0/0 -- a /24
+    still passes and keeps this exact description. Trusting the label alone
+    would bless SSH from the whole block. Codex re-review on #88."""
+    permissions = [
+        {
+            "IpProtocol": "tcp",
+            "FromPort": 22,
+            "ToPort": 22,
+            "IpRanges": [
+                {
+                    "CidrIp": "203.0.113.0/24",
+                    "Description": infra_status.MAINTAINER_SSH_DESCRIPTION,
+                }
+            ],
+        }
+    ]
+    findings = infra_status.evaluate_ssh_exposure(permissions)
+    assert findings[0].status == WARN
+    assert "not a single host" in findings[0].detail
+
+
+def test_maintainer_rule_over_ipv6_single_host_is_whitelisted():
+    """/128 is the IPv6 equivalent of a single host."""
+    permissions = [
+        {
+            "IpProtocol": "tcp",
+            "FromPort": 22,
+            "ToPort": 22,
+            "Ipv6Ranges": [
+                {
+                    "CidrIpv6": "2001:db8::1/128",
+                    "Description": infra_status.MAINTAINER_SSH_DESCRIPTION,
+                }
+            ],
+        }
+    ]
+    findings = infra_status.evaluate_ssh_exposure(permissions)
+    assert findings[0].status == OK
+
+
 # --- disk ---------------------------------------------------------------------
 
 
@@ -267,6 +308,31 @@ def test_unhealthy_param_defaults_to_none_and_is_treated_as_no_unhealthy_contain
     -a`-format collector) must keep working exactly as before."""
     findings = infra_status.evaluate_containers(list(infra_status.STACK_CONTAINERS))
     assert all(f.status == OK for f in findings)
+
+
+def test_running_but_still_starting_container_is_not_ok():
+    """Docker's `(health: starting)` means the HEALTHCHECK has not
+    completed its start_period yet (the api's warm-up can take minutes) --
+    running mid-warm-up must not read the same as confirmed healthy. Codex
+    re-review on #88."""
+    findings = infra_status.evaluate_containers(
+        list(infra_status.STACK_CONTAINERS), starting=frozenset({"janasunani-api"})
+    )
+    by_name = {f.name: f for f in findings}
+    assert by_name["janasunani-api"].status == WARN
+    assert "starting" in by_name["janasunani-api"].detail.lower()
+    assert by_name["janasunani-oltp"].status == OK
+
+
+def test_unhealthy_takes_priority_over_starting_if_somehow_both():
+    """Defensive: unhealthy is the more severe, definitive signal."""
+    findings = infra_status.evaluate_containers(
+        list(infra_status.STACK_CONTAINERS),
+        unhealthy=frozenset({"janasunani-api"}),
+        starting=frozenset({"janasunani-api"}),
+    )
+    by_name = {f.name: f for f in findings}
+    assert by_name["janasunani-api"].status == CRIT
 
 
 # --- backups (issue #31) ------------------------------------------------------
@@ -448,6 +514,54 @@ def test_collect_instances_returns_not_found_when_the_call_succeeds_empty(monkey
     monkeypatch.setattr(infra_status, "_aws_json", lambda args, region: {"Reservations": []})
     found = infra_status.collect_instances({"cpu box": "cpu"}, "ap-south-1")
     assert found == {"cpu box": None}
+
+
+def _reservation(*instances):
+    return {"Reservations": [{"Instances": list(instances)}]}
+
+
+def _instance(name, project="janasunani", state="running"):
+    tags = []
+    if name is not None:
+        tags.append({"Key": "Name", "Value": name})
+    if project is not None:
+        tags.append({"Key": "Project", "Value": project})
+    return {"State": {"Name": state}, "Tags": tags}
+
+
+def test_collect_instances_requires_exact_name_not_substring(monkeypatch):
+    """A shared-account instance like "batch-cpu-worker" must not stand in
+    for the missing "janasunani-cpu-box". Codex re-review on #88."""
+    monkeypatch.setattr(
+        infra_status,
+        "_aws_json",
+        lambda args, region: _reservation(_instance("batch-cpu-worker")),
+    )
+    found = infra_status.collect_instances(infra_status.INSTANCE_NAME_TAGS, "ap-south-1")
+    assert found == {"cpu box": None, "gpu box": None}
+
+
+def test_collect_instances_requires_the_project_tag(monkeypatch):
+    """An instance with the exact Name but no (or the wrong) Project tag is
+    not this deployment's box -- the Name alone is not enough in a shared
+    account."""
+    monkeypatch.setattr(
+        infra_status,
+        "_aws_json",
+        lambda args, region: _reservation(_instance("janasunani-cpu-box", project="other-project")),
+    )
+    found = infra_status.collect_instances(infra_status.INSTANCE_NAME_TAGS, "ap-south-1")
+    assert found == {"cpu box": None, "gpu box": None}
+
+
+def test_collect_instances_matches_exact_name_and_project(monkeypatch):
+    found_instance = _instance("janasunani-cpu-box")
+    monkeypatch.setattr(
+        infra_status, "_aws_json", lambda args, region: _reservation(found_instance)
+    )
+    found = infra_status.collect_instances(infra_status.INSTANCE_NAME_TAGS, "ap-south-1")
+    assert found["cpu box"] is found_instance
+    assert found["gpu box"] is None
 
 
 def test_collect_backup_returns_none_when_the_aws_call_fails(monkeypatch):

--- a/tests/test_infra_status.py
+++ b/tests/test_infra_status.py
@@ -268,6 +268,27 @@ def test_unparseable_backup_timestamp_warns_rather_than_crashing():
     assert infra_status.evaluate_backup("not-a-date", 1).status == WARN
 
 
+def test_empty_backup_object_is_critical_even_when_fresh():
+    """A 0-byte object after a failed `pg_dump | aws s3 cp` must not read as
+    healthy just because it is recent -- there is nothing restorable in it.
+    Codex review on #88."""
+    finding = infra_status.evaluate_backup(_ago(0.1), 0)
+    assert finding.status == CRIT
+    assert "failed" in finding.detail
+
+
+def test_near_empty_backup_object_is_critical():
+    finding = infra_status.evaluate_backup(_ago(0.1), 512)
+    assert finding.status == CRIT
+
+
+def test_backup_of_unknown_size_is_judged_on_freshness_only():
+    """S3 not reporting a size is not itself evidence of a failed dump --
+    don't invent a size-based CRIT out of missing data."""
+    finding = infra_status.evaluate_backup(_ago(1), None)
+    assert finding.status == OK
+
+
 # --- demo health --------------------------------------------------------------
 
 
@@ -286,6 +307,22 @@ def test_real_processor_is_ok():
 
 def test_unreachable_health_is_critical():
     assert infra_status.evaluate_health(None, "unreachable").status == CRIT
+
+
+def test_unrecognized_processor_warns_not_ok():
+    """Only "pipeline" (PipelineGrievanceProcessor.name) and "mock"
+    (MockGrievanceProcessor.name) are values this codebase can actually
+    produce. Anything else -- a malformed, renamed, or wrong API -- must not
+    read as a healthy demo just because it isn't literally "mock". Codex
+    review on #88."""
+    finding = infra_status.evaluate_health({"status": "ok", "processor": "bogus"}, None)
+    assert finding.status == WARN
+    assert "bogus" in finding.detail
+
+
+def test_missing_processor_field_warns_not_ok():
+    finding = infra_status.evaluate_health({"status": "ok"}, None)
+    assert finding.status == WARN
 
 
 # --- report aggregation -------------------------------------------------------

--- a/tests/test_infra_status.py
+++ b/tests/test_infra_status.py
@@ -1,0 +1,295 @@
+"""Real-code-path tests for the infra status pass.
+
+Drives the actual evaluation functions in `scripts/infra_status.py` with
+AWS-shaped payloads, rather than mocking the module. The collectors shell out
+to `aws`/`ssh`/`curl`, which cannot run here and must never be pointed at
+production from a test, so the split is deliberate: collection is thin and
+dumb, every judgement lives in a pure function, and the judgements are what
+get tested.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from janasunani.config import ROOT_DIR
+
+_spec = importlib.util.spec_from_file_location(
+    "infra_status", Path(ROOT_DIR) / "scripts" / "infra_status.py"
+)
+infra_status = importlib.util.module_from_spec(_spec)
+# scripts/ is not a package; register before exec so @dataclass can resolve
+# the module (matches tests/test_bootstrap_pii_gold.py)
+sys.modules[_spec.name] = infra_status
+_spec.loader.exec_module(infra_status)
+
+CRIT, WARN, OK, INFO = (
+    infra_status.CRIT,
+    infra_status.WARN,
+    infra_status.OK,
+    infra_status.INFO,
+)
+
+
+def _ago(hours: float) -> str:
+    return (datetime.now(UTC) - timedelta(hours=hours)).isoformat()
+
+
+# --- compute ------------------------------------------------------------------
+
+
+def test_cpu_box_not_running_is_critical():
+    """It is always-on and holds the production Postgres."""
+    stopped = {"State": {"Name": "stopped"}, "InstanceType": "t3.large"}
+    assert infra_status.evaluate_instance("cpu box", stopped, always_on=True).status == CRIT
+
+
+def test_cpu_box_running_is_ok():
+    running = {"State": {"Name": "running"}, "InstanceType": "t3.large"}
+    finding = infra_status.evaluate_instance("cpu box", running, always_on=True)
+    assert finding.status == OK
+    assert "t3.large" in finding.detail
+
+
+def test_missing_cpu_box_is_critical_but_missing_gpu_box_is_not():
+    """gpu_box_count = 0 is the normal resting state; a missing CPU box is not."""
+    assert infra_status.evaluate_instance("cpu box", None, always_on=True).status == CRIT
+    assert infra_status.evaluate_instance("gpu box", None, always_on=False).status == OK
+
+
+def test_running_gpu_box_warns_because_it_bills_by_the_hour():
+    running = {
+        "State": {"Name": "running"},
+        "InstanceType": "g5.xlarge",
+        "LaunchTime": _ago(3),
+    }
+    finding = infra_status.evaluate_instance("gpu box", running, always_on=False)
+    assert finding.status == WARN
+    assert "billing" in finding.detail
+    assert "3.0h" in finding.detail
+
+
+def test_stopped_gpu_box_is_ok():
+    stopped = {"State": {"Name": "stopped"}, "InstanceType": "g5.xlarge"}
+    assert infra_status.evaluate_instance("gpu box", stopped, always_on=False).status == OK
+
+
+# --- network (issue #32) ------------------------------------------------------
+
+
+def test_no_ssh_ingress_is_ok():
+    findings = infra_status.evaluate_ssh_exposure([])
+    assert [f.status for f in findings] == [OK]
+
+
+def test_world_open_ssh_is_critical():
+    permissions = [{"FromPort": 22, "IpRanges": [{"CidrIp": "0.0.0.0/0"}]}]
+    findings = infra_status.evaluate_ssh_exposure(permissions)
+    assert findings[0].status == CRIT
+    assert "production PII" in findings[0].detail
+
+
+def test_leftover_runner_rule_warns_and_cites_the_issue():
+    """A /32 left behind means a deploy runner died between authorize and
+    revoke — the leak half of #32."""
+    permissions = [
+        {
+            "FromPort": 22,
+            "IpRanges": [{"CidrIp": "10.1.2.3/32", "Description": "ci-deploy"}],
+        }
+    ]
+    findings = infra_status.evaluate_ssh_exposure(permissions)
+    assert findings[0].status == WARN
+    assert "#32" in findings[0].detail
+    assert "ci-deploy" in findings[0].detail
+
+
+def test_non_ssh_ports_are_ignored():
+    permissions = [{"FromPort": 443, "IpRanges": [{"CidrIp": "0.0.0.0/0"}]}]
+    findings = infra_status.evaluate_ssh_exposure(permissions)
+    assert [f.status for f in findings] == [OK], "443 open to the world is the proxy, by design"
+
+
+# --- disk ---------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "free_gib,expected",
+    [(5.0, CRIT), (19.9, CRIT), (20.1, WARN), (39.0, WARN), (80.0, OK), (None, INFO)],
+)
+def test_disk_thresholds_match_deploy_sh(free_gib, expected):
+    """20 GiB is deploy.sh's own MIN_FREE_KIB floor, not an invented number."""
+    assert infra_status.evaluate_disk(free_gib).status == expected
+
+
+def test_critical_disk_explains_the_blast_radius():
+    detail = infra_status.evaluate_disk(3.0).detail
+    assert "Postgres" in detail, "a disk-full takes prod down, not just the deploy"
+
+
+# --- containers ---------------------------------------------------------------
+
+
+def test_all_containers_running_is_ok():
+    findings = infra_status.evaluate_containers(list(infra_status.STACK_CONTAINERS))
+    assert all(f.status == OK for f in findings)
+    assert len(findings) == len(infra_status.STACK_CONTAINERS)
+
+
+def test_a_missing_container_is_critical():
+    running = [c for c in infra_status.STACK_CONTAINERS if c != "janasunani-api"]
+    findings = infra_status.evaluate_containers(running)
+    by_name = {f.name: f for f in findings}
+    assert by_name["janasunani-api"].status == CRIT
+    assert by_name["janasunani-proxy"].status == OK
+
+
+def test_no_containers_reads_as_not_deployed_not_as_broken():
+    """Before the first deploy the box legitimately has no stack."""
+    findings = infra_status.evaluate_containers([])
+    assert [f.status for f in findings] == [INFO]
+    assert "not deployed" in findings[0].detail
+
+
+# --- backups (issue #31) ------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "hours,expected", [(2, OK), (25, OK), (30, WARN), (60, CRIT)]
+)
+def test_backup_staleness_thresholds(hours, expected):
+    assert infra_status.evaluate_backup(_ago(hours), 1_000_000_000).status == expected
+
+
+def test_absent_backup_is_critical_and_names_the_reason():
+    """The cron lives only on the box, so a rebuild silently loses it."""
+    finding = infra_status.evaluate_backup(None, None)
+    assert finding.status == CRIT
+    assert "#31" in finding.detail
+
+
+def test_backup_reports_size():
+    detail = infra_status.evaluate_backup(_ago(1), 2_500_000_000).detail
+    assert "2.50 GB" in detail
+
+
+def test_unparseable_backup_timestamp_warns_rather_than_crashing():
+    assert infra_status.evaluate_backup("not-a-date", 1).status == WARN
+
+
+# --- demo health --------------------------------------------------------------
+
+
+def test_mock_processor_warns_even_though_the_site_is_up():
+    """Healthy and responsive, serving canned results. This is the failure the
+    history mock badge exists for, seen from the outside."""
+    finding = infra_status.evaluate_health({"status": "ok", "processor": "mock"}, None)
+    assert finding.status == WARN
+    assert "mock" in finding.detail
+
+
+def test_real_processor_is_ok():
+    finding = infra_status.evaluate_health({"status": "ok", "processor": "pipeline"}, None)
+    assert finding.status == OK
+
+
+def test_unreachable_health_is_critical():
+    assert infra_status.evaluate_health(None, "unreachable").status == CRIT
+
+
+# --- report aggregation -------------------------------------------------------
+
+
+def test_exit_code_is_nonzero_only_for_critical():
+    report = infra_status.Report()
+    report.add("box", "disk", WARN, "")
+    assert report.exit_code() == 0, "warnings must not fail a cron run"
+    report.add("box", "stack", CRIT, "")
+    assert report.exit_code() == 1
+
+
+def test_worst_ignores_info():
+    report = infra_status.Report()
+    report.add("box", "ssh", INFO, "skipped")
+    report.add("compute", "cpu box", OK, "running")
+    assert report.worst == OK
+    assert report.exit_code() == 0
+
+
+def test_render_groups_by_section_and_summarizes():
+    report = infra_status.Report()
+    report.add("compute", "cpu box", OK, "running")
+    report.add("box", "disk", CRIT, "3 GiB free")
+    text = infra_status.render(report)
+    assert "=== compute ===" in text and "=== box ===" in text
+    assert "1 critical" in text
+
+
+def test_render_says_all_clear_when_nothing_is_wrong():
+    report = infra_status.Report()
+    report.add("compute", "cpu box", OK, "running")
+    assert "all clear" in infra_status.render(report)
+
+
+def test_render_never_says_all_clear_when_nothing_was_checked():
+    """--no-aws --no-ssh, unreachable AWS and an unreachable box all produce a
+    report of pure INFO. Reading that as healthy is the exact mistake this tool
+    exists to prevent."""
+    report = infra_status.Report()
+    report.add("compute", "aws", INFO, "skipped (--no-aws)")
+    report.add("box", "ssh", INFO, "skipped (--no-ssh)")
+    text = infra_status.render(report)
+    assert "all clear" not in text
+    assert "NOTHING CHECKED" in text
+
+
+def test_render_counts_skips_alongside_real_results():
+    report = infra_status.Report()
+    report.add("compute", "cpu box", OK, "running")
+    report.add("box", "ssh", INFO, "unreachable")
+    text = infra_status.render(report)
+    assert "all clear (1 checks)" in text
+    assert "1 not checked" in text
+
+
+# --- the read-only guarantee --------------------------------------------------
+
+
+def test_script_runs_no_mutating_commands():
+    """The whole design rests on this being a query-only tool. Asserted against
+    the source so a later edit cannot quietly add a mutation."""
+    source = (Path(ROOT_DIR) / "scripts" / "infra_status.py").read_text()
+    # Mutating invocations only. `terraform output` and `aws ec2 describe-*`
+    # are queries and are fine; the point is that nothing here changes state.
+    forbidden = (
+        "start-instances",
+        "stop-instances",
+        "terminate-instances",
+        "authorize-security-group",
+        "revoke-security-group",
+        "docker compose",
+        "docker rm",
+        "docker stop",
+        "docker prune",
+        "s3 cp",
+        "s3 rm",
+        "s3 sync",
+        "terraform apply",
+        "terraform destroy",
+        "rm -rf",
+    )
+    hits = [token for token in forbidden if token in source]
+    assert not hits, f"infra_status must stay read-only; found {hits}"
+
+
+def test_parser_defaults_skip_nothing_but_require_opt_in_for_targets():
+    args = infra_status.build_parser().parse_args([])
+    assert args.no_ssh is False and args.no_aws is False
+    # site and sg-id have no safe default: guessing them would either check the
+    # wrong account's resources or silently report "not checked" as healthy
+    assert args.site is None and args.sg_id is None

--- a/tests/test_infra_status.py
+++ b/tests/test_infra_status.py
@@ -222,6 +222,61 @@ def test_maintainer_rule_over_ipv6_single_host_is_whitelisted():
     assert findings[0].status == OK
 
 
+def test_ssh_via_referenced_security_group_is_not_absorbed_into_ok():
+    """A rule can grant 22 through UserIdGroupPairs (another security group
+    as the source) instead of a CIDR. Before #102 this source type was never
+    classified, so the "no findings -> OK" fallback below printed a clean
+    all-clear regardless of what that referenced group actually contains."""
+    permissions = [
+        {
+            "IpProtocol": "tcp",
+            "FromPort": 22,
+            "ToPort": 22,
+            "UserIdGroupPairs": [{"GroupId": "sg-0abc123", "Description": "bastion"}],
+        }
+    ]
+    findings = infra_status.evaluate_ssh_exposure(permissions)
+    assert [f.status for f in findings] == [WARN]
+    assert "sg-0abc123" in findings[0].detail
+    assert "bastion" in findings[0].detail
+
+
+def test_ssh_via_prefix_list_is_not_absorbed_into_ok():
+    """Same gap, for a managed prefix list (PrefixListIds) instead of a
+    referenced security group -- also never classified before #102."""
+    permissions = [
+        {
+            "IpProtocol": "tcp",
+            "FromPort": 22,
+            "ToPort": 22,
+            "PrefixListIds": [{"PrefixListId": "pl-0def456", "Description": "vpn"}],
+        }
+    ]
+    findings = infra_status.evaluate_ssh_exposure(permissions)
+    assert [f.status for f in findings] == [WARN]
+    assert "pl-0def456" in findings[0].detail
+    assert "vpn" in findings[0].detail
+
+
+def test_ssh_rule_with_both_cidr_and_group_source_reports_both():
+    """A single rule can carry more than one source type at once -- both
+    must be reported, not just the CIDR half that was already handled."""
+    permissions = [
+        {
+            "IpProtocol": "tcp",
+            "FromPort": 22,
+            "ToPort": 22,
+            "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+            "UserIdGroupPairs": [{"GroupId": "sg-0abc123"}],
+        }
+    ]
+    findings = infra_status.evaluate_ssh_exposure(permissions)
+    assert len(findings) == 2
+    statuses = {f.status for f in findings}
+    assert CRIT in statuses  # the 0.0.0.0/0 CIDR
+    assert WARN in statuses  # the referenced group
+
+
 # --- disk ---------------------------------------------------------------------
 
 
@@ -584,6 +639,104 @@ def test_collect_instances_matches_exact_name_and_project(monkeypatch):
     found = infra_status.collect_instances(infra_status.INSTANCE_NAME_TAGS, "ap-south-1")
     assert found["cpu box"] is found_instance
     assert found["gpu box"] is None
+
+
+# --- security group attachment: the P1 (checking only the supplied --sg-id) --
+# https://github.com/Data-Policy-and-Innovation-Centre/janasunani/pull/88#discussion_r3728680714
+#
+# A CPU box can have more than one security group attached, and any one of
+# them can expose SSH. Checking only whatever --sg-id an operator happened
+# to pass -- or a group that isn't even attached to the box -- let a real
+# exposure through a different attached group print a clean "OK no port-22
+# ingress". _attached_security_group_ids reads every group actually attached
+# to an instance straight out of describe-instances' own response (already
+# fetched for evaluate_instance), so main() can check all of them.
+
+
+def test_attached_security_group_ids_returns_every_group():
+    instance = {
+        "SecurityGroups": [
+            {"GroupId": "sg-111", "GroupName": "default"},
+            {"GroupId": "sg-222", "GroupName": "cpu-box"},
+        ]
+    }
+    assert infra_status._attached_security_group_ids(instance) == ["sg-111", "sg-222"]
+
+
+def test_attached_security_group_ids_is_none_for_no_instance():
+    assert infra_status._attached_security_group_ids(None) is None
+
+
+def test_attached_security_group_ids_is_none_for_no_groups():
+    """Defensive: a real EC2 instance always has at least one group, but
+    treat an empty/missing list as "nothing to check from," not "checked
+    and found zero groups" -- the caller must not read this as an all-clear."""
+    assert infra_status._attached_security_group_ids({"SecurityGroups": []}) is None
+    assert infra_status._attached_security_group_ids({}) is None
+
+
+def test_main_checks_every_attached_security_group_not_just_one(monkeypatch, capsys):
+    """The core P1 regression: the CPU box has two attached groups, only one
+    of which exposes SSH. Neither --sg-id nor its absence should matter --
+    both groups must be checked from the instance's own attachment list."""
+    cpu_instance = _instance("janasunani-cpu-box")
+    cpu_instance["SecurityGroups"] = [
+        {"GroupId": "sg-clean"},
+        {"GroupId": "sg-open"},
+    ]
+
+    def fake_aws_json(args, region):
+        if args[:2] == ["ec2", "describe-instances"]:
+            return _reservation(cpu_instance)
+        if args[:2] == ["ec2", "describe-security-groups"]:
+            group_id = args[args.index("--group-ids") + 1]
+            if group_id == "sg-open":
+                perms = [
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 22,
+                        "ToPort": 22,
+                        "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                    }
+                ]
+            else:
+                perms = []
+            return {"SecurityGroups": [{"IpPermissions": perms}]}
+        if args[:2] == ["s3api", "list-objects-v2"]:
+            return {}
+        raise AssertionError(f"unexpected aws call: {args}")
+
+    monkeypatch.setattr(infra_status, "_aws_json", fake_aws_json)
+    monkeypatch.setattr(sys, "argv", ["infra_status.py", "--no-ssh"])
+    exit_code = infra_status.main()
+    out = capsys.readouterr().out
+    assert "0.0.0.0/0" in out
+    assert exit_code == 1  # CRIT present
+
+
+def test_main_warns_when_supplied_sg_id_is_not_an_attached_group(monkeypatch, capsys):
+    """A --sg-id naming a group that is not actually attached to the CPU box
+    must not be silently substituted for the real attached groups -- and the
+    real attached groups are checked regardless, per the P1 fix above."""
+    cpu_instance = _instance("janasunani-cpu-box")
+    cpu_instance["SecurityGroups"] = [{"GroupId": "sg-real"}]
+
+    def fake_aws_json(args, region):
+        if args[:2] == ["ec2", "describe-instances"]:
+            return _reservation(cpu_instance)
+        if args[:2] == ["ec2", "describe-security-groups"]:
+            return {"SecurityGroups": [{"IpPermissions": []}]}
+        if args[:2] == ["s3api", "list-objects-v2"]:
+            return {}
+        raise AssertionError(f"unexpected aws call: {args}")
+
+    monkeypatch.setattr(infra_status, "_aws_json", fake_aws_json)
+    monkeypatch.setattr(sys, "argv", ["infra_status.py", "--no-ssh", "--sg-id", "sg-wrong"])
+    infra_status.main()
+    out = capsys.readouterr().out
+    assert "sg-wrong" in out
+    assert "not among the CPU box's attached groups" in out
+    assert "sg-real" in out
 
 
 def test_collect_backup_returns_none_when_the_aws_call_fails(monkeypatch):

--- a/tests/test_infra_status.py
+++ b/tests/test_infra_status.py
@@ -242,6 +242,33 @@ def test_oltp_plus_one_more_is_a_real_partial_deploy():
     assert by_name["janasunani-proxy"].status == CRIT
 
 
+def test_running_but_unhealthy_container_is_critical():
+    """A container Docker itself has marked failing its HEALTHCHECK
+    (oltp/api/frontend all define one) must not read as OK just because a
+    name-only `docker ps` still lists it. Codex review on #88."""
+    findings = infra_status.evaluate_containers(
+        list(infra_status.STACK_CONTAINERS), unhealthy=frozenset({"janasunani-api"})
+    )
+    by_name = {f.name: f for f in findings}
+    assert by_name["janasunani-api"].status == CRIT
+    assert "HEALTHCHECK" in by_name["janasunani-api"].detail
+    assert by_name["janasunani-oltp"].status == OK
+
+
+def test_running_and_healthy_stays_ok_when_unhealthy_set_is_empty():
+    findings = infra_status.evaluate_containers(
+        list(infra_status.STACK_CONTAINERS), unhealthy=frozenset()
+    )
+    assert all(f.status == OK for f in findings)
+
+
+def test_unhealthy_param_defaults_to_none_and_is_treated_as_no_unhealthy_containers():
+    """Existing callers that don't pass `unhealthy` (e.g. a pre-`docker ps
+    -a`-format collector) must keep working exactly as before."""
+    findings = infra_status.evaluate_containers(list(infra_status.STACK_CONTAINERS))
+    assert all(f.status == OK for f in findings)
+
+
 # --- backups (issue #31) ------------------------------------------------------
 
 

--- a/tests/test_infra_status.py
+++ b/tests/test_infra_status.py
@@ -88,7 +88,9 @@ def test_no_ssh_ingress_is_ok():
 
 
 def test_world_open_ssh_is_critical():
-    permissions = [{"FromPort": 22, "IpRanges": [{"CidrIp": "0.0.0.0/0"}]}]
+    permissions = [
+        {"IpProtocol": "tcp", "FromPort": 22, "ToPort": 22, "IpRanges": [{"CidrIp": "0.0.0.0/0"}]}
+    ]
     findings = infra_status.evaluate_ssh_exposure(permissions)
     assert findings[0].status == CRIT
     assert "production PII" in findings[0].detail
@@ -99,7 +101,9 @@ def test_leftover_runner_rule_warns_and_cites_the_issue():
     revoke — the leak half of #32."""
     permissions = [
         {
+            "IpProtocol": "tcp",
             "FromPort": 22,
+            "ToPort": 22,
             "IpRanges": [{"CidrIp": "10.1.2.3/32", "Description": "ci-deploy"}],
         }
     ]
@@ -110,9 +114,71 @@ def test_leftover_runner_rule_warns_and_cites_the_issue():
 
 
 def test_non_ssh_ports_are_ignored():
-    permissions = [{"FromPort": 443, "IpRanges": [{"CidrIp": "0.0.0.0/0"}]}]
+    permissions = [
+        {"IpProtocol": "tcp", "FromPort": 443, "ToPort": 443, "IpRanges": [{"CidrIp": "0.0.0.0/0"}]}
+    ]
     findings = infra_status.evaluate_ssh_exposure(permissions)
     assert [f.status for f in findings] == [OK], "443 open to the world is the proxy, by design"
+
+
+def test_all_protocols_wildcard_is_seen_as_ssh_exposure():
+    """IpProtocol="-1" is AWS's all-protocols-all-ports rule. It has no
+    meaningful FromPort/ToPort, and a guard keyed on FromPort==22 misses it
+    entirely — the exact P1 Codex flagged on #88."""
+    permissions = [{"IpProtocol": "-1", "IpRanges": [{"CidrIp": "0.0.0.0/0"}]}]
+    findings = infra_status.evaluate_ssh_exposure(permissions)
+    assert findings[0].status == CRIT
+    assert "production PII" in findings[0].detail
+
+
+def test_wide_tcp_port_range_covering_22_is_seen_as_ssh_exposure():
+    """FromPort=0, ToPort=65535 covers 22 exactly as much as FromPort=22,
+    ToPort=22 — a range, not a single port, per AWS's IpPermission."""
+    permissions = [
+        {
+            "IpProtocol": "tcp",
+            "FromPort": 0,
+            "ToPort": 65535,
+            "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+        }
+    ]
+    findings = infra_status.evaluate_ssh_exposure(permissions)
+    assert findings[0].status == CRIT
+
+
+def test_ipv6_ssh_source_is_checked_too():
+    permissions = [
+        {
+            "IpProtocol": "tcp",
+            "FromPort": 22,
+            "ToPort": 22,
+            "Ipv6Ranges": [{"CidrIpv6": "::/0"}],
+        }
+    ]
+    findings = infra_status.evaluate_ssh_exposure(permissions)
+    assert findings[0].status == CRIT
+    assert "::/0" in findings[0].detail
+
+
+def test_maintainer_rule_reads_ok_not_as_a_leftover():
+    """deploy/terraform/main.tf's standing admin rule must let a healthy box
+    render all clear, distinct from a leftover deploy-runner /32 (#32)."""
+    permissions = [
+        {
+            "IpProtocol": "tcp",
+            "FromPort": 22,
+            "ToPort": 22,
+            "IpRanges": [
+                {
+                    "CidrIp": "203.0.113.4/32",
+                    "Description": infra_status.MAINTAINER_SSH_DESCRIPTION,
+                }
+            ],
+        }
+    ]
+    findings = infra_status.evaluate_ssh_exposure(permissions)
+    assert findings[0].status == OK
+    assert "maintainer" in findings[0].detail
 
 
 # --- disk ---------------------------------------------------------------------
@@ -154,6 +220,26 @@ def test_no_containers_reads_as_not_deployed_not_as_broken():
     findings = infra_status.evaluate_containers([])
     assert [f.status for f in findings] == [INFO]
     assert "not deployed" in findings[0].detail
+
+
+def test_oltp_only_reads_as_pre_deploy_not_as_three_missing_containers():
+    """docs/DEPLOY.md's documented first-time state (`up -d oltp` only,
+    before the app images are deployed) must not CRIT api/frontend/proxy --
+    they were never asked to start. Codex review on #88."""
+    findings = infra_status.evaluate_containers(["janasunani-oltp"])
+    assert [f.status for f in findings] == [INFO]
+    assert "not deployed" in findings[0].detail
+
+
+def test_oltp_plus_one_more_is_a_real_partial_deploy():
+    """Once more than just oltp is up, a missing container is a genuine gap,
+    not the documented pre-deploy state."""
+    findings = infra_status.evaluate_containers(["janasunani-oltp", "janasunani-api"])
+    by_name = {f.name: f for f in findings}
+    assert by_name["janasunani-oltp"].status == OK
+    assert by_name["janasunani-api"].status == OK
+    assert by_name["janasunani-frontend"].status == CRIT
+    assert by_name["janasunani-proxy"].status == CRIT
 
 
 # --- backups (issue #31) ------------------------------------------------------
@@ -221,6 +307,25 @@ def test_worst_ignores_info():
     assert report.exit_code() == 0
 
 
+def test_nothing_checked_true_only_when_every_finding_is_info():
+    """`worst` reads OK on a pure-INFO report by design (see its docstring);
+    `nothing_checked` is the separate signal `--json` needs so a monitor
+    cannot mistake a fully-skipped run for a healthy one. Codex review on
+    #88 flagged `--json` emitting `"worst": "OK"` for exactly this case."""
+    report = infra_status.Report()
+    report.add("compute", "aws", INFO, "skipped (--no-aws)")
+    report.add("box", "ssh", INFO, "skipped (--no-ssh)")
+    assert report.nothing_checked is True
+    assert report.checked_count == 0
+    assert report.skipped_count == 2
+    assert report.worst == OK  # unchanged, deliberate -- see docstring
+
+    report.add("compute", "cpu box", OK, "running")
+    assert report.nothing_checked is False
+    assert report.checked_count == 1
+    assert report.skipped_count == 2
+
+
 def test_render_groups_by_section_and_summarizes():
     report = infra_status.Report()
     report.add("compute", "cpu box", OK, "running")
@@ -257,6 +362,54 @@ def test_render_qualifies_all_clear_when_some_checks_did_not_run():
     text = infra_status.render(report)
     assert "were not run" in text
     assert "all clear on 1 checks" in text
+
+
+# --- collection: a failed AWS call is not the same as an empty result ---------
+#
+# Codex review on #88: a failed `describe-instances`/`list-objects-v2` call
+# (bad credentials, wrong region, IAM, network) collapsed into the same "not
+# found"/"no objects" result as a *successful* call that legitimately found
+# nothing, raising a false production alarm instead of degrading to "not
+# checked". These monkeypatch `_aws_json` (the one seam between the collectors
+# and the actual `aws` subprocess) rather than shelling out for real, keeping
+# with the file's collection-is-thin-collectors-are-dumb split.
+
+
+def test_collect_instances_returns_none_when_the_aws_call_fails(monkeypatch):
+    monkeypatch.setattr(infra_status, "_aws_json", lambda args, region: None)
+    assert infra_status.collect_instances({"cpu box": "cpu"}, "ap-south-1") is None
+
+
+def test_collect_instances_returns_not_found_when_the_call_succeeds_empty(monkeypatch):
+    monkeypatch.setattr(infra_status, "_aws_json", lambda args, region: {"Reservations": []})
+    found = infra_status.collect_instances({"cpu box": "cpu"}, "ap-south-1")
+    assert found == {"cpu box": None}
+
+
+def test_collect_backup_returns_none_when_the_aws_call_fails(monkeypatch):
+    monkeypatch.setattr(infra_status, "_aws_json", lambda args, region: None)
+    assert infra_status.collect_backup("ap-south-1") is None
+
+
+def test_collect_backup_returns_no_objects_when_the_call_succeeds_empty(monkeypatch):
+    monkeypatch.setattr(infra_status, "_aws_json", lambda args, region: {})
+    assert infra_status.collect_backup("ap-south-1") == (None, None)
+
+
+def test_aws_json_pins_the_region(monkeypatch):
+    """An operator whose default CLI profile points at another region gets a
+    *successful, empty* response, not an error -- indistinguishable from the
+    box actually being gone unless the region is pinned explicitly."""
+    captured: dict = {}
+
+    def fake_run(command, timeout=30):
+        captured["command"] = command
+        return "{}"
+
+    monkeypatch.setattr(infra_status, "_run", fake_run)
+    infra_status._aws_json(["ec2", "describe-instances"], "ap-south-1")
+    assert "--region" in captured["command"]
+    assert "ap-south-1" in captured["command"]
 
 
 # --- the read-only guarantee --------------------------------------------------

--- a/tests/test_makefile_dotenv.py
+++ b/tests/test_makefile_dotenv.py
@@ -1,6 +1,10 @@
-"""Real-code-path checks that OLTP_DB_URL survives adversarial characters
-through every documented precedence tier of the Makefile (#60 and its
-sequels): command line, shell-exported environment, and `.env`.
+"""Real-code-path checks for the Makefile's `.env`-sourced settings (#60 and
+its sequels, #103, #104): that OLTP_DB_URL survives adversarial characters
+through every documented precedence tier (command line, shell-exported
+environment, `.env`), that a parse-time `uv` failure fails loudly rather than
+silently keeping the throwaway demo default, and that `.env` still supplies
+the other Make settings README.md documents (BOX_REMOTE, BOX_PROJECT_ROOT,
+INCOMING_REMOTE, EXHIBITS_REMOTE).
 
 Shells out to the actual `make` binary against the real Makefile -- not a
 copy, not a reimplementation of its logic -- with `-C` pointed at an isolated
@@ -244,3 +248,81 @@ def test_db_guard_resolves_a_matching_default_identically(isolated_dir):
         line for line in result.stdout.splitlines() if line.strip().startswith("if [")
     )
     assert guard_line.count(f"'{demo_url}'") == 2, guard_line
+
+
+# --- #104: .env must still supply BOX_REMOTE/BOX_PROJECT_ROOT/INCOMING_REMOTE/
+# EXHIBITS_REMOTE -----------------------------------------------------------
+#
+# README.md's "Box paths and data ops" tells collaborators to persist these
+# four in .env. 17bad32 replaced `-include .env` with a parser that imported
+# only OLTP_DB_URL, silently dropping the rest -- `make ingest`/`make
+# deliver` then read from or published to the built-in Box paths with no
+# indication the operator's own .env was ignored.
+
+
+def test_dotenv_supplied_box_remote_reaches_box_paths(isolated_dir):
+    """A .env-only BOX_REMOTE must actually reach the recipe that consumes
+    it (`box-paths`, which just echoes the resolved Make variables --
+    exactly what `ingest`/`publish-raw`/`deliver` build their rclone
+    invocations from), not merely exist as a Make variable somewhere."""
+    (isolated_dir / ".env").write_text("BOX_REMOTE=my-custom-remote\n")
+    result = _make("box-paths", cwd=isolated_dir)
+    assert result.returncode == 0, result.stderr
+    assert "BOX_REMOTE=my-custom-remote" in result.stdout, result.stdout
+
+
+def test_dotenv_supplied_box_project_root_propagates_to_derived_remotes(isolated_dir):
+    """BOX_PROJECT_ROOT itself contains spaces by default (its own `?=`:
+    "2. Projects/21. Governance/") -- a real value operators set, not just a
+    hypothetical adversarial case. INCOMING_REMOTE/EXHIBITS_REMOTE derive
+    from it via their own `?=` (recursively expanded, so they pick up
+    whatever BOX_PROJECT_ROOT resolves to at reference time), so a .env
+    override must flow through to both without being set directly."""
+    (isolated_dir / ".env").write_text("BOX_PROJECT_ROOT=DPIC/janasunani\n")
+    result = _make("box-paths", cwd=isolated_dir)
+    assert result.returncode == 0, result.stderr
+    assert "BOX_PROJECT_ROOT=DPIC/janasunani" in result.stdout
+    assert "DPIC/janasunani/Data/Raw/" in result.stdout
+    assert "DPIC/janasunani/Analysis/Exhibits/" in result.stdout
+
+
+def test_dotenv_supplied_incoming_and_exhibits_remote_override_directly(isolated_dir):
+    """README.md: "If a derived path doesn't match your Box layout, override
+    the full endpoint (INCOMING_REMOTE / EXHIBITS_REMOTE) in .env" -- these
+    must be settable independently of BOX_REMOTE/BOX_PROJECT_ROOT."""
+    (isolated_dir / ".env").write_text(
+        "INCOMING_REMOTE=customremote:'Custom/Path/'\n"
+        "EXHIBITS_REMOTE=customremote:'Other/Path/'\n"
+    )
+    result = _make("box-paths", cwd=isolated_dir)
+    assert result.returncode == 0, result.stderr
+    assert "INCOMING_REMOTE=customremote:'Custom/Path/'" in result.stdout
+    assert "EXHIBITS_REMOTE=customremote:'Other/Path/'" in result.stdout
+    # BOX_REMOTE/BOX_PROJECT_ROOT untouched by .env here -- still the `?=` defaults.
+    assert "BOX_REMOTE=box" in result.stdout
+
+
+def test_command_line_still_wins_over_dotenv_for_box_remote(isolated_dir):
+    """Same precedence guarantee as OLTP_DB_URL, now proven for the restored
+    keys too: command line > .env > shell export > default."""
+    (isolated_dir / ".env").write_text("BOX_REMOTE=from-dotenv\n")
+    result = _make("box-paths", "BOX_REMOTE=from-cmdline", cwd=isolated_dir)
+    assert result.returncode == 0, result.stderr
+    assert "BOX_REMOTE=from-cmdline" in result.stdout
+    assert "from-dotenv" not in result.stdout
+
+
+def test_oltp_db_url_still_survives_adversarial_characters_alongside_box_remote(
+    isolated_dir,
+):
+    """Regression guard for the #104 refactor: extending the shared
+    dotenv_get machinery to four more keys must not reintroduce #60's bug
+    class for OLTP_DB_URL, which still needs the $/#/'/comment handling the
+    other four don't."""
+    (isolated_dir / ".env").write_text(
+        f"OLTP_DB_URL={ADVERSARIAL_DSN}\nBOX_REMOTE=myremote\n"
+    )
+    result = _make("-n", "preflight", cwd=isolated_dir)
+    assert result.returncode == 0, result.stderr
+    dsn_without_comment = ADVERSARIAL_DSN.split(" # ")[0]
+    assert _sh_quote(dsn_without_comment) in result.stdout, result.stdout

--- a/tests/test_makefile_dotenv.py
+++ b/tests/test_makefile_dotenv.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -170,6 +171,58 @@ def test_db_guard_skips_provisioning_for_a_command_line_dsn_with_special_charact
     assert result.returncode == 0, result.stderr
     assert "skipping provisioning" in result.stdout
     assert "Creating throwaway Postgres" not in result.stdout
+
+
+def test_dotenv_extraction_finds_uv_installed_only_under_user_bin(isolated_dir):
+    """#103: the parse-time `uv run python ...` call used to look `uv` up on
+    whatever PATH the invoking shell already had -- before the later
+    `export PATH := $(USER_BIN):$(PATH)` line, which only reaches recipe
+    subprocesses, not this earlier $(shell ...) call. Reproduces the
+    documented install shape (uv under ~/.local/bin) by removing exactly
+    that directory from PATH (keeping the rest of the real environment
+    intact, unlike the fully-stripped env below -- `uv run` needs more than
+    a bare PATH to resolve this repo's project/dependencies from an
+    unrelated tmp_path) and pointing USER_BIN at it instead."""
+    real_uv = shutil.which("uv")
+    if real_uv is None:
+        pytest.skip("uv not installed on this machine")
+    user_bin = str(Path(real_uv).parent)
+    (isolated_dir / ".env").write_text(
+        "OLTP_DB_URL=postgresql+asyncpg://postgres:fromenv@127.0.0.1:5544/janasunani\n"
+    )
+    env = dict(os.environ)
+    env["PATH"] = os.pathsep.join(
+        p for p in env.get("PATH", "").split(os.pathsep) if p != user_bin
+    )
+    assert shutil.which("uv", path=env["PATH"]) is None, "test setup: uv must not resolve via PATH"
+    result = _make(
+        "-n", f"USER_BIN={user_bin}", "preflight", cwd=isolated_dir, env=env
+    )
+    assert result.returncode == 0, result.stderr
+    assert "fromenv" in result.stdout, result.stdout
+
+
+def test_missing_uv_fails_loudly_instead_of_silently_using_the_demo_default(isolated_dir):
+    """#103's more dangerous half: when `uv` cannot be resolved at all (not
+    on PATH, not under USER_BIN), the extraction must not silently leave
+    OLTP_DB_URL at the throwaway demo default -- `.env` names a real
+    database here, and silently ignoring that is exactly the outcome `make
+    OLTP_DB_URL=... db`'s guard exists to prevent, reached by a different
+    route (a broken uv install instead of a forgotten override)."""
+    (isolated_dir / ".env").write_text(
+        "OLTP_DB_URL=postgresql+asyncpg://postgres:fromenv@127.0.0.1:5544/janasunani\n"
+    )
+    env = {"HOME": os.environ.get("HOME", ""), "PATH": "/usr/bin:/bin"}
+    result = _make(
+        "-n", "USER_BIN=/nonexistent-dir-for-this-test", "preflight",
+        cwd=isolated_dir, env=env,
+    )
+    assert result.returncode != 0
+    assert "could not be parsed" in result.stderr
+    demo_default = "postgresql+asyncpg://postgres:demo@127.0.0.1:5544/janasunani"
+    assert demo_default not in result.stdout, (
+        "must fail loudly, not silently resolve to the throwaway demo default"
+    )
 
 
 def test_db_guard_resolves_a_matching_default_identically(isolated_dir):

--- a/tests/test_makefile_dotenv.py
+++ b/tests/test_makefile_dotenv.py
@@ -1,0 +1,193 @@
+"""Real-code-path checks that OLTP_DB_URL survives adversarial characters
+through every documented precedence tier of the Makefile (#60 and its
+sequels): command line, shell-exported environment, and `.env`.
+
+Shells out to the actual `make` binary against the real Makefile -- not a
+copy, not a reimplementation of its logic -- with `-C` pointed at an isolated
+`tmp_path` so a developer's own real `.env` at the repo root can never leak
+into (or be mistaken for) the command-line/environment-tier assertions here.
+`-n` (dry run) is used everywhere it is safe to; the one exception is `db`'s
+guard, which is exercised for real because dry run only ever *prints* the
+recipe text and cannot tell us which branch of `if [ ... ]` a real shell
+would take -- and a real run here is safe: the guard's whole job is to exit
+before touching Docker when OLTP_DB_URL is not the throwaway demo default,
+which is exactly the case under test.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+
+import pytest
+
+from janasunani.config import ROOT_DIR
+
+MAKEFILE_PATH = ROOT_DIR / "Makefile"
+
+pytestmark = pytest.mark.skipif(shutil.which("make") is None, reason="make not installed")
+
+# Exercises every character class this bug's four rounds each fixed one at a
+# time: `$` (Make variable-reference syntax), `#` (Make/shell comment
+# syntax), `'` (shell quote), and a trailing " # ..." that *looks* like a
+# dotenv inline comment. That last one must survive intact for the
+# command-line/environment tiers (see test_command_line_value_is_not_treated_
+# as_dotenv_text below) -- only python-dotenv's parse of an actual `.env`
+# file treats it as a real comment and strips it
+# (test_dotenv_value_survives_intact_and_its_real_comment_is_stripped).
+ADVERSARIAL_DSN = (
+    "postgresql+asyncpg://postgres:pa$word#hash'quote@127.0.0.1:5544/janasunani"
+    " # not a real comment"
+)
+
+
+def _make(*args: str, cwd, env=None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["make", "-C", str(cwd), "-f", str(MAKEFILE_PATH), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+
+
+def _sh_quote(value: str) -> str:
+    """Python port of the Makefile's `sh_quote`: wrap in single quotes, with
+    each embedded `'` replaced by `'\\''` (close the quote, an escaped
+    literal quote outside it, reopen the quote). ADVERSARIAL_DSN contains a
+    `'`, so its *quoted* form is not a contiguous copy of the original string
+    -- sh_quote splits it at that point by design -- and assertions below
+    must compare against this, not the raw value.
+    """
+    return "'" + value.replace("'", "'\\''") + "'"
+
+
+@pytest.fixture
+def isolated_dir(tmp_path):
+    """No `.env` here, ever. Isolates the command-line/environment-tier
+    assertions below from whatever `.env` (if any) exists at the real repo
+    root -- command-line values already beat `.env` unconditionally (Make
+    locks in command-line variables before reading any of the makefile), but
+    the shell-exported-environment tier does not: `.env` > shell export is
+    the documented precedence, so a real `.env` with its own OLTP_DB_URL
+    would silently invalidate that specific assertion if this ran against
+    ROOT_DIR directly.
+    """
+    return tmp_path
+
+
+@pytest.mark.parametrize("target", ["preflight", "api", "up"])
+def test_command_line_override_survives_intact(isolated_dir, target):
+    result = _make(
+        "-n", f"OLTP_DB_URL={ADVERSARIAL_DSN}", target, cwd=isolated_dir
+    )
+    assert result.returncode == 0, result.stderr
+    assert _sh_quote(ADVERSARIAL_DSN) in result.stdout, result.stdout
+
+
+def test_shell_exported_environment_value_survives_intact(isolated_dir):
+    env = dict(os.environ)
+    env["OLTP_DB_URL"] = ADVERSARIAL_DSN
+    result = _make("-n", "preflight", cwd=isolated_dir, env=env)
+    assert result.returncode == 0, result.stderr
+    assert _sh_quote(ADVERSARIAL_DSN) in result.stdout, result.stdout
+
+
+def test_dotenv_value_survives_intact_and_its_real_comment_is_stripped(isolated_dir):
+    """The third tier (#60's original bug, fixed in 17bad32 by shelling out
+    to python-dotenv): unlike the command-line/environment tiers above, a
+    genuine `.env` file's ` # ...` *is* a real dotenv inline comment and must
+    be stripped -- Settings (janasunani/config.py) would strip it too, and
+    the whole point of parsing via python-dotenv instead of hand-rolled sed
+    is that Make and Settings agree on where the value ends."""
+    dsn_without_comment = (
+        "postgresql+asyncpg://postgres:pa$word#hash'quote@127.0.0.1:5544/janasunani"
+    )
+    (isolated_dir / ".env").write_text(f"OLTP_DB_URL={dsn_without_comment} # local\n")
+    result = _make("-n", "preflight", cwd=isolated_dir)
+    assert result.returncode == 0, result.stderr
+    assert _sh_quote(dsn_without_comment) in result.stdout, result.stdout
+    assert "local" not in result.stdout
+
+
+def test_preflight_recipe_reconstructs_the_exact_value_at_runtime(isolated_dir):
+    """Stronger than the text-matching tests above: replaces `uv` with a shim
+    that writes $OLTP_DB_URL back out, then runs the *real* (non-dry-run)
+    preflight recipe. Proves the shell that actually executes the recipe
+    reconstructs ADVERSARIAL_DSN exactly -- not just that `-n` prints text
+    that looks right -- without touching the real uv, network, or Docker.
+
+    Shadowing `uv` needs a command-line USER_BIN override, not just a PATH
+    prefix on the subprocess env: the Makefile's own
+    `export PATH := $(USER_BIN):$(PATH)` (USER_BIN defaults to
+    ~/.local/bin, where uv is commonly installed) puts USER_BIN *ahead* of
+    whatever PATH this test starts with, so a real uv there would still win
+    over a merely-prepended fake one.
+    """
+    fake_bin = isolated_dir / "fakebin"
+    fake_bin.mkdir()
+    shim = fake_bin / "uv"
+    output_file = isolated_dir / "fake_uv_saw.txt"
+    shim.write_text(
+        "#!/bin/sh\n"
+        f'printf %s "$OLTP_DB_URL" > "{output_file}"\n'
+    )
+    shim.chmod(0o755)
+
+    result = _make(
+        f"OLTP_DB_URL={ADVERSARIAL_DSN}",
+        f"USER_BIN={fake_bin}",
+        "preflight",
+        cwd=isolated_dir,
+    )
+    assert result.returncode == 0, result.stderr
+    assert output_file.read_text() == ADVERSARIAL_DSN
+
+
+def test_command_line_value_is_not_treated_as_dotenv_text(isolated_dir):
+    """The trailing ` # not a real comment` in ADVERSARIAL_DSN is only ever
+    stripped by python-dotenv's parse of an actual `.env` file (see
+    Makefile's OLTP_DB_URL_RAW block) -- a command-line value never goes
+    through that parser, so it must come through whole, comment-looking
+    suffix and all. This is the inverse of test_makefile's `.env` coverage:
+    that one proves the comment *is* stripped from `.env`; this one proves
+    it is *not* stripped from a literal command-line string."""
+    result = _make("-n", f"OLTP_DB_URL={ADVERSARIAL_DSN}", "preflight", cwd=isolated_dir)
+    assert result.returncode == 0, result.stderr
+    assert "# not a real comment" in result.stdout
+
+
+def test_db_guard_skips_provisioning_for_a_command_line_dsn_with_special_characters(
+    isolated_dir,
+):
+    """Real (non-dry-run) execution: the guard's job is to compare
+    OLTP_DB_URL against the throwaway demo default and exit before touching
+    Docker when they differ -- exactly this case, since ADVERSARIAL_DSN is
+    not the demo default. Proves the *comparison itself* sees the intact
+    value at runtime, not just that `-n` prints it correctly."""
+    result = _make("OLTP_DB_URL=" + ADVERSARIAL_DSN, "db", cwd=isolated_dir)
+    assert result.returncode == 0, result.stderr
+    assert "skipping provisioning" in result.stdout
+    assert "Creating throwaway Postgres" not in result.stdout
+
+
+def test_db_guard_resolves_a_matching_default_identically(isolated_dir):
+    """Control for the test above: an OLTP_DB_URL that *does* equal the
+    throwaway demo default must still resolve identically to it through the
+    same OLTP_DB_URL_RAW path, so the guard's `[ ... != ... ]` sees two equal
+    strings -- checked directly in the substituted recipe text. `-n` only
+    ever prints text linearly (both branches of the recipe appear regardless
+    of which a real shell would take), so it cannot show *which* branch
+    fires without actually running `db` -- which would provision a real
+    throwaway Postgres via Docker for this matching case, too heavy for a
+    unit test. Checking the two compared strings are identical is the
+    side-effect-free equivalent: it is exactly what determines the shell's
+    `!=` result."""
+    demo_url = "postgresql+asyncpg://postgres:demo@127.0.0.1:5544/janasunani"
+    result = _make("-n", f"OLTP_DB_URL={demo_url}", "db", cwd=isolated_dir)
+    assert result.returncode == 0, result.stderr
+    guard_line = next(
+        line for line in result.stdout.splitlines() if line.strip().startswith("if [")
+    )
+    assert guard_line.count(f"'{demo_url}'") == 2, guard_line


### PR DESCRIPTION
## Summary
- Preflight now catches the three failures that pass `/health` but leave the demo quietly degraded: missing routing mappings (silent `method:"fallback"`), an unmaterialized lake, and an implicit OLTP fallback to the in-memory store. `--strict` promotes these from advisory to fatal; DEPLOY.md's one-time box setup runs preflight `--strict` before the first deploy.
- Adds `make infra` / `scripts/infra_status.py`: a read-only status pass over the CPU box, GPU box, deployed stack, and backups (SSH/AWS queries only, no mutating calls — enforced by a source-scan test). Reports `--` for anything skipped/unreachable rather than reading it as healthy, and a run where nothing was checked prints "NOTHING CHECKED" rather than "all clear."
- Fixes the summary line so a partial pass reads as partial: "all clear on 3 checks, but 3 were not run" instead of leading with the reassuring half.
- **Fixes #60**: `-include .env` handed the whole file to Make's own parser instead of reading it as key=value, so a `$` or `#` in `OLTP_DB_URL`'s password silently truncated it, and an unbalanced `$(` was a hard parse error that aborted `make` for *every* target. Replaced with a targeted grep/sed extraction of just `OLTP_DB_URL` (the one Makefile variable this actually affects), read as text and never evaluated by Make or a shell. Also switched every recipe's `OLTP_DB_URL="$(OLTP_DB_URL)"` to single quotes — double quotes hand a literal `$` in the password to that recipe's own shell to re-expand, the same bug one layer lower.

  Precedence is unchanged and verified: `command line > .env > shell export > default`. A `make OLTP_DB_URL=... db` command-line value still beats a conflicting `.env` (Make locks in command-line variables before reading any of the makefile; no plain assignment can override them), which I confirmed by running `make db` for real against a conflicting `.env` and watching the "not the throwaway default" guard still fire correctly.

## Why
The preflight/infra-status commits exist to make the one-time AWS bring-up (#30) fail loudly rather than quietly, so they need to land before that bring-up runs, not after. #60 is folded into the same pass per #86's own checklist, since box setup writes `POSTGRES_PASSWORD`/`OLTP_DB_URL` into exactly the kind of `.env` this bug mangles.

Closes #86. Closes #60.

## Test plan
- [x] `uv run --extra serving --extra pipeline-core pytest` — 323 passed, 14 skipped
- [x] `uv run ruff check .` — all checks passed
- [x] Manually verified the dotenv fix: `.env` with `OLTP_DB_URL=postgresql+asyncpg://postgres:pa$word#hash@127.0.0.1:5544/janasunani` resolves correctly (both `$` and `#` preserved) under `make -n preflight`; `make OLTP_DB_URL=<other> db` against that same `.env` still resolves to the command-line value; plain `make db` against that `.env` correctly skips provisioning (the DSN isn't the throwaway default) without touching Docker.