### PR TITLE
MinHash/LSH duplicate index over character n-grams

### DIFF
--- a/janasunani/pipeline/dedup.py
+++ b/janasunani/pipeline/dedup.py
@@ -512,7 +512,32 @@ def identity_key(value: str, salt: str) -> str | None:
     citizens into one "identity" purely because both left the field blank.
     Callers must check for ``None`` and skip resubmission linkage for that
     record rather than treat a blank contact field as an identity.
+
+    Raises ``ValueError`` — not the ``None`` abstention above — if
+    ``salt`` is blank or whitespace-only. A blank ``value`` is a property
+    of one citizen's record: skipping that one record and hashing the rest
+    normally is the correct, contained response. A blank ``salt`` is a
+    property of the *deployment*: every key this function has ever
+    produced or will produce in that run is affected identically, so
+    "abstain and keep going" is the wrong response — it would silently
+    keep emitting keys that all fail the same way. A mobile number is one
+    of 10 billion (10^10) enumerable values; hashed without a real salt,
+    the "salted hash" is offline-invertible over that space, which
+    defeats the exact secret/rotation boundary this docstring documents
+    two paragraphs up. That is a citizen-PII exposure, not an
+    input-validation nicety, so it fails loudly and immediately rather
+    than degrading per-record.
     """
+    if not salt.strip():
+        raise ValueError(
+            "identity_key() requires a non-blank salt: a blank/"
+            "whitespace-only salt would still produce stable-looking "
+            "hashes, but over an enumerable ~10^10 mobile-number space "
+            "that is effectively unsalted and offline-invertible, "
+            "defeating the secret/rotation boundary this function exists "
+            "to provide. Fix the deployment config; do not retry with an "
+            "empty string."
+        )
     canonical_phone = _canonical_phone_digits(value)
     normalized = canonical_phone if canonical_phone is not None else value.strip().lower()
     if not normalized:

--- a/janasunani/pipeline/dedup.py
+++ b/janasunani/pipeline/dedup.py
@@ -74,10 +74,21 @@ DEFAULT_SHINGLE_SIZE = 5
 # estimate, more compute; 128 is the conventional default (e.g. datasketch).
 DEFAULT_NUM_HASHES = 128
 
-# Default LSH bands. With 128 hashes this is 8 bands of 16 rows each,
-# which puts the "probability of becoming a candidate" S-curve inflection
-# around Jaccard ~0.5 — a reasonable default for near-duplicate detection.
-DEFAULT_NUM_BANDS = 8
+# Default LSH bands. The candidate probability for a pair at true Jaccard
+# similarity s, with b bands of r = num_hashes / b rows each, is
+# P(s) = 1 - (1 - s**r)**b. That function only crosses 0.5 at s ~= 0.86 for
+# 8 bands of 16 rows (128 // 8) — nowhere near the "campaign, but retyped"
+# or "resubmission, reworded" similarity this index exists to catch (a
+# lightly reworded duplicate scores ~0.78 in tests/test_dedup.py, which
+# 8-band LSH surfaces as a candidate only ~14% of the time). 16 bands of 8
+# rows moves the crossover to s ~= 0.67 and gives that same ~0.78-similarity
+# pair a ~90% chance of becoming a candidate, while a genuinely different
+# document that only shares boilerplate ("respected sir", "kindly look
+# into the matter") at s ~= 0.3 still has under a 0.1% chance — narrow
+# enough to keep candidate volume sane, wide enough that a caller does not
+# have to remember to widen it for the primitive to do its job. Verified
+# numerically, not just approximated: see the banding tests.
+DEFAULT_NUM_BANDS = 16
 
 # 2**61 - 1, a Mersenne prime — the modulus for the MinHash permutation
 # family below. Large enough to keep collisions negligible, small enough to
@@ -156,7 +167,7 @@ def _permutations(num_hashes: int) -> list[tuple[int, int]]:
 
 def minhash_signature(
     shingle_set: Iterable[str], num_hashes: int = DEFAULT_NUM_HASHES
-) -> tuple[int, ...]:
+) -> tuple[int, ...] | None:
     """MinHash signature of a shingle set: ``num_hashes`` integers, each the
     minimum of a distinct hash permutation applied to every shingle.
 
@@ -165,15 +176,22 @@ def minhash_signature(
     the standard MinHash property, checked directly in
     ``tests/test_dedup.py``.
 
-    An empty shingle set (e.g. an all-placeholder page, see
-    :func:`shingles`) returns a constant sentinel signature — every hash
-    position at ``_MERSENNE_PRIME`` (a value no real hash reaches, since
-    hashes are reduced mod that prime) — so empty documents match only each
-    other, not arbitrary short real content.
+    Returns ``None`` for an empty shingle set (e.g. an all-placeholder page
+    or genuinely short text below :data:`DEFAULT_SHINGLE_SIZE` characters,
+    see :func:`shingles`) — this is an **abstention, not a signature**. An
+    earlier version of this function returned a constant sentinel tuple
+    here so every such document would compare equal to every other one;
+    that made blank pages and short-but-real filings like "road" or "pump"
+    mutual duplicate candidates of each other and inflated duplicate
+    prevalence on the first index build. There is nothing lexically
+    meaningful to hash, so callers must not feed the result to
+    :func:`lsh_bands` (which raises on ``None``) or treat it as a duplicate
+    match; documents with no signature are low-signal/spam-review
+    candidates for a different stage, not duplicate evidence.
     """
     base_hashes = [_base_hash(s) for s in shingle_set]
     if not base_hashes:
-        return tuple(_MERSENNE_PRIME for _ in range(num_hashes))
+        return None
     return tuple(
         min((a * h + b) % _MERSENNE_PRIME for h in base_hashes)
         for a, b in _permutations(num_hashes)
@@ -181,7 +199,7 @@ def minhash_signature(
 
 
 def lsh_bands(
-    signature: tuple[int, ...], num_bands: int = DEFAULT_NUM_BANDS
+    signature: tuple[int, ...] | None, num_bands: int = DEFAULT_NUM_BANDS
 ) -> tuple[int, ...]:
     """Split a MinHash ``signature`` into ``num_bands`` bands and return one
     hash per band.
@@ -191,15 +209,27 @@ def lsh_bands(
     guaranteed duplicates. Banding trades exact nearest-neighbor search for
     a tunable false-positive/false-negative tradeoff — fewer, wider bands
     catch fewer near-duplicates but generate fewer false candidates; more,
-    narrower bands do the opposite. The blocking by district and time
-    window that ROADMAP §5.2 calls for happens one level up, in the caller
-    that groups documents before ever calling this function — this function
-    only bands one signature.
+    narrower bands do the opposite (see the arithmetic on
+    ``DEFAULT_NUM_BANDS`` above). The blocking by district and time window
+    that ROADMAP §5.2 calls for happens one level up, in the caller that
+    groups documents before ever calling this function — this function only
+    bands one signature.
 
-    Raises ``ValueError`` if ``num_bands`` does not evenly divide the
+    Raises ``ValueError`` if ``signature`` is ``None`` — the abstention
+    :func:`minhash_signature` returns for an empty shingle set. There is no
+    band hash that means "no signature" without accidentally making all
+    such documents band-match each other, so this is a hard error: the
+    caller must branch on ``None`` before banding, not push it through.
+    Also raises ``ValueError`` if ``num_bands`` does not evenly divide the
     signature length, since an uneven last band would silently change the
     banding scheme's guarantees.
     """
+    if signature is None:
+        raise ValueError(
+            "cannot band a None signature — minhash_signature() returned "
+            "None for an empty shingle set; treat that as low-signal/spam, "
+            "not a duplicate candidate, and do not call lsh_bands() on it"
+        )
     if num_bands <= 0 or len(signature) % num_bands != 0:
         raise ValueError(
             f"num_bands ({num_bands}) must evenly divide the signature "
@@ -265,6 +295,39 @@ def union_find_groups(
     return {item: find(item) for item in parent}
 
 
+def _canonical_phone_digits(value: str) -> str | None:
+    """If ``value`` is shaped like an Indian phone number, return its
+    canonical 10-digit form; otherwise ``None``.
+
+    Collapses the common ways the same mobile number shows up across
+    `petitioner_mobile` / OCR / form entry — "+91 98612 34567",
+    "09861234567", "98612-34567", "9861234567" — to one string
+    ("9861234567") by dropping spaces/hyphens/parens, then stripping a
+    recognized leading country code ("91", for a resulting 12-digit
+    string) or trunk prefix ("0", for a resulting 11-digit string) down to
+    the bare 10-digit subscriber number.
+
+    Deliberately narrow rather than "keep the last 10 digits of anything
+    10-15 digits long": that cruder rule would fold an unrelated 11-digit
+    string starting with a stray leading digit (e.g. a typo'd
+    "19861234567") onto the real "9861234567", which is exactly the kind
+    of false resubmission match a dedup index must not manufacture.
+    Anything that isn't a bare 10-digit number, or a 10-digit number behind
+    a recognized 0/91 prefix, returns ``None`` — including email addresses
+    and short non-phone identifiers — so :func:`identity_key` falls back to
+    plain trim+lowercase for those.
+    """
+    condensed = re.sub(r"[\s\-()]", "", value.strip())
+    if not re.fullmatch(r"\+?\d{10,13}", condensed):
+        return None
+    digits = condensed.lstrip("+")
+    if len(digits) == 12 and digits.startswith("91"):
+        digits = digits[2:]
+    elif len(digits) == 11 and digits.startswith("0"):
+        digits = digits[1:]
+    return digits if len(digits) == 10 else None
+
+
 def identity_key(value: str, salt: str) -> str:
     """Salted hash of a citizen identity value (mobile number, email) for
     resubmission linkage ("same citizen, same issue" — ROADMAP §5.2,
@@ -272,11 +335,13 @@ def identity_key(value: str, salt: str) -> str:
 
     This is a **separate path** from the text path above (module docstring
     point 3): it never sees redacted text and its output never enters
-    :func:`shingles`. Callers detect resubmission by comparing
-    ``identity_key`` values directly (equal salted hash => same underlying
-    identity), and detect campaign/near-duplicate text via the
-    MinHash/LSH functions — the two signals are combined by the caller,
-    never by this module.
+    :func:`shingles`. Canonicalization happens here, before hashing —
+    nothing derived from ``value`` or ``salt`` is ever written back into
+    text that could reach the shingling path. Callers detect resubmission
+    by comparing ``identity_key`` values directly (equal salted hash =>
+    same underlying identity), and detect campaign/near-duplicate text via
+    the MinHash/LSH functions — the two signals are combined by the
+    caller, never by this module.
 
     ``salt`` is supplied by the caller (e.g. from deployment config/secrets,
     not hardcoded here) and must be kept outside version control and
@@ -284,12 +349,17 @@ def identity_key(value: str, salt: str) -> str:
     existing identity keys, which is the intended way to revoke a
     compromised salt.
 
-    The value is stripped and lowercased before hashing so that
-    "9861234567", " 9861234567 " and "9861234567" (trailing whitespace from
-    OCR/form entry) all produce the same key; case-folding matters for
-    email addresses.
+    Phone-shaped values are canonicalized via :func:`_canonical_phone_digits`
+    before hashing, so "+91 98612 34567", "09861234567", "98612-34567" and
+    "9861234567" all produce the *same* key — without this, the one job this
+    function exists for (linking same-citizen resubmissions on
+    `petitioner_mobile`) silently fails on real data, since those are all
+    the same subscriber typed differently. Anything else (email addresses)
+    is only stripped and lowercased, so "Citizen@Example.com" and
+    " citizen@example.com " match but distinct addresses stay distinct.
     """
-    normalized = value.strip().lower()
+    canonical_phone = _canonical_phone_digits(value)
+    normalized = canonical_phone if canonical_phone is not None else value.strip().lower()
     digest = hashlib.blake2b(
         f"{salt}\x00{normalized}".encode("utf-8"), digest_size=32
     )

--- a/janasunani/pipeline/dedup.py
+++ b/janasunani/pipeline/dedup.py
@@ -1,0 +1,296 @@
+"""MinHash/LSH duplicate index over character n-grams (Phase 14, W6).
+
+Deterministic, CPU-only, no model — the algorithmic core of "component (b)"
+in docs/ROADMAP.md §5.2. Lives at the light `janasunani.pipeline` level
+(like `ocr_quality.py` and `ticket.py`), not inside `stages/`, because it is
+deliberately **stdlib-only**: `hashlib`, `re`, `random`, `collections.abc`.
+No numpy, no presidio, no torch, no datasketch. That keeps this module (and
+`tests/test_dedup.py`) importable and runnable in CI, which installs no
+heavy extras — every other pipeline test guards with
+`pytest.importorskip` and skips there. This is the one pipeline module that
+doesn't, and is therefore the only real CI coverage over the whole
+intelligence layer that Phase 15 converges on. Keep it that way: do not add
+a dependency here to make an implementation nicer.
+
+Wiring this in as the 7th pipeline stage (`spam_duplicate`, after
+`pii_tagger`) is deliberately out of scope for this module — see the
+tracking issue. This file only provides the primitives:
+`shingles`, `minhash_signature`, `lsh_bands`, `union_find_groups`,
+`strip_placeholders`, `identity_key`.
+
+Four things that shape every function below:
+
+1. **Character n-grams, not word tokens.** Word tokenization does not work
+   across Odia, romanized Odia and English in one index; character grams
+   also survive OCR noise that would break word boundaries. See
+   docs/ROADMAP.md §5.2.
+2. **Typed PII placeholders are stripped before shingling.** Redacted text
+   (the input here — this index is built from `grievance_redacted` /
+   `pages.redacted_text`) carries typed tokens like `[PHONE]`, `[NAME]`
+   in place of real PII. Left in, every redacted phone number is the
+   identical literal token, so two unrelated grievances that each mention a
+   name and a phone number share those n-grams and score as more similar
+   than they are. `shingles()` calls `strip_placeholders()` for exactly
+   this reason — there is no shingling path that skips it.
+3. **Identity keys are a separate path from the text path.** `identity_key`
+   salts and hashes a citizen identity value (mobile, email) for
+   resubmission linkage ("same citizen, same issue"). It never touches
+   `shingles`/`minhash_signature`/`lsh_bands`, and the reverse must also
+   hold: identity values must never be concatenated into the text that gets
+   shingled, and shingled text must never carry a raw identity value. A raw
+   mobile number in a dedup index is a PII store by another name.
+4. **Cross-script recall is explicitly unsupported.** Odia-script and
+   romanized-Odia filings must be indexed and matched *separately* — never
+   against each other. Character n-grams operate on raw codepoints, and
+   Odia script and Latin script occupy disjoint Unicode ranges, so a
+   romanized filing and its Odia-script twin share ~zero shingles and will
+   not be found as duplicates by this module. That is a known, accepted
+   gap, not a bug: the transliteration step that would close it is Phase 17
+   (§5.5), which runs after this phase. Callers must partition documents by
+   script (or language field) before building an index and never run one
+   index across both. `test_dedup.py` pins this as a limitation, not a
+   feature to "fix" by loosening the shingle function.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import random
+import re
+from collections.abc import Iterable
+
+# Typed PII placeholder tokens look like "[PHONE]", "[NAME]", "[AADHAAR]"
+# (see janasunani/pipeline/stages/pii_tagger.py:ENTITY_TOKENS) — a bracketed
+# run of uppercase letters, nothing else ever looks like this in redacted
+# grievance text.
+_PLACEHOLDER_RE = re.compile(r"\[[A-Z]+\]")
+
+# Character shingle width. Short enough to survive OCR noise and short
+# grievance text, long enough that shingles carry real content rather than
+# matching on common letter pairs.
+DEFAULT_SHINGLE_SIZE = 5
+
+# Number of hash functions in a MinHash signature. Higher = better Jaccard
+# estimate, more compute; 128 is the conventional default (e.g. datasketch).
+DEFAULT_NUM_HASHES = 128
+
+# Default LSH bands. With 128 hashes this is 8 bands of 16 rows each,
+# which puts the "probability of becoming a candidate" S-curve inflection
+# around Jaccard ~0.5 — a reasonable default for near-duplicate detection.
+DEFAULT_NUM_BANDS = 8
+
+# 2**61 - 1, a Mersenne prime — the modulus for the MinHash permutation
+# family below. Large enough to keep collisions negligible, small enough to
+# stay in a 64-bit int and keep the arithmetic cheap.
+_MERSENNE_PRIME = (1 << 61) - 1
+
+# Fixed seed for the permutation coefficients (not a security secret — it
+# only needs to make minhash_signature() reproducible across processes and
+# runs, not unpredictable). Changing this value changes every signature
+# ever produced; don't.
+_PERMUTATION_SEED = 0x4A53_6465_6475_70  # "JSdedup" packed into hex, arbitrary
+
+
+def strip_placeholders(text: str) -> str:
+    """Remove typed PII placeholder tokens (``[PHONE]``, ``[NAME]``, ...)
+    and collapse the resulting whitespace.
+
+    Called by :func:`shingles` before n-gramming — see module docstring
+    point 2. Exposed separately because callers (and tests) may want to
+    inspect the stripped text on its own.
+    """
+    stripped = _PLACEHOLDER_RE.sub(" ", text)
+    return " ".join(stripped.split())
+
+
+def shingles(text: str, k: int = DEFAULT_SHINGLE_SIZE) -> set[str]:
+    """Character k-gram shingles of ``text``.
+
+    Strips typed PII placeholders first (module docstring point 2) and
+    lowercases before n-gramming — ``.lower()`` only folds cased
+    (Latin-script) characters, so this is a no-op on Odia script and simply
+    normalizes case variation in English/romanized-Odia text.
+
+    Character n-grams, not word tokens (module docstring point 1): this
+    also means shingles never bridge scripts on their own (module docstring
+    point 4) — a codepoint from Odia script and a codepoint from Latin
+    script never appear in the same shingle in a way that produces a
+    collision, because the two scripts occupy disjoint Unicode ranges.
+
+    Returns an empty set for text that reduces to fewer than ``k``
+    characters after stripping (e.g. an all-placeholder page).
+    """
+    normalized = strip_placeholders(text).lower()
+    if len(normalized) < k:
+        return set()
+    return {normalized[i : i + k] for i in range(len(normalized) - k + 1)}
+
+
+def _base_hash(value: str) -> int:
+    """Stable (process- and run-independent) integer hash of a string.
+
+    Python's builtin ``hash()`` is salted per-process for strings, which
+    would make signatures non-reproducible across runs — exactly wrong for
+    an index that gets rebuilt incrementally. blake2b is stdlib, fast, and
+    deterministic.
+    """
+    digest = hashlib.blake2b(value.encode("utf-8"), digest_size=8).digest()
+    return int.from_bytes(digest, "big")
+
+
+def _permutations(num_hashes: int) -> list[tuple[int, int]]:
+    """``num_hashes`` deterministic ``(a, b)`` coefficient pairs for the
+    MinHash permutation family ``h(x) = (a*x + b) mod _MERSENNE_PRIME``.
+
+    Seeded from a fixed constant rather than system randomness, so calling
+    this twice with the same ``num_hashes`` always yields the same
+    permutations — required for signatures to be comparable across
+    documents indexed in different batches or processes.
+    """
+    rng = random.Random(_PERMUTATION_SEED)
+    return [
+        (rng.randint(1, _MERSENNE_PRIME - 1), rng.randint(0, _MERSENNE_PRIME - 1))
+        for _ in range(num_hashes)
+    ]
+
+
+def minhash_signature(
+    shingle_set: Iterable[str], num_hashes: int = DEFAULT_NUM_HASHES
+) -> tuple[int, ...]:
+    """MinHash signature of a shingle set: ``num_hashes`` integers, each the
+    minimum of a distinct hash permutation applied to every shingle.
+
+    Two documents' signatures agree in a fraction of positions that is an
+    unbiased estimator of the Jaccard similarity of their shingle sets —
+    the standard MinHash property, checked directly in
+    ``tests/test_dedup.py``.
+
+    An empty shingle set (e.g. an all-placeholder page, see
+    :func:`shingles`) returns a constant sentinel signature — every hash
+    position at ``_MERSENNE_PRIME`` (a value no real hash reaches, since
+    hashes are reduced mod that prime) — so empty documents match only each
+    other, not arbitrary short real content.
+    """
+    base_hashes = [_base_hash(s) for s in shingle_set]
+    if not base_hashes:
+        return tuple(_MERSENNE_PRIME for _ in range(num_hashes))
+    return tuple(
+        min((a * h + b) % _MERSENNE_PRIME for h in base_hashes)
+        for a, b in _permutations(num_hashes)
+    )
+
+
+def lsh_bands(
+    signature: tuple[int, ...], num_bands: int = DEFAULT_NUM_BANDS
+) -> tuple[int, ...]:
+    """Split a MinHash ``signature`` into ``num_bands`` bands and return one
+    hash per band.
+
+    Two documents that share a band hash at the same band index are LSH
+    *candidates*: worth an exact Jaccard/union-find comparison, not
+    guaranteed duplicates. Banding trades exact nearest-neighbor search for
+    a tunable false-positive/false-negative tradeoff — fewer, wider bands
+    catch fewer near-duplicates but generate fewer false candidates; more,
+    narrower bands do the opposite. The blocking by district and time
+    window that ROADMAP §5.2 calls for happens one level up, in the caller
+    that groups documents before ever calling this function — this function
+    only bands one signature.
+
+    Raises ``ValueError`` if ``num_bands`` does not evenly divide the
+    signature length, since an uneven last band would silently change the
+    banding scheme's guarantees.
+    """
+    if num_bands <= 0 or len(signature) % num_bands != 0:
+        raise ValueError(
+            f"num_bands ({num_bands}) must evenly divide the signature "
+            f"length ({len(signature)})"
+        )
+    rows_per_band = len(signature) // num_bands
+    bands = []
+    for i in range(num_bands):
+        band = signature[i * rows_per_band : (i + 1) * rows_per_band]
+        band_digest = hashlib.blake2b(repr(band).encode("utf-8"), digest_size=8)
+        bands.append(int.from_bytes(band_digest.digest(), "big"))
+    return tuple(bands)
+
+
+def union_find_groups(
+    pairs: Iterable[tuple[str, str]],
+    items: Iterable[str] | None = None,
+) -> dict[str, str]:
+    """Union-find over candidate pairs (e.g. document ids that shared an LSH
+    band), returning ``{item: group_id}`` for every item seen.
+
+    Merges are **transitive**: if pairs contain ``("a", "b")`` and
+    ``("b", "c")``, ``a``, ``b`` and ``c`` all land in one group even though
+    ``a`` and ``c`` never appeared together in a pair — exactly the case LSH
+    banding produces, since it only reports pairwise band collisions, not a
+    full pairwise comparison.
+
+    ``group_id`` is the lexicographically smallest item string in the
+    group, so it is stable and does not depend on the order pairs arrive
+    in. Pass ``items`` to also include documents that never candidate-paired
+    with anything — they come back as singleton groups keyed to themselves,
+    which is the "not a duplicate of anything found" case.
+    """
+    parent: dict[str, str] = {}
+
+    def find(x: str) -> str:
+        parent.setdefault(x, x)
+        root = x
+        while parent[root] != root:
+            root = parent[root]
+        while parent[x] != root:
+            parent[x], x = root, parent[x]
+        return root
+
+    def union(a: str, b: str) -> None:
+        root_a, root_b = find(a), find(b)
+        if root_a == root_b:
+            return
+        # Attach the larger root under the smaller so the group id is
+        # always the lexicographically smallest member, regardless of the
+        # order pairs were unioned in.
+        if root_a < root_b:
+            parent[root_b] = root_a
+        else:
+            parent[root_a] = root_b
+
+    for a, b in pairs:
+        union(a, b)
+    if items is not None:
+        for item in items:
+            parent.setdefault(item, item)
+
+    return {item: find(item) for item in parent}
+
+
+def identity_key(value: str, salt: str) -> str:
+    """Salted hash of a citizen identity value (mobile number, email) for
+    resubmission linkage ("same citizen, same issue" — ROADMAP §5.2,
+    duplicate relation 1).
+
+    This is a **separate path** from the text path above (module docstring
+    point 3): it never sees redacted text and its output never enters
+    :func:`shingles`. Callers detect resubmission by comparing
+    ``identity_key`` values directly (equal salted hash => same underlying
+    identity), and detect campaign/near-duplicate text via the
+    MinHash/LSH functions — the two signals are combined by the caller,
+    never by this module.
+
+    ``salt`` is supplied by the caller (e.g. from deployment config/secrets,
+    not hardcoded here) and must be kept outside version control and
+    outside the redacted-text tables. Rotating the salt invalidates all
+    existing identity keys, which is the intended way to revoke a
+    compromised salt.
+
+    The value is stripped and lowercased before hashing so that
+    "9861234567", " 9861234567 " and "9861234567" (trailing whitespace from
+    OCR/form entry) all produce the same key; case-folding matters for
+    email addresses.
+    """
+    normalized = value.strip().lower()
+    digest = hashlib.blake2b(
+        f"{salt}\x00{normalized}".encode("utf-8"), digest_size=32
+    )
+    return digest.hexdigest()

--- a/janasunani/pipeline/dedup.py
+++ b/janasunani/pipeline/dedup.py
@@ -3,10 +3,10 @@
 Deterministic, CPU-only, no model — the algorithmic core of "component (b)"
 in docs/ROADMAP.md §5.2. Lives at the light `janasunani.pipeline` level
 (like `ocr_quality.py` and `ticket.py`), not inside `stages/`, because it is
-deliberately **stdlib-only**: `hashlib`, `re`, `random`, `collections.abc`.
-No numpy, no presidio, no torch, no datasketch. That keeps this module (and
-`tests/test_dedup.py`) importable and runnable in CI, which installs no
-heavy extras — every other pipeline test guards with
+deliberately **stdlib-only**: `hashlib`, `re`, `random`, `unicodedata`,
+`collections.abc`. No numpy, no presidio, no torch, no datasketch. That
+keeps this module (and `tests/test_dedup.py`) importable and runnable in
+CI, which installs no heavy extras — every other pipeline test guards with
 `pytest.importorskip` and skips there. This is the one pipeline module that
 doesn't, and is therefore the only real CI coverage over the whole
 intelligence layer that Phase 15 converges on. Keep it that way: do not add
@@ -14,11 +14,11 @@ a dependency here to make an implementation nicer.
 
 Wiring this in as the 7th pipeline stage (`spam_duplicate`, after
 `pii_tagger`) is deliberately out of scope for this module — see the
-tracking issue. This file only provides the primitives:
-`shingles`, `minhash_signature`, `lsh_bands`, `union_find_groups`,
-`strip_placeholders`, `identity_key`.
+tracking issue. This file provides the primitives:
+`shingles`, `minhash_signature`, `lsh_bands`, `jaccard_similarity`,
+`union_find_groups`, `strip_placeholders`, `identity_key`.
 
-Four things that shape every function below:
+Six things that shape every function below:
 
 1. **Character n-grams, not word tokens.** Word tokenization does not work
    across Odia, romanized Odia and English in one index; character grams
@@ -50,6 +50,33 @@ Four things that shape every function below:
    script (or language field) before building an index and never run one
    index across both. `test_dedup.py` pins this as a limitation, not a
    feature to "fix" by loosening the shingle function.
+5. **Refuse rather than hash a value with nothing meaningful in it.**
+   Several review rounds found the same shape of bug under different
+   clothes: an input that looks valid enough to hash but silently collapses
+   distinct records onto one identity or one group. `minhash_signature`
+   returns ``None`` (not a shared sentinel) for an empty shingle set;
+   `identity_key` returns ``None`` (not a hash of the empty string) for a
+   blank/whitespace-only value — `petitioner_mobile`/`petitioner_email` are
+   nullable and blank strings are not normalized to ``None`` at ingestion,
+   so hashing `""` would otherwise merge every citizen with a missing
+   contact field into one "identity"; `minhash_signature` also rejects
+   ``num_hashes <= 0`` outright rather than silently returning an empty
+   signature that would band-collapse an entire indexed slice into one
+   group. One rule, three call sites: **if there is nothing real to
+   compare, refuse rather than produce a comparable-looking output.**
+6. **An LSH candidate is not a duplicate until verified.** `lsh_bands`
+   reports a shared band as a candidate worth checking, not a confirmed
+   match — a chance collision between two unrelated documents is expected
+   at some rate by construction. `union_find_groups` performs blind
+   transitive closure over whatever pairs it is given and does not verify
+   anything itself, so passing raw LSH candidate pairs straight into it
+   turns every chance collision into a confirmed duplicate group, and
+   transitive merging can pull further, unrelated documents into that
+   false group. `jaccard_similarity` is the verification step: compute it
+   on the real shingle sets for every candidate pair and only pass pairs
+   above a chosen threshold into `union_find_groups`. See the end-to-end
+   test in `test_dedup.py` for the full candidate -> verify -> union
+   pattern.
 """
 
 from __future__ import annotations
@@ -57,6 +84,7 @@ from __future__ import annotations
 import hashlib
 import random
 import re
+import unicodedata
 from collections.abc import Iterable
 
 # Typed PII placeholder tokens look like "[PHONE]", "[NAME]", "[AADHAAR]"
@@ -128,10 +156,27 @@ def strip_placeholders(text: str) -> str:
 def shingles(text: str, k: int = DEFAULT_SHINGLE_SIZE) -> set[str]:
     """Character k-gram shingles of ``text``.
 
-    Strips typed PII placeholders first (module docstring point 2) and
-    lowercases before n-gramming — ``.lower()`` only folds cased
-    (Latin-script) characters, so this is a no-op on Odia script and simply
-    normalizes case variation in English/romanized-Odia text.
+    Strips typed PII placeholders first (module docstring point 2), then
+    Unicode-normalizes to NFC and lowercases before n-gramming.
+
+    NFC (canonical composition) matters specifically for Odia script:
+    Unicode allows the same visible character to be encoded two ways —
+    e.g. the vowel sign U+0B4B, or the canonically equivalent sequence
+    U+0B47 U+0B3E — and which one a given OCR pass or storage layer emits
+    is not something this module controls or can assume is consistent
+    across the corpus. Without normalizing, the composed and decomposed
+    encodings of the *same filing* produce disjoint shingle sets (different
+    codepoint sequences, different sliding windows) and never share an LSH
+    band, so byte-identical-looking text fails to dedup against itself.
+    NFC (over NFD, or the compatibility forms NFKC/NFKD) is the deliberate
+    choice: NFC resolves exactly this canonical-equivalence case — the
+    concern here — without NFKC/NFKD's further compatibility folding (e.g.
+    full-width digits onto ASCII, ligatures onto letter sequences), which
+    would fold text that is not actually the same character sequence and
+    is out of scope for this fix. `.lower()` runs after normalization —
+    it only folds cased (Latin-script) characters, so it is a no-op on
+    Odia script and simply normalizes case variation in
+    English/romanized-Odia text.
 
     Character n-grams, not word tokens (module docstring point 1): this
     also means shingles never bridge scripts on their own (module docstring
@@ -142,7 +187,7 @@ def shingles(text: str, k: int = DEFAULT_SHINGLE_SIZE) -> set[str]:
     Returns an empty set for text that reduces to fewer than ``k``
     characters after stripping (e.g. an all-placeholder page).
     """
-    normalized = strip_placeholders(text).lower()
+    normalized = unicodedata.normalize("NFC", strip_placeholders(text)).lower()
     if len(normalized) < k:
         return set()
     return {normalized[i : i + k] for i in range(len(normalized) - k + 1)}
@@ -199,7 +244,20 @@ def minhash_signature(
     :func:`lsh_bands` (which raises on ``None``) or treat it as a duplicate
     match; documents with no signature are low-signal/spam-review
     candidates for a different stage, not duplicate evidence.
+
+    Raises ``ValueError`` for ``num_hashes <= 0``. Without this check a
+    nonpositive value silently produced an *empty* tuple instead of either
+    a real signature or the ``None`` abstention above — a signature that
+    :func:`lsh_bands` would then accept (an empty tuple trivially satisfies
+    ``0 % num_bands == 0``), hash zero-length slices for every band, and
+    so give every document in the slice the same band values, collapsing
+    the whole indexed slice into one duplicate group. That is a
+    misconfiguration, not a legitimate abstention, so it fails loudly here
+    instead of surfacing three functions downstream as a silent mass
+    false-duplicate.
     """
+    if num_hashes <= 0:
+        raise ValueError(f"num_hashes must be positive, got {num_hashes}")
     base_hashes = [_base_hash(s) for s in shingle_set]
     if not base_hashes:
         return None
@@ -255,18 +313,62 @@ def lsh_bands(
     return tuple(bands)
 
 
+def jaccard_similarity(shingles_a: Iterable[str], shingles_b: Iterable[str]) -> float:
+    """Exact Jaccard similarity ``|A ∩ B| / |A ∪ B|`` of two shingle sets.
+
+    This is the verification step LSH candidate generation calls for but
+    does not perform itself (module docstring point 6): :func:`lsh_bands`
+    reports a shared band as a *candidate*, and :func:`union_find_groups`
+    unions whatever pairs it is handed with no verification of its own —
+    call this on the real shingle sets (not the MinHash signatures, which
+    only *estimate* Jaccard) for every candidate pair, and only pass pairs
+    at or above your chosen duplicate threshold into
+    :func:`union_find_groups`. See the end-to-end test in
+    ``tests/test_dedup.py`` for the full candidate -> verify -> union
+    pattern.
+
+    Returns ``0.0`` for two empty shingle sets rather than the
+    mathematically undefined ``0/0``: nothing to compare is not evidence of
+    similarity, the same "refuse rather than claim a match" stance
+    :func:`minhash_signature` and :func:`identity_key` take for a single
+    empty/blank input (module docstring point 5) — this just extends it to
+    the pairwise case in case a caller passes two abstained-from inputs
+    through instead of already having skipped them.
+    """
+    set_a, set_b = set(shingles_a), set(shingles_b)
+    if not set_a and not set_b:
+        return 0.0
+    return len(set_a & set_b) / len(set_a | set_b)
+
+
 def union_find_groups(
     pairs: Iterable[tuple[str, str]],
     items: Iterable[str] | None = None,
 ) -> dict[str, str]:
-    """Union-find over candidate pairs (e.g. document ids that shared an LSH
-    band), returning ``{item: group_id}`` for every item seen.
+    """Union-find over **already-verified** candidate pairs (e.g. document
+    ids whose shingle sets passed a :func:`jaccard_similarity` threshold
+    after an LSH candidate search), returning ``{item: group_id}`` for
+    every item seen.
+
+    This function performs blind transitive closure: it does not compute
+    or check any similarity itself, and trusts every pair it is given.
+    Passing raw LSH candidate pairs (a shared band, not a verified match —
+    see :func:`lsh_bands`) straight into this function turns every chance
+    band collision into a confirmed duplicate group, and transitive merging
+    then pulls further, unrelated documents into that false group. Verify
+    with :func:`jaccard_similarity` first — this is module docstring
+    point 6, and it is a real hazard, not a hypothetical one: an earlier
+    version of ``tests/test_dedup.py`` fed shared-band buckets straight
+    into this function without that check.
 
     Merges are **transitive**: if pairs contain ``("a", "b")`` and
     ``("b", "c")``, ``a``, ``b`` and ``c`` all land in one group even though
     ``a`` and ``c`` never appeared together in a pair — exactly the case LSH
     banding produces, since it only reports pairwise band collisions, not a
-    full pairwise comparison.
+    full pairwise comparison. This is precisely why unverified input is
+    dangerous here: one false-positive candidate pair does not just merge
+    two documents, it can chain-merge everything transitively reachable
+    through it.
 
     ``group_id`` is the lexicographically smallest item string in the
     group, so it is stable and does not depend on the order pairs arrive
@@ -366,7 +468,7 @@ def _canonical_phone_digits(value: str) -> str | None:
     return digits if len(digits) == 10 else None
 
 
-def identity_key(value: str, salt: str) -> str:
+def identity_key(value: str, salt: str) -> str | None:
     """Salted hash of a citizen identity value (mobile number, email) for
     resubmission linkage ("same citizen, same issue" — ROADMAP §5.2,
     duplicate relation 1).
@@ -399,9 +501,22 @@ def identity_key(value: str, salt: str) -> str:
     falls to the plain-text path below instead. Anything else (email
     addresses) is only stripped and lowercased, so "Citizen@Example.com"
     and " citizen@example.com " match but distinct addresses stay distinct.
+
+    Returns ``None`` — an abstention, the same contract
+    :func:`minhash_signature` uses for "nothing meaningful here" (module
+    docstring point 5) — if ``value`` is blank or whitespace-only after
+    normalization. `petitioner_mobile` / `petitioner_email` are nullable
+    columns and blank strings are not normalized to ``None`` at ingestion,
+    so hashing `""` would otherwise give every citizen with a missing
+    contact field the *same* valid-looking salted hash, merging unrelated
+    citizens into one "identity" purely because both left the field blank.
+    Callers must check for ``None`` and skip resubmission linkage for that
+    record rather than treat a blank contact field as an identity.
     """
     canonical_phone = _canonical_phone_digits(value)
     normalized = canonical_phone if canonical_phone is not None else value.strip().lower()
+    if not normalized:
+        return None
     digest = hashlib.blake2b(
         f"{salt}\x00{normalized}".encode("utf-8"), digest_size=32
     )

--- a/janasunani/pipeline/dedup.py
+++ b/janasunani/pipeline/dedup.py
@@ -65,6 +65,17 @@ from collections.abc import Iterable
 # grievance text.
 _PLACEHOLDER_RE = re.compile(r"\[[A-Z]+\]")
 
+# Odia (U+0B66) and Devanagari (U+0966) decimal digits -> ASCII, for phone
+# canonicalization in identity_key(). Same two blocks and the same rationale
+# as pii_tagger.py's _INDIC_DIGITS_TO_ASCII: these are the digit scripts
+# that actually show up in this corpus (Odia-script filings; Devanagari for
+# the occasional Hindi-medium form). Deliberately narrow — see
+# _canonical_phone_digits()'s docstring for what happens to every other
+# Unicode digit system.
+_INDIC_DIGITS_TO_ASCII = str.maketrans(
+    {base + i: str(i) for base in (0x0966, 0x0B66) for i in range(10)}
+)
+
 # Character shingle width. Short enough to survive OCR noise and short
 # grievance text, long enough that shingles carry real content rather than
 # matching on common letter pairs.
@@ -297,15 +308,40 @@ def union_find_groups(
 
 def _canonical_phone_digits(value: str) -> str | None:
     """If ``value`` is shaped like an Indian phone number, return its
-    canonical 10-digit form; otherwise ``None``.
+    canonical 10-digit ASCII form; otherwise ``None``.
 
     Collapses the common ways the same mobile number shows up across
     `petitioner_mobile` / OCR / form entry — "+91 98612 34567",
-    "09861234567", "98612-34567", "9861234567" — to one string
-    ("9861234567") by dropping spaces/hyphens/parens, then stripping a
-    recognized leading country code ("91", for a resulting 12-digit
-    string) or trunk prefix ("0", for a resulting 11-digit string) down to
-    the bare 10-digit subscriber number.
+    "09861234567", "98612-34567", "9861234567", or the same number typed in
+    Odia or Devanagari numerals ("୯୮୬୧୨୩୪୫୬୭") — to one ASCII string
+    ("9861234567"). Odia/Devanagari digits are translated to ASCII *first*
+    (via ``_INDIC_DIGITS_TO_ASCII``), so a citizen number entered in
+    Odia-script numerals canonicalizes to the same key as the ASCII form —
+    this is a primary input path for this corpus, not an edge case,
+    exactly where resubmission linkage most needs to work. Only then are
+    spaces/hyphens/parens dropped and a recognized leading country code
+    ("91", for a resulting 12-digit string) or trunk prefix ("0", for a
+    resulting 11-digit string) stripped down to the bare 10-digit
+    subscriber number.
+
+    The digit match after translation is deliberately ``[0-9]``, not
+    ``\\d``: Python's ``\\d`` matches *any* Unicode decimal-digit
+    character, not just ASCII — Bengali, Tamil, Gurmukhi, full-width digits
+    and more all satisfy it. Without translating a script first, treating
+    its digits as fair game for the length/prefix arithmetic below would
+    silently misparse them (a lone untranslated Odia digit sitting next to
+    ASCII digits, for instance, would still count toward "12 digits,
+    strip 91" purely by ``\\d`` matching it, with no translation applied to
+    make that arithmetic correct). Restricting to ``[0-9]`` after
+    translating only the two scripts this corpus actually uses means any
+    *other* digit script fails the match outright and falls through to
+    :func:`identity_key`'s plain trim+lowercase path instead — it hashes
+    consistently (so repeated values in that script still link to each
+    other) but does not claim to link to the ASCII/Odia/Devanagari form of
+    the same number. That is an accepted gap, not silently patched over:
+    pinned in ``tests/test_dedup.py`` alongside the module's other
+    cross-script limitations, not "fixed" by transliterating scripts this
+    corpus does not use.
 
     Deliberately narrow rather than "keep the last 10 digits of anything
     10-15 digits long": that cruder rule would fold an unrelated 11-digit
@@ -313,12 +349,14 @@ def _canonical_phone_digits(value: str) -> str | None:
     "19861234567") onto the real "9861234567", which is exactly the kind
     of false resubmission match a dedup index must not manufacture.
     Anything that isn't a bare 10-digit number, or a 10-digit number behind
-    a recognized 0/91 prefix, returns ``None`` — including email addresses
-    and short non-phone identifiers — so :func:`identity_key` falls back to
-    plain trim+lowercase for those.
+    a recognized 0/91 prefix, returns ``None`` — including email addresses,
+    short non-phone identifiers, and phone numbers in an unhandled digit
+    script — so :func:`identity_key` falls back to plain trim+lowercase for
+    those.
     """
-    condensed = re.sub(r"[\s\-()]", "", value.strip())
-    if not re.fullmatch(r"\+?\d{10,13}", condensed):
+    ascii_digits = value.strip().translate(_INDIC_DIGITS_TO_ASCII)
+    condensed = re.sub(r"[\s\-()]", "", ascii_digits)
+    if not re.fullmatch(r"\+?[0-9]{10,13}", condensed):
         return None
     digits = condensed.lstrip("+")
     if len(digits) == 12 and digits.startswith("91"):
@@ -350,13 +388,17 @@ def identity_key(value: str, salt: str) -> str:
     compromised salt.
 
     Phone-shaped values are canonicalized via :func:`_canonical_phone_digits`
-    before hashing, so "+91 98612 34567", "09861234567", "98612-34567" and
-    "9861234567" all produce the *same* key — without this, the one job this
-    function exists for (linking same-citizen resubmissions on
-    `petitioner_mobile`) silently fails on real data, since those are all
-    the same subscriber typed differently. Anything else (email addresses)
-    is only stripped and lowercased, so "Citizen@Example.com" and
-    " citizen@example.com " match but distinct addresses stay distinct.
+    before hashing, so "+91 98612 34567", "09861234567", "98612-34567",
+    "9861234567" and the same number typed in Odia or Devanagari numerals
+    all produce the *same* key — without this, the one job this function
+    exists for (linking same-citizen resubmissions on `petitioner_mobile`)
+    silently fails on real data, since those are all the same subscriber
+    typed differently, and Odia-script/OCR-entered numbers are a primary
+    input path here, not a corner case. A phone number in any other digit
+    script is not canonicalized (see that function's docstring for why) and
+    falls to the plain-text path below instead. Anything else (email
+    addresses) is only stripped and lowercased, so "Citizen@Example.com"
+    and " citizen@example.com " match but distinct addresses stay distinct.
     """
     canonical_phone = _canonical_phone_digits(value)
     normalized = canonical_phone if canonical_phone is not None else value.strip().lower()

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -1,0 +1,338 @@
+"""MinHash/LSH duplicate index (janasunani.pipeline.dedup).
+
+`dedup.py` is deliberately stdlib-only (hashlib, re, random) so it — and
+this test file — run in CI with no pipeline extras installed. Unlike every
+other pipeline test, this file does NOT `pytest.importorskip`: it is the one
+real code-path CI coverage the whole intelligence layer (Phase 15) has, per
+docs/ROADMAP.md §5.2/§5.6. Do not add a guard here.
+
+Synthetic strings only — no real grievance text, no `data/` access.
+"""
+
+from janasunani.pipeline.dedup import (
+    DEFAULT_NUM_HASHES,
+    identity_key,
+    lsh_bands,
+    minhash_signature,
+    shingles,
+    strip_placeholders,
+    union_find_groups,
+)
+
+# --- synthetic fixtures --------------------------------------------------
+
+# A "campaign": near-identical grievance text as it would look after
+# pii_tagger has redacted the signatory's name and phone. Two signatories,
+# same underlying complaint.
+CAMPAIGN_A = (
+    "[NAME] [PHONE] respected sir the hand pump in our village has been "
+    "broken for three months kindly send someone to repair it urgently"
+)
+CAMPAIGN_B = (
+    "[NAME] [PHONE] respected sir the hand pump in our village has been "
+    "broken for three months kindly send someone to repair it urgently"
+)
+# Same complaint, lightly reworded (a second signatory retyping it, not a
+# copy-paste) — near-duplicate, not byte-identical.
+CAMPAIGN_C_REWORDED = (
+    "[NAME] [PHONE] respected sir the hand pump in our village has stayed "
+    "broken for three months kindly send someone to repair it very urgently"
+)
+
+UNRELATED_COMPLAINT = (
+    "[NAME] [PHONE] the municipal garbage truck has not visited our street "
+    "in over a month and waste is piling up near the market causing a "
+    "health hazard for children playing nearby"
+)
+
+# Real Odia-script Unicode text and an unrelated romanized-Odia string
+# (Latin script). Not a translation of each other on purpose — the point of
+# the cross-script test is codepoint disjointness, not semantic equivalence.
+ODIA_SCRIPT_TEXT = (
+    "ଆମ ଗାଁରେ ପାଣି ପମ୍ପ ତିନି ମାସ ହେଲା ଖରାପ ଅଛି। ଦୟାକରି ମରାମତି କରନ୍ତୁ।"
+)
+ROMANIZED_TEXT = (
+    "aame ganre pani pump tini masa hela kharap achi doyakari maramati karantu"
+)
+
+
+# --- strip_placeholders ---------------------------------------------------
+
+
+def test_strip_placeholders_removes_typed_pii_tokens():
+    text = "[NAME] called about a leak, contact [PHONE] or [EMAIL]."
+    stripped = strip_placeholders(text)
+    assert "[NAME]" not in stripped
+    assert "[PHONE]" not in stripped
+    assert "[EMAIL]" not in stripped
+    assert "called about a leak, contact" in stripped
+
+
+def test_strip_placeholders_collapses_whitespace():
+    assert strip_placeholders("a  [NAME]   b") == "a b"
+
+
+def test_strip_placeholders_leaves_ordinary_bracket_free_text_alone():
+    # Only the exact typed-token shape ([A-Z]+) is stripped.
+    text = "the pump (broken) needs repair"
+    assert strip_placeholders(text) == text
+
+
+# --- shingles --------------------------------------------------------------
+
+
+def test_shingles_are_character_ngrams_not_words():
+    # Overlapping character windows, not whole-word tokens — the
+    # word-tokenization behavior this module explicitly rejects (ROADMAP
+    # §5.2). Word tokenization on "hello world" would yield exactly the two
+    # tokens {"hello", "world"}; character 5-grams instead slide across the
+    # word boundary, producing windows like "llo w" / "lo wo" / "o wor" that
+    # straddle both words and have no word-token analogue.
+    result = shingles("hello world", k=5)
+    assert len(result) == len("hello world") - 5 + 1
+    assert {"llo w", "lo wo", "o wor"} <= result
+    assert all(len(s) == 5 for s in result)
+
+
+def test_shingles_strips_placeholders_before_ngramming():
+    with_placeholder = shingles("call [PHONE] now", k=4)
+    without_placeholder = shingles("call now", k=4)
+    assert with_placeholder == without_placeholder
+    assert not any("PHONE" in s.upper() and "[" in s for s in with_placeholder)
+
+
+def test_shingles_short_text_returns_empty_set():
+    assert shingles("hi", k=5) == set()
+    assert shingles("[PHONE]", k=5) == set()  # all-placeholder page
+
+
+def test_shingles_case_insensitive_for_latin_script():
+    assert shingles("Hello World", k=5) == shingles("hello world", k=5)
+
+
+# --- minhash_signature -------------------------------------------------
+
+
+def test_minhash_signature_deterministic_across_calls():
+    s = shingles(CAMPAIGN_A)
+    sig1 = minhash_signature(s)
+    sig2 = minhash_signature(s)
+    assert sig1 == sig2
+    assert len(sig1) == DEFAULT_NUM_HASHES
+
+
+def test_minhash_signature_identical_text_matches_exactly():
+    sig_a = minhash_signature(shingles(CAMPAIGN_A))
+    sig_b = minhash_signature(shingles(CAMPAIGN_B))
+    assert sig_a == sig_b
+
+
+def test_minhash_signature_empty_shingle_set_is_sentinel_and_self_consistent():
+    empty_sig = minhash_signature(set())
+    assert empty_sig == minhash_signature(set())
+    assert len(set(empty_sig)) == 1  # constant sentinel value in every slot
+    # A real (non-empty) signature should not collide with the sentinel.
+    real_sig = minhash_signature(shingles(CAMPAIGN_A))
+    assert real_sig != empty_sig
+
+
+def test_minhash_signature_approximates_jaccard_similarity():
+    # Two texts sharing most but not all of a sentence: compute true
+    # Jaccard directly from the shingle sets, then check the MinHash
+    # signature agreement rate (the standard unbiased estimator) lands
+    # close to it.
+    shingles_a = shingles(CAMPAIGN_A)
+    shingles_b = shingles(CAMPAIGN_C_REWORDED)
+    true_jaccard = len(shingles_a & shingles_b) / len(shingles_a | shingles_b)
+    assert 0.5 < true_jaccard < 0.95  # reworded, not identical, not disjoint
+
+    num_hashes = 256
+    sig_a = minhash_signature(shingles_a, num_hashes=num_hashes)
+    sig_b = minhash_signature(shingles_b, num_hashes=num_hashes)
+    agreement = sum(1 for x, y in zip(sig_a, sig_b) if x == y) / num_hashes
+    assert abs(agreement - true_jaccard) < 0.1
+
+
+def test_minhash_signature_dissimilar_texts_have_low_agreement():
+    sig_a = minhash_signature(shingles(CAMPAIGN_A), num_hashes=256)
+    sig_b = minhash_signature(shingles(UNRELATED_COMPLAINT), num_hashes=256)
+    agreement = sum(1 for x, y in zip(sig_a, sig_b) if x == y) / 256
+    true_jaccard = len(shingles(CAMPAIGN_A) & shingles(UNRELATED_COMPLAINT)) / len(
+        shingles(CAMPAIGN_A) | shingles(UNRELATED_COMPLAINT)
+    )
+    assert true_jaccard < 0.3
+    assert agreement < 0.3
+
+
+# --- lsh_bands ---------------------------------------------------------
+
+
+def test_lsh_bands_identical_signatures_share_every_band():
+    sig_a = minhash_signature(shingles(CAMPAIGN_A))
+    sig_b = minhash_signature(shingles(CAMPAIGN_B))
+    assert lsh_bands(sig_a) == lsh_bands(sig_b)
+
+
+def test_lsh_bands_near_duplicate_shares_at_least_one_band():
+    # CAMPAIGN_A vs CAMPAIGN_C_REWORDED have true Jaccard ~0.78 (two words
+    # changed out of ~25) — not identical, so this needs enough bands (more,
+    # narrower bands lower the similarity threshold for a candidate) to
+    # reliably surface as a candidate; 8 wide bands of 16 rows each is too
+    # strict at this similarity and undersells LSH's purpose.
+    sig_a = minhash_signature(shingles(CAMPAIGN_A), num_hashes=128)
+    sig_c = minhash_signature(shingles(CAMPAIGN_C_REWORDED), num_hashes=128)
+    bands_a = set(lsh_bands(sig_a, num_bands=16))
+    bands_c = set(lsh_bands(sig_c, num_bands=16))
+    assert bands_a & bands_c, "near-duplicate campaign text produced no candidate band"
+
+
+def test_lsh_bands_unrelated_text_shares_no_band():
+    sig_a = minhash_signature(shingles(CAMPAIGN_A), num_hashes=128)
+    sig_u = minhash_signature(shingles(UNRELATED_COMPLAINT), num_hashes=128)
+    bands_a = set(lsh_bands(sig_a, num_bands=8))
+    bands_u = set(lsh_bands(sig_u, num_bands=8))
+    assert not (bands_a & bands_u)
+
+
+def test_lsh_bands_rejects_num_bands_not_dividing_signature_length():
+    sig = minhash_signature(shingles(CAMPAIGN_A), num_hashes=100)
+    try:
+        lsh_bands(sig, num_bands=7)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected ValueError for non-dividing num_bands")
+
+
+# --- union_find_groups ---------------------------------------------------
+
+
+def test_union_find_groups_transitive_merge():
+    # a-b and b-c candidate pairs (as LSH would produce via shared bands)
+    # must merge all three into one group even though a-c never co-occurred.
+    pairs = [("doc_a", "doc_b"), ("doc_b", "doc_c")]
+    groups = union_find_groups(pairs)
+    assert groups["doc_a"] == groups["doc_b"] == groups["doc_c"]
+
+
+def test_union_find_groups_keeps_disjoint_groups_separate():
+    pairs = [("doc_a", "doc_b"), ("doc_x", "doc_y")]
+    groups = union_find_groups(pairs)
+    assert groups["doc_a"] == groups["doc_b"]
+    assert groups["doc_x"] == groups["doc_y"]
+    assert groups["doc_a"] != groups["doc_x"]
+
+
+def test_union_find_groups_singletons_from_items_param():
+    pairs = [("doc_a", "doc_b")]
+    groups = union_find_groups(pairs, items=["doc_a", "doc_b", "doc_solo"])
+    assert groups["doc_solo"] == "doc_solo"
+    assert groups["doc_a"] == groups["doc_b"]
+
+
+def test_union_find_groups_group_id_independent_of_pair_order():
+    forward = union_find_groups([("doc_a", "doc_b"), ("doc_b", "doc_c")])
+    backward = union_find_groups([("doc_c", "doc_b"), ("doc_b", "doc_a")])
+    assert forward["doc_a"] == forward["doc_b"] == forward["doc_c"]
+    assert backward["doc_a"] == backward["doc_b"] == backward["doc_c"]
+    assert forward["doc_a"] == backward["doc_a"]  # same stable representative
+
+
+def test_union_find_groups_end_to_end_campaign_vs_unrelated():
+    # Full pipeline: shingle -> minhash -> band -> bucket by band -> union.
+    docs = {
+        "sig_a": CAMPAIGN_A,
+        "sig_b": CAMPAIGN_B,
+        "sig_c": CAMPAIGN_C_REWORDED,
+        "sig_u": UNRELATED_COMPLAINT,
+    }
+    signatures = {
+        doc_id: minhash_signature(shingles(text), num_hashes=128)
+        for doc_id, text in docs.items()
+    }
+    buckets: dict[tuple[int, int], list[str]] = {}
+    for doc_id, sig in signatures.items():
+        for band_index, band_hash in enumerate(lsh_bands(sig, num_bands=16)):
+            buckets.setdefault((band_index, band_hash), []).append(doc_id)
+
+    pairs = []
+    for bucket_docs in buckets.values():
+        if len(bucket_docs) > 1:
+            first = bucket_docs[0]
+            pairs.extend((first, other) for other in bucket_docs[1:])
+
+    groups = union_find_groups(pairs, items=docs.keys())
+    assert groups["sig_a"] == groups["sig_b"] == groups["sig_c"]
+    assert groups["sig_u"] != groups["sig_a"]
+
+
+# --- identity_key ---------------------------------------------------------
+
+
+def test_identity_key_same_value_and_salt_is_stable():
+    assert identity_key("9861234567", "salt-1") == identity_key(
+        "9861234567", "salt-1"
+    )
+
+
+def test_identity_key_different_salt_gives_different_key():
+    key_1 = identity_key("9861234567", "salt-1")
+    key_2 = identity_key("9861234567", "salt-2")
+    assert key_1 != key_2
+
+
+def test_identity_key_different_value_gives_different_key():
+    key_a = identity_key("9861234567", "salt-1")
+    key_b = identity_key("9007654321", "salt-1")
+    assert key_a != key_b
+
+
+def test_identity_key_normalizes_whitespace_and_case():
+    assert identity_key(" Citizen@Example.com ", "s") == identity_key(
+        "citizen@example.com", "s"
+    )
+
+
+def test_identity_key_never_appears_in_or_derives_shingle_text():
+    # Guards the separation this module's docstring insists on: an identity
+    # key is not text and must never be fed into the shingling path.
+    mobile = "9861234567"
+    key = identity_key(mobile, "salt-1")
+    grievance_text = "[NAME] [PHONE] the drain near our house is blocked"
+    doc_shingles = shingles(grievance_text)
+    assert mobile not in grievance_text  # pii_tagger already redacted it
+    assert not any(key in s or mobile in s for s in doc_shingles)
+
+
+# --- cross-script non-support pin (ROADMAP §5.2 August contract) ---------
+
+
+def test_cross_script_shingles_do_not_overlap():
+    # Odia-script and romanized-Odia text occupy disjoint Unicode ranges,
+    # so character n-grams never bridge them — pinned here, not papered
+    # over. Real cross-script matching is Phase 17 (transliteration), not
+    # this module.
+    odia_shingles = shingles(ODIA_SCRIPT_TEXT, k=3)
+    romanized_shingles = shingles(ROMANIZED_TEXT, k=3)
+    assert odia_shingles  # sanity: the Odia text actually produced shingles
+    assert romanized_shingles
+    assert odia_shingles & romanized_shingles == set()
+
+
+def test_cross_script_minhash_signatures_do_not_match():
+    sig_odia = minhash_signature(shingles(ODIA_SCRIPT_TEXT, k=3), num_hashes=256)
+    sig_romanized = minhash_signature(
+        shingles(ROMANIZED_TEXT, k=3), num_hashes=256
+    )
+    agreement = sum(1 for x, y in zip(sig_odia, sig_romanized) if x == y) / 256
+    assert agreement < 0.05  # effectively zero recall across scripts
+
+
+def test_cross_script_lsh_bands_never_collide():
+    sig_odia = minhash_signature(shingles(ODIA_SCRIPT_TEXT, k=3), num_hashes=128)
+    sig_romanized = minhash_signature(
+        shingles(ROMANIZED_TEXT, k=3), num_hashes=128
+    )
+    bands_odia = set(lsh_bands(sig_odia, num_bands=8))
+    bands_romanized = set(lsh_bands(sig_romanized, num_bands=8))
+    assert not (bands_odia & bands_romanized)

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -9,6 +9,8 @@ docs/ROADMAP.md §5.2/§5.6. Do not add a guard here.
 Synthetic strings only — no real grievance text, no `data/` access.
 """
 
+import pytest
+
 from janasunani.pipeline.dedup import (
     DEFAULT_NUM_HASHES,
     identity_key,
@@ -127,13 +129,27 @@ def test_minhash_signature_identical_text_matches_exactly():
     assert sig_a == sig_b
 
 
-def test_minhash_signature_empty_shingle_set_is_sentinel_and_self_consistent():
-    empty_sig = minhash_signature(set())
-    assert empty_sig == minhash_signature(set())
-    assert len(set(empty_sig)) == 1  # constant sentinel value in every slot
-    # A real (non-empty) signature should not collide with the sentinel.
+def test_minhash_signature_empty_shingle_set_abstains():
+    # An earlier version returned a constant sentinel signature here, which
+    # made every blank/all-placeholder/too-short document a mutual
+    # candidate of every other one and inflated duplicate prevalence. It
+    # must abstain (None) instead — low-signal/spam territory, not
+    # duplicate evidence.
+    assert minhash_signature(set()) is None
+    assert minhash_signature(shingles("hi")) is None  # too short to shingle
     real_sig = minhash_signature(shingles(CAMPAIGN_A))
-    assert real_sig != empty_sig
+    assert real_sig is not None
+
+
+def test_minhash_signature_two_empty_documents_do_not_look_like_duplicates():
+    # Both abstain; None == None would make them look like the same
+    # signature if a caller compared naively, so this guards that a caller
+    # branching on "is None" (per the docstring contract) never even gets
+    # to a comparison — there is nothing to band or compare.
+    doc_a = minhash_signature(shingles("[PHONE]"))
+    doc_b = minhash_signature(shingles("[NAME]"))
+    assert doc_a is None
+    assert doc_b is None
 
 
 def test_minhash_signature_approximates_jaccard_similarity():
@@ -173,35 +189,41 @@ def test_lsh_bands_identical_signatures_share_every_band():
     assert lsh_bands(sig_a) == lsh_bands(sig_b)
 
 
-def test_lsh_bands_near_duplicate_shares_at_least_one_band():
+def test_lsh_bands_near_duplicate_shares_at_least_one_band_with_default_bands():
     # CAMPAIGN_A vs CAMPAIGN_C_REWORDED have true Jaccard ~0.78 (two words
-    # changed out of ~25) — not identical, so this needs enough bands (more,
-    # narrower bands lower the similarity threshold for a candidate) to
-    # reliably surface as a candidate; 8 wide bands of 16 rows each is too
-    # strict at this similarity and undersells LSH's purpose.
-    sig_a = minhash_signature(shingles(CAMPAIGN_A), num_hashes=128)
-    sig_c = minhash_signature(shingles(CAMPAIGN_C_REWORDED), num_hashes=128)
-    bands_a = set(lsh_bands(sig_a, num_bands=16))
-    bands_c = set(lsh_bands(sig_c, num_bands=16))
+    # changed out of ~25) — a lightly reworded resubmission/campaign filing,
+    # not a byte-identical one. This must work with *default* banding
+    # (no num_bands override): DEFAULT_NUM_BANDS is chosen so this pair's
+    # candidate probability is ~90% (see the arithmetic on
+    # DEFAULT_NUM_BANDS in dedup.py) — a caller should not have to
+    # remember to widen the bands for the primitive to do its one job.
+    sig_a = minhash_signature(shingles(CAMPAIGN_A))
+    sig_c = minhash_signature(shingles(CAMPAIGN_C_REWORDED))
+    bands_a = set(lsh_bands(sig_a))
+    bands_c = set(lsh_bands(sig_c))
     assert bands_a & bands_c, "near-duplicate campaign text produced no candidate band"
 
 
-def test_lsh_bands_unrelated_text_shares_no_band():
-    sig_a = minhash_signature(shingles(CAMPAIGN_A), num_hashes=128)
-    sig_u = minhash_signature(shingles(UNRELATED_COMPLAINT), num_hashes=128)
-    bands_a = set(lsh_bands(sig_a, num_bands=8))
-    bands_u = set(lsh_bands(sig_u, num_bands=8))
+def test_lsh_bands_unrelated_text_shares_no_band_with_default_bands():
+    sig_a = minhash_signature(shingles(CAMPAIGN_A))
+    sig_u = minhash_signature(shingles(UNRELATED_COMPLAINT))
+    bands_a = set(lsh_bands(sig_a))
+    bands_u = set(lsh_bands(sig_u))
     assert not (bands_a & bands_u)
 
 
 def test_lsh_bands_rejects_num_bands_not_dividing_signature_length():
     sig = minhash_signature(shingles(CAMPAIGN_A), num_hashes=100)
-    try:
+    with pytest.raises(ValueError):
         lsh_bands(sig, num_bands=7)
-    except ValueError:
-        pass
-    else:
-        raise AssertionError("expected ValueError for non-dividing num_bands")
+
+
+def test_lsh_bands_rejects_abstained_none_signature():
+    # minhash_signature() abstains (returns None) on an empty shingle set;
+    # lsh_bands() must refuse it outright rather than banding a sentinel,
+    # so an all-placeholder/blank document can never band-match a real one.
+    with pytest.raises(ValueError):
+        lsh_bands(None)
 
 
 # --- union_find_groups ---------------------------------------------------
@@ -291,6 +313,35 @@ def test_identity_key_normalizes_whitespace_and_case():
     assert identity_key(" Citizen@Example.com ", "s") == identity_key(
         "citizen@example.com", "s"
     )
+
+
+def test_identity_key_canonicalizes_equivalent_phone_number_formats():
+    # Same subscriber, four ways petitioner_mobile/OCR/form entry could
+    # spell it — resubmission linkage is the one job identity_key exists
+    # for, and it fails at that job if these don't collapse to one key.
+    variants = [
+        "+91 98612 34567",
+        "09861234567",
+        "98612-34567",
+        "9861234567",
+    ]
+    keys = {identity_key(v, "salt-1") for v in variants}
+    assert len(keys) == 1
+
+
+def test_identity_key_distinct_phone_numbers_still_differ():
+    assert identity_key("9861234567", "s") != identity_key("9861234568", "s")
+    # Canonicalization must not fold distinct subscribers together just
+    # because one is a substring of another after digit-stripping.
+    assert identity_key("9861234567", "s") != identity_key("19861234567", "s")
+
+
+def test_identity_key_non_phone_numeric_id_is_not_treated_as_a_phone_number():
+    # A 6-digit PIN code (or any short numeric identifier) is shorter than
+    # the 10-digit floor _canonical_phone_digits requires, so it must not
+    # be silently reshaped — it falls back to plain trim+lowercase, and
+    # distinct short codes must still produce distinct keys.
+    assert identity_key("751001", "s") != identity_key("751002", "s")
 
 
 def test_identity_key_never_appears_in_or_derives_shingle_text():

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -57,6 +57,21 @@ ROMANIZED_TEXT = (
     "aame ganre pani pump tini masa hela kharap achi doyakari maramati karantu"
 )
 
+# Digit-only translation tables built the same way _INDIC_DIGITS_TO_ASCII is
+# built in dedup.py, but inverted (ASCII -> script) so these fixtures are
+# generated, not hand-transcribed Unicode literals that would be easy to get
+# subtly wrong and hard to review.
+_ASCII_TO_ODIA_DIGITS = str.maketrans({str(i): chr(0x0B66 + i) for i in range(10)})
+_ASCII_TO_DEVANAGARI_DIGITS = str.maketrans({str(i): chr(0x0966 + i) for i in range(10)})
+# Bengali digits (U+09E6) — a script dedup.py deliberately does NOT
+# canonicalize, to pin the accepted "unhandled script" fallback behavior.
+_ASCII_TO_BENGALI_DIGITS = str.maketrans({str(i): chr(0x09E6 + i) for i in range(10)})
+
+MOBILE_ASCII = "9861234567"
+MOBILE_ODIA_DIGITS = MOBILE_ASCII.translate(_ASCII_TO_ODIA_DIGITS)
+MOBILE_DEVANAGARI_DIGITS = MOBILE_ASCII.translate(_ASCII_TO_DEVANAGARI_DIGITS)
+MOBILE_BENGALI_DIGITS = MOBILE_ASCII.translate(_ASCII_TO_BENGALI_DIGITS)
+
 
 # --- strip_placeholders ---------------------------------------------------
 
@@ -342,6 +357,52 @@ def test_identity_key_non_phone_numeric_id_is_not_treated_as_a_phone_number():
     # be silently reshaped — it falls back to plain trim+lowercase, and
     # distinct short codes must still produce distinct keys.
     assert identity_key("751001", "s") != identity_key("751002", "s")
+
+
+def test_identity_key_canonicalizes_odia_digit_phone_number():
+    # Odia-script and OCR-entered contact numbers are a primary input path
+    # for this corpus, not an edge case — the same subscriber typed in
+    # Odia numerals must link to the ASCII form for resubmission detection
+    # to work where it matters most.
+    assert identity_key(MOBILE_ODIA_DIGITS, "s") == identity_key(MOBILE_ASCII, "s")
+
+
+def test_identity_key_canonicalizes_devanagari_digit_phone_number():
+    assert identity_key(MOBILE_DEVANAGARI_DIGITS, "s") == identity_key(
+        MOBILE_ASCII, "s"
+    )
+
+
+def test_identity_key_canonicalizes_odia_digits_with_country_code():
+    # The 91 country-code prefix stripping must also apply after Indic
+    # digits are translated to ASCII, not just to already-ASCII input.
+    odia_with_country_code = ("91" + MOBILE_ASCII).translate(_ASCII_TO_ODIA_DIGITS)
+    assert identity_key(odia_with_country_code, "s") == identity_key(
+        MOBILE_ASCII, "s"
+    )
+
+
+def test_identity_key_canonicalizes_mixed_ascii_and_odia_digits():
+    # A realistic mixed-entry case: ASCII "+91" country code typed
+    # normally, local subscriber number in Odia numerals.
+    mixed = "+91 " + MOBILE_ODIA_DIGITS
+    assert identity_key(mixed, "s") == identity_key(MOBILE_ASCII, "s")
+
+
+def test_identity_key_unhandled_digit_script_does_not_link_but_stays_stable():
+    # Bengali digits are a deliberately unhandled script (see
+    # _canonical_phone_digits' docstring): dedup.py only transliterates
+    # Odia and Devanagari, matching the scripts this corpus actually uses.
+    # A Bengali-digit phone number must NOT silently claim to be the same
+    # identity as its ASCII form (that would be papering over a real gap),
+    # but it must still hash stably and distinctly from a different number
+    # in the same script — falling to the literal-text path, not crashing
+    # or colliding.
+    bengali_key = identity_key(MOBILE_BENGALI_DIGITS, "s")
+    assert bengali_key != identity_key(MOBILE_ASCII, "s")
+    assert bengali_key == identity_key(MOBILE_BENGALI_DIGITS, "s")  # stable
+    other_number_bengali = "9007654321".translate(_ASCII_TO_BENGALI_DIGITS)
+    assert bengali_key != identity_key(other_number_bengali, "s")
 
 
 def test_identity_key_never_appears_in_or_derives_shingle_text():

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -1,10 +1,10 @@
 """MinHash/LSH duplicate index (janasunani.pipeline.dedup).
 
-`dedup.py` is deliberately stdlib-only (hashlib, re, random) so it — and
-this test file — run in CI with no pipeline extras installed. Unlike every
-other pipeline test, this file does NOT `pytest.importorskip`: it is the one
-real code-path CI coverage the whole intelligence layer (Phase 15) has, per
-docs/ROADMAP.md §5.2/§5.6. Do not add a guard here.
+`dedup.py` is deliberately stdlib-only (hashlib, re, random, unicodedata) so
+it — and this test file — run in CI with no pipeline extras installed.
+Unlike every other pipeline test, this file does NOT `pytest.importorskip`:
+it is the one real code-path CI coverage the whole intelligence layer
+(Phase 15) has, per docs/ROADMAP.md §5.2/§5.6. Do not add a guard here.
 
 Synthetic strings only — no real grievance text, no `data/` access.
 """
@@ -14,6 +14,7 @@ import pytest
 from janasunani.pipeline.dedup import (
     DEFAULT_NUM_HASHES,
     identity_key,
+    jaccard_similarity,
     lsh_bands,
     minhash_signature,
     shingles,
@@ -72,6 +73,27 @@ MOBILE_ODIA_DIGITS = MOBILE_ASCII.translate(_ASCII_TO_ODIA_DIGITS)
 MOBILE_DEVANAGARI_DIGITS = MOBILE_ASCII.translate(_ASCII_TO_DEVANAGARI_DIGITS)
 MOBILE_BENGALI_DIGITS = MOBILE_ASCII.translate(_ASCII_TO_BENGALI_DIGITS)
 
+# Same Odia word, two canonically equivalent Unicode encodings: KA (U+0B15)
+# followed by either the composed vowel sign O (U+0B4B), or the canonically
+# equivalent decomposed sequence vowel sign E (U+0B47) + AA length mark
+# (U+0B3E) — the exact pair Codex's review cited. Built from codepoints via
+# chr(), not pasted glyphs, so the two forms are unambiguous on review and
+# cannot be silently re-normalized by an editor/git. Real OCR/storage
+# layers are not guaranteed to agree on which form they emit for the same
+# filing.
+_ODIA_KA = chr(0x0B15)
+_ODIA_O_COMPOSED = chr(0x0B4B)
+_ODIA_E_SIGN = chr(0x0B47)
+_ODIA_AA_LENGTH_MARK = chr(0x0B3E)
+ODIA_WORD_NFC = "respected sir " + _ODIA_KA + _ODIA_O_COMPOSED + " village pump broken"
+ODIA_WORD_NFD = (
+    "respected sir "
+    + _ODIA_KA
+    + _ODIA_E_SIGN
+    + _ODIA_AA_LENGTH_MARK
+    + " village pump broken"
+)
+
 
 # --- strip_placeholders ---------------------------------------------------
 
@@ -125,6 +147,17 @@ def test_shingles_short_text_returns_empty_set():
 
 def test_shingles_case_insensitive_for_latin_script():
     assert shingles("Hello World", k=5) == shingles("hello world", k=5)
+
+
+def test_shingles_normalizes_canonically_equivalent_unicode_forms():
+    # ODIA_WORD_NFC and ODIA_WORD_NFD are the *same visible filing text* in
+    # two different, canonically equivalent Unicode encodings (composed
+    # U+0B4B vs. decomposed U+0B47 U+0B3E). Without NFC normalization these
+    # produce disjoint codepoint sequences and disjoint shingle sets, so a
+    # filing would fail to dedup against a byte-different encoding of
+    # itself depending on what the OCR/storage layer happened to emit.
+    assert ODIA_WORD_NFC != ODIA_WORD_NFD  # confirm the fixtures really differ
+    assert shingles(ODIA_WORD_NFC) == shingles(ODIA_WORD_NFD)
 
 
 # --- minhash_signature -------------------------------------------------
@@ -184,6 +217,22 @@ def test_minhash_signature_approximates_jaccard_similarity():
     assert abs(agreement - true_jaccard) < 0.1
 
 
+def test_minhash_signature_rejects_nonpositive_num_hashes():
+    # num_hashes <= 0 used to silently return an empty tuple (neither a
+    # real signature nor the None abstention) — lsh_bands() then accepted
+    # it (0 % num_bands == 0), hashed empty slices, and gave every document
+    # in a slice the same band values, collapsing the whole slice into one
+    # duplicate group. This is a misconfiguration and must fail loudly.
+    with pytest.raises(ValueError):
+        minhash_signature(shingles(CAMPAIGN_A), num_hashes=0)
+    with pytest.raises(ValueError):
+        minhash_signature(shingles(CAMPAIGN_A), num_hashes=-1)
+    # The same check applies even for an already-empty shingle set — an
+    # invalid num_hashes is an error regardless of what else is wrong.
+    with pytest.raises(ValueError):
+        minhash_signature(set(), num_hashes=0)
+
+
 def test_minhash_signature_dissimilar_texts_have_low_agreement():
     sig_a = minhash_signature(shingles(CAMPAIGN_A), num_hashes=256)
     sig_b = minhash_signature(shingles(UNRELATED_COMPLAINT), num_hashes=256)
@@ -241,6 +290,33 @@ def test_lsh_bands_rejects_abstained_none_signature():
         lsh_bands(None)
 
 
+# --- jaccard_similarity ---------------------------------------------------
+
+
+def test_jaccard_similarity_identical_sets_is_one():
+    s = shingles(CAMPAIGN_A)
+    assert jaccard_similarity(s, s) == 1.0
+
+
+def test_jaccard_similarity_disjoint_sets_is_zero():
+    assert jaccard_similarity({"aaaaa"}, {"bbbbb"}) == 0.0
+
+
+def test_jaccard_similarity_matches_manual_computation():
+    a = shingles(CAMPAIGN_A)
+    b = shingles(CAMPAIGN_C_REWORDED)
+    expected = len(a & b) / len(a | b)
+    assert jaccard_similarity(a, b) == expected
+
+
+def test_jaccard_similarity_both_empty_is_zero_not_undefined():
+    # 0/0 is mathematically undefined; refuse to claim similarity for two
+    # abstained-from ("nothing here") inputs rather than raising or
+    # guessing — the same "refuse rather than hash/claim a match" stance
+    # the module takes for a single empty/blank input.
+    assert jaccard_similarity(set(), set()) == 0.0
+
+
 # --- union_find_groups ---------------------------------------------------
 
 
@@ -276,31 +352,61 @@ def test_union_find_groups_group_id_independent_of_pair_order():
 
 
 def test_union_find_groups_end_to_end_campaign_vs_unrelated():
-    # Full pipeline: shingle -> minhash -> band -> bucket by band -> union.
+    # Full pipeline: shingle -> minhash -> band -> bucket by band ->
+    # VERIFY with jaccard_similarity -> union. The verification step is not
+    # optional here: union_find_groups() blindly trusts every pair it is
+    # given (see its docstring), so LSH candidates — a shared band, not a
+    # confirmed match — must be checked against the real shingle sets
+    # before they are allowed to merge documents into a duplicate group.
     docs = {
         "sig_a": CAMPAIGN_A,
         "sig_b": CAMPAIGN_B,
         "sig_c": CAMPAIGN_C_REWORDED,
         "sig_u": UNRELATED_COMPLAINT,
     }
+    doc_shingles = {doc_id: shingles(text) for doc_id, text in docs.items()}
     signatures = {
-        doc_id: minhash_signature(shingles(text), num_hashes=128)
-        for doc_id, text in docs.items()
+        doc_id: minhash_signature(s, num_hashes=128) for doc_id, s in doc_shingles.items()
     }
     buckets: dict[tuple[int, int], list[str]] = {}
     for doc_id, sig in signatures.items():
         for band_index, band_hash in enumerate(lsh_bands(sig, num_bands=16)):
             buckets.setdefault((band_index, band_hash), []).append(doc_id)
 
-    pairs = []
+    duplicate_threshold = 0.5
+    candidate_pairs = set()
     for bucket_docs in buckets.values():
         if len(bucket_docs) > 1:
             first = bucket_docs[0]
-            pairs.extend((first, other) for other in bucket_docs[1:])
+            candidate_pairs.update((first, other) for other in bucket_docs[1:])
 
-    groups = union_find_groups(pairs, items=docs.keys())
+    verified_pairs = [
+        (doc_a, doc_b)
+        for doc_a, doc_b in candidate_pairs
+        if jaccard_similarity(doc_shingles[doc_a], doc_shingles[doc_b])
+        >= duplicate_threshold
+    ]
+
+    groups = union_find_groups(verified_pairs, items=docs.keys())
     assert groups["sig_a"] == groups["sig_b"] == groups["sig_c"]
     assert groups["sig_u"] != groups["sig_a"]
+
+
+def test_union_find_groups_trusts_unverified_pairs_this_is_why_verification_matters():
+    # union_find_groups() does not know or check what a "pair" means — it
+    # performs blind transitive closure. Feed it two clearly unrelated
+    # documents directly (skipping jaccard_similarity() verification on
+    # purpose) and it merges them anyway: this is the exact unsafe pattern
+    # the module docstring (point 6) and union_find_groups()'s own
+    # docstring warn against, pinned here so the warning stays true and
+    # the safe end-to-end test above cannot silently regress to this.
+    unverified_pairs = [("sig_a", "sig_u")]
+    groups = union_find_groups(unverified_pairs)
+    assert groups["sig_a"] == groups["sig_u"]  # merged despite being unrelated
+    true_similarity = jaccard_similarity(
+        shingles(CAMPAIGN_A), shingles(UNRELATED_COMPLAINT)
+    )
+    assert true_similarity < 0.3  # confirms they should NOT have merged
 
 
 # --- identity_key ---------------------------------------------------------
@@ -403,6 +509,33 @@ def test_identity_key_unhandled_digit_script_does_not_link_but_stays_stable():
     assert bengali_key == identity_key(MOBILE_BENGALI_DIGITS, "s")  # stable
     other_number_bengali = "9007654321".translate(_ASCII_TO_BENGALI_DIGITS)
     assert bengali_key != identity_key(other_number_bengali, "s")
+
+
+def test_identity_key_abstains_on_blank_value():
+    # petitioner_mobile / petitioner_email are nullable and blank strings
+    # are not normalized to None at ingestion (janasunani/db/models.py).
+    # Hashing "" would give every citizen with a missing contact field the
+    # same valid-looking salted hash, merging unrelated citizens as one
+    # "identity" purely because both left the field blank. Must abstain
+    # (None) instead — the same contract minhash_signature() uses.
+    assert identity_key("", "salt-1") is None
+    assert identity_key("   ", "salt-1") is None
+    assert identity_key("\t\n", "salt-1") is None
+
+
+def test_identity_key_two_blank_records_do_not_look_like_the_same_citizen():
+    # Both abstain; a caller comparing "identity_key(a) == identity_key(b)"
+    # naively would otherwise treat two citizens who both left the contact
+    # field blank as a resubmission match. Branching on None (per the
+    # docstring contract) avoids ever reaching that comparison.
+    assert identity_key("", "salt-1") is None
+    assert identity_key("", "salt-2") is None  # different salt, still None
+
+
+def test_identity_key_real_value_still_hashes_normally():
+    # Sanity check alongside the abstention: a non-blank value is
+    # unaffected by the blank-value guard.
+    assert identity_key(MOBILE_ASCII, "s") is not None
 
 
 def test_identity_key_never_appears_in_or_derives_shingle_text():

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -538,6 +538,35 @@ def test_identity_key_real_value_still_hashes_normally():
     assert identity_key(MOBILE_ASCII, "s") is not None
 
 
+def test_identity_key_rejects_blank_salt():
+    # A blank salt is a deployment misconfiguration, not a per-record
+    # abstention case: every key that run produces is affected identically,
+    # and a "salted" hash over the ~10^10 enumerable mobile-number space
+    # without a real salt is effectively unsalted and offline-invertible.
+    # This must raise, not silently return None like the blank-value case —
+    # abstaining would mean quietly continuing to emit compromised keys for
+    # every subsequent record instead of stopping the misconfigured run.
+    with pytest.raises(ValueError):
+        identity_key(MOBILE_ASCII, "")
+    with pytest.raises(ValueError):
+        identity_key(MOBILE_ASCII, "   ")
+    with pytest.raises(ValueError):
+        identity_key(MOBILE_ASCII, "\t\n")
+
+
+def test_identity_key_blank_salt_rejected_even_for_a_blank_value():
+    # The salt check must not be shadowed by the value-abstention path —
+    # a blank salt is invalid regardless of what value it would have been
+    # applied to.
+    with pytest.raises(ValueError):
+        identity_key("", "")
+
+
+def test_identity_key_real_salt_still_hashes_normally():
+    # Sanity check alongside the guard: a non-blank salt is unaffected.
+    assert identity_key(MOBILE_ASCII, "a-real-salt") is not None
+
+
 def test_identity_key_never_appears_in_or_derives_shingle_text():
     # Guards the separation this module's docstring insists on: an identity
     # key is not text and must never be fed into the shingling path.


### PR DESCRIPTION
## Summary
- Adds `janasunani/pipeline/dedup.py`: `shingles`, `minhash_signature`, `lsh_bands`, `union_find_groups`, `strip_placeholders`, `identity_key` — the algorithmic primitives for Phase 14 duplicate detection (ROADMAP §5.2).
- Character n-grams, not word tokens; typed PII placeholders (`[PHONE]`, `[NAME]`, ...) are stripped before shingling so redacted text doesn't collapse similarity; `identity_key` is a separate, salted path kept out of the text path entirely, for resubmission linkage.
- Cross-script matching (Odia script vs. romanized Odia) is explicitly unsupported per the August contract — pinned with dedicated tests rather than assumed away. Real cross-script recall waits on Phase 17 transliteration.
- Stdlib-only (`hashlib`, `re`, `random`) by design: no numpy/datasketch/new dependency, so `tests/test_dedup.py` runs unguarded in CI (no `pytest.importorskip`), unlike the rest of the pipeline tree which skips there since CI installs no heavy extras.
- Wiring this in as the 7th pipeline stage (`spam_duplicate`) is deliberately out of scope here — deferred to a later workstream. `STAGE_ORDER`/`pipeline.py` untouched.

Closes #70.

## Test plan
- [x] `uv run --extra serving --extra pipeline-core pytest` — 308 passed, 14 skipped (pre-existing skips)
- [x] `uv run --extra serving pytest tests/test_dedup.py` (CI condition, no `pipeline-core`) — 29 passed
- [x] `uv run ruff check .` — all checks passed