### PR TITLE
fix(pii): dates/file numbers no longer tagged PHONE; government email never redacted

### DIFF
--- a/janasunani/pipeline/pii_eval.py
+++ b/janasunani/pipeline/pii_eval.py
@@ -24,6 +24,7 @@ from typing import Callable, Iterable, Mapping, Sequence
 from janasunani.pipeline.stages.pii_tagger import (
     PIISpan,
     detect_pii_spans,
+    is_government_email,
     normalize_entity,
 )
 
@@ -65,6 +66,11 @@ class EvaluationReport:
     overall: EntityMetrics
     coverage: EntityMetrics
     baseline_overlap_recall: float
+    # Gold EMAIL spans on a government domain (#56): out of scope for
+    # redaction by policy, so they never enter the gold/predicted counts
+    # above. Tracked separately so the denominator change is visible rather
+    # than silently shrinking the scorecard.
+    excluded_by_policy: int = 0
 
     @property
     def passed_baseline(self) -> bool:
@@ -84,6 +90,7 @@ class EvaluationReport:
             },
             "baseline_overlap_recall": self.baseline_overlap_recall,
             "passed_baseline": self.passed_baseline,
+            "excluded_by_policy": self.excluded_by_policy,
         }
 
 
@@ -139,6 +146,7 @@ def score_predictions(
     exact_hits: Counter[str] = Counter()
     coverage_overlap_hits = 0
     coverage_exact_hits = 0
+    excluded_by_policy = 0
 
     for example in examples:
         predicted = tuple(_normalize_span(span) for span in predictions.get(example.id, ()))
@@ -149,6 +157,14 @@ def score_predictions(
 
         for gold in example.entities:
             gold = _normalize_span(gold)
+            # Government email addresses are not PII by policy (#56): drop
+            # them from the denominator instead of scoring the tagger against
+            # spans it is now deliberately built not to redact.
+            if gold.entity == "EMAIL" and is_government_email(
+                example.text[gold.start : gold.end]
+            ):
+                excluded_by_policy += 1
+                continue
             gold_counts[gold.entity] += 1
             candidates = predicted_by_entity.get(gold.entity, ())
             if any(_exact_match(gold, candidate) for candidate in candidates):
@@ -189,6 +205,7 @@ def score_predictions(
         overall=overall,
         coverage=coverage,
         baseline_overlap_recall=baseline_overlap_recall,
+        excluded_by_policy=excluded_by_policy,
     )
 
 
@@ -204,7 +221,8 @@ def format_report(report: EvaluationReport) -> str:
         "baseline_overlap_recall="
         f"{report.baseline_overlap_recall:.4f} "
         f"coverage_overlap_recall={report.coverage.overlap_recall:.4f} "
-        f"passed={str(report.passed_baseline).lower()}"
+        f"passed={str(report.passed_baseline).lower()} "
+        f"excluded_by_policy={report.excluded_by_policy}"
     )
     return "\n".join(lines)
 

--- a/janasunani/pipeline/stages/pii_tagger.py
+++ b/janasunani/pipeline/stages/pii_tagger.py
@@ -7,8 +7,8 @@ contract is unchanged:
     pages.extracted_text -> pages.redacted_text
 
 Detection is Presidio's analyzer with pattern recognizers tuned for Indian
-grievances — mobile numbers, Aadhaar, PAN, email — plus spaCy NER for person
-names in English text. Improvements over the legacy model:
+grievances — mobile numbers, landlines, Aadhaar, PAN, email — plus spaCy NER
+for person names in English text. Improvements over the legacy model:
 
   - no token window: whole pages are analyzed, so nothing past the first
     512 tokens silently escapes redaction;
@@ -26,6 +26,7 @@ structure.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -38,10 +39,16 @@ from janasunani.pipeline.db import connect
 DB_BATCH_SIZE = 200
 
 # entity -> replacement token
+#
+# PHONE_NUMBER (Presidio's built-in PhoneRecognizer, backed by the
+# `phonenumbers` library) is deliberately absent: it treats dotted/hyphenated
+# dates and bare 10-digit file numbers as plausible phone numbers (#55). Our
+# own IN_MOBILE/IN_LANDLINE recognizers below are the sole source of PHONE
+# hits, so detection is entirely ours and testable.
 ENTITY_TOKENS = {
     "PERSON": "[NAME]",
-    "PHONE_NUMBER": "[PHONE]",
     "IN_MOBILE": "[PHONE]",
+    "IN_LANDLINE": "[PHONE]",
     "IN_AADHAAR": "[AADHAAR]",
     "IN_PAN": "[PAN]",
     "EMAIL_ADDRESS": "[EMAIL]",
@@ -52,6 +59,7 @@ ENTITY_ALIASES = {
     "NAME": "NAME",
     "PHONE_NUMBER": "PHONE",
     "IN_MOBILE": "PHONE",
+    "IN_LANDLINE": "PHONE",
     "PHONE": "PHONE",
     "IN_AADHAAR": "AADHAAR",
     "AADHAAR": "AADHAAR",
@@ -60,6 +68,45 @@ ENTITY_ALIASES = {
     "EMAIL_ADDRESS": "EMAIL",
     "EMAIL": "EMAIL",
 }
+
+# Government domains whose addresses are published contact details of public
+# officers, not citizen PII (#56, maintainer decision 2026-07-27). This is
+# our own rule, not the Public Suffix List: `nic.in`/`gov.in`/`ac.in`/`co.in`
+# happen to be PSL entries in their own right, which made tldextract parse a
+# bare "@nic.in" address as an empty registrable domain and made Presidio's
+# EmailRecognizer discard it as invalid -- an accident that only covered part
+# of the domain space (subdomains like `rb.nic.in` were still redacted) and
+# that a PSL/tldextract update could silently flip.
+_GOVERNMENT_EMAIL_SUFFIXES = ("nic.in", "gov.in", "mil.in")
+
+
+def is_government_email(address: str) -> bool:
+    """True if ``address`` is an official government email (#56).
+
+    Matches the domain itself and any subdomain of it (``rb.nic.in``,
+    ``pmo.gov.in``), case-insensitively. Not PII for redaction purposes.
+    """
+    if "@" not in address:
+        return False
+    domain = address.strip().lower().rsplit("@", 1)[-1]
+    if not domain:
+        return False
+    return any(
+        domain == suffix or domain.endswith(f".{suffix}")
+        for suffix in _GOVERNMENT_EMAIL_SUFFIXES
+    )
+
+
+# A dotted/hyphenated/slash date (DD.MM.YYYY and its variants) is shaped
+# enough like a run of phone digits that Presidio's built-in PhoneRecognizer
+# used to tag it PHONE (#55). Applied to every PHONE-normalized candidate
+# regardless of which recognizer produced it, so it stays a guard even if a
+# future recognizer or the built-in is reintroduced.
+_DATE_SHAPE_RE = re.compile(r"^\d{1,2}[.\-/]\d{1,2}[.\-/]\d{2,4}$")
+
+
+def _is_date_shaped(candidate: str) -> bool:
+    return bool(_DATE_SHAPE_RE.match(candidate.strip()))
 
 
 @dataclass(frozen=True)
@@ -151,9 +198,69 @@ def _get_engines():
             context=["pan", "income tax", "permanent account"],
         )
     )
+    # Landline: STD code (2-4 digits after the leading 0) plus a 6-8 digit
+    # subscriber number, one space/hyphen separator, e.g. Bhubaneswar
+    # "0674 2536789". Presidio's built-in PhoneRecognizer used to be the only
+    # thing catching these, at the same low confidence as its date/file-number
+    # false positives (#55); this recognizer is ours so a real landline scores
+    # on a pattern we own and test.
+    analyzer.registry.add_recognizer(
+        PatternRecognizer(
+            supported_entity="IN_LANDLINE",
+            name="in_landline_recognizer",
+            patterns=[
+                Pattern(
+                    "in_landline",
+                    r"(?<!\d)0\d{2,4}[\s-]\d{6,8}(?!\d)",
+                    0.6,
+                )
+            ],
+            context=["landline", "office", "std code", "telephone"],
+        )
+    )
 
     _engines = (analyzer, AnonymizerEngine())
     return _engines
+
+
+def _postfilter(analyzed_text: str, results: list) -> list:
+    """Drop analyzer results that are out of scope for our redaction policy.
+
+    Applied identically inside ``redact_text`` and ``detect_pii_spans`` so
+    the two never disagree about what counts as PII (#55, #56):
+
+    - PHONE-normalized hits whose matched text is date-shaped (dotted,
+      hyphenated, or slash-separated) rather than a real phone number.
+    - Any hit overlapping a government-domain email address, which is
+      published contact information, not citizen PII. Not just the
+      EMAIL_ADDRESS hit itself: spaCy's NER recognizer independently tags
+      the same span PERSON (e.g. "officer@rb.nic.in" reads as a name to
+      en_core_web_sm), and a policy that exempted the email label but left
+      an overlapping NAME hit standing would still redact the address.
+    """
+    government_ranges = [
+        (result.start, result.end)
+        for result in results
+        if normalize_entity(result.entity_type) == "EMAIL"
+        and is_government_email(analyzed_text[result.start : result.end])
+    ]
+
+    def _overlaps_government_email(result) -> bool:
+        return any(
+            max(result.start, start) < min(result.end, end)
+            for start, end in government_ranges
+        )
+
+    filtered = []
+    for result in results:
+        entity = normalize_entity(result.entity_type)
+        candidate = analyzed_text[result.start : result.end]
+        if entity == "PHONE" and _is_date_shaped(candidate):
+            continue
+        if _overlaps_government_email(result):
+            continue
+        filtered.append(result)
+    return filtered
 
 
 def redact_text(text: str) -> str:
@@ -163,9 +270,11 @@ def redact_text(text: str) -> str:
     analyzer, anonymizer = _get_engines()
     # Analyze the digit-normalized copy (Indic numerals -> ASCII, same length),
     # anonymize the original: offsets carry over 1:1.
+    analyzed_text = _ascii_digits(text)
     results = analyzer.analyze(
-        text=_ascii_digits(text), language="en", entities=list(ENTITY_TOKENS)
+        text=analyzed_text, language="en", entities=list(ENTITY_TOKENS)
     )
+    results = _postfilter(analyzed_text, results)
     if not results:
         return text
     operators = {
@@ -190,9 +299,11 @@ def detect_pii_spans(text: str) -> list[PIISpan]:
     recognizers, not a parallel implementation.
     """
     analyzer, _ = _get_engines()
+    analyzed_text = _ascii_digits(text)
     results = analyzer.analyze(
-        text=_ascii_digits(text), language="en", entities=list(ENTITY_TOKENS)
+        text=analyzed_text, language="en", entities=list(ENTITY_TOKENS)
     )
+    results = _postfilter(analyzed_text, results)
     spans: dict[tuple[str, int, int], PIISpan] = {}
     for result in results:
         entity = normalize_entity(result.entity_type)

--- a/janasunani/pipeline/stages/pii_tagger.py
+++ b/janasunani/pipeline/stages/pii_tagger.py
@@ -109,6 +109,30 @@ def _is_date_shaped(candidate: str) -> bool:
     return bool(_DATE_SHAPE_RE.match(candidate.strip()))
 
 
+# A zero-prefixed, single-separator digit run (STD code + subscriber number)
+# is structurally identical to a zero-prefixed file/case/order/letter/memo
+# number -- see the long comment on the landline recognizer for why shape
+# alone cannot tell them apart (#55 review on #91). The one reliable signal
+# left is the written citation convention itself: government correspondence
+# labels these numbers "Letter No. 0674-2536789", "Case No.", "File No.",
+# "Order No.", "Reference No.", "Memo No." immediately before the digits.
+# This is a context check, not a confidence threshold: it looks at the text,
+# not the recognizer's score.
+_REFERENCE_NUMBER_CONTEXT_RE = re.compile(
+    r"\b(?:letters?|cases?|files?|orders?|references?|refs?|memos?)\.?\s*no\.?\s*[:#-]?\s*$",
+    re.IGNORECASE,
+)
+# Comfortably covers "Reference No: " (14 chars) with room to spare, without
+# reaching back far enough to catch an unrelated marker word earlier in the
+# sentence.
+_REFERENCE_CONTEXT_WINDOW = 30
+
+
+def _preceded_by_reference_marker(analyzed_text: str, start: int) -> bool:
+    window = analyzed_text[max(0, start - _REFERENCE_CONTEXT_WINDOW) : start]
+    return bool(_REFERENCE_NUMBER_CONTEXT_RE.search(window))
+
+
 @dataclass(frozen=True)
 class PIISpan:
     entity: str
@@ -156,19 +180,44 @@ def _get_engines():
         nlp_engine=provider.create_engine(), supported_languages=["en"]
     )
 
-    # Indian mobile: optional +91/0 prefix, then 10 digits starting 6-9,
-    # allowing the common "98765 43210" split. Digit look-arounds keep it
-    # from firing inside longer numbers (e.g. Aadhaar).
+    # Indian mobile: optional +91/0 prefix, then 10 digits starting 6-9.
+    # Three explicit groupings, each with its own named Pattern rather than
+    # one digit-by-digit-permissive regex: bare/5-5 ("9876543210" /
+    # "98765 43210"), 4-3-3 ("9876 543 210"), and 3-3-4 ("987 654 3210") --
+    # all attested real formats (Codex review on #91). A fully permissive
+    # "separator before any digit" version was tried and rejected: it also
+    # matched STD-code-shaped landlines like "0674 2536789" over their
+    # *entire* span (a leading "0" plus a 6-9 digit plus 9 more digits with
+    # one internal split is exactly that shape) for no coverage gain, since
+    # both already redact as PHONE. These three fixed-group patterns are far
+    # more restrictive, but one harmless overlap remains: 3-3-4 and the
+    # landline's split-subscriber pattern both match "0674 253 6789" on the
+    # same span (see test_split_subscriber_landline_also_matches_new_mobile_
+    # pattern_harmlessly) -- normalization plus dict-keyed dedup in
+    # detect_pii_spans, and Presidio's own overlap handling in
+    # redact_text, collapse it to one [PHONE], so this is a documented,
+    # tested non-issue rather than a silent one. Digit look-arounds keep
+    # these patterns from firing inside longer numbers (e.g. Aadhaar).
     analyzer.registry.add_recognizer(
         PatternRecognizer(
             supported_entity="IN_MOBILE",
             name="in_mobile_recognizer",
             patterns=[
                 Pattern(
-                    "in_mobile",
+                    "in_mobile_bare_or_5_5",
                     r"(?<!\d)(?:\+91[\s-]?|0)?[6-9]\d{4}[\s-]?\d{5}(?!\d)",
                     0.6,
-                )
+                ),
+                Pattern(
+                    "in_mobile_4_3_3",
+                    r"(?<!\d)(?:\+91[\s-]?|0)?[6-9]\d{3}[\s-]\d{3}[\s-]\d{3}(?!\d)",
+                    0.6,
+                ),
+                Pattern(
+                    "in_mobile_3_3_4",
+                    r"(?<!\d)(?:\+91[\s-]?|0)?[6-9]\d{2}[\s-]\d{3}[\s-]\d{4}(?!\d)",
+                    0.6,
+                ),
             ],
             context=["mobile", "phone", "contact", "call", "whatsapp"],
         )
@@ -199,21 +248,53 @@ def _get_engines():
         )
     )
     # Landline: STD code (2-4 digits after the leading 0) plus a 6-8 digit
-    # subscriber number, one space/hyphen separator, e.g. Bhubaneswar
-    # "0674 2536789". Presidio's built-in PhoneRecognizer used to be the only
-    # thing catching these, at the same low confidence as its date/file-number
-    # false positives (#55); this recognizer is ours so a real landline scores
-    # on a pattern we own and test.
+    # subscriber number, e.g. Bhubaneswar "0674 2536789". Presidio's built-in
+    # PhoneRecognizer used to be the only thing catching these, at the same
+    # low confidence as its date/file-number false positives (#55); this
+    # recognizer is ours so a real landline scores on a pattern we own and
+    # test. Three named patterns cover the separator styles reported on the
+    # #91 review: bare space/hyphen (original), an optional wrapping
+    # paren pair plus "/" as an additional separator, and a split
+    # subscriber number ("0674 253 6789").
+    #
+    # Known, accepted ambiguity: this shape (0 + STD-length digits + one
+    # separator + subscriber-length digits) is structurally identical to a
+    # zero-prefixed file/order/case number, e.g. "0123-4567890" -- exactly
+    # the false-positive class #55 was filed about, and #55's own evidence
+    # table lists this shape (`9999-9999999`) among the false positives.
+    # We deliberately do NOT try to exclude it by digit-shape, e.g. by
+    # requiring the STD code's first significant digit to be in some
+    # "plausible" range: Delhi's real STD code is 011 (first significant
+    # digit "1"), so any such range would either admit the same file-number
+    # shapes it's meant to reject or reject real metro landlines -- shape
+    # alone cannot decide this case. Redacting is the safe failure direction
+    # (#55's own framing), so we keep matching and erring toward
+    # over-redaction here. What we do add is a context guard, not a
+    # confidence threshold: `_preceded_by_reference_marker` below drops the
+    # match when it is immediately preceded by a written reference-number
+    # convention ("Letter No.", "Case No.", "File No.", "Order No.",
+    # "Reference No.", "Memo No."), which is the common, reliable textual
+    # signal that this is a citation, not a callback number.
     analyzer.registry.add_recognizer(
         PatternRecognizer(
             supported_entity="IN_LANDLINE",
             name="in_landline_recognizer",
             patterns=[
                 Pattern(
-                    "in_landline",
+                    "in_landline_bare",
                     r"(?<!\d)0\d{2,4}[\s-]\d{6,8}(?!\d)",
                     0.6,
-                )
+                ),
+                Pattern(
+                    "in_landline_parens_or_slash",
+                    r"(?<!\d)\(?0\d{2,4}\)?[\s/-]\d{6,8}(?!\d)",
+                    0.6,
+                ),
+                Pattern(
+                    "in_landline_split_subscriber",
+                    r"(?<!\d)0\d{2,4}[\s-]\d{3}[\s-]\d{4}(?!\d)",
+                    0.6,
+                ),
             ],
             context=["landline", "office", "std code", "telephone"],
         )
@@ -231,6 +312,12 @@ def _postfilter(analyzed_text: str, results: list) -> list:
 
     - PHONE-normalized hits whose matched text is date-shaped (dotted,
       hyphenated, or slash-separated) rather than a real phone number.
+    - PHONE-normalized hits immediately preceded by a written
+      reference-number convention ("Letter No.", "Case No.", ...): the
+      zero-prefixed STD-code shape is structurally identical to a
+      zero-prefixed file number and shape alone can't separate them (see
+      the landline recognizer comment), but this textual citation pattern
+      is a reliable signal the digits are being cited, not dialed.
     - Any hit overlapping a government-domain email address, which is
       published contact information, not citizen PII. Not just the
       EMAIL_ADDRESS hit itself: spaCy's NER recognizer independently tags
@@ -255,7 +342,10 @@ def _postfilter(analyzed_text: str, results: list) -> list:
     for result in results:
         entity = normalize_entity(result.entity_type)
         candidate = analyzed_text[result.start : result.end]
-        if entity == "PHONE" and _is_date_shaped(candidate):
+        if entity == "PHONE" and (
+            _is_date_shaped(candidate)
+            or _preceded_by_reference_marker(analyzed_text, result.start)
+        ):
             continue
         if _overlaps_government_email(result):
             continue

--- a/tests/test_pii_eval.py
+++ b/tests/test_pii_eval.py
@@ -127,6 +127,94 @@ def test_coverage_counts_untyped_hits_and_gates():
     assert "COVERAGE 1 1 1 1 1.0000 1.0000" in format_report(report)
 
 
+def test_score_predictions_excludes_government_email_from_denominator():
+    """#56: government email addresses are not PII by policy, so a gold
+    EMAIL span on nic.in/gov.in/mil.in must not enter the gold denominator
+    -- otherwise the tagger is scored against spans it is now deliberately
+    built not to redact."""
+    text = "Contact officer@nic.in or citizen@gmail.com for help."
+    gov_start = text.index("officer@nic.in")
+    gov_end = gov_start + len("officer@nic.in")
+    citizen_start = text.index("citizen@gmail.com")
+    citizen_end = citizen_start + len("citizen@gmail.com")
+
+    examples = [
+        GoldExample(
+            id="p1",
+            text=text,
+            entities=(
+                PIISpan(entity="EMAIL", start=gov_start, end=gov_end),
+                PIISpan(entity="EMAIL", start=citizen_start, end=citizen_end),
+            ),
+        ),
+    ]
+    predictions = {
+        "p1": (PIISpan(entity="EMAIL", start=citizen_start, end=citizen_end),),
+    }
+
+    report = score_predictions(examples, predictions, baseline_overlap_recall=0.0)
+
+    assert report.excluded_by_policy == 1
+    assert report.by_entity["EMAIL"].gold == 1  # only the citizen span counts
+    assert report.by_entity["EMAIL"].overlap_hits == 1
+    assert report.by_entity["EMAIL"].overlap_recall == 1.0
+    assert report.overall.gold == 1
+    assert report.to_dict()["excluded_by_policy"] == 1
+    assert "excluded_by_policy=1" in format_report(report)
+
+
+def _span_for(text: str, substring: str) -> tuple[int, int]:
+    start = text.index(substring)
+    return start, start + len(substring)
+
+
+def test_score_predictions_excluded_count_sums_across_domains_and_examples():
+    """Subdomains and every government suffix count, spread across pages."""
+    text1 = "Reach the BDO at bdo.khordha@nic.in for the update."
+    start1, end1 = _span_for(text1, "bdo.khordha@nic.in")
+
+    text2 = "CC the PMO at officer@pmo.gov.in and the base at officer@station.mil.in."
+    start2, end2 = _span_for(text2, "officer@pmo.gov.in")
+    start3, end3 = _span_for(text2, "officer@station.mil.in")
+
+    examples = [
+        GoldExample(
+            id="p1",
+            text=text1,
+            entities=(PIISpan(entity="EMAIL", start=start1, end=end1),),
+        ),
+        GoldExample(
+            id="p2",
+            text=text2,
+            entities=(
+                PIISpan(entity="EMAIL", start=start2, end=end2),
+                PIISpan(entity="EMAIL", start=start3, end=end3),
+            ),
+        ),
+    ]
+
+    report = score_predictions(examples, {}, baseline_overlap_recall=0.0)
+
+    assert report.excluded_by_policy == 3
+    assert report.by_entity == {}  # every gold span in this fixture was excluded
+    assert report.overall.gold == 0
+
+
+def test_score_predictions_excluded_by_policy_defaults_to_zero_when_no_government_email():
+    examples = [
+        GoldExample(
+            id="p1",
+            text="Ramesh called 9876543210",
+            entities=(PIISpan(entity="PHONE", start=14, end=24),),
+        ),
+    ]
+
+    report = score_predictions(examples, {"p1": ()}, baseline_overlap_recall=0.0)
+
+    assert report.excluded_by_policy == 0
+    assert report.to_dict()["excluded_by_policy"] == 0
+
+
 def test_cli_gate_exits_nonzero_when_below_baseline(tmp_path, capsys, monkeypatch):
     gold = tmp_path / "gold.jsonl"
     gold.write_text(

--- a/tests/test_pii_redaction.py
+++ b/tests/test_pii_redaction.py
@@ -13,7 +13,12 @@ pytest.importorskip("en_core_web_sm")
 
 from janasunani.pipeline.config import PipelineConfig  # noqa: E402
 from janasunani.pipeline.db import initialize_database  # noqa: E402
-from janasunani.pipeline.stages.pii_tagger import redact_text, run_pii_tagger  # noqa: E402
+from janasunani.pipeline.stages.pii_tagger import (  # noqa: E402
+    detect_pii_spans,
+    is_government_email,
+    redact_text,
+    run_pii_tagger,
+)
 
 
 def test_indian_pii_patterns_redacted():
@@ -102,3 +107,128 @@ def test_rerun_is_idempotent_and_terminates(tmp_path):
     with sqlite3.connect(db) as con:
         (red,) = con.execute("SELECT redacted_text FROM pages").fetchone()
     assert red == "no pii here at all"
+
+
+# --- #55: dates and file numbers must not be tagged PHONE ------------------
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "The hearing was held on 06.05.2025 at the block office.",
+        "Order dated 06-05-2025 was not implemented.",
+        "Application dated 12/03/2024 was rejected.",
+    ],
+)
+def test_dates_are_not_tagged_phone(text):
+    assert not [s for s in detect_pii_spans(text) if s.entity == "PHONE"]
+    assert redact_text(text) == text
+
+
+def test_bare_file_number_in_letter_context_is_not_tagged_phone():
+    text = "Letter no. 1234567890 dated 12.03.2024 refers."
+    assert not [s for s in detect_pii_spans(text) if s.entity == "PHONE"]
+    assert redact_text(text) == text
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "My mobile is 9876543210, please call.",
+        "Reach me at +91 98765 43210 today.",
+        "Call 09876543210 for updates.",
+        "Contact on 98765 43210 anytime.",
+        "Contact on 98765-43210 anytime.",
+    ],
+)
+def test_mobiles_still_detected_across_formats(text):
+    spans = [s for s in detect_pii_spans(text) if s.entity == "PHONE"]
+    assert len(spans) == 1
+    red = redact_text(text)
+    assert "9876543210" not in red and "[PHONE]" in red
+
+
+def test_landline_still_detected():
+    text = "Office 0674 2536789 during hours."
+    spans = [s for s in detect_pii_spans(text) if s.entity == "PHONE"]
+    assert len(spans) == 1
+    red = redact_text(text)
+    assert "0674" not in red and "2536789" not in red and "[PHONE]" in red
+
+
+def test_aadhaar_unaffected_by_phone_changes():
+    text = "Aadhaar number 2345 6789 0123 attached."
+    spans = detect_pii_spans(text)
+    assert any(s.entity == "AADHAAR" for s in spans)
+    assert not [s for s in spans if s.entity == "PHONE"]
+    red = redact_text(text)
+    assert "[AADHAAR]" in red and "6789" not in red
+
+
+# --- #56: government email addresses are not PII ----------------------------
+
+
+@pytest.mark.parametrize(
+    "address",
+    [
+        "officer@nic.in",
+        "bdo.khordha@nic.in",
+        "officer@rb.nic.in",
+        "officer@odisha.gov.in",
+        "officer@pmo.gov.in",
+        "OFFICER@NIC.IN",
+    ],
+)
+def test_government_emails_are_not_redacted(address):
+    assert is_government_email(address)
+    text = f"Please contact {address} for grievance status."
+    assert redact_text(text) == text
+    assert not [s for s in detect_pii_spans(text) if s.entity == "EMAIL"]
+
+
+@pytest.mark.parametrize(
+    "address",
+    [
+        "citizen@gmail.com",
+        "citizen@yahoo.co.in",
+        "citizen@hotmail.com",
+        "citizen@example.in",
+    ],
+)
+def test_citizen_emails_still_redacted(address):
+    assert not is_government_email(address)
+    text = f"Please contact {address} for grievance status."
+    red = redact_text(text)
+    assert address not in red and "[EMAIL]" in red
+    spans = [s for s in detect_pii_spans(text) if s.entity == "EMAIL"]
+    assert len(spans) == 1
+    assert text[spans[0].start : spans[0].end] == address
+
+
+def test_government_email_exclusion_is_not_a_psl_accident():
+    """Regression guard: the old behaviour rode on tldextract parsing a bare
+    "@nic.in"/"@gov.in" address as an empty registrable domain -- an accident
+    that only covered part of the domain space (subdomains like
+    "rb.nic.in" were still redacted, and "mil.in" isn't a PSL suffix at all,
+    so a PSL-driven rule would never protect it). Our predicate must exclude
+    all three uniformly regardless of what tldextract/the PSL says."""
+    assert is_government_email("officer@mil.in")
+    assert is_government_email("officer@station.mil.in")
+    text = "Contact officer@mil.in or officer@rb.nic.in for status."
+    assert redact_text(text) == text
+    assert not [s for s in detect_pii_spans(text) if s.entity == "EMAIL"]
+
+
+def test_redact_text_and_detect_pii_spans_agree_on_government_email():
+    """The two entry points must never diverge (#56): one gates production
+    redaction, the other gates the eval scorecard."""
+    text = "Contact officer@nic.in or citizen@gmail.com for details."
+
+    red = redact_text(text)
+    spans = detect_pii_spans(text)
+    email_spans = [s for s in spans if s.entity == "EMAIL"]
+
+    assert "officer@nic.in" in red  # government address: untouched
+    assert "citizen@gmail.com" not in red and "[EMAIL]" in red  # citizen: redacted
+    assert len(email_spans) == 1
+    assert text[email_spans[0].start : email_spans[0].end] == "citizen@gmail.com"

--- a/tests/test_pii_redaction.py
+++ b/tests/test_pii_redaction.py
@@ -139,6 +139,11 @@ def test_bare_file_number_in_letter_context_is_not_tagged_phone():
         "Call 09876543210 for updates.",
         "Contact on 98765 43210 anytime.",
         "Contact on 98765-43210 anytime.",
+        # Codex review on #91 (P1): removing the built-in PhoneRecognizer
+        # left only the bare/5-5 IN_MOBILE pattern, so these two common
+        # groupings escaped redaction entirely.
+        "My number is 9876 543 210, please call.",  # 4-3-3
+        "My number is 987 654 3210, please call.",  # 3-3-4
     ],
 )
 def test_mobiles_still_detected_across_formats(text):
@@ -148,12 +153,38 @@ def test_mobiles_still_detected_across_formats(text):
     assert "9876543210" not in red and "[PHONE]" in red
 
 
-def test_landline_still_detected():
-    text = "Office 0674 2536789 during hours."
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Office 0674 2536789 during hours.",
+        "Office 0674-2536789 during hours.",
+        # Codex review on #91 (P2): these separator styles escaped every
+        # PHONE recognizer once the built-in was removed.
+        "Office (0674) 2536789 during hours.",
+        "Office 0674/2536789 during hours.",
+        "Office 0674 253 6789 during hours.",
+    ],
+)
+def test_landline_still_detected(text):
     spans = [s for s in detect_pii_spans(text) if s.entity == "PHONE"]
     assert len(spans) == 1
     red = redact_text(text)
-    assert "0674" not in red and "2536789" not in red and "[PHONE]" in red
+    assert "0674" not in red and "6789" not in red and "[PHONE]" in red
+
+
+def test_split_subscriber_landline_also_matches_new_mobile_pattern_harmlessly():
+    """Recognizer interaction found while broadening formats for the Codex
+    review on #91: IN_LANDLINE's split-subscriber pattern and IN_MOBILE's
+    new 3-3-4 pattern (added for '987 654 3210') both match
+    '0674 253 6789' on the exact same span -- the STD code doubles as a
+    valid leading digit + trunk-zero mobile shape. Both normalize to PHONE
+    and land on identical (start, end), so detect_pii_spans's dict-keyed
+    dedup collapses them to one span (keeping the higher score) and
+    redact_text produces a single [PHONE], not a double replacement."""
+    text = "Office 0674 253 6789 during hours."
+    spans = [s for s in detect_pii_spans(text) if s.entity == "PHONE"]
+    assert len(spans) == 1
+    assert redact_text(text) == "Office [PHONE] during hours."
 
 
 def test_aadhaar_unaffected_by_phone_changes():
@@ -163,6 +194,58 @@ def test_aadhaar_unaffected_by_phone_changes():
     assert not [s for s in spans if s.entity == "PHONE"]
     red = redact_text(text)
     assert "[AADHAAR]" in red and "6789" not in red
+
+
+# --- #55 (Codex review on #91, P2): the zero-prefixed STD-code shape is ----
+# structurally identical to a zero-prefixed file/case/order number, and
+# shape alone cannot tell them apart (a real Delhi STD code, 011, starts
+# with the same digit "1" a lot of file-number shapes do -- there is no
+# "implausible leading digit" rule to hang an exclusion on). We deliberately
+# keep matching this shape -- over-redaction is the safe failure direction
+# -- and only suppress it when the text itself names it as a citation via
+# the standard "Letter/Case/File/Order/Reference/Memo No." convention. That
+# is a context check, not a confidence threshold: #55 already established
+# that a genuine landline and these false positives score identically
+# (0.40 against the old built-in), so no score-based cut could do this.
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "The number is 0123-4567890 for reference.",
+        "The number is 0123 4567890 for reference.",
+    ],
+)
+def test_zero_prefixed_reference_shape_without_marker_is_over_redacted(text):
+    """Deliberate trade-off, not a Codex-endorsed fix: without a written
+    citation marker immediately before it, this shape is indistinguishable
+    from a real landline, so it is still redacted."""
+    spans = [s for s in detect_pii_spans(text) if s.entity == "PHONE"]
+    assert len(spans) == 1
+    assert "[PHONE]" in redact_text(text)
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Letter No. 0123-4567890 dated 12.03.2024 refers.",
+        "Letter No. 0123 4567890 dated 12.03.2024 refers.",
+        "Case No. 0674-2536789 refers to the earlier complaint.",
+        "File No: 0674 2536789 is attached.",
+        "Order No. 0674-2536789 was issued yesterday.",
+        "Reference No. 0674-2536789 is cited above.",
+        "Ref. No. 0674-2536789 is cited above.",
+        "Memo No. 0674-2536789 dated last week.",
+    ],
+)
+def test_reference_number_marker_suppresses_phone_tag(text):
+    """The one reliable, non-score signal that a zero-prefixed digit run is
+    a citation rather than a callback number: it is introduced by the
+    standard government-correspondence convention."""
+    assert not [s for s in detect_pii_spans(text) if s.entity == "PHONE"]
+    # spaCy NER may separately (mis)tag the marker phrase itself as a NAME
+    # (unrelated to #55/#56); what matters here is that PHONE never fires.
+    assert "[PHONE]" not in redact_text(text)
 
 
 # --- #56: government email addresses are not PII ----------------------------


### PR DESCRIPTION
## Summary

- #55: `PHONE_NUMBER` (Presidio's built-in `PhoneRecognizer`, backed by `phonenumbers`) is removed from `ENTITY_TOKENS`. It tagged dotted/hyphenated dates and bare file numbers `PHONE` at the same 0.40 score as genuine Odisha landlines, so a confidence threshold can't separate them (evidence in the issue). PHONE detection is now entirely our own: `IN_MOBILE` (existing) plus a new `IN_LANDLINE` `PatternRecognizer` (STD code + 6-8 digit subscriber number), plus a date-shape guard applied to every PHONE candidate regardless of which recognizer produced it.
- #56: government officer addresses (`nic.in`, `gov.in`, `mil.in`, and any subdomain) are excluded from redaction via a new, exported `is_government_email()` predicate -- our own explicit rule, not `tldextract`/the Public Suffix List. Applied identically inside `redact_text()` and `detect_pii_spans()` so production redaction and the offline eval can never disagree.
- `pii_eval.py`: gold `EMAIL` spans on a government domain are dropped from the scoring denominator via the same predicate and the count is surfaced as `excluded_by_policy` on `EvaluationReport`/`to_dict()`, so the 49 now-out-of-scope gold spans don't silently shrink the scorecard unexplained.

## Recognizer interaction not described in the issues

spaCy's NER (`en_core_web_sm`) independently tags some government email addresses as `PERSON` -- e.g. `officer@rb.nic.in` reads as a name to the model, at the *exact same span* as the `EMAIL_ADDRESS` hit. A fix that only filtered the `EMAIL_ADDRESS`-labeled result would still redact the address under `[NAME]`. `_postfilter()` in `pii_tagger.py` therefore drops *any* recognizer result overlapping a confirmed government-email span, not just the email-typed one. Covered by `test_government_email_exclusion_is_not_a_psl_accident` and `test_redact_text_and_detect_pii_spans_agree_on_government_email` in `tests/test_pii_redaction.py`.

## Test plan

- [x] `uv run --extra serving --extra pipeline-core pytest` -- 305 passed, 14 skipped
- [x] `uv run ruff check .` -- all checks passed
- [x] New tests in `tests/test_pii_redaction.py` (dates/file numbers not tagged PHONE, mobiles/landline/Aadhaar unaffected, government vs. citizen email both directions, PSL-independence regression guard, redact/detect agreement) and `tests/test_pii_eval.py` (`excluded_by_policy` denominator drop, synthetic fixtures only)

Closes #55
Closes #56