### PR TITLE
docs: correct the Sarvam Vision handwriting claim

### DIFF
--- a/docs/DELIVERY.md
+++ b/docs/DELIVERY.md
@@ -103,7 +103,7 @@ Three Sarvam models are relevant.
 
 Cost is a few hundred rupees for the whole comparison.
 
-One caveat. Sarvam documents their vision model as strong on printed text, tables and layout, with no mention of handwriting. Much of our corpus is handwritten. We will report handwritten and printed pages separately, because a result that holds only for printed forms is a much smaller result than it appears.
+One caveat, and it is not the one we first wrote down. Sarvam state that Vision is trained on handwritten text across all 22 Indian languages, so handwriting is a supported case rather than an unmentioned one. What they do not publish is a handwriting-specific number: the headline benchmarks are general document scores, and they note accuracy is lower on highly stylised handwriting without saying by how much. Much of our corpus is handwritten. We will report handwritten and printed pages separately, because the split is the part nobody has measured.
 
 ## Schedule
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1131,13 +1131,18 @@ benchmark design; latency, rate limits, and quality should.
 
 Four things to check before relying on any of it:
 
-- ⚠️ **Handwriting is not mentioned anywhere in the Vision documentation.** Tables,
-  layout, and printed Indic script are the advertised strengths. A large share of
-  our corpus is handwritten grievance letters, which is exactly the hardest case
-  and the one we most need solved. **Put handwritten pages in the benchmark
-  sample deliberately, stratified, and report them separately.** If Sarvam Vision
-  only wins on printed forms, that is a much smaller result than the headline
-  suggests.
+- ⚠️ **Handwriting is claimed but not benchmarked.** Corrected 2026-08-07: an
+  earlier revision of this section said handwriting was unmentioned in the Vision
+  documentation. It is mentioned, and directly — Sarvam state the model is trained
+  on handwritten text across all 22 Indian languages, and that it beats
+  general-purpose OCR on Indian-language handwriting. What they publish no number
+  for is handwriting itself: the headline scores are general document benchmarks,
+  and the only handwriting statement is qualitative, that accuracy is lower on
+  highly stylised hands. A large share of our corpus is handwritten grievance
+  letters. **Put handwritten pages in the benchmark sample deliberately,
+  stratified, and report them separately** — not as a hedge against an
+  unsupported case, but because the printed/handwritten split is the number
+  nobody has published and the one our corpus turns on.
 - ⚠️ **Sarvam-30B runs with reasoning enabled by default, and reasoning tokens bill
   as completion tokens** at 4x the input rate. Disable it for classification or
   the cost model above is wrong.


### PR DESCRIPTION
`docs/ROADMAP.md` §Sarvam and `docs/DELIVERY.md` both said Sarvam's vision documentation made **no mention of handwriting**, with printed text, tables and layout as the advertised strengths.

That is wrong. Sarvam state Vision is trained on handwritten text across all 22 Indian languages, and that it outperforms general-purpose OCR on Indian-language handwriting.

## The conclusion holds but its reasoning inverts

Reporting handwritten and printed separately was written as a **hedge against a case the vendor might not support**. The real justification is stronger: handwriting is supported and claimed, and Sarvam publish **no handwriting-specific benchmark**. The headline numbers are general document scores, and the only handwriting statement is qualitative — accuracy is lower on highly stylised hands, with no figure attached.

So the split is not a defensive caveat about a suspected weak spot. It is the number nobody has published, on the case our corpus actually consists of. Better line to take to the ED, and a better reason to spend the sample on it.

## Knock-on

#84's body and my deferral comment on #65 both repeat the old claim; comments posted there correcting it. Nothing in the plan changes: handwritten and printed still get reported separately, and #84 still ships in its comparative fallback form after #65 was deferred.

Sources: [sarvam.ai/blogs/sarvam-vision](https://www.sarvam.ai/blogs/sarvam-vision), [sarvamvision.com](https://sarvamvision.com/)