### PR TITLE
docs: separate Sarvam Akshar the product from sarvam-vision the model

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -190,8 +190,11 @@ release gates.
     terms, encryption, audit policy, and fallback. The tier is the index into
     those fields, not the control by itself;
   - a kill switch reverts every `authorized-external` entry to a **maintained**
-    lower-tier counterpart, and Sarvam-30B / 105B being Apache 2.0 means the
-    GPU-box deployment is a real exit ramp, not a notional one;
+    lower-tier counterpart. The GPU-box deployment was the exit ramp on the
+    argument that Sarvam-30B is Apache 2.0 and fits the box; 30B has since been
+    withdrawn and 105B exceeds the current 24 GB L4, so **that ramp is
+    unconfirmed** until the licence and sizing are re-checked (#125). The
+    same-host counterparts remain the working fallback;
   - the network allowlist permits Sarvam and nothing else, which is **stricter
     than today**, where no-egress is policy only and BART downloads from a public
     hub at startup.

--- a/docs/DELIVERY.md
+++ b/docs/DELIVERY.md
@@ -105,6 +105,8 @@ Cost is a few hundred rupees for the whole comparison.
 
 One caveat, and it is not the one we first wrote down. Sarvam state that Vision is trained on handwritten text across all 22 Indian languages, so handwriting is a supported case rather than an unmentioned one. What they do not publish is a handwriting-specific number: the headline benchmarks are general document scores, and they note accuracy is lower on highly stylised handwriting without saying by how much. Much of our corpus is handwritten. We will report handwritten and printed pages separately, because the split is the part nobody has measured.
 
+A naming note, since the two are easy to conflate. Sarvam Akshar is the document digitisation platform; Sarvam Vision is the model underneath it. We benchmark the model, and the scorecard will say which surface was called.
+
 ## Schedule
 
 **Table 3. Three weeks**

--- a/docs/DELIVERY.md
+++ b/docs/DELIVERY.md
@@ -32,7 +32,7 @@ The document-reading half of that comparison is gated by something else entirely
 | Spam and duplicates | Repeat submissions linked and mass campaigns grouped as one issue, across a defined portion of the backlog, with a count of how much of it is duplicated work. Complaints written in Odia script and in Roman letters are matched separately, not against each other | **Bounded** | Duplicates without spam scoring. A smaller portion of the backlog |
 | The intelligence layer | Duplicate-adjusted workload. One worked example of a spike separated into filings, distinct problems and distinct citizens. Local issue themes for one category. The closure finding | **Bounded** | Themes drop first. If duplicate detection slips, only the closure finding survives, since it is the one item needing no new processing |
 | A/B testing of the automation | The experiment design, the size of effect we could detect, and where the AI already agrees with officers today | **Framework only** | None needed. Nothing here depends on new engineering |
-| Sarvam benchmark | Sarvam Vision against our text extraction on a transcribed sample, with handwritten and printed pages reported separately | **Bounded** | Document reading only. Comparing Sarvam on categorisation and summarisation, and the switch between providers, are stretch |
+| Sarvam benchmark | Sarvam Vision against our pipeline on a paired sample of a few hundred pages. **Categorisation reports accuracy against the recorded category; document reading reports only how the two differ**, since no transcription owner was named | **Bounded** | Categorisation is now in scope, because its reference is administrative data we already hold. Transcription accuracy is out, and reported comparatively |
 
 **Committed** means we will demonstrate it. **Bounded** means we will demonstrate it on a defined slice rather than the full 1.37 million. **Framework only** means a design and a calculation, not running software.
 
@@ -45,7 +45,7 @@ The portion of the backlog is not yet fixed. We will settle it after a brainstor
 | Stage | Earlier figure, and what it was measured on | 14 August |
 |---|---|---|
 | Personal information removal | 80.6% of items found, on a 106-sentence English validation split | Re-measured on our corrected 85-page set, by data type and by language |
-| Text extraction from scans | 77.9% of pages passed three plausibility checks, on 96,469 English pages. Not transcription accuracy: there was no ground truth | Measured against a deliberately transcribed sample, handwritten and printed separately, against Sarvam Vision |
+| Text extraction from scans | 77.9% of pages passed three plausibility checks, on 96,469 English pages. Not transcription accuracy: there was no ground truth | **No accuracy figure.** No transcription sample was commissioned, so there is still no ground truth. Reported as divergence from Sarvam Vision, handwritten and printed separately, with no verdict on which is right |
 | Duplicate detection | Not attempted | Recall against the 34,000 duplicates officers have already identified |
 | Page type | 67% accurate, on the earlier team's own 1,500-page sample | Historical context only. No labelled set exists for August |
 | Category assignment | 71% accurate, on the earlier team's train/test split | Historical context only, unless a held-out labelled set is identified in week 1 |
@@ -97,8 +97,8 @@ The fifth is a measurement: does Sarvam read Odia better than we do? The scoreca
 
 Three Sarvam models are relevant.
 
-- **Sarvam Vision** reads scanned documents in 22 Indian languages including Odia, at 50 paise per page. Direct comparison against our text extraction.
-- **Sarvam-30B**, tested on categorisation and summarisation.
+- **Sarvam Vision** reads scanned documents in 22 Indian languages including Odia. Two modes: reading a page as text at 50 paise, or pulling named fields out of it at ₹1. The second is what a grievance officer would actually use, and our pipeline has no equivalent.
+- **Sarvam-105B** for categorisation and summarisation. Note that the model we originally costed, Sarvam-30B, has since been withdrawn, and its replacement is roughly twelve times the price. The whole comparison is still a few thousand rupees.
 - **Transliteration**, converting Odia written in Roman letters into Odia script. Our pipeline does not solve this at all today.
 
 Cost is a few hundred rupees for the whole comparison.
@@ -115,7 +115,7 @@ A naming note, since the two are easy to conflate. Sarvam Akshar is the document
 |---|---|---|
 | 27 to 31 July | Manual privacy labelling complete. System live on AWS. Pipeline run end to end | A grievance submitted in a browser returns a result. Counts reconcile at every pipeline step |
 | 3 to 7 August | Privacy scorecard. Historical complaint text redacted. Spam and duplicate detection. Backlog duplication count. Management metrics, local issue themes, and spike view | Missed-PII rate by data type and language. Redaction pass completes over the chosen portion before any matching runs. Known repeat submissions found in a held-out sample. Each metric reconciles against source data. One real spike found and explained |
-| 10 to 14 August | Sarvam scorecard. Experiment design and power calculation. Full benchmark table | Sarvam and our models compared on the same test data. Every stage in Table 2 has a number |
+| 10 to 14 August | Sarvam scorecard. Experiment design and power calculation. Full benchmark table | Sarvam and our models compared on the same pages, as a paired sample with stated uncertainty. Every stage in Table 2 has a number **except text extraction, which has no reference to score against** |
 
 Work stops Thursday 13 August. Friday is rehearsal, no code changes.
 
@@ -150,9 +150,11 @@ Below that, three kinds of work, and they scale differently.
 | Choosing which portion of the backlog to demonstrate on | A judgement about what is defensible. It is also the starting gun for the overnight processing, which cannot begin until the portion is fixed |
 | Fixing the A/B analysis plan | The estimator and the power calculation need statistical judgement |
 
-**One request, and it is the main one.** The transcription sample has no owner, and it sits on the final week's path. It needs perhaps fifty pages, printed and handwritten, transcribed by someone who reads Odia. Naming that person is on the agenda for our next meeting.
+**Resolved, and not in the direction we wanted.** No owner was named for the transcription sample, so on 7 August we took the written fallback rather than let the decision block the final week. The document-reading comparison reports how the two systems differ, with no verdict on which is right.
 
-If we have an owner, the Sarvam comparison reports accuracy. If not, it reports a narrower result: how the two systems differ from each other, without a verdict on which is right.
+What that costs is narrower than it first appears. Only one of the three comparisons needed a transcriber. **Categorisation is measured against the category already recorded on each ticket**, and that reference costs nothing to assemble, so the benchmark still produces a real accuracy result — arguably the more decision-relevant one, since it is the number that would change how a grievance is routed.
+
+The transcription sample is still worth commissioning after 14 August. Sarvam say their model is trained on handwritten text in all 22 languages but publish no handwriting-specific figure, and much of this corpus is handwritten. An independent split result on printed versus handwritten pages would be a measurement nobody has published, on precisely the case this corpus consists of.
 
 ## Not in scope for August
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1136,13 +1136,24 @@ Four things to check before relying on any of it:
   documentation. It is mentioned, and directly — Sarvam state the model is trained
   on handwritten text across all 22 Indian languages, and that it beats
   general-purpose OCR on Indian-language handwriting. What they publish no number
-  for is handwriting itself: the headline scores are general document benchmarks,
-  and the only handwriting statement is qualitative, that accuracy is lower on
-  highly stylised hands. A large share of our corpus is handwritten grievance
-  letters. **Put handwritten pages in the benchmark sample deliberately,
-  stratified, and report them separately** — not as a hedge against an
-  unsupported case, but because the printed/handwritten split is the number
-  nobody has published and the one our corpus turns on.
+  for is handwriting itself: the headline scores are general document benchmarks
+  (olmOCR-Bench, OmniDocBench, Sarvam Indic OCR Bench), and the only handwriting
+  statement is qualitative, that accuracy is lower on highly stylised hands. A
+  large share of our corpus is handwritten grievance letters. **Put handwritten
+  pages in the benchmark sample deliberately, stratified, and report them
+  separately** — not as a hedge against an unsupported case, but because the
+  printed/handwritten split is the number nobody has published and the one our
+  corpus turns on.
+- ⚠️ **"Akshar" is the product, `sarvam-vision` is still the model. Do not treat
+  them as the same thing when benchmarking.** Sarvam Akshar is a document
+  digitisation platform layered on Sarvam Vision, described as an intelligence
+  layer over it rather than a rename of it. The API model list still carries
+  Sarvam Vision for document intelligence and no Akshar entry. This matters for
+  what §Phase 17 actually measures: benchmarking the Akshar platform against
+  pytesseract compares a pipeline with its own reasoning and validation on top
+  against a bare OCR engine, which is not the comparison the scorecard claims to
+  make. **Benchmark the model, name the surface in the artifact, and state which
+  one was called.**
 - ⚠️ **Sarvam-30B runs with reasoning enabled by default, and reasoning tokens bill
   as completion tokens** at 4x the input rate. Disable it for classification or
   the cost model above is wrong.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1155,17 +1155,36 @@ Four things to check before relying on any of it:
   make. **Benchmark the model, name the surface in the artifact, and state which
   one was called.** The Doc AI endpoint takes `model: "sarvam-vision-v1"`, so the
   model id is what the API accepts and Akshar is the surface around it.
-- ⚠️ **The Doc AI endpoint is an async job API and takes a `schema`, so it is not a
-  drop-in OCR call.** `POST /doc-ai/v1/job/extract` returns a `job_id` and a
-  status; results are polled. Two consequences that are easy to get wrong once
-  and expensive to fix. **The `Idempotency-Key` must be derived deterministically
-  from document identity, never randomly** — a random key means a crashed backfill
-  reprocesses and re-bills every page it retries, and at 10 req/min a re-run is
-  not cheap in time either. And given a JSON `schema` the endpoint returns
-  *structured fields rather than text*, which is a different task from OCR:
-  pytesseract cannot do it, so a schema-driven run is a capability demonstration
-  and not a comparison. **Pin which of the two runs the scorecard reports before
-  the run, not after.**
+- ⚠️ **Doc AI is an async job API with two distinct endpoints, not a drop-in OCR
+  call.** `POST /doc-ai/v1/job/digitise` is the transcription path (`output_format`
+  `html` default or `md`, no schema); `POST /doc-ai/v1/job/extract` is the
+  structured path (`schema` or a saved `config_id` in, `json`/`csv`/`xlsx` out).
+  Both return a `job_id`, polled at `GET /doc-ai/v1/job/{id}/status`. Separate
+  submissions, separate results endpoints, presumably separate billing, so the
+  provider interface must cover both operations rather than one with an optional
+  schema. Odia is `od-IN`. Limits: 10 req/min on all plans, 10 PDF pages or 10 ZIP
+  images per submission, 200 MB.
+- ⚠️ **`partially_completed` is a terminal state, so outcomes are per page.**
+  Terminal states are `completed`, `partially_completed`, `failed`, `rejected`,
+  and the status response carries `pages_total` / `pages_succeeded` /
+  `pages_failed`. An adapter that treats a job as success-or-failure silently
+  drops the failed pages inside a partially completed job and reports the batch as
+  done — at a 10-page cap, one bad page is a 10% loss. **Reconcile
+  `pages_succeeded` against `pages_total` per job and record the delta.**
+- ⚠️ **Idempotency is undocumented, so our own submission log is the control.**
+  The dashboard sample sends an `Idempotency-Key` header; the API reference
+  documents no idempotency parameter. Send a deterministic key derived from
+  document identity anyway, but **do not depend on undocumented dedup semantics
+  to prevent double-billing**: write the job id to the audit log at submission and
+  check it before resubmitting. At 10 req/min a re-run is expensive in time as
+  well as money.
+- ⚠️ **A schema run and a Digitise run answer different questions.** Given a
+  schema, Extract returns structured fields rather than text, which is a task
+  pytesseract cannot attempt — so a schema-driven run is a capability
+  demonstration, not a comparison. Use Digitise for the scorecard. **Digitise
+  returns Markdown, not plain text**, so comparing it against pytesseract's flat
+  character stream needs a normaliser whose aggressiveness moves the headline
+  number. Write and freeze that normaliser before looking at any output.
 - ⚠️ **Structured extraction is not PII detection, and the gap is the redaction
   case.** A schema field like `complainant_name` returns the one salient name;
   the n50 gold holds ~4.5 NAME spans per page, the rest being officials,

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1101,9 +1101,11 @@ building, this moves fast).
 
 | Model / API | ID | What it does | Price | Limits |
 |---|---|---|---|---|
-| Sarvam Vision | `sarvam-vision-v1` | 3B vision-language model for document digitisation. Text extraction, **table structure**, layout preservation, and **schema-driven structured extraction**. Out: HTML / Markdown / JSON. In: PDF, PNG, JPG, ZIP | **₹0.50 / page** | 10 pages per PDF, 200 MB, **10 req/min** |
-| Sarvam-30B | `sarvam-30b` | MoE, 30B total / 2.4B active, 128 experts, **64K context**. Native tool calling. OpenAI-compatible | ₹2.5 / ₹1.5 cached / ₹10 per 1M tokens (in / cached / out) | Tiered, below |
-| Sarvam-105B | `sarvam-105b` | Flagship, ~9B active, 128K context | ₹4 / ₹2.5 / ₹16 per 1M tokens | Tiered, below |
+| Sarvam Vision | `sarvam-vision-v1` | 3B vision-language model for document digitisation. **Digitise** (text, tables, layout; HTML or Markdown out) and **Extract** (schema-driven structured fields; JSON, CSV or XLSX out) are separate endpoints and bill separately. In: PDF, PNG, JPG, ZIP | **₹0.50 / page digitise, ₹1.00 / page extract.** Per page, not per field | 10 pages per PDF, 200 MB, **10 req/min** |
+| ~~Sarvam-30B~~ | ~~`sarvam-30b`~~ | **Withdrawn.** Absent from the billing page as of 2026-08-07, so not callable. Superseded by 105B | — | — |
+| Sarvam-105B | `sarvam-105b` | Flagship, ~9B active, 128K context. Also `sarvam-105b-chat` | **₹29.28 / ₹10.98 / ₹73.20 per 1M tokens** (in / cached / out) | Tiered, below |
+| GLM 5.2 | third-party, billed via Sarvam | Available on the same account. **Not a Sarvam model** — see the authorization note below | ₹128.10 / ₹23.79 / ₹402.60 per 1M tokens | Tiered, below |
+| Gemma-4 31B | third-party, billed via Sarvam | Available on the same account. **Not a Sarvam model** | ₹36.60 / ₹13.73 / ₹91.50 per 1M tokens | Tiered, below |
 | Transliteration | text API | Roman ↔ native script, bidirectional. **Odia is `od-IN`** | Text pricing | 1,000 chars per request |
 | Sarvam Translate / Mayura | translate API | 22 scheduled languages (Translate); colloquial and code-mixed (Mayura) | Text pricing | Tiered |
 | Saaras v3 / Saarika v2.5 | speech APIs | ASR with transcribe / translate / **transliterate** / codemix output modes | ₹30 per hour (₹45 diarised) | Tiered |
@@ -1124,10 +1126,35 @@ limits, 2026-07-28.
 languages plus English, Odia among them explicitly, which is more than our current
 OCR can honestly claim.
 
-**Cost is not the constraint either.** A 500-page benchmark is **₹250**. Running
-Sarvam-30B over all 1.37M grievance subjects is roughly 275M input tokens, on the
-order of **₹700**. These numbers are small enough that cost should not shape the
-benchmark design; latency, rate limits, and quality should.
+**Cost is not the constraint for the benchmark. It is for the corpus.** Corrected
+2026-08-07 against the dashboard billing page; the earlier figures costed
+Sarvam-30B, which has been withdrawn.
+
+| Run | Figure |
+|---|---|
+| 500-page benchmark, digitise only | **₹250** |
+| 500-page benchmark, digitise + extract | **₹750** |
+| 1.37M grievance subjects, ~275M input tokens, on 105B | **₹8,050** (was quoted as ₹700 on 30B) |
+| 96,469-page English corpus, digitise only | **₹48,000** |
+| 96,469-page English corpus, both endpoints | **₹145,000** |
+
+Sarvam-105B is **11.7x the input rate and 7.3x the output rate** that Sarvam-30B
+was costed at, so the ₹700 estimate was low by an order of magnitude. Output
+pricing is the one to watch for summarisation, where output volume drives the
+bill rather than input.
+
+The benchmark numbers remain small enough that cost should not shape its design;
+latency, rate limits and quality should. **The corpus numbers are not.** At
+₹0.50-₹1.50 a page and 10 req/min — roughly ten days of continuous calling for
+the full corpus — Doc AI is a measurement instrument, not a production backfill
+path. Any proposal to run it over the corpus is its own decision and needs its
+own approval, rather than being absorbed into a backfill ticket.
+
+⚠️ **The account also bills GLM 5.2 and Gemma-4 31B, which are not Sarvam
+models.** "Route through Sarvam" and "use a Sarvam model" are therefore different
+decisions. The MoU covers Sarvam; it should not be assumed to extend to a
+third-party model reached through the same key. The per-call audit log's model id
+is what makes the distinction auditable after the fact (§Phase 17, #83).
 
 Four things to check before relying on any of it:
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1101,7 +1101,7 @@ building, this moves fast).
 
 | Model / API | ID | What it does | Price | Limits |
 |---|---|---|---|---|
-| Sarvam Vision | `sarvam-vision` | 3B vision-language model for document digitisation. Text extraction, **table structure**, layout preservation. Out: HTML / Markdown / JSON. In: PDF, PNG, JPG, ZIP | **₹0.50 / page** | 10 pages per PDF, 200 MB, **10 req/min** |
+| Sarvam Vision | `sarvam-vision-v1` | 3B vision-language model for document digitisation. Text extraction, **table structure**, layout preservation, and **schema-driven structured extraction**. Out: HTML / Markdown / JSON. In: PDF, PNG, JPG, ZIP | **₹0.50 / page** | 10 pages per PDF, 200 MB, **10 req/min** |
 | Sarvam-30B | `sarvam-30b` | MoE, 30B total / 2.4B active, 128 experts, **64K context**. Native tool calling. OpenAI-compatible | ₹2.5 / ₹1.5 cached / ₹10 per 1M tokens (in / cached / out) | Tiered, below |
 | Sarvam-105B | `sarvam-105b` | Flagship, ~9B active, 128K context | ₹4 / ₹2.5 / ₹16 per 1M tokens | Tiered, below |
 | Transliteration | text API | Roman ↔ native script, bidirectional. **Odia is `od-IN`** | Text pricing | 1,000 chars per request |
@@ -1153,7 +1153,26 @@ Four things to check before relying on any of it:
   pytesseract compares a pipeline with its own reasoning and validation on top
   against a bare OCR engine, which is not the comparison the scorecard claims to
   make. **Benchmark the model, name the surface in the artifact, and state which
-  one was called.**
+  one was called.** The Doc AI endpoint takes `model: "sarvam-vision-v1"`, so the
+  model id is what the API accepts and Akshar is the surface around it.
+- ⚠️ **The Doc AI endpoint is an async job API and takes a `schema`, so it is not a
+  drop-in OCR call.** `POST /doc-ai/v1/job/extract` returns a `job_id` and a
+  status; results are polled. Two consequences that are easy to get wrong once
+  and expensive to fix. **The `Idempotency-Key` must be derived deterministically
+  from document identity, never randomly** — a random key means a crashed backfill
+  reprocesses and re-bills every page it retries, and at 10 req/min a re-run is
+  not cheap in time either. And given a JSON `schema` the endpoint returns
+  *structured fields rather than text*, which is a different task from OCR:
+  pytesseract cannot do it, so a schema-driven run is a capability demonstration
+  and not a comparison. **Pin which of the two runs the scorecard reports before
+  the run, not after.**
+- ⚠️ **Structured extraction is not PII detection, and the gap is the redaction
+  case.** A schema field like `complainant_name` returns the one salient name;
+  the n50 gold holds ~4.5 NAME spans per page, the rest being officials,
+  witnesses, third parties and names inside quoted correspondence. All of them
+  need redacting. A high extraction score on the complainant field is not
+  evidence that the PII problem is solved, and reading it that way ships a
+  redactor that misses most names on the page. See #92.
 - ⚠️ **Sarvam-30B runs with reasoning enabled by default, and reasoning tokens bill
   as completion tokens** at 4x the input rate. Disable it for classification or
   the cost model above is wrong.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -191,9 +191,11 @@ Tier alone is not the control; it is the index into those fields.
   and the authorization record it relies on.
 - A kill switch reverts every `authorized-external` entry to a maintained
   counterpart at a lower tier.
-- Sarvam-30B and 105B are Apache 2.0, so a `dpic-infra` deployment on the GPU box
-  is the standing exit ramp. The decision to use the third party rests on
-  something better than trust.
+- Sarvam-105B is the standing exit ramp *if* it is still Apache 2.0 and *if* it
+  fits the box — both now unverified (#125). Sarvam-30B, the model this argument
+  was written around, has been withdrawn, and 105B does not fit the 24 GB L4 that
+  30B was borderline on. **Treat the exit ramp as unconfirmed until measured.**
+  The decision to use the third party rests on something better than trust.
 
 This is stricter than the old rule in the place that matters and more honest in
 two places it was quietly wrong. `dpic-infra` traffic was never covered by
@@ -1116,7 +1118,7 @@ limits differ by model class, and **the limit that binds us is the lower one**:
 | Model class | Starter | Pro | Business |
 |---|---|---|---|
 | Default chat models | 60 | 200 | 1,000 |
-| **Sarvam-30B / 105B** (our candidates) | **40** | **60** | **120** |
+| **Sarvam-105B** (our candidate) | **40** | **60** | **120** |
 | Vision, document intelligence | 10 | 10 | 10 |
 
 Vision limits do not rise with the plan. Verified against Sarvam's published rate
@@ -1219,9 +1221,11 @@ Four things to check before relying on any of it:
   need redacting. A high extraction score on the complainant field is not
   evidence that the PII problem is solved, and reading it that way ships a
   redactor that misses most names on the page. See #92.
-- ⚠️ **Sarvam-30B runs with reasoning enabled by default, and reasoning tokens bill
-  as completion tokens** at 4x the input rate. Disable it for classification or
-  the cost model above is wrong.
+- ⚠️ **Reasoning-by-default was a Sarvam-30B trap; confirm whether it carries to
+  105B.** On 30B, reasoning ran by default and reasoning tokens billed as
+  completion tokens at 4x the input rate. At 105B's ₹73.20/1M output that would be
+  a far larger multiplier than it was, so verify before costing anything (#125).
+  Disable it for classification either way.
 - **Vision is capped at 10 pages per PDF and 10 requests per minute.** Our pipeline
   is already page-level so the page cap is harmless, but 10 req/min is the binding
   constraint on any full-corpus run: at 10 pages per request that is 6,000 pages an
@@ -1240,9 +1244,10 @@ backends*, not an external dependency:
 
 Both sit behind one registry entry. That is what makes the egress decision
 reversible, and why §3.1 replaces the invariant rather than abandoning it.
-Sarvam-30B at 4-bit is roughly at the limit of the current 24 GB L4; 105B is beyond
-it and would need a larger instance. **Measure before assuming the exit ramp is
-usable.**
+Sarvam-30B at 4-bit was roughly at the limit of the current 24 GB L4, and it has
+since been withdrawn. **105B is beyond that box and would need a larger instance,
+so the self-hosted exit ramp is closed at current hardware** unless the box is
+replaced. Measure before assuming otherwise (#125).
 
 **Registry generalization.** Today a model is a local DVC path. It becomes:
 
@@ -1282,9 +1287,9 @@ romanized Odia, English.
 |---|---|---|---|
 | OCR | Sarvam Vision | pytesseract `ori`, DeepSeek-OCR | Largest expected gain. DeepSeek is English-only in practice; Odia comes out script-confused |
 | Transliteration | Sarvam Translate / Mayura | IndicXlit (Phase 21) | Code-mixed romanized Odia is the designed-for case |
-| Categorization | Sarvam-30B, structured output | MuRIL, 0.7104 acc | MuRIL is English-gated today; the 0.51 worst-class F1 has headroom |
-| Summarization | Sarvam-30B | BART | BART is English-only; DSI usefulness 1.9 at best, 0.45 on IDs |
-| PII detection | Sarvam-30B NER | Presidio + spaCy | spaCy has no Odia name model. The biggest measured gap |
+| Categorization | **Doc AI Extract**, category in the schema (#126) | MuRIL, 0.7104 acc | Runs off the same call as the OCR arm. MuRIL is English-gated today; the 0.51 worst-class F1 has headroom. **Do not compare against the 0.7104 headline** — that is typed subject lines, not scans (#127) |
+| Summarization | Doc AI Extract, summary in the schema | BART | Possible reference set in officer-typed subjects (#128). DSI usefulness 1.9 at best, 0.45 on IDs, with no reproducible basis in this repo |
+| PII detection | Doc AI Extract, exhaustive-name schema | Presidio + spaCy | spaCy has no Odia name model. The biggest measured gap. **Extraction is not detection** — see #92 before reading any score here |
 
 Two cautions on the PII row. Spans must be returned over the **original** text or
 they are unusable for redaction. And using an external model to *find* PII means


### PR DESCRIPTION
Follow-up to #123, which was merged before these two corrections landed.

## Sourcing error

#123 cited `sarvamvision.com`. **That is not a Sarvam domain.** Re-sourced from [sarvam.ai](https://www.sarvam.ai/products/akshar) and [docs.sarvam.ai](https://docs.sarvam.ai/api-reference-docs/getting-started/models). The handwriting claim itself holds: Vision is trained on handwritten text across all 22 Indian languages, with no published handwriting-specific benchmark.

## The distinction #123 missed

**Sarvam Akshar is the product. `sarvam-vision` is still the model.** Akshar is a document digitisation platform described as an intelligence layer *over* Sarvam Vision, not a rename of it, and the API model list still carries Sarvam Vision for document intelligence with no Akshar entry.

This is not pedantry about names. Benchmarking the Akshar platform against pytesseract compares **a pipeline with its own reasoning and validation on top against a bare OCR engine**. That is not the comparison the Phase 17 scorecard claims to make, and it would flatter Sarvam for reasons that have nothing to do with the model. So: benchmark the model, and state in the artifact which surface was called.

Affects #83 (provider adapter — which endpoint) and #84 (scorecard — what the numbers mean).

## Separately, needs verifying

`docs.sarvam.ai` lists **Sarvam-105B** as the flagship chat LLM and appears to mark **Sarvam-30B deprecated**. ROADMAP §Phase 17 costs categorisation, summarisation and PII against Sarvam-30B in five places. Not changed here, because I only have a summarised read of that page and a deprecation is worth confirming directly before rewriting the costing. Filed as #125.
