### PR TITLE
fix(ci): constrain sidecar counter keys and stop echoing rejected values

### DIFF
--- a/.github/workflows/data-check.yml
+++ b/.github/workflows/data-check.yml
@@ -33,15 +33,9 @@ jobs:
 
       # Provenance sidecars are the one exception above: they record versions,
       # checksums and span counts so a gold artifact can be reviewed without
-      # pulling it. The exception is granted by filename, so this step checks
-      # that the contents actually match that description.
-      #
-      # This is an allowlist, deliberately. Enumerating forbidden keys cannot
-      # work: citizen text under a key named "content", "excerpt" or "raw"
-      # would pass a denylist and be committed to a repo that must never hold
-      # it. Anything not named here fails, so a new field is a conscious edit
-      # to this list rather than a silent addition. The value rules are the
-      # real barrier — prose cannot survive a 200-character scalar cap.
+      # pulling it. The exception is granted by filename, so the contents have
+      # to be checked against the metadata contract. The rules, and why they
+      # are an allowlist rather than a denylist, live in the script.
       - name: Check provenance sidecars carry metadata only
         shell: bash
         run: |
@@ -50,104 +44,9 @@ jobs:
           sidecars="$(git ls-files 'data/external/*.provenance.json' || true)"
           [ -n "$sidecars" ] || exit 0
 
-          python3 - "$sidecars" <<'PY'
-          import json
-          import pathlib
-          import sys
-
-          # Mirrors provenance() in scripts/rederive_pii_draft.py.
-          ALLOWED_TOP = {
-              "kind", "note", "created_utc", "out", "source_gold",
-              "source_gold_md5", "records", "spans", "spans_by_entity",
-              "analyzer", "environment",
-          }
-          # Nested objects: fixed key sets, except span counts which are keyed
-          # by entity label and must map to integers.
-          ALLOWED_NESTED = {
-              "analyzer": {
-                  "git_commit", "presidio_analyzer", "spacy", "en_core_web_sm",
-              },
-              "environment": {"python", "system", "machine"},
-          }
-          COUNTER_OBJECTS = {"spans_by_entity"}
-
-          MAX_BYTES = 16 * 1024
-          MAX_STRING = 200
-          # "note" is the one deliberately long field: a fixed caveat written by
-          # the script, never derived from a record.
-          MAX_NOTE = 1000
-
-          def check_scalar(name, path, value, limit):
-              if isinstance(value, bool) or value is None:
-                  return []
-              if isinstance(value, (int, float)):
-                  return []
-              if not isinstance(value, str):
-                  return [f"{name}: {path} is {type(value).__name__}, expected a scalar"]
-              if len(value) > limit:
-                  return [f"{name}: {path} is {len(value)} chars, over the {limit}-char cap"]
-              return []
-
-          def check_sidecar(name, payload):
-              if not isinstance(payload, dict):
-                  return [f"{name}: top level is {type(payload).__name__}, expected an object"]
-
-              problems = []
-              for key, value in payload.items():
-                  if key not in ALLOWED_TOP:
-                      problems.append(f"{name}: unknown key '{key}' (add it here if intended)")
-                      continue
-
-                  if key in COUNTER_OBJECTS:
-                      if not isinstance(value, dict):
-                          problems.append(f"{name}: '{key}' must be an object of counts")
-                          continue
-                      for label, count in value.items():
-                          if isinstance(count, bool) or not isinstance(count, int):
-                              problems.append(f"{name}: '{key}.{label}' must be an integer count")
-                      continue
-
-                  if key in ALLOWED_NESTED:
-                      if not isinstance(value, dict):
-                          problems.append(f"{name}: '{key}' must be an object")
-                          continue
-                      for sub, sub_value in value.items():
-                          if sub not in ALLOWED_NESTED[key]:
-                              problems.append(f"{name}: unknown key '{key}.{sub}'")
-                              continue
-                          problems += check_scalar(name, f"{key}.{sub}", sub_value, MAX_STRING)
-                      continue
-
-                  limit = MAX_NOTE if key == "note" else MAX_STRING
-                  problems += check_scalar(name, key, value, limit)
-
-              return problems
-
-          names = sys.argv[1].split()
-          failures = []
-          for name in names:
-              path = pathlib.Path(name)
-              size = path.stat().st_size
-              if size > MAX_BYTES:
-                  failures.append(f"{name}: {size} bytes exceeds the {MAX_BYTES}-byte metadata cap")
-                  continue
-              try:
-                  payload = json.loads(path.read_text())
-              except json.JSONDecodeError as exc:
-                  failures.append(f"{name}: not valid JSON ({exc})")
-                  continue
-              failures += check_sidecar(name, payload)
-
-          if failures:
-              print("Provenance sidecars must hold metadata only:")
-              for failure in failures:
-                  print(f"  {failure}")
-              print("")
-              print("Never put document text or spans in a sidecar; it is committed to Git.")
-              raise SystemExit(1)
-
-          print(f"Checked {len(names)} provenance sidecar(s) against the metadata schema.")
-          PY
+          # Word-split intentionally: git ls-files gives one path per line.
+          # shellcheck disable=SC2086
+          python3 scripts/check_provenance_sidecars.py $sidecars
 
       - name: Reject local state and secret files
         shell: bash

--- a/scripts/check_provenance_sidecars.py
+++ b/scripts/check_provenance_sidecars.py
@@ -1,0 +1,183 @@
+"""Check that committed provenance sidecars hold metadata and nothing else.
+
+`data/external/*.provenance.json` is the one exception to the rule that nothing
+under `data/` enters git: a sidecar records analyzer versions, checksums and
+span counts so a gold artifact can be reviewed without pulling citizen text.
+The exception is granted by filename, so something has to verify that the
+contents actually match that description.
+
+This is an allowlist, deliberately. Enumerating forbidden keys cannot work:
+citizen text under a key named "content", "excerpt" or "raw" would pass a
+denylist and be committed to a public repo. Anything not named here fails, so a
+new field is a conscious edit rather than a silent addition.
+
+The value rules are the real barrier. Prose does not survive a 200-character
+scalar cap, and a counter's keys must be canonical entity labels, so a
+label-to-count map lifted from an annotation tool whose labels are surface
+forms is rejected rather than committed.
+
+Nothing here prints the value it rejected. This runs in CI, whose logs are
+public, so a rejected key is reported by position and never by content --
+publishing the thing you are refusing to publish defeats the gate.
+
+Stdlib only: it runs on a bare runner before any dependency is installed.
+
+    python3 scripts/check_provenance_sidecars.py data/external/*.provenance.json
+
+Exits 0 when every file passes, 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+# Mirrors provenance() in scripts/rederive_pii_draft.py.
+ALLOWED_TOP = {
+    "kind",
+    "note",
+    "created_utc",
+    "out",
+    "source_gold",
+    "source_gold_md5",
+    "records",
+    "spans",
+    "spans_by_entity",
+    "analyzer",
+    "environment",
+}
+
+# Nested objects with a fixed key set.
+ALLOWED_NESTED = {
+    "analyzer": {"git_commit", "presidio_analyzer", "spacy", "en_core_web_sm"},
+    "environment": {"python", "system", "machine"},
+}
+
+# Objects keyed by entity label rather than by a fixed key set. The keys are
+# data, so they are constrained too: this is the field a surface form would
+# arrive in. Must equal KNOWN_ENTITIES in scripts/verify_pii_gold.py; a test
+# asserts that, because the two drifting apart is how a gap reopens.
+COUNTER_OBJECTS = {"spans_by_entity"}
+ENTITY_LABELS = {"NAME", "PHONE", "EMAIL", "AADHAAR", "PAN"}
+
+MAX_BYTES = 16 * 1024
+MAX_STRING = 200
+# "note" is the one deliberately long field: a fixed caveat written by the
+# script, never derived from a record.
+MAX_NOTE = 1000
+
+_MD5_RE = re.compile(r"^[0-9a-f]{32}$")
+
+
+def _check_scalar(path: str, value: Any, limit: int) -> list[str]:
+    if value is None or isinstance(value, bool) or isinstance(value, (int, float)):
+        return []
+    if not isinstance(value, str):
+        return [f"{path} is {type(value).__name__}, expected a scalar"]
+    if len(value) > limit:
+        return [f"{path} is {len(value)} chars, over the {limit}-char cap"]
+    return []
+
+
+def _check_counter(key: str, value: Any) -> list[str]:
+    if not isinstance(value, dict):
+        return [f"'{key}' must be an object of counts"]
+
+    problems: list[str] = []
+    for position, (label, count) in enumerate(value.items()):
+        # Reported by position: the label is the thing that may need withholding.
+        if label not in ENTITY_LABELS:
+            problems.append(
+                f"'{key}' entry {position} is not a canonical entity label "
+                f"(expected one of {sorted(ENTITY_LABELS)}); value withheld, "
+                "it may contain citizen text"
+            )
+        if isinstance(count, bool) or not isinstance(count, int):
+            problems.append(f"'{key}' entry {position} must map to an integer count")
+    return problems
+
+
+def check_payload(payload: Any) -> list[str]:
+    """Every way this document fails the metadata contract. Empty means it passes."""
+    if not isinstance(payload, dict):
+        return [f"top level is {type(payload).__name__}, expected an object"]
+
+    problems: list[str] = []
+    for key, value in payload.items():
+        if key not in ALLOWED_TOP:
+            # The key itself is untrusted, so it is located, not quoted.
+            problems.append(
+                f"unknown top-level key at position {list(payload).index(key)} "
+                f"(expected a subset of {sorted(ALLOWED_TOP)}); name withheld"
+            )
+            continue
+
+        if key in COUNTER_OBJECTS:
+            problems += _check_counter(key, value)
+            continue
+
+        if key in ALLOWED_NESTED:
+            if not isinstance(value, dict):
+                problems.append(f"'{key}' must be an object")
+                continue
+            for sub, sub_value in value.items():
+                if sub not in ALLOWED_NESTED[key]:
+                    problems.append(
+                        f"unknown key in '{key}' at position {list(value).index(sub)} "
+                        f"(expected a subset of {sorted(ALLOWED_NESTED[key])}); name withheld"
+                    )
+                    continue
+                problems += _check_scalar(f"{key}.{sub}", sub_value, MAX_STRING)
+            continue
+
+        if key == "source_gold_md5" and isinstance(value, str) and not _MD5_RE.match(value):
+            problems.append("'source_gold_md5' is not a 32-character hex digest")
+            continue
+
+        problems += _check_scalar(key, value, MAX_NOTE if key == "note" else MAX_STRING)
+
+    return problems
+
+
+def check_file(path: Path) -> list[str]:
+    size = path.stat().st_size
+    if size > MAX_BYTES:
+        return [f"{size} bytes exceeds the {MAX_BYTES}-byte metadata cap"]
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return [f"not valid JSON ({exc})"]
+    return check_payload(payload)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="*", type=Path, help="Sidecar files to check")
+    args = parser.parse_args()
+
+    if not args.paths:
+        print("No provenance sidecars to check.")
+        return 0
+
+    failures: list[str] = []
+    for path in args.paths:
+        failures += [f"{path}: {problem}" for problem in check_file(path)]
+
+    if failures:
+        print("Provenance sidecars must hold metadata only:")
+        for failure in failures:
+            print(f"  {failure}")
+        print("")
+        print("Never put document text or spans in a sidecar; it is committed to Git.")
+        print("Rejected values are withheld on purpose: these logs are public.")
+        return 1
+
+    print(f"Checked {len(args.paths)} provenance sidecar(s) against the metadata schema.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_provenance_sidecars.py
+++ b/scripts/check_provenance_sidecars.py
@@ -133,7 +133,13 @@ def check_payload(payload: Any) -> list[str]:
                 problems += _check_scalar(f"{key}.{sub}", sub_value, MAX_STRING)
             continue
 
-        if key == "source_gold_md5" and isinstance(value, str) and not _MD5_RE.match(value):
+        # Negated as a whole, not guarded by isinstance: a non-string checksum
+        # (123, null, true) would otherwise skip this rule and be waved through
+        # by _check_scalar, which accepts every non-string scalar. fullmatch,
+        # not match, because `$` also matches before a trailing newline.
+        if key == "source_gold_md5" and not (
+            isinstance(value, str) and _MD5_RE.fullmatch(value)
+        ):
             problems.append("'source_gold_md5' is not a 32-character hex digest")
             continue
 

--- a/tests/test_check_provenance_sidecars.py
+++ b/tests/test_check_provenance_sidecars.py
@@ -1,0 +1,170 @@
+"""Tests for scripts/check_provenance_sidecars.py.
+
+Synthetic sidecars only. The point of the gate is that citizen text never
+reaches git, so nothing here uses a real one.
+
+Loaded via importlib (scripts/ is not a package).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, _SCRIPTS / f"{name}.py")
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+check = _load("check_provenance_sidecars")
+verify = _load("verify_pii_gold")
+
+# A structurally valid sidecar, matching what rederive_pii_draft.py writes.
+VALID = {
+    "kind": "rederived_draft",
+    "note": "Analyzer output on the gold's own text, NOT the original bootstrap draft.",
+    "created_utc": "2026-08-07T09:00:00+00:00",
+    "out": "pii_draft_n50.jsonl",
+    "source_gold": "pii_gold_draft_n50.jsonl",
+    "source_gold_md5": "c4862fcc95548934cfd5bf004e77542d",
+    "records": 89,
+    "spans": 618,
+    "spans_by_entity": {"AADHAAR": 14, "EMAIL": 34, "NAME": 497, "PHONE": 73},
+    "analyzer": {
+        "git_commit": "abc1234",
+        "presidio_analyzer": "2.2.355",
+        "spacy": "3.7.5",
+        "en_core_web_sm": "3.7.1",
+    },
+    "environment": {"python": "3.12.4", "system": "Darwin", "machine": "arm64"},
+}
+
+# What must never be committable. Used as a key, a value and a label below.
+CITIZEN_TEXT = "Ramesh Chandra Sahoo, At/Po Bhubaneswar"
+
+
+def sidecar(tmp_path: Path, payload: dict, name: str = "x.provenance.json") -> Path:
+    path = tmp_path / name
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_the_real_shape_passes():
+    assert check.check_payload(VALID) == []
+
+
+class TestCounterKeysAreConstrained:
+    """#95. The counter's keys were exempt from every rule because they are
+    entity labels rather than a fixed key set, so a label-to-count map from a
+    tool whose labels are surface forms would have been committed."""
+
+    def test_a_surface_form_as_a_counter_key_is_rejected(self):
+        payload = dict(VALID, spans_by_entity={CITIZEN_TEXT: 1})
+        assert check.check_payload(payload)
+
+    def test_the_rejected_key_is_never_echoed(self):
+        """CI logs are public. Publishing what you refuse to publish defeats the gate."""
+        payload = dict(VALID, spans_by_entity={CITIZEN_TEXT: 1})
+        problems = check.check_payload(payload)
+        assert all(CITIZEN_TEXT not in problem for problem in problems)
+        assert any("withheld" in problem for problem in problems)
+
+    def test_a_valid_label_with_a_bad_count_is_still_rejected(self):
+        assert check.check_payload(dict(VALID, spans_by_entity={"NAME": CITIZEN_TEXT}))
+
+    def test_a_bool_is_not_an_integer_count(self):
+        assert check.check_payload(dict(VALID, spans_by_entity={"NAME": True}))
+
+    def test_canonical_labels_pass(self):
+        payload = dict(VALID, spans_by_entity={"NAME": 1, "PAN": 2})
+        assert check.check_payload(payload) == []
+
+    def test_label_set_matches_the_verifier(self):
+        """The two drifting apart is how this gap reopens: a label the verifier
+        accepts but the gate rejects, or worse, the reverse."""
+        assert check.ENTITY_LABELS == verify.KNOWN_ENTITIES
+
+
+class TestUnknownKeysAreRejectedWithoutEchoing:
+    @pytest.mark.parametrize("key", ["content", "excerpt", "raw", "body", "entities"])
+    def test_plausible_content_keys_are_rejected(self, key):
+        assert check.check_payload(dict(VALID, **{key: CITIZEN_TEXT}))
+
+    def test_unknown_top_level_key_name_is_withheld(self):
+        problems = check.check_payload({**VALID, CITIZEN_TEXT: 1})
+        assert problems
+        assert all(CITIZEN_TEXT not in problem for problem in problems)
+
+    def test_unknown_nested_key_name_is_withheld(self):
+        payload = dict(VALID, analyzer={**VALID["analyzer"], CITIZEN_TEXT: "x"})
+        problems = check.check_payload(payload)
+        assert problems
+        assert all(CITIZEN_TEXT not in problem for problem in problems)
+
+
+class TestValueRules:
+    def test_prose_over_the_cap_is_rejected(self):
+        assert check.check_payload(dict(VALID, source_gold="x" * 500))
+
+    def test_note_may_be_longer_than_other_scalars(self):
+        assert check.check_payload(dict(VALID, note="x" * 500)) == []
+
+    def test_note_still_has_a_ceiling(self):
+        assert check.check_payload(dict(VALID, note="x" * 2000))
+
+    def test_a_list_of_records_is_rejected(self):
+        assert check.check_payload(dict(VALID, records=[{"id": "a", "text": CITIZEN_TEXT}]))
+
+    def test_a_non_digest_checksum_is_rejected(self):
+        assert check.check_payload(dict(VALID, source_gold_md5=CITIZEN_TEXT))
+
+    def test_top_level_must_be_an_object(self):
+        assert check.check_payload([VALID])
+
+
+class TestFileLevelChecks:
+    def test_oversized_file_is_rejected(self, tmp_path):
+        path = sidecar(tmp_path, dict(VALID, note="x" * 40_000))
+        assert check.check_file(path)
+
+    def test_malformed_json_is_rejected(self, tmp_path):
+        path = tmp_path / "broken.provenance.json"
+        path.write_text("not json", encoding="utf-8")
+        assert check.check_file(path)
+
+    def test_valid_file_passes(self, tmp_path):
+        assert check.check_file(sidecar(tmp_path, VALID)) == []
+
+
+class TestCLI:
+    def _run(self, monkeypatch, *paths: Path) -> int:
+        monkeypatch.setattr(
+            sys, "argv", ["check_provenance_sidecars.py", *[str(p) for p in paths]]
+        )
+        return check.main()
+
+    def test_no_paths_is_not_a_failure(self, monkeypatch):
+        assert self._run(monkeypatch) == 0
+
+    def test_clean_sidecar_exits_zero(self, tmp_path, monkeypatch):
+        assert self._run(monkeypatch, sidecar(tmp_path, VALID)) == 0
+
+    def test_bad_sidecar_exits_one(self, tmp_path, monkeypatch):
+        payload = dict(VALID, spans_by_entity={CITIZEN_TEXT: 1})
+        assert self._run(monkeypatch, sidecar(tmp_path, payload)) == 1
+
+    def test_bad_sidecar_output_withholds_the_value(self, tmp_path, monkeypatch, capsys):
+        payload = dict(VALID, spans_by_entity={CITIZEN_TEXT: 1})
+        self._run(monkeypatch, sidecar(tmp_path, payload))
+        assert CITIZEN_TEXT not in capsys.readouterr().out

--- a/tests/test_check_provenance_sidecars.py
+++ b/tests/test_check_provenance_sidecars.py
@@ -129,6 +129,19 @@ class TestValueRules:
     def test_a_non_digest_checksum_is_rejected(self):
         assert check.check_payload(dict(VALID, source_gold_md5=CITIZEN_TEXT))
 
+    @pytest.mark.parametrize("value", [123, None, True, 1.5, ["a" * 32]])
+    def test_a_non_string_checksum_is_rejected(self, value):
+        # _check_scalar accepts every non-string scalar, so a checksum rule that
+        # only applies to strings leaves the field a reviewer trusts unguarded.
+        assert check.check_payload(dict(VALID, source_gold_md5=value))
+
+    def test_a_digest_with_a_trailing_newline_is_rejected(self):
+        # `$` matches before a trailing newline; only fullmatch anchors the end.
+        assert check.check_payload(dict(VALID, source_gold_md5="a" * 32 + "\n"))
+
+    def test_a_well_formed_digest_still_passes(self):
+        assert check.check_payload(dict(VALID, source_gold_md5="0" * 31 + "f")) == []
+
     def test_top_level_must_be_an_object(self):
         assert check.check_payload([VALID])
 


### PR DESCRIPTION
Closes #95.

## The hole

`spans_by_entity` was exempt from every rule in the sidecar gate, because its keys are entity labels rather than a fixed key set. Only the *values* were checked:

```json
{"spans_by_entity": {"Ramesh Chandra Sahoo, At/Po Bhubaneswar": 1}}
```

That passed CI and would have been committed to a public repo, in the one directory the gate exists to protect. Keys are now checked against the canonical entity set.

## The second, quieter hole

The failure message echoed the rejected key verbatim. **CI logs are public**, so the gate published the thing it was refusing to publish. Rejected keys are now reported by position and never by content, which is the rule `verify_pii_gold.py` already applies to untrusted entity labels.

## Extracted rather than patched in place

Moved out of the workflow into `scripts/check_provenance_sidecars.py`, as the issue asks. Inline YAML Python could not be tested, and the schema was written twice. Still stdlib-only, so it runs on a bare runner before any dependency is installed, and its tests run **unguarded** in CI rather than `importorskip`ing away, which is the right posture for a citizen-data gate.

Also tightened while the schema was in one place: `source_gold_md5` must be a 32-character hex digest, so free text cannot sit in the field a reviewer trusts to identify the artifact.

## Test plan

- [x] `uv run --extra serving --extra pipeline-core pytest` — 567 passed, 7 skipped
- [x] `uv run ruff check .` — clean
- [x] `python3 scripts/check_provenance_sidecars.py $(git ls-files 'data/external/*.provenance.json')` under bare system python — passes on the real sidecar
- [x] 27 new tests in `tests/test_check_provenance_sidecars.py`, synthetic sidecars only

One of them asserts `ENTITY_LABELS == verify_pii_gold.KNOWN_ENTITIES`. The two sets drifting apart is how this gap reopens.