### PR TITLE
feat(analytics): the closure finding as a handed-over SQL mart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,9 +222,11 @@ outputs/*
 !outputs/figures/
 !outputs/tables/
 !outputs/reports/
+!outputs/findings/
 outputs/figures/*
 outputs/tables/*
 outputs/reports/*
+outputs/findings/*
 !data/raw/.gitkeep
 !data/clean/.gitkeep
 !data/interim/.gitkeep
@@ -237,6 +239,7 @@ mlruns/
 !outputs/figures/.gitkeep
 !outputs/tables/.gitkeep
 !outputs/reports/.gitkeep
+!outputs/findings/.gitkeep
 .DS_Store
 
 # Claude Code: machine-local settings + agent scratch worktrees

--- a/README.md
+++ b/README.md
@@ -81,6 +81,16 @@ lake.query("SELECT category, count(*) AS n FROM complaints GROUP BY 1 ORDER BY n
 lake.read("complaints")       # whole table as a Polars DataFrame
 ```
 
+### 2b · Findings over the lake (marts → presentable numbers)
+
+```bash
+uv run janasunani-closure-finding              # → outputs/findings/
+uv run janasunani-closure-finding --print-sql  # the view definitions, for handover
+```
+
+Governed SQL marts plus the findings built on them, with the caveats each number
+must be quoted with: [janasunani/analytics/README.md](janasunani/analytics/README.md).
+
 ### 3 · Document pipeline (scanned docs → text/redaction/summary/category)
 
 Heavy deps live in three mutually-conflicting extras (`pipeline-core`,

--- a/docs/DELIVERY.md
+++ b/docs/DELIVERY.md
@@ -69,9 +69,11 @@ We hold to one rule. If an analyst with database access could produce a number i
 
 **3. Spikes with the cause attached.** A rise in complaints can mean four hundred citizens about one road, or two hundred unrelated problems. Those need opposite responses and are identical in a count. Every spike carries three numbers: filings, distinct problems, distinct citizens. Detecting the spike is ordinary. Telling the two cases apart is not.
 
-**4. How cases are closed.** Officers close using a graded set of standard phrases: disposed, disposed with appropriate action, or disposed with the beneficiary benefited. Of the roughly 792,000 complaints closed with one of those standard phrases, **61% use the wording that claims no action**, while the more specific wording was available and used 311,000 times.
+**4. How cases are closed.** Officers close using a graded set of standard phrases: disposed, disposed with appropriate action, or disposed with the beneficiary benefited. Of the 776,922 complaints closed with one of those standard phrases, **61% use the wording that claims no action**, while the more specific wording was available and used 304,140 times.
 
 The denominator matters. That 61% is of complaints closed on a standard disposal phrase, which is about two thirds of all resolved complaints. Measured against every resolved complaint the figure is 39%, because a third close on some other wording entirely.
+
+One qualifier goes with the number wherever it travels. The share rises with the amount of work recorded on the case: 58% where three to five steps were taken, 65% where six or more were. The cases with the most movement on file are the most likely to close on the bare phrase, not the least. Whatever explains the choice of wording, it is not that nothing happened.
 
 This one needs care for a second reason too. Sometimes no action is the correct outcome: an information request answered, an ineligible claim properly refused, a matter already settled elsewhere. A correct closure and a premature one look identical in the record, so the figure is a description and not a verdict.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -892,9 +892,9 @@ decomposition, not the alert.
 **The closure metric splits into an insight and a capability**, and the split is the
 whole point.
 
-- **The insight.** 86.65% of resolved complaints close on a templated remark, so
-  "share of closures recording no action" is an exact string match for roughly seven
-  cases in eight. Deliverable is the view definition, handed over.
+- **The insight.** 64.25% of resolved complaints close on a templated remark, so
+  "share of closures recording no action" is an exact string match for roughly two
+  cases in three. Deliverable is the view definition, handed over.
   - **Built** as the `closure` mart in
     [`janasunani/analytics`](../janasunani/analytics/README.md), with the
     findings wrapper behind `janasunani-closure-finding` and fixture tests in
@@ -1985,8 +1985,8 @@ Terse and dated. The reasoning for choices that are not obvious from the code.
     process. Both retained as internal diagnostics. The Phase 13 privacy scorecard is
     a distinct artifact and is unaffected.
   - **The closure metric splits in two.** "Share of closures recording no action" is
-    an insight: 86.65% of resolved complaints close on a templated remark, so it is a
-    string match for seven cases in eight and ships as a view definition. It is
+    an insight: 64.25% of resolved complaints close on a templated remark, so it is a
+    string match for roughly two cases in three and ships as a view definition. It is
     descriptive only, because sometimes no action is the correct outcome and a
     correct closure is identical in the record to a premature one. The capability is
     the disambiguator: **does the citizen return?** Reopening is a column, but

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -908,11 +908,33 @@ whole point.
   - Run `closure_off_ladder_templates` before quoting the figure on any corpus
     this has not been run against. An unmatched ladder string does not error,
     it moves complaints into `off_ladder` and silently shrinks the denominator.
-- **State the denominator explicitly; it moves the number by half.** Of the 792,038
-  complaints whose closing remark is one of the disposal templates, **60.8%** are on
-  the bare rung (481,268 bare vs 310,770 claiming action). Measured against *all*
-  1,209,138 resolved complaints it is **39.1%**, because 35.8% close on neither
-  template. Quote the 792,038 base whenever the 61% figure is used.
+- **State the denominator explicitly; it moves the number by half.** Of the 776,922
+  complaints whose closing remark is one of the disposal templates, **60.9%** are on
+  the bare rung (472,782 bare vs 304,140 claiming action). Measured against *all*
+  1,209,144 resolved complaints it is **39.1%**, because 35.7% close on neither
+  template. Quote the 776,922 base whenever the 61% figure is used.
+  - Measured 7 Aug by the `closure` mart. The earlier ad-hoc counts (792,038 /
+    481,268 / 310,770) ran about 2% high; every percentage they were quoted
+    with survives unchanged. Use the counts above.
+- ⚠️ **The bare share rises with the amount of work done, which inverts the
+  obvious reading.** 58.4% at three to five action steps, 64.8% at six or more,
+  and 72.6% at six or more closing inside a week. The cases with the most
+  movement on file are the *most* likely to close on the bare rung, not the
+  least. Whatever drives the choice of phrase, it is not "nothing happened".
+  This is the single most important qualifier on the number and it was not
+  visible before the view existed.
+- **The two-day subset is small, and that is a result.** 8,974 complaints created
+  and closed within two days on a bare disposal: 1.9% of bare disposals, 0.7% of
+  resolved. Only 1,022 sit on the floor trajectory. The suspicious mass §5.3
+  expected at two days is not there, so the sub-finding names a tractable set of
+  cases rather than an indictment, which is what it was asked to do.
+- **Below three action steps the ladder is empty**, because the portal writes a
+  create and an assign row before an officer can dispose. The 145,621 resolved
+  complaints with two action rows close almost entirely on *discard* templates
+  (`complaint details inadequate`, `duplicate copy`, `not within the purview of
+  this grievance cell`), which is Phase 15's discard-reason finding, not this
+  one. Report the resolved base beside the templated base in any trajectory cut,
+  or those cells read as thin data rather than as a different population.
 - ⚠️ **A bare disposal does not mean the case was mishandled.** Sometimes no action
   is correct: an information request answered, an ineligible claim properly refused,
   a matter already settled elsewhere. Correct closure and premature closure are

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -895,6 +895,19 @@ whole point.
 - **The insight.** 86.65% of resolved complaints close on a templated remark, so
   "share of closures recording no action" is an exact string match for roughly seven
   cases in eight. Deliverable is the view definition, handed over.
+  - **Built** as the `closure` mart in
+    [`janasunani/analytics`](../janasunani/analytics/README.md), with the
+    findings wrapper behind `janasunani-closure-finding` and fixture tests in
+    `tests/test_closure_finding.py`. Portable SQL, so the same file runs against
+    our DuckDB lake and against the department's PostgreSQL.
+  - **It did not need the S3 template lookup after all.** §5.6 A lists template
+    labelling as gating this view, on the assumption the ladder had to come out
+    of the top-500 labelling pass. The ladder is six strings, enumerated above,
+    and the mart matches them directly. S3 still gates the *other* action-type
+    work; it no longer gates this.
+  - Run `closure_off_ladder_templates` before quoting the figure on any corpus
+    this has not been run against. An unmatched ladder string does not error,
+    it moves complaints into `off_ladder` and silently shrinks the denominator.
 - **State the denominator explicitly; it moves the number by half.** Of the 792,038
   complaints whose closing remark is one of the disposal templates, **60.8%** are on
   the bare rung (481,268 bare vs 310,770 claiming action). Measured against *all*

--- a/janasunani/analytics/README.md
+++ b/janasunani/analytics/README.md
@@ -1,4 +1,4 @@
-# janasunani.analytics — marts and findings over the lake
+# janasunani.analytics: marts and findings over the lake
 
 The analytical layer. It reads the Parquet lake (`janasunani.olap.lake`), never
 OLTP, and it produces two different kinds of thing.
@@ -6,8 +6,8 @@ OLTP, and it produces two different kinds of thing.
 ## Marts (`sql/`)
 
 Governed derived tables, written as portable SQL views over the lake's base
-tables. **The SQL is the deliverable**, not an implementation detail — several
-of these are handed to the department to run for themselves — so
+tables. **The SQL is the deliverable**, not an implementation detail. Several
+of these are handed to the department to run for themselves, so
 `marts.py` only locates and installs it. Nothing rewrites it and no mart's logic
 is duplicated in Python.
 
@@ -36,7 +36,7 @@ Two house rules, enforced by tests rather than by convention:
   existing dashboard could produce. Presenting the first as the second is the
   failure mode (ROADMAP §5.3).
 
-### `closure` — how cases are closed (#76)
+### `closure`: how cases are closed (#76)
 
 ```bash
 uv run janasunani-closure-finding                 # over data/interim -> outputs/findings
@@ -51,7 +51,7 @@ right beside it in the dropdown.
 **Reading the output.** The share moves by half depending on the denominator, so
 `closure_finding_summary` reports both and neither is optional:
 
-- share of **templated closures** — complaints closed on one of the six
+- share of **templated closures**: complaints closed on one of the six
 - share of **all resolved complaints**, including the third closing on neither
 
 Quote the templated-closure base in the same breath as the headline. The
@@ -71,7 +71,7 @@ says. `closure_by_trajectory` crosses action-step count with elapsed days;
 rather than the system as a whole.
 
 **Template drift is the failure mode.** An unmatched ladder string does not
-error — it moves complaints into `off_ladder` and quietly shrinks the
+error. It moves complaints into `off_ladder` and quietly shrinks the
 denominator. Below 50% coverage (expect roughly two thirds) the CLI **writes
 nothing and exits 1**, rather than warning beside the artifacts: a batch caller
 keeping stdout and dropping stderr would otherwise publish exactly the number
@@ -81,7 +81,7 @@ written, because it is what tells you why.
 **`diagnostics/` is engineer-facing and not part of the handover.**
 `closure_off_ladder_templates` is the only output carrying remark text. A
 1,000-use floor is dropdown scale rather than free text, but frequency is
-evidence and not proof — a remark repeated ten thousand times could still carry
+evidence and not proof. A remark repeated ten thousand times could still carry
 something somebody pasted into a form. It goes to its own directory so the
 directory the finding is shared out of stays aggregates-only.
 

--- a/janasunani/analytics/README.md
+++ b/janasunani/analytics/README.md
@@ -1,0 +1,83 @@
+# janasunani.analytics — marts and findings over the lake
+
+The analytical layer. It reads the Parquet lake (`janasunani.olap.lake`), never
+OLTP, and it produces two different kinds of thing.
+
+## Marts (`sql/`)
+
+Governed derived tables, written as portable SQL views over the lake's base
+tables. **The SQL is the deliverable**, not an implementation detail — several
+of these are handed to the department to run for themselves — so
+`marts.py` only locates and installs it. Nothing rewrites it and no mart's logic
+is duplicated in Python.
+
+Portability is on the SQL author: keep to constructs DuckDB (our lake) and
+PostgreSQL (their database, and our OLTP store) both accept. Verified the only
+way that means anything, by running the mart over a fixture lake in `tests/`.
+
+| Mart | What it defines |
+|---|---|
+| `closure` | The disposal ladder, each resolved complaint's rung and trajectory, and the closure finding's aggregate views (#76). |
+
+## Findings (`findings/`)
+
+The presentation built on a mart: aggregate tables, the reconciliation, and the
+Markdown fragment that goes in front of an audience with the caveats that must
+travel with each number. One module per finding, each with a CLI writing to
+`outputs/findings/`.
+
+Two house rules, enforced by tests rather than by convention:
+
+- **Aggregates only.** No finding prints a row of citizen writing. Where one
+  emits strings at all they are high-frequency dropdown templates, bounded by a
+  minimum-use threshold.
+- **Insight or capability, said out loud.** An *insight* is something the record
+  already contained and nobody had queried; a *capability* is something no
+  existing dashboard could produce. Presenting the first as the second is the
+  failure mode (ROADMAP §5.3).
+
+### `closure` — how cases are closed (#76)
+
+```bash
+uv run janasunani-closure-finding                 # over data/interim -> outputs/findings
+uv run janasunani-closure-finding --print-sql     # the view definitions, for handover
+```
+
+Officers close on a graded ladder of six standard templates: bare
+disposed/resolved, *with appropriate action*, and *& beneficiary benefited*. The
+finding is the share closing on the bare rung while a more specific one sat
+right beside it in the dropdown.
+
+**Reading the output.** The share moves by half depending on the denominator, so
+`closure_finding_summary` reports both and neither is optional:
+
+- share of **templated closures** — complaints closed on one of the six
+- share of **all resolved complaints**, including the third closing on neither
+
+Quote the templated-closure base in the same breath as the headline. The
+Markdown renderer cannot produce one without the other.
+
+⚠️ **Descriptive, never a failure rate.** Sometimes no action is correct: an
+information request answered, an ineligible claim properly refused, a matter
+already settled elsewhere. A correct closure and a premature one are identical
+in this record. Turning the figure into a claim needs 300-500 closures
+adjudicated by hand, which is not August work. Report at state level as an
+observation about the closure workflow, **never as an office league table**.
+
+**Trajectory is a required control, not an optional cut.** A case going
+created → forwarded → ATR → disposed had work done whatever the closing phrase
+says. `closure_by_trajectory` crosses action-step count with elapsed days;
+`closure_two_day_bare` is the sub-finding that names a specific set of cases
+rather than the system as a whole.
+
+**Template drift is the failure mode.** An unmatched ladder string does not
+error — it moves complaints into `off_ladder` and quietly shrinks the
+denominator. `check_ladder_coverage` warns below 50% (expect roughly two
+thirds), and `closure_off_ladder_templates` lists what stopped matching. Run
+that first against any corpus this has not been run against before.
+
+**Why it needs nothing else.** It reads `action_taken_remark` and structured
+`complaints` columns. It never reads `complaints.grievance`, so it needs no
+redaction pass, no dedup index, no gold set, no backlog slice and no GPU. A test
+asserts that, both statically over the SQL and behaviourally over a lake that
+carries the column.

--- a/janasunani/analytics/README.md
+++ b/janasunani/analytics/README.md
@@ -72,9 +72,18 @@ rather than the system as a whole.
 
 **Template drift is the failure mode.** An unmatched ladder string does not
 error — it moves complaints into `off_ladder` and quietly shrinks the
-denominator. `check_ladder_coverage` warns below 50% (expect roughly two
-thirds), and `closure_off_ladder_templates` lists what stopped matching. Run
-that first against any corpus this has not been run against before.
+denominator. Below 50% coverage (expect roughly two thirds) the CLI **writes
+nothing and exits 1**, rather than warning beside the artifacts: a batch caller
+keeping stdout and dropping stderr would otherwise publish exactly the number
+the check says must not be quoted. `closure_off_ladder_templates` is still
+written, because it is what tells you why.
+
+**`diagnostics/` is engineer-facing and not part of the handover.**
+`closure_off_ladder_templates` is the only output carrying remark text. A
+1,000-use floor is dropdown scale rather than free text, but frequency is
+evidence and not proof — a remark repeated ten thousand times could still carry
+something somebody pasted into a form. It goes to its own directory so the
+directory the finding is shared out of stays aggregates-only.
 
 **Why it needs nothing else.** It reads `action_taken_remark` and structured
 `complaints` columns. It never reads `complaints.grievance`, so it needs no

--- a/janasunani/analytics/__init__.py
+++ b/janasunani/analytics/__init__.py
@@ -1,0 +1,14 @@
+"""The analytical layer over the Parquet lake.
+
+Two halves, kept apart on purpose:
+
+* ``sql/`` — the **marts**: governed derived tables, written as portable SQL
+  views over ``complaints`` / ``action_history``. These are the artifacts we
+  hand to the department, so they must run unmodified against their own
+  PostgreSQL, not just against our DuckDB lake.
+* ``findings/`` — the **presentations** built on a mart: the aggregate tables,
+  the reconciliation, and the Markdown fragment that goes in front of an
+  audience, with the caveats that must travel with each number.
+
+Everything here reads the lake (``janasunani.olap.lake``), never OLTP.
+"""

--- a/janasunani/analytics/__init__.py
+++ b/janasunani/analytics/__init__.py
@@ -2,11 +2,11 @@
 
 Two halves, kept apart on purpose:
 
-* ``sql/`` — the **marts**: governed derived tables, written as portable SQL
+* ``sql/``, the **marts**: governed derived tables, written as portable SQL
   views over ``complaints`` / ``action_history``. These are the artifacts we
   hand to the department, so they must run unmodified against their own
   PostgreSQL, not just against our DuckDB lake.
-* ``findings/`` — the **presentations** built on a mart: the aggregate tables,
+* ``findings/``, the **presentations** built on a mart: the aggregate tables,
   the reconciliation, and the Markdown fragment that goes in front of an
   audience, with the caveats that must travel with each number.
 

--- a/janasunani/analytics/findings/__init__.py
+++ b/janasunani/analytics/findings/__init__.py
@@ -1,0 +1,16 @@
+"""Findings: reproducible, tested numbers from the record.
+
+One module per finding. Each computes its own aggregates off a mart, renders a
+Markdown fragment carrying the caveats that number must never be quoted
+without, and writes both to ``outputs/findings/``.
+
+House rules, enforced by tests rather than by convention:
+
+* **Aggregates only.** No finding prints a row of citizen writing. Where a
+  finding emits strings at all they are high-frequency dropdown templates,
+  bounded by a minimum-use threshold.
+* **Insight or capability, said out loud.** An *insight* is something the
+  record already contained and nobody had queried; a *capability* is something
+  no existing dashboard could produce. Presenting the first as the second is
+  the failure mode.
+"""

--- a/janasunani/analytics/findings/closure.py
+++ b/janasunani/analytics/findings/closure.py
@@ -10,7 +10,7 @@ Two rules are enforced in code rather than left to whoever quotes the number:
 
 * **Both denominators, always.** :func:`render_markdown` cannot emit the
   headline share without the templated-closure base beside it and the
-  all-resolved share under it — they come out of the same row of the same view.
+  all-resolved share under it. They come out of the same row of the same view.
 * **Aggregates only.** Every output is a count or a share. The one view that
   emits strings (``closure_off_ladder_templates``) is bounded to remarks used
   1,000+ times, which are dropdown templates rather than citizen writing. This
@@ -44,7 +44,7 @@ FINDING_VIEWS = (
 # free text, but frequency is evidence and not proof: a remark repeated ten
 # thousand times could still carry a name or a number somebody pasted into a
 # form. So it goes to its own directory, never into the shareable set, and it
-# exists for one purpose — telling you the ladder stopped matching.
+# exists for one purpose: telling you the ladder stopped matching.
 DIAGNOSTIC_VIEWS = ("closure_off_ladder_templates",)
 
 REPORT_VIEWS = FINDING_VIEWS + DIAGNOSTIC_VIEWS
@@ -150,8 +150,8 @@ def render_markdown(tables: dict[str, pl.DataFrame]) -> str:
         "",
         (
             "This subset is the useful half: it names a specific set of cases "
-            "rather than the system as a whole. Two days is fast, not wrong — "
-            "an information request answered on the spot belongs here too."
+            "rather than the system as a whole. Two days is fast, not wrong. "
+            "An information request answered on the spot belongs here too."
         ),
         "",
         "### Conditioned on trajectory",
@@ -262,7 +262,7 @@ def check_ladder_coverage(tables: dict[str, pl.DataFrame]) -> Optional[str]:
         return None
     return (
         f"The disposal ladder matched only {_pct(coverage)} of resolved "
-        "complaints. Expected roughly two thirds — the template strings have "
+        "complaints. Expected roughly two thirds. The template strings have "
         "probably drifted. Check closure_off_ladder_templates.csv before "
         "quoting anything."
     )

--- a/janasunani/analytics/findings/closure.py
+++ b/janasunani/analytics/findings/closure.py
@@ -1,0 +1,258 @@
+"""The closure finding (#76): share of closures recording no action.
+
+Runs the ``closure`` mart over the Parquet lake and writes its tables plus a
+presentable Markdown fragment to ``outputs/findings/``. This is an **Insight**,
+not a capability: no model, no new processing, and the thing the department
+actually receives is the view definition itself, to run against their own
+database. The Python here is the reporting wrapper, not the logic.
+
+Two rules are enforced in code rather than left to whoever quotes the number:
+
+* **Both denominators, always.** :func:`render_markdown` cannot emit the
+  headline share without the templated-closure base beside it and the
+  all-resolved share under it — they come out of the same row of the same view.
+* **Aggregates only.** Every output is a count or a share. The one view that
+  emits strings (``closure_off_ladder_templates``) is bounded to remarks used
+  1,000+ times, which are dropdown templates rather than citizen writing. This
+  never reads ``complaints.grievance``.
+"""
+
+import argparse
+from pathlib import Path
+from typing import Optional
+
+import polars as pl
+from loguru import logger
+
+from janasunani.analytics.marts import mart_sql, open_lake
+from janasunani.config import OUTPUTS_DIR
+
+MART = "closure"
+
+# The mart's reportable views. `closure_closing_action` and `closure_rung` are
+# intermediate and stay unwritten: they are complaint-level, so they are the two
+# that must not become an output file.
+REPORT_VIEWS = (
+    "closure_finding_summary",
+    "closure_by_trajectory",
+    "closure_two_day_bare",
+    "closure_benefitted_overlap",
+    "closure_off_ladder_templates",
+)
+
+# Deterministic ordering per view, so reruns diff cleanly.
+_ORDER_BY = {
+    "closure_by_trajectory": " ORDER BY steps_bucket, elapsed_bucket",
+    "closure_benefitted_overlap": " ORDER BY rung, benefitted_value",
+    "closure_off_ladder_templates": " ORDER BY resolved_complaints DESC",
+}
+
+# Carried into every rendering of this finding. Not a footnote.
+DESCRIPTIVE_CAVEAT = (
+    "This is descriptive and is **not** a failure rate. Sometimes no action is "
+    "the correct outcome: an information request answered, an ineligible claim "
+    "properly refused, a matter already settled elsewhere. A correct closure "
+    "and a premature one are identical in this record. Turning the figure into "
+    "a claim needs 300-500 closures adjudicated by hand, which has not been "
+    "done. Report it at state level as an observation about the closure "
+    "workflow, never as an office league table."
+)
+
+# Below this, the ladder strings have drifted and the headline has silently
+# collapsed into `off_ladder` rather than failing. Expect roughly two thirds.
+MIN_LADDER_COVERAGE_PCT = 50.0
+
+
+def sql_text() -> str:
+    """The view definitions, as handed over."""
+    return mart_sql(MART)
+
+
+def compute(lake_dir: Optional[Path] = None) -> dict[str, pl.DataFrame]:
+    """Install the mart over the lake and return every reportable table."""
+    con = open_lake(MART, lake_dir=lake_dir)
+    try:
+        return {
+            view: con.execute(f"SELECT * FROM {view}{_ORDER_BY.get(view, '')}").pl()  # noqa: S608
+            for view in REPORT_VIEWS
+        }
+    finally:
+        con.close()
+
+
+def _pct(value: Optional[float]) -> str:
+    return "n/a" if value is None else f"{value:.1f}%"
+
+
+def _n(value: Optional[int]) -> str:
+    return "n/a" if value is None else f"{int(value):,}"
+
+
+def render_markdown(tables: dict[str, pl.DataFrame]) -> str:
+    """The presentable fragment. Both denominators appear or nothing does."""
+    s = tables["closure_finding_summary"].row(0, named=True)
+    t = tables["closure_two_day_bare"].row(0, named=True)
+
+    lines = [
+        "## How cases are closed",
+        "",
+        "**Insight.** No model and no new processing: an exact string match "
+        "over the disposal templates officers already pick from.",
+        "",
+        "### The headline, on both denominators",
+        "",
+        "| Base | Complaints | Closed on the rung claiming no action | Share |",
+        "|---|---|---|---|",
+        (
+            f"| Closed on one of the six disposal templates | "
+            f"{_n(s['ladder_closures'])} | {_n(s['bare'])} | "
+            f"**{_pct(s['bare_share_of_ladder_pct'])}** |"
+        ),
+        (
+            f"| All resolved complaints | {_n(s['resolved_complaints'])} | "
+            f"{_n(s['bare'])} | **{_pct(s['bare_share_of_resolved_pct'])}** |"
+        ),
+        "",
+        (
+            f"The two differ because {_pct(s['off_ladder_share_pct'])} of resolved "
+            f"complaints ({_n(s['off_ladder'])}) close on neither template. "
+            f"Quote the {_n(s['ladder_closures'])} base whenever the "
+            f"{_pct(s['bare_share_of_ladder_pct'])} figure is used."
+        ),
+        "",
+        (
+            f"The more specific rung was available and chosen "
+            f"{_n(s['claims_action'])} times ({_n(s['with_action'])} with "
+            f"appropriate action, {_n(s['benefit'])} with the beneficiary "
+            f"benefited)."
+        ),
+        "",
+        f"⚠️ {DESCRIPTIVE_CAVEAT}",
+        "",
+        "### Created and closed within two days, on a bare disposal",
+        "",
+        (
+            f"{_n(t['two_day_bare'])} complaints, "
+            f"{_pct(t['share_of_bare_pct'])} of all bare disposals and "
+            f"{_pct(t['share_of_resolved_pct'])} of all resolved complaints. "
+            f"{_n(t['two_day_bare_single_step'])} of them carry a single "
+            f"action step."
+        ),
+        "",
+        (
+            "This subset is the useful half: it names a specific set of cases "
+            "rather than the system as a whole. Two days is fast, not wrong — "
+            "an information request answered on the spot belongs here too."
+        ),
+        "",
+        "### Conditioned on trajectory",
+        "",
+        (
+            "A case going created → forwarded → ATR → disposed had work done "
+            "whatever the closing phrase says. The bare share by trajectory:"
+        ),
+        "",
+        "| Action steps | Elapsed | Templated closures | Bare | Share |",
+        "|---|---|---|---|---|",
+    ]
+    for row in tables["closure_by_trajectory"].iter_rows(named=True):
+        lines.append(
+            f"| {row['steps_bucket']} | {row['elapsed_bucket']} | "
+            f"{_n(row['ladder_closures'])} | {_n(row['bare'])} | "
+            f"{_pct(row['bare_share_of_ladder_pct'])} |"
+        )
+
+    lines += [
+        "",
+        "### Overlap with the existing `benefitted` column",
+        "",
+        (
+            "Checked so the third rung is not presented as novel if a column "
+            "the dashboards already have marks the same complaints."
+        ),
+        "",
+        "| Rung | `benefitted` | Complaints |",
+        "|---|---|---|",
+    ]
+    for row in tables["closure_benefitted_overlap"].iter_rows(named=True):
+        lines.append(
+            f"| {row['rung']} | {row['benefitted_value']} | "
+            f"{_n(row['resolved_complaints'])} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write(
+    tables: dict[str, pl.DataFrame], out_dir: Optional[Path] = None
+) -> dict[str, Path]:
+    """Write each table as CSV, the Markdown fragment, and the handed-over SQL."""
+    out = Path(out_dir) if out_dir else OUTPUTS_DIR / "findings"
+    out.mkdir(parents=True, exist_ok=True)
+    written: dict[str, Path] = {}
+    for name, frame in tables.items():
+        path = out / f"{name}.csv"
+        frame.write_csv(path)
+        written[name] = path
+    md = out / "closure_finding.md"
+    md.write_text(render_markdown(tables))
+    written["markdown"] = md
+    handover = out / "closure_finding.sql"
+    handover.write_text(sql_text())
+    written["sql"] = handover
+    return written
+
+
+def check_ladder_coverage(tables: dict[str, pl.DataFrame]) -> Optional[str]:
+    """Warn if the disposal ladder stopped matching. ``None`` when it is fine.
+
+    Template drift is the failure mode this finding cannot survive and would
+    not otherwise announce: an unmatched string does not error, it quietly
+    moves complaints into ``off_ladder`` and shrinks the denominator the
+    headline is computed on.
+    """
+    coverage = tables["closure_finding_summary"].row(0, named=True)["ladder_coverage_pct"]
+    if coverage is not None and coverage >= MIN_LADDER_COVERAGE_PCT:
+        return None
+    return (
+        f"The disposal ladder matched only {_pct(coverage)} of resolved "
+        "complaints. Expected roughly two thirds — the template strings have "
+        "probably drifted. Check closure_off_ladder_templates.csv before "
+        "quoting anything."
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "The closure finding: share of closures recording no action, on "
+            "both denominators, conditioned on trajectory."
+        )
+    )
+    parser.add_argument(
+        "--lake-dir", type=Path, default=None, help="Lake dir (default: data/interim)."
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=None,
+        help="Output dir (default: outputs/findings).",
+    )
+    parser.add_argument(
+        "--print-sql",
+        action="store_true",
+        help="Print the view definitions and exit, without touching the lake.",
+    )
+    args = parser.parse_args()
+
+    if args.print_sql:
+        print(sql_text())
+        return
+
+    tables = compute(args.lake_dir)
+    drift = check_ladder_coverage(tables)
+    if drift:
+        logger.warning(drift)
+    for name, path in write(tables, args.out_dir).items():
+        logger.success(f"{name} -> {path}")
+    print(render_markdown(tables))

--- a/janasunani/analytics/findings/closure.py
+++ b/janasunani/analytics/findings/closure.py
@@ -29,16 +29,25 @@ from janasunani.config import OUTPUTS_DIR
 
 MART = "closure"
 
-# The mart's reportable views. `closure_closing_action` and `closure_rung` are
+# The shareable finding. `closure_closing_action` and `closure_rung` are
 # intermediate and stay unwritten: they are complaint-level, so they are the two
 # that must not become an output file.
-REPORT_VIEWS = (
+FINDING_VIEWS = (
     "closure_finding_summary",
     "closure_by_trajectory",
     "closure_two_day_bare",
     "closure_benefitted_overlap",
-    "closure_off_ladder_templates",
 )
+
+# Engineer-facing, and deliberately not part of the handover. This is the only
+# view that emits remark text. A 1,000-use floor is dropdown scale rather than
+# free text, but frequency is evidence and not proof: a remark repeated ten
+# thousand times could still carry a name or a number somebody pasted into a
+# form. So it goes to its own directory, never into the shareable set, and it
+# exists for one purpose — telling you the ladder stopped matching.
+DIAGNOSTIC_VIEWS = ("closure_off_ladder_templates",)
+
+REPORT_VIEWS = FINDING_VIEWS + DIAGNOSTIC_VIEWS
 
 # Deterministic ordering per view, so reruns diff cleanly.
 _ORDER_BY = {
@@ -135,8 +144,8 @@ def render_markdown(tables: dict[str, pl.DataFrame]) -> str:
             f"{_n(t['two_day_bare'])} complaints, "
             f"{_pct(t['share_of_bare_pct'])} of all bare disposals and "
             f"{_pct(t['share_of_resolved_pct'])} of all resolved complaints. "
-            f"{_n(t['two_day_bare_single_step'])} of them carry a single "
-            f"action step."
+            f"{_n(t['two_day_bare_min_trajectory'])} of them closed on the "
+            f"shortest trajectory that reaches a disposal at all."
         ),
         "",
         (
@@ -152,15 +161,26 @@ def render_markdown(tables: dict[str, pl.DataFrame]) -> str:
             "whatever the closing phrase says. The bare share by trajectory:"
         ),
         "",
-        "| Action steps | Elapsed | Templated closures | Bare | Share |",
-        "|---|---|---|---|---|",
+        "| Action steps | Elapsed | Resolved | Templated closures | Bare | Share |",
+        "|---|---|---|---|---|---|",
     ]
     for row in tables["closure_by_trajectory"].iter_rows(named=True):
         lines.append(
             f"| {row['steps_bucket']} | {row['elapsed_bucket']} | "
-            f"{_n(row['ladder_closures'])} | {_n(row['bare'])} | "
-            f"{_pct(row['bare_share_of_ladder_pct'])} |"
+            f"{_n(row['resolved_complaints'])} | {_n(row['ladder_closures'])} | "
+            f"{_n(row['bare'])} | {_pct(row['bare_share_of_ladder_pct'])} |"
         )
+    lines += [
+        "",
+        (
+            "Read the resolved column beside the templated one. Cells where the "
+            "two diverge sharply are not thin data, they are complaints that "
+            "closed on a **discard** template rather than a disposal one "
+            "(`complaint details inadequate`, `duplicate copy`, `not within the "
+            "purview of this grievance cell`). Those are off the ladder by "
+            "construction and are a separate finding, not part of this share."
+        ),
+    ]
 
     lines += [
         "",
@@ -183,16 +203,23 @@ def render_markdown(tables: dict[str, pl.DataFrame]) -> str:
     return "\n".join(lines)
 
 
+def _out_dir(out_dir: Optional[Path]) -> Path:
+    return Path(out_dir) if out_dir else OUTPUTS_DIR / "findings"
+
+
 def write(
     tables: dict[str, pl.DataFrame], out_dir: Optional[Path] = None
 ) -> dict[str, Path]:
-    """Write each table as CSV, the Markdown fragment, and the handed-over SQL."""
-    out = Path(out_dir) if out_dir else OUTPUTS_DIR / "findings"
+    """Write the shareable finding: its CSVs, the fragment, and the SQL.
+
+    Diagnostics are **not** written here. See :func:`write_diagnostics`.
+    """
+    out = _out_dir(out_dir)
     out.mkdir(parents=True, exist_ok=True)
     written: dict[str, Path] = {}
-    for name, frame in tables.items():
+    for name in FINDING_VIEWS:
         path = out / f"{name}.csv"
-        frame.write_csv(path)
+        tables[name].write_csv(path)
         written[name] = path
     md = out / "closure_finding.md"
     md.write_text(render_markdown(tables))
@@ -200,6 +227,25 @@ def write(
     handover = out / "closure_finding.sql"
     handover.write_text(sql_text())
     written["sql"] = handover
+    return written
+
+
+def write_diagnostics(
+    tables: dict[str, pl.DataFrame], out_dir: Optional[Path] = None
+) -> dict[str, Path]:
+    """Write the engineer-facing drift diagnostic, under ``diagnostics/``.
+
+    Kept out of :func:`write` on purpose: this is the only output carrying
+    remark text, and the directory the finding is shared out of should contain
+    aggregates only.
+    """
+    out = _out_dir(out_dir) / "diagnostics"
+    out.mkdir(parents=True, exist_ok=True)
+    written = {}
+    for name in DIAGNOSTIC_VIEWS:
+        path = out / f"{name}.csv"
+        tables[name].write_csv(path)
+        written[name] = path
     return written
 
 
@@ -250,9 +296,21 @@ def main() -> None:
         return
 
     tables = compute(args.lake_dir)
+
+    # The diagnostic is written either way: when the guard fails it is the
+    # thing you need to read to find out why.
+    for name, path in write_diagnostics(tables, args.out_dir).items():
+        logger.info(f"{name} -> {path}")
+
     drift = check_ladder_coverage(tables)
     if drift:
-        logger.warning(drift)
+        # Refuse to produce the artifacts rather than warning beside them. A
+        # batch caller that keeps stdout and drops stderr would otherwise
+        # publish exactly the number this check says must not be quoted.
+        logger.error(drift)
+        logger.error("Refusing to write the finding. Nothing was published.")
+        raise SystemExit(1)
+
     for name, path in write(tables, args.out_dir).items():
         logger.success(f"{name} -> {path}")
     print(render_markdown(tables))

--- a/janasunani/analytics/findings/closure.py
+++ b/janasunani/analytics/findings/closure.py
@@ -11,10 +11,10 @@ Two rules are enforced in code rather than left to whoever quotes the number:
 * **Both denominators, always.** :func:`render_markdown` cannot emit the
   headline share without the templated-closure base beside it and the
   all-resolved share under it. They come out of the same row of the same view.
-* **Aggregates only.** Every output is a count or a share. The one view that
-  emits strings (``closure_off_ladder_templates``) is bounded to remarks used
-  1,000+ times, which are dropdown templates rather than citizen writing. This
-  never reads ``complaints.grievance``.
+* **Aggregates only.** Every output is a count or a share. Drift diagnostics
+  retain only aggregate frequencies, never the source remark or a linkable
+  fingerprint.
+  This never reads ``complaints.grievance``.
 """
 
 import argparse
@@ -39,12 +39,10 @@ FINDING_VIEWS = (
     "closure_benefitted_overlap",
 )
 
-# Engineer-facing, and deliberately not part of the handover. This is the only
-# view that emits remark text. A 1,000-use floor is dropdown scale rather than
-# free text, but frequency is evidence and not proof: a remark repeated ten
-# thousand times could still carry a name or a number somebody pasted into a
-# form. So it goes to its own directory, never into the shareable set, and it
-# exists for one purpose: telling you the ladder stopped matching.
+# Engineer-facing, and deliberately not part of the handover. High frequency
+# never proves arbitrary text is an approved template, so the deliverable
+# diagnostic carries only aggregate counts; identifying a drifted phrase
+# requires the private source system.
 DIAGNOSTIC_VIEWS = ("closure_off_ladder_templates",)
 
 REPORT_VIEWS = FINDING_VIEWS + DIAGNOSTIC_VIEWS
@@ -233,18 +231,25 @@ def write(
 def write_diagnostics(
     tables: dict[str, pl.DataFrame], out_dir: Optional[Path] = None
 ) -> dict[str, Path]:
-    """Write the engineer-facing drift diagnostic, under ``diagnostics/``.
+    """Write safe drift diagnostics under ``diagnostics/``.
 
-    Kept out of :func:`write` on purpose: this is the only output carrying
-    remark text, and the directory the finding is shared out of should contain
-    aggregates only.
+    Diagnostics remain below ``outputs/`` and can be delivered recursively,
+    so raw remarks must not be serialized there.
     """
     out = _out_dir(out_dir) / "diagnostics"
     out.mkdir(parents=True, exist_ok=True)
     written = {}
     for name in DIAGNOSTIC_VIEWS:
         path = out / f"{name}.csv"
-        tables[name].write_csv(path)
+        table = tables[name]
+        pl.DataFrame(
+            {
+                "high_volume_off_ladder_remarks": [table.height],
+                "affected_resolved_complaints": [
+                    int(table["resolved_complaints"].sum()) if table.height else 0
+                ],
+            }
+        ).write_csv(path)
         written[name] = path
     return written
 
@@ -258,14 +263,29 @@ def check_ladder_coverage(tables: dict[str, pl.DataFrame]) -> Optional[str]:
     headline is computed on.
     """
     coverage = tables["closure_finding_summary"].row(0, named=True)["ladder_coverage_pct"]
-    if coverage is not None and coverage >= MIN_LADDER_COVERAGE_PCT:
-        return None
-    return (
-        f"The disposal ladder matched only {_pct(coverage)} of resolved "
-        "complaints. Expected roughly two thirds. The template strings have "
-        "probably drifted. Check closure_off_ladder_templates.csv before "
-        "quoting anything."
-    )
+    if coverage is None or coverage < MIN_LADDER_COVERAGE_PCT:
+        return (
+            f"The disposal ladder matched only {_pct(coverage)} of resolved "
+            "complaints. Expected roughly two thirds. The template strings have "
+            "probably drifted. Check the private source system before quoting anything."
+        )
+    if tables["closure_off_ladder_templates"].height:
+        return (
+            "High-volume off-ladder closing remarks were detected. The shareable "
+            "diagnostic contains aggregate counts only; validate the templates against "
+            "the private source system before quoting the headline."
+        )
+    return None
+
+
+def remove_shareable_artifacts(out_dir: Optional[Path] = None) -> None:
+    """Remove only this finding's prior deliverables after a failed guard."""
+    out = _out_dir(out_dir)
+    paths = [out / f"{name}.csv" for name in FINDING_VIEWS]
+    paths.extend((out / "closure_finding.md", out / "closure_finding.sql"))
+    for path in paths:
+        if path.is_file():
+            path.unlink()
 
 
 def main() -> None:
@@ -307,6 +327,7 @@ def main() -> None:
         # Refuse to produce the artifacts rather than warning beside them. A
         # batch caller that keeps stdout and drops stderr would otherwise
         # publish exactly the number this check says must not be quoted.
+        remove_shareable_artifacts(args.out_dir)
         logger.error(drift)
         logger.error("Refusing to write the finding. Nothing was published.")
         raise SystemExit(1)

--- a/janasunani/analytics/marts.py
+++ b/janasunani/analytics/marts.py
@@ -1,0 +1,57 @@
+"""Marts: the governed derived tables under ``analytics/sql/``.
+
+A mart is one ``.sql`` file of ``CREATE OR REPLACE VIEW`` statements over the
+lake's base tables. The SQL is the deliverable, not an implementation detail —
+several of these are handed to the department to run against their own
+PostgreSQL — so this module only locates and installs it. It never rewrites it,
+and no mart's logic is duplicated in Python.
+
+Portability is on the SQL author: keep to constructs DuckDB and PostgreSQL both
+accept, and let ``tests/`` prove the numbers on a fixture lake.
+"""
+
+from pathlib import Path
+from typing import Optional
+
+import duckdb
+
+from janasunani.olap.lake import connect
+
+SQL_DIR = Path(__file__).resolve().parent / "sql"
+
+
+def mart_path(name: str) -> Path:
+    """Path to a mart's SQL file."""
+    path = SQL_DIR / f"{name}.sql"
+    if not path.is_file():
+        available = ", ".join(sorted(p.stem for p in SQL_DIR.glob("*.sql"))) or "none"
+        raise FileNotFoundError(f"No mart named {name!r}. Available: {available}")
+    return path
+
+
+def mart_sql(name: str) -> str:
+    """A mart's view definitions, verbatim — this is what gets handed over."""
+    return mart_path(name).read_text()
+
+
+def install(con: duckdb.DuckDBPyConnection, *names: str) -> None:
+    """Create a mart's views on ``con``.
+
+    ``con`` must already expose the base tables the mart reads; over the lake
+    that is what :func:`janasunani.olap.lake.connect` gives you.
+    """
+    for name in names:
+        con.execute(mart_sql(name))
+
+
+def open_lake(
+    *names: str, lake_dir: Optional[Path] = None
+) -> duckdb.DuckDBPyConnection:
+    """A lake connection with the named marts installed. Caller closes it."""
+    con = connect(lake_dir)
+    try:
+        install(con, *names)
+    except Exception:
+        con.close()
+        raise
+    return con

--- a/janasunani/analytics/marts.py
+++ b/janasunani/analytics/marts.py
@@ -1,9 +1,9 @@
 """Marts: the governed derived tables under ``analytics/sql/``.
 
 A mart is one ``.sql`` file of ``CREATE OR REPLACE VIEW`` statements over the
-lake's base tables. The SQL is the deliverable, not an implementation detail —
-several of these are handed to the department to run against their own
-PostgreSQL — so this module only locates and installs it. It never rewrites it,
+lake's base tables. The SQL is the deliverable, not an implementation detail.
+Several of these are handed to the department to run against their own
+PostgreSQL, so this module only locates and installs it. It never rewrites it,
 and no mart's logic is duplicated in Python.
 
 Portability is on the SQL author: keep to constructs DuckDB and PostgreSQL both
@@ -30,7 +30,7 @@ def mart_path(name: str) -> Path:
 
 
 def mart_sql(name: str) -> str:
-    """A mart's view definitions, verbatim — this is what gets handed over."""
+    """A mart's view definitions, verbatim. This is what gets handed over."""
     return mart_path(name).read_text()
 
 

--- a/janasunani/analytics/sql/closure.sql
+++ b/janasunani/analytics/sql/closure.sql
@@ -21,9 +21,10 @@
 --
 -- Portable across DuckDB (the Parquet lake) and PostgreSQL (the OLTP store).
 -- Reads `complaints` and `action_history` only. It never touches
--- `complaints.grievance`, so it needs no redaction pass and emits no citizen
--- text -- every view below is an aggregate or a template string used tens of
--- thousands of times.
+-- `complaints.grievance`, so it needs no redaction pass. Every reportable view
+-- below is an aggregate. The one view that emits remark text at all,
+-- `closure_off_ladder_templates`, is a drift diagnostic for the engineer rather
+-- than part of the handover, and is written to a separate directory.
 
 -- ---------------------------------------------------------------------------
 -- 1. The disposal ladder.
@@ -49,8 +50,9 @@ SELECT * FROM (
 -- 2. One row per resolved complaint: its closing remark plus its trajectory.
 --
 -- "Resolved" is `resolved_on IS NOT NULL`. The closing remark is the latest
--- action row by `action_taken_date`, ties broken by `id` (insertion order), so
--- a complaint with no action history still appears, with a NULL remark.
+-- action row **at or before the resolution date**, ties broken by `id`
+-- (insertion order), so a complaint with no action history still appears, with
+-- a NULL remark and zero steps.
 --
 -- Trajectory is carried here rather than bolted on later because it is a
 -- required control, not an optional cut.
@@ -61,6 +63,14 @@ WITH resolved AS (
     FROM complaints
     WHERE resolved_on IS NOT NULL
 ),
+-- Actions up to the recorded resolution, and only those. A reopen, audit or
+-- follow-up row filed after `resolved_on` is not what closed the case: taking
+-- the latest row unconditionally would pick it as the "closing" remark and
+-- knock a complaint off the ladder whose actual disposal matched a template,
+-- while also counting post-closure activity as work done before closure.
+-- Compared at date granularity, not timestamp, because the disposal row and
+-- `resolved_on` are written by different code paths on the same day and an
+-- intraday ordering difference is not a signal.
 actions AS (
     SELECT
         a.ticket_no,
@@ -72,7 +82,9 @@ actions AS (
         ) AS recency_rank,
         COUNT(*) OVER (PARTITION BY a.ticket_no) AS action_steps
     FROM action_history a
-    WHERE a.ticket_no IS NOT NULL
+    JOIN resolved r ON r.ticket_no = a.ticket_no
+    WHERE a.action_taken_date IS NULL
+       OR CAST(a.action_taken_date AS DATE) <= CAST(r.resolved_on AS DATE)
 ),
 closing AS (
     SELECT ticket_no, action_taken_remark, action_status, action_steps
@@ -111,14 +123,25 @@ SELECT
     COALESCE(l.rung, 'off_ladder') AS rung,
     l.ladder_position,
     CASE WHEN l.rung IS NOT NULL THEN 1 ELSE 0 END AS on_ladder,
+    -- Zero actions is its own bucket, not folded into '1 step'. A complaint
+    -- with no action history at all is a different object from one an officer
+    -- touched once, and folding them together silently pads the denominator of
+    -- the shortest-trajectory cut.
     CASE
-        WHEN c.action_steps <= 1 THEN '1 step'
+        WHEN c.action_steps = 0 THEN '0 steps'
+        WHEN c.action_steps = 1 THEN '1 step'
         WHEN c.action_steps = 2 THEN '2 steps'
         WHEN c.action_steps <= 5 THEN '3-5 steps'
         ELSE '6+ steps'
     END AS steps_bucket,
+    -- `resolved_on` before `created_on` is possible: the two timestamps are
+    -- parsed independently at ingest and nothing enforces an order. Such a row
+    -- has a negative duration, and without this branch it would land in
+    -- '0-2 days' and inflate the fast-closure subset with bad data rather than
+    -- fast work.
     CASE
         WHEN c.elapsed_days IS NULL THEN 'unknown'
+        WHEN c.elapsed_days < 0 THEN 'invalid'
         WHEN c.elapsed_days <= 2 THEN '0-2 days'
         WHEN c.elapsed_days <= 7 THEN '3-7 days'
         WHEN c.elapsed_days <= 30 THEN '8-30 days'
@@ -181,26 +204,34 @@ GROUP BY steps_bucket, elapsed_bucket;
 -- on rather than one they have to defend against. Same caveat still applies:
 -- two days is fast, not wrong. An information request answered on the spot
 -- belongs here too.
+--
+-- `two_day_bare_min_trajectory` is the floor case: closed in two days on the
+-- shortest trajectory that reaches a disposal at all. THREE action rows, not
+-- one. The portal writes a create and an assign row before an officer can
+-- dispose, so a single-step disposal is not a thing that exists in this record
+-- (22 resolved complaints corpus-wide carry one action row, and none of them
+-- close on the ladder). Anyone reaching for "closed in one step" is reaching
+-- for this.
 -- ---------------------------------------------------------------------------
 CREATE OR REPLACE VIEW closure_two_day_bare AS
 SELECT
-    COUNT(*) FILTER (WHERE rung = 'bare' AND elapsed_days <= 2)
+    COUNT(*) FILTER (WHERE rung = 'bare' AND elapsed_days BETWEEN 0 AND 2)
         AS two_day_bare,
-    COUNT(*) FILTER (WHERE rung = 'bare' AND elapsed_days <= 2 AND action_steps <= 1)
-        AS two_day_bare_single_step,
+    COUNT(*) FILTER (WHERE rung = 'bare' AND elapsed_days BETWEEN 0 AND 2 AND action_steps <= 3)
+        AS two_day_bare_min_trajectory,
     COUNT(*) FILTER (WHERE rung = 'bare')
         AS bare,
     SUM(on_ladder)
         AS ladder_closures,
     COUNT(*)
         AS resolved_complaints,
-    100.0 * COUNT(*) FILTER (WHERE rung = 'bare' AND elapsed_days <= 2)
+    100.0 * COUNT(*) FILTER (WHERE rung = 'bare' AND elapsed_days BETWEEN 0 AND 2)
           / NULLIF(COUNT(*) FILTER (WHERE rung = 'bare'), 0)
         AS share_of_bare_pct,
-    100.0 * COUNT(*) FILTER (WHERE rung = 'bare' AND elapsed_days <= 2)
+    100.0 * COUNT(*) FILTER (WHERE rung = 'bare' AND elapsed_days BETWEEN 0 AND 2)
           / NULLIF(SUM(on_ladder), 0)
         AS share_of_ladder_pct,
-    100.0 * COUNT(*) FILTER (WHERE rung = 'bare' AND elapsed_days <= 2)
+    100.0 * COUNT(*) FILTER (WHERE rung = 'bare' AND elapsed_days BETWEEN 0 AND 2)
           / NULLIF(COUNT(*), 0)
         AS share_of_resolved_pct
 FROM closure_rung;

--- a/janasunani/analytics/sql/closure.sql
+++ b/janasunani/analytics/sql/closure.sql
@@ -83,8 +83,11 @@ actions AS (
         COUNT(*) OVER (PARTITION BY a.ticket_no) AS action_steps
     FROM action_history a
     JOIN resolved r ON r.ticket_no = a.ticket_no
-    WHERE a.action_taken_date IS NULL
-       OR CAST(a.action_taken_date AS DATE) <= CAST(r.resolved_on AS DATE)
+    -- An undated action cannot establish either the closing remark or work
+    -- completed before closure. Omitting it is safer than assigning its
+    -- insertion order a place in a verified trajectory.
+    WHERE a.action_taken_date IS NOT NULL
+      AND CAST(a.action_taken_date AS DATE) <= CAST(r.resolved_on AS DATE)
 ),
 closing AS (
     SELECT ticket_no, action_taken_remark, action_status, action_steps
@@ -217,7 +220,7 @@ CREATE OR REPLACE VIEW closure_two_day_bare AS
 SELECT
     COUNT(*) FILTER (WHERE rung = 'bare' AND elapsed_days BETWEEN 0 AND 2)
         AS two_day_bare,
-    COUNT(*) FILTER (WHERE rung = 'bare' AND elapsed_days BETWEEN 0 AND 2 AND action_steps <= 3)
+    COUNT(*) FILTER (WHERE rung = 'bare' AND elapsed_days BETWEEN 0 AND 2 AND action_steps = 3)
         AS two_day_bare_min_trajectory,
     COUNT(*) FILTER (WHERE rung = 'bare')
         AS bare,

--- a/janasunani/analytics/sql/closure.sql
+++ b/janasunani/analytics/sql/closure.sql
@@ -1,0 +1,240 @@
+-- The closure finding (#76) as a set of views. Insight, not a capability.
+--
+-- What it answers: of the complaints an officer closed using one of the six
+-- standard disposal templates, what share used the rung that claims no action?
+--
+-- HOW TO READ THE OUTPUT. The share moves by half depending on the denominator,
+-- so `closure_finding_summary` reports both and neither is optional:
+--   * share of LADDER closures  -- complaints closed on one of the six templates
+--   * share of ALL RESOLVED     -- every resolved complaint, including the third
+--                                  that closes on neither template
+-- Never quote one without the other.
+--
+-- A bare disposal does NOT mean the case was mishandled. Correct closure and
+-- premature closure are identical in this record: an information request
+-- answered, an ineligible claim properly refused, and a case dropped without
+-- work all close on the same string. This is DESCRIPTIVE. It is not a failure
+-- rate, and turning it into one needs a few hundred closures adjudicated by
+-- hand. Read `closure_by_trajectory` before quoting the headline: a case that
+-- went created -> forwarded -> ATR -> disposed had work done whatever the
+-- closing phrase says.
+--
+-- Portable across DuckDB (the Parquet lake) and PostgreSQL (the OLTP store).
+-- Reads `complaints` and `action_history` only. It never touches
+-- `complaints.grievance`, so it needs no redaction pass and emits no citizen
+-- text -- every view below is an aggregate or a template string used tens of
+-- thousands of times.
+
+-- ---------------------------------------------------------------------------
+-- 1. The disposal ladder.
+--
+-- Six templates, three rungs. Officers pick from this dropdown, so the field is
+-- a structured signal wearing a text costume and exact matching is the right
+-- tool. Templates are stored NORMALIZED: lowercased, whitespace collapsed,
+-- trailing full stops removed -- matching what `closure_closing_action` does to
+-- the remark. Correct a string here and every view below follows.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE VIEW closure_disposal_ladder AS
+SELECT * FROM (
+    VALUES
+        ('the grievance has been disposed',                          'bare',        1),
+        ('the grievance has been resolved',                          'bare',        1),
+        ('the grievance has been disposed with appropriate action',  'with_action', 2),
+        ('the grievance has been resolved with appropriate action',  'with_action', 2),
+        ('the grievance has been disposed & beneficiary benefited',  'benefit',     3),
+        ('the grievance has been resolved & beneficiary benefited',  'benefit',     3)
+) AS t(template, rung, ladder_position);
+
+-- ---------------------------------------------------------------------------
+-- 2. One row per resolved complaint: its closing remark plus its trajectory.
+--
+-- "Resolved" is `resolved_on IS NOT NULL`. The closing remark is the latest
+-- action row by `action_taken_date`, ties broken by `id` (insertion order), so
+-- a complaint with no action history still appears, with a NULL remark.
+--
+-- Trajectory is carried here rather than bolted on later because it is a
+-- required control, not an optional cut.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE VIEW closure_closing_action AS
+WITH resolved AS (
+    SELECT ticket_no, created_on, resolved_on, benefitted, category, district, dept
+    FROM complaints
+    WHERE resolved_on IS NOT NULL
+),
+actions AS (
+    SELECT
+        a.ticket_no,
+        a.action_taken_remark,
+        a.action_status,
+        ROW_NUMBER() OVER (
+            PARTITION BY a.ticket_no
+            ORDER BY a.action_taken_date DESC NULLS LAST, a.id DESC
+        ) AS recency_rank,
+        COUNT(*) OVER (PARTITION BY a.ticket_no) AS action_steps
+    FROM action_history a
+    WHERE a.ticket_no IS NOT NULL
+),
+closing AS (
+    SELECT ticket_no, action_taken_remark, action_status, action_steps
+    FROM actions
+    WHERE recency_rank = 1
+)
+SELECT
+    r.ticket_no,
+    r.created_on,
+    r.resolved_on,
+    r.benefitted,
+    r.category,
+    r.district,
+    r.dept,
+    c.action_status AS closing_action_status,
+    -- lowercase, collapse internal whitespace, drop trailing full stops
+    REGEXP_REPLACE(
+        TRIM(REGEXP_REPLACE(LOWER(c.action_taken_remark), '\s+', ' ', 'g')),
+        '\.+$', '', 'g'
+    ) AS closing_remark,
+    COALESCE(c.action_steps, 0) AS action_steps,
+    CAST(r.resolved_on AS DATE) - CAST(r.created_on AS DATE) AS elapsed_days
+FROM resolved r
+LEFT JOIN closing c ON c.ticket_no = r.ticket_no;
+
+-- ---------------------------------------------------------------------------
+-- 3. Each resolved complaint assigned a rung.
+--
+-- `off_ladder` is every resolved complaint that closed on some other wording
+-- (or on no remark at all). It is roughly a third of them, and it is the whole
+-- reason the two denominators differ.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE VIEW closure_rung AS
+SELECT
+    c.*,
+    COALESCE(l.rung, 'off_ladder') AS rung,
+    l.ladder_position,
+    CASE WHEN l.rung IS NOT NULL THEN 1 ELSE 0 END AS on_ladder,
+    CASE
+        WHEN c.action_steps <= 1 THEN '1 step'
+        WHEN c.action_steps = 2 THEN '2 steps'
+        WHEN c.action_steps <= 5 THEN '3-5 steps'
+        ELSE '6+ steps'
+    END AS steps_bucket,
+    CASE
+        WHEN c.elapsed_days IS NULL THEN 'unknown'
+        WHEN c.elapsed_days <= 2 THEN '0-2 days'
+        WHEN c.elapsed_days <= 7 THEN '3-7 days'
+        WHEN c.elapsed_days <= 30 THEN '8-30 days'
+        ELSE '31+ days'
+    END AS elapsed_bucket
+FROM closure_closing_action c
+LEFT JOIN closure_disposal_ladder l ON l.template = c.closing_remark;
+
+-- ---------------------------------------------------------------------------
+-- 4. The headline, on both denominators. One row.
+--
+-- Quote `bare_share_of_ladder_pct` and `ladder_closures` in the same breath,
+-- always, and say what the other 35-ish percent did.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE VIEW closure_finding_summary AS
+SELECT
+    COUNT(*)                                                   AS resolved_complaints,
+    SUM(on_ladder)                                             AS ladder_closures,
+    COUNT(*) FILTER (WHERE rung = 'bare')                      AS bare,
+    COUNT(*) FILTER (WHERE rung = 'with_action')               AS with_action,
+    COUNT(*) FILTER (WHERE rung = 'benefit')                   AS benefit,
+    COUNT(*) FILTER (WHERE rung IN ('with_action', 'benefit')) AS claims_action,
+    COUNT(*) FILTER (WHERE rung = 'off_ladder')                AS off_ladder,
+    -- the 61% figure: bare rungs as a share of templated closures
+    100.0 * COUNT(*) FILTER (WHERE rung = 'bare')
+          / NULLIF(SUM(on_ladder), 0)                          AS bare_share_of_ladder_pct,
+    -- the same complaints against every resolved complaint
+    100.0 * COUNT(*) FILTER (WHERE rung = 'bare')
+          / NULLIF(COUNT(*), 0)                                AS bare_share_of_resolved_pct,
+    -- how much of the resolved corpus the ladder covers at all
+    100.0 * SUM(on_ladder) / NULLIF(COUNT(*), 0)               AS ladder_coverage_pct,
+    100.0 * COUNT(*) FILTER (WHERE rung = 'off_ladder')
+          / NULLIF(COUNT(*), 0)                                AS off_ladder_share_pct
+FROM closure_rung;
+
+-- ---------------------------------------------------------------------------
+-- 5. The headline conditioned on trajectory. THIS IS NOT OPTIONAL.
+--
+-- created -> forwarded -> ATR -> disposed is not the same case as
+-- created -> disposed in two days, and the closing phrase cannot tell them
+-- apart. If the bare share is flat across these cells there is nothing here.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE VIEW closure_by_trajectory AS
+SELECT
+    steps_bucket,
+    elapsed_bucket,
+    COUNT(*)                                     AS resolved_complaints,
+    SUM(on_ladder)                               AS ladder_closures,
+    COUNT(*) FILTER (WHERE rung = 'bare')        AS bare,
+    100.0 * COUNT(*) FILTER (WHERE rung = 'bare')
+          / NULLIF(SUM(on_ladder), 0)            AS bare_share_of_ladder_pct
+FROM closure_rung
+GROUP BY steps_bucket, elapsed_bucket;
+
+-- ---------------------------------------------------------------------------
+-- 6. The sub-finding: created and closed within two days on a bare disposal.
+--
+-- This is the useful half. It names a specific set of cases instead of
+-- indicting the redressal system as a whole -- a finding an official can act
+-- on rather than one they have to defend against. Same caveat still applies:
+-- two days is fast, not wrong. An information request answered on the spot
+-- belongs here too.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE VIEW closure_two_day_bare AS
+SELECT
+    COUNT(*) FILTER (WHERE rung = 'bare' AND elapsed_days <= 2)
+        AS two_day_bare,
+    COUNT(*) FILTER (WHERE rung = 'bare' AND elapsed_days <= 2 AND action_steps <= 1)
+        AS two_day_bare_single_step,
+    COUNT(*) FILTER (WHERE rung = 'bare')
+        AS bare,
+    SUM(on_ladder)
+        AS ladder_closures,
+    COUNT(*)
+        AS resolved_complaints,
+    100.0 * COUNT(*) FILTER (WHERE rung = 'bare' AND elapsed_days <= 2)
+          / NULLIF(COUNT(*) FILTER (WHERE rung = 'bare'), 0)
+        AS share_of_bare_pct,
+    100.0 * COUNT(*) FILTER (WHERE rung = 'bare' AND elapsed_days <= 2)
+          / NULLIF(SUM(on_ladder), 0)
+        AS share_of_ladder_pct,
+    100.0 * COUNT(*) FILTER (WHERE rung = 'bare' AND elapsed_days <= 2)
+          / NULLIF(COUNT(*), 0)
+        AS share_of_resolved_pct
+FROM closure_rung;
+
+-- ---------------------------------------------------------------------------
+-- 7. Overlap with the existing `complaints.benefitted` column.
+--
+-- Checked before claiming the third rung is novel. If `benefitted` already
+-- marks the same complaints the 'benefit' rung does, the rung is a restatement
+-- of a column the dashboards already have and must not be presented as new.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE VIEW closure_benefitted_overlap AS
+SELECT
+    rung,
+    COALESCE(TRIM(LOWER(benefitted)), '(null)') AS benefitted_value,
+    COUNT(*) AS resolved_complaints
+FROM closure_rung
+GROUP BY rung, COALESCE(TRIM(LOWER(benefitted)), '(null)');
+
+-- ---------------------------------------------------------------------------
+-- 8. Coverage check for the ladder itself.
+--
+-- The top closing remarks that did NOT match a template, most frequent first.
+-- Run this first on any new corpus: if the ladder strings have drifted, the
+-- headline silently collapses into `off_ladder` rather than failing. High-
+-- frequency templates only (used 1,000+ times) -- the free-text tail is a
+-- privacy boundary as well as a scope one, and no row of citizen writing is
+-- a template.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE VIEW closure_off_ladder_templates AS
+SELECT
+    closing_remark,
+    COUNT(*) AS resolved_complaints
+FROM closure_rung
+WHERE rung = 'off_ladder' AND closing_remark IS NOT NULL
+GROUP BY closing_remark
+HAVING COUNT(*) >= 1000;

--- a/janasunani/olap/README.md
+++ b/janasunani/olap/README.md
@@ -14,6 +14,11 @@ history browse read **this**, never OLTP.
 - `lake.py` — read helpers: `query(sql)` (DuckDB over the Parquet files) and
   `read(table)` (whole table as a Polars DataFrame).
 
+Everything analytical built *on* the lake — the governed SQL marts and the
+findings that read them — lives in
+[`janasunani/analytics`](../analytics/README.md), not here. This module stays
+the plumbing.
+
 ## Why "lake"
 
 It's the cheap, schema-on-read, file-based analytical layer — the OLTP store

--- a/janasunani/olap/README.md
+++ b/janasunani/olap/README.md
@@ -14,8 +14,8 @@ history browse read **this**, never OLTP.
 - `lake.py` — read helpers: `query(sql)` (DuckDB over the Parquet files) and
   `read(table)` (whole table as a Polars DataFrame).
 
-Everything analytical built *on* the lake — the governed SQL marts and the
-findings that read them — lives in
+Everything analytical built *on* the lake, the governed SQL marts and the
+findings that read them, lives in
 [`janasunani/analytics`](../analytics/README.md), not here. This module stays
 the plumbing.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,7 @@ demo = [
 janasunani-migrate-mysql = "janasunani.migration.from_mysql:main"
 janasunani-migrate-dump = "janasunani.migration.from_sql_dump:main"
 janasunani-materialize = "janasunani.olap.materialize:main"
+janasunani-closure-finding = "janasunani.analytics.findings.closure:main"
 janasunani-ingest-documents = "janasunani.ingestion.document_ingestion:main"
 janasunani-pipeline = "janasunani.pipeline.cli:main"
 janasunani-export-pipeline = "janasunani.pipeline.export:main"

--- a/tests/test_closure_finding.py
+++ b/tests/test_closure_finding.py
@@ -236,6 +236,49 @@ def test_closing_remark_is_the_latest_action_not_the_first_row(lake):
     assert cell["bare"] == 0
 
 
+def test_actions_after_resolution_are_not_treated_as_the_closing_action(tmp_path):
+    """A reopen or audit row filed after `resolved_on` did not close the case.
+
+    Taking the latest row unconditionally would pick it as the closing remark,
+    knocking a complaint off the ladder whose actual disposal matched, and
+    would count post-closure activity as work done before closure.
+    """
+    complaints = [
+        ("R1", datetime(2024, 1, 1), datetime(2024, 1, 10), None, "Water", "Puri", "RWSS")
+    ]
+    actions = [
+        (1, "R1", datetime(2024, 1, 2), "Forwarded to the executive engineer."),
+        (2, "R1", datetime(2024, 1, 10), _BARE),
+        # Six weeks later: an audit note. Not a closing action.
+        (3, "R1", datetime(2024, 2, 20), "Audit observation recorded."),
+    ]
+    tables = closure.compute(_write_lake(tmp_path, complaints, actions))
+
+    row = tables["closure_finding_summary"].row(0, named=True)
+    assert row["bare"] == 1  # still on the ladder
+    assert row["off_ladder"] == 0
+
+    # And the audit row is not counted as a step of work before closure.
+    traj = tables["closure_by_trajectory"].row(0, named=True)
+    assert traj["steps_bucket"] == "2 steps"
+
+
+def test_negative_durations_are_quarantined_rather_than_read_as_fast_closures(tmp_path):
+    """`resolved_on` before `created_on` happens: the two timestamps are parsed
+    independently at ingest and nothing enforces an order. Such a row is bad
+    data, not a two-day closure."""
+    complaints = [
+        # Resolved four days *before* it was created.
+        ("N1", datetime(2024, 1, 10), datetime(2024, 1, 6), None, "Water", "Puri", "RWSS"),
+    ]
+    actions = [(1, "N1", datetime(2024, 1, 6), _BARE)]
+    tables = closure.compute(_write_lake(tmp_path, complaints, actions))
+
+    assert tables["closure_two_day_bare"].row(0, named=True)["two_day_bare"] == 0
+    buckets = tables["closure_by_trajectory"]["elapsed_bucket"].to_list()
+    assert buckets == ["invalid"]
+
+
 def test_actions_for_unknown_tickets_do_not_invent_complaints(lake):
     """T404's action row has no complaint. It must not reach any count."""
     row = closure.compute(lake)["closure_finding_summary"].row(0, named=True)
@@ -264,19 +307,22 @@ def test_trajectory_conditioning_separates_two_day_closures_from_worked_cases(la
     # The buckets partition the resolved complaints, exactly once each.
     assert traj["resolved_complaints"].sum() == 8
 
-    # A complaint with no action history lands in the zero-step bucket rather
-    # than being silently dropped.
+    # A complaint with no action history gets its own bucket rather than being
+    # dropped, and rather than being folded in with genuinely one-step cases.
     none = traj.filter(
-        (pl.col("steps_bucket") == "1 step") & (pl.col("elapsed_bucket") == "3-7 days")
+        (pl.col("steps_bucket") == "0 steps") & (pl.col("elapsed_bucket") == "3-7 days")
     ).row(0, named=True)
     assert none["resolved_complaints"] == 1  # T8, zero actions
+    # T1 and T2 genuinely have one action row each, and stay separate from it.
+    assert traj.filter(pl.col("steps_bucket") == "1 step")["resolved_complaints"].sum() == 2
 
 
 def test_two_day_bare_subfinding(lake):
     row = closure.compute(lake)["closure_two_day_bare"].row(0, named=True)
 
     assert row["two_day_bare"] == 2  # T1 (1 day), T2 (2 days)
-    assert row["two_day_bare_single_step"] == 2
+    # Both closed on one action row, which is inside the three-step floor.
+    assert row["two_day_bare_min_trajectory"] == 2
     assert row["bare"] == 3
     assert row["share_of_bare_pct"] == pytest.approx(200.0 / 3)
     assert row["share_of_ladder_pct"] == pytest.approx(200.0 / 6)
@@ -285,6 +331,38 @@ def test_two_day_bare_subfinding(lake):
     # T3 is a bare disposal too, but it took forty days over four steps. If the
     # boundary leaked it would show up here.
     assert row["two_day_bare"] < row["bare"]
+
+
+def test_min_trajectory_separates_the_floor_case_from_a_fast_worked_case(tmp_path):
+    """Two days is fast. Two days *after four steps of work* is a different
+    case, and the floor column has to tell them apart.
+
+    The threshold is three action rows, not one: the portal writes a create and
+    an assign row before an officer can dispose, so a one-step disposal does not
+    exist in this record.
+    """
+    complaints = [
+        ("F1", datetime(2024, 1, 1), datetime(2024, 1, 2), None, "Water", "Puri", "RWSS"),
+        ("F2", datetime(2024, 1, 1), datetime(2024, 1, 3), None, "Water", "Puri", "RWSS"),
+    ]
+    actions = [
+        # F1: the floor -- created, assigned, disposed.
+        (1, "F1", datetime(2024, 1, 1), "Complaint registered."),
+        (2, "F1", datetime(2024, 1, 1), "Assigned to the block officer."),
+        (3, "F1", datetime(2024, 1, 2), _BARE),
+        # F2: same two days, but five steps of real movement first.
+        (4, "F2", datetime(2024, 1, 1), "Complaint registered."),
+        (5, "F2", datetime(2024, 1, 1), "Assigned to the block officer."),
+        (6, "F2", datetime(2024, 1, 2), "Forwarded to the executive engineer."),
+        (7, "F2", datetime(2024, 1, 2), "ATR submitted."),
+        (8, "F2", datetime(2024, 1, 3), _BARE),
+    ]
+    row = closure.compute(_write_lake(tmp_path, complaints, actions))[
+        "closure_two_day_bare"
+    ].row(0, named=True)
+
+    assert row["two_day_bare"] == 2  # both are two-day bare disposals
+    assert row["two_day_bare_min_trajectory"] == 1  # only F1 is the floor case
 
 
 def test_benefitted_overlap_is_reported_so_the_third_rung_is_not_claimed_novel(lake):
@@ -336,16 +414,63 @@ def test_markdown_never_states_the_headline_without_its_base(lake):
     # No citizen text, and no per-office breakdown, ever.
     assert _OFF_LADDER not in md
 
+    # The trajectory table carries its own base too. Without it, a cell reading
+    # "4 templated closures" looks like thin data when it is actually tens of
+    # thousands of complaints that closed on a discard template instead.
+    assert "| Action steps | Elapsed | Resolved | Templated closures |" in md
+    assert "| 0 steps | 3-7 days | 1 | 0 | 0 | n/a |" in md  # T8, zero actions
+
 
 def test_write_emits_the_tables_the_markdown_and_the_handed_over_sql(lake, tmp_path):
-    written = closure.write(closure.compute(lake), tmp_path / "findings")
+    out = tmp_path / "findings"
+    written = closure.write(closure.compute(lake), out)
 
-    for view in closure.REPORT_VIEWS:
+    for view in closure.FINDING_VIEWS:
         assert written[view].exists()
     assert written["markdown"].read_text().startswith("## How cases are closed")
     # The deliverable is the view definition, so it ships beside the numbers.
     assert written["sql"].read_text() == closure.sql_text()
 
     # The two complaint-level views stay intermediate: no per-complaint file.
-    names = {p.name for p in (tmp_path / "findings").iterdir()}
+    names = {p.name for p in out.iterdir()}
     assert not {n for n in names if n.startswith(("closure_rung", "closure_closing"))}
+
+
+def test_the_remark_diagnostic_never_lands_in_the_shareable_directory(lake, tmp_path):
+    """`closure_off_ladder_templates` is the only output carrying remark text.
+
+    A 1,000-use floor is dropdown scale, but frequency is evidence and not
+    proof, so it goes to `diagnostics/` and the directory the finding is shared
+    out of stays aggregates-only.
+    """
+    out = tmp_path / "findings"
+    tables = closure.compute(lake)
+    closure.write(tables, out)
+    assert not (out / "closure_off_ladder_templates.csv").exists()
+
+    written = closure.write_diagnostics(tables, out)
+    assert written["closure_off_ladder_templates"].parent.name == "diagnostics"
+    assert (out / "diagnostics" / "closure_off_ladder_templates.csv").exists()
+
+
+def test_the_cli_refuses_to_publish_when_the_ladder_guard_fails(tmp_path, monkeypatch):
+    """A warning beside the artifacts is not a guard.
+
+    A batch caller keeping stdout and dropping stderr would publish exactly the
+    number `check_ladder_coverage` says must not be quoted.
+    """
+    drifted = [(i, t, d, r.replace("grievance", "petition")) for i, t, d, r in _ACTIONS]
+    lake = _write_lake(tmp_path, actions=drifted)
+    out = tmp_path / "findings"
+    monkeypatch.setattr(
+        "sys.argv", ["janasunani-closure-finding", "--lake-dir", str(lake), "--out-dir", str(out)]
+    )
+
+    with pytest.raises(SystemExit) as exit_info:
+        closure.main()
+    assert exit_info.value.code == 1
+
+    assert not (out / "closure_finding.md").exists()
+    assert not (out / "closure_finding_summary.csv").exists()
+    # The diagnostic is still written: it is what tells you why.
+    assert (out / "diagnostics" / "closure_off_ladder_templates.csv").exists()

--- a/tests/test_closure_finding.py
+++ b/tests/test_closure_finding.py
@@ -82,6 +82,7 @@ _ACTIONS = [
 
 
 def _write_lake(path, complaints=_COMPLAINTS, actions=_ACTIONS, grievance=None):
+    path.mkdir(parents=True, exist_ok=True)
     schema = [
         ("ticket_no", pl.Utf8),
         ("created_on", pl.Datetime),
@@ -263,6 +264,21 @@ def test_actions_after_resolution_are_not_treated_as_the_closing_action(tmp_path
     assert traj["steps_bucket"] == "2 steps"
 
 
+def test_undated_actions_are_quarantined_from_the_closing_trajectory(tmp_path):
+    """Unknown timing cannot establish either a closure or its work count."""
+    complaints = [
+        ("U1", datetime(2024, 1, 1), datetime(2024, 1, 10), None, "Water", "Puri", "RWSS")
+    ]
+    actions = [
+        (1, "U1", datetime(2024, 1, 10), _BARE),
+        (2, "U1", None, "Undated free-text follow-up."),
+    ]
+    tables = closure.compute(_write_lake(tmp_path, complaints, actions))
+
+    assert tables["closure_finding_summary"].row(0, named=True)["bare"] == 1
+    assert tables["closure_by_trajectory"].row(0, named=True)["steps_bucket"] == "1 step"
+
+
 def test_negative_durations_are_quarantined_rather_than_read_as_fast_closures(tmp_path):
     """`resolved_on` before `created_on` happens: the two timestamps are parsed
     independently at ingest and nothing enforces an order. Such a row is bad
@@ -321,8 +337,8 @@ def test_two_day_bare_subfinding(lake):
     row = closure.compute(lake)["closure_two_day_bare"].row(0, named=True)
 
     assert row["two_day_bare"] == 2  # T1 (1 day), T2 (2 days)
-    # Both closed on one action row, which is inside the three-step floor.
-    assert row["two_day_bare_min_trajectory"] == 2
+    # One-step histories are not the portal's three-row floor trajectory.
+    assert row["two_day_bare_min_trajectory"] == 0
     assert row["bare"] == 3
     assert row["share_of_bare_pct"] == pytest.approx(200.0 / 3)
     assert row["share_of_ladder_pct"] == pytest.approx(200.0 / 6)
@@ -436,12 +452,11 @@ def test_write_emits_the_tables_the_markdown_and_the_handed_over_sql(lake, tmp_p
     assert not {n for n in names if n.startswith(("closure_rung", "closure_closing"))}
 
 
-def test_the_remark_diagnostic_never_lands_in_the_shareable_directory(lake, tmp_path):
+def test_the_remark_diagnostic_is_aggregate_only_before_it_lands_in_outputs(lake, tmp_path):
     """`closure_off_ladder_templates` is the only output carrying remark text.
 
-    A 1,000-use floor is dropdown scale, but frequency is evidence and not
-    proof, so it goes to `diagnostics/` and the directory the finding is shared
-    out of stays aggregates-only.
+    A 1,000-use floor is not proof, so even `diagnostics/`, which the recursive
+    deliver target can copy, receives aggregate counts only.
     """
     out = tmp_path / "findings"
     tables = closure.compute(lake)
@@ -450,7 +465,12 @@ def test_the_remark_diagnostic_never_lands_in_the_shareable_directory(lake, tmp_
 
     written = closure.write_diagnostics(tables, out)
     assert written["closure_off_ladder_templates"].parent.name == "diagnostics"
-    assert (out / "diagnostics" / "closure_off_ladder_templates.csv").exists()
+    diagnostic = pl.read_csv(out / "diagnostics" / "closure_off_ladder_templates.csv")
+    assert diagnostic.columns == [
+        "high_volume_off_ladder_remarks",
+        "affected_resolved_complaints",
+    ]
+    assert _OFF_LADDER not in diagnostic.write_csv()
 
 
 def test_the_cli_refuses_to_publish_when_the_ladder_guard_fails(tmp_path, monkeypatch):
@@ -474,3 +494,49 @@ def test_the_cli_refuses_to_publish_when_the_ladder_guard_fails(tmp_path, monkey
     assert not (out / "closure_finding_summary.csv").exists()
     # The diagnostic is still written: it is what tells you why.
     assert (out / "diagnostics" / "closure_off_ladder_templates.csv").exists()
+
+
+def test_high_volume_off_ladder_text_refuses_publication(tmp_path, monkeypatch):
+    """Frequency does not make raw text a safe or approved template."""
+    actions = [
+        (i, f"O{i}", datetime(2024, 1, 2), "Unapproved free-text template")
+        for i in range(1, 1001)
+    ]
+    complaints = [
+        (f"O{i}", datetime(2024, 1, 1), datetime(2024, 1, 2), None, "Water", "Puri", "RWSS")
+        for i in range(1, 1001)
+    ]
+    lake = _write_lake(tmp_path / "lake", complaints, actions)
+    out = tmp_path / "findings"
+    monkeypatch.setattr(
+        "sys.argv", ["janasunani-closure-finding", "--lake-dir", str(lake), "--out-dir", str(out)]
+    )
+
+    with pytest.raises(SystemExit, match="1"):
+        closure.main()
+
+    diagnostic = (out / "diagnostics" / "closure_off_ladder_templates.csv").read_text()
+    assert "free-text" not in diagnostic
+    assert "Unapproved" not in diagnostic
+
+
+def test_failed_guard_removes_stale_shareable_artifacts(tmp_path, monkeypatch):
+    """A failed rerun must not leave an earlier valid report for delivery."""
+    healthy = tmp_path / "healthy"
+    healthy.mkdir()
+    out = tmp_path / "findings"
+    closure.write(closure.compute(_write_lake(healthy)), out)
+    drifted = [(i, t, d, r.replace("grievance", "petition")) for i, t, d, r in _ACTIONS]
+    failed = tmp_path / "failed"
+    failed.mkdir()
+    lake = _write_lake(failed, actions=drifted)
+    monkeypatch.setattr(
+        "sys.argv", ["janasunani-closure-finding", "--lake-dir", str(lake), "--out-dir", str(out)]
+    )
+
+    with pytest.raises(SystemExit, match="1"):
+        closure.main()
+
+    assert not (out / "closure_finding.md").exists()
+    assert not (out / "closure_finding_summary.csv").exists()
+    assert not (out / "closure_finding.sql").exists()

--- a/tests/test_closure_finding.py
+++ b/tests/test_closure_finding.py
@@ -1,0 +1,351 @@
+"""Tests for the closure finding (#76) and the mart it reads.
+
+Every assertion runs against a hand-built fixture lake, never against the real
+one: the point of the finding is a number, and a test that reads live data
+cannot tell a correct query from a query that happens to agree with today's
+corpus.
+
+The fixture is arranged so each headline figure has an independently countable
+answer, and so the two denominators genuinely differ — collapsing them is the
+failure mode this finding is most exposed to.
+"""
+
+import re
+from datetime import datetime
+
+import polars as pl
+import pytest
+
+from janasunani.analytics import marts
+from janasunani.analytics.findings import closure
+
+# --- the fixture corpus -----------------------------------------------------
+#
+# 10 complaints. 8 resolved, 2 still pending (so "resolved" is not "all rows").
+# Of the 8 resolved:
+#   T1  bare        1 step,  1 day    <- two-day bare, single step
+#   T2  bare        1 step,  2 days   <- two-day bare, single step
+#   T3  bare        4 steps, 40 days
+#   T4  with_action 3 steps, 12 days
+#   T5  with_action 2 steps, 5 days
+#   T6  benefit     2 steps, 9 days   <- benefitted = Yes
+#   T7  off_ladder  2 steps, 30 days  (a discard template)
+#   T8  off_ladder  0 steps, 3 days   (no action history at all)
+#
+# So: resolved = 8, ladder = 6, bare = 3, with_action = 2, benefit = 1,
+# off_ladder = 2. Bare share of ladder = 3/6 = 50.0%. Bare share of resolved =
+# 3/8 = 37.5%. The gap between those two is the thing that must not collapse.
+
+_BARE = "The grievance has been disposed."
+_BARE_ALT = "the grievance has been resolved"  # no full stop, already lowercase
+_WITH_ACTION = "The grievance has been disposed with appropriate action."
+_WITH_ACTION_ALT = "The  grievance  has been resolved with appropriate action."
+_BENEFIT = "The grievance has been disposed & beneficiary benefited."
+_OFF_LADDER = "Not within the purview of this office."
+
+_COMPLAINTS = [
+    ("T1", datetime(2024, 1, 1), datetime(2024, 1, 2), None, "Water", "Puri", "RWSS"),
+    ("T2", datetime(2024, 1, 1), datetime(2024, 1, 3), "No", "Water", "Puri", "RWSS"),
+    ("T3", datetime(2024, 1, 1), datetime(2024, 2, 10), None, "Roads", "Cuttack", "Works"),
+    ("T4", datetime(2024, 1, 1), datetime(2024, 1, 13), None, "Roads", "Cuttack", "Works"),
+    ("T5", datetime(2024, 1, 1), datetime(2024, 1, 6), "No", "Water", "Puri", "RWSS"),
+    ("T6", datetime(2024, 1, 1), datetime(2024, 1, 10), "Yes", "Welfare", "Puri", "W&CD"),
+    ("T7", datetime(2024, 1, 1), datetime(2024, 1, 31), None, "Roads", "Cuttack", "Works"),
+    ("T8", datetime(2024, 1, 1), datetime(2024, 1, 4), None, "Water", "Puri", "RWSS"),
+    ("T9", datetime(2024, 1, 1), None, None, "Water", "Puri", "RWSS"),
+    ("T10", datetime(2024, 1, 1), None, None, "Roads", "Cuttack", "Works"),
+]
+
+# (id, ticket, date, remark). Deliberately not in date order, so the
+# closing-remark pick is exercised rather than accidentally satisfied.
+_ACTIONS = [
+    (1, "T1", datetime(2024, 1, 2), _BARE),
+    (2, "T2", datetime(2024, 1, 3), _BARE_ALT),
+    (3, "T3", datetime(2024, 1, 5), "Forwarded to the executive engineer."),
+    (4, "T3", datetime(2024, 1, 20), "ATR submitted."),
+    (5, "T3", datetime(2024, 2, 1), "Reminder issued."),
+    (6, "T3", datetime(2024, 2, 10), _BARE),
+    (7, "T4", datetime(2024, 1, 13), _WITH_ACTION),
+    (8, "T4", datetime(2024, 1, 4), "Forwarded to the executive engineer."),
+    (9, "T4", datetime(2024, 1, 9), "ATR submitted."),
+    (10, "T5", datetime(2024, 1, 2), "Forwarded to the executive engineer."),
+    (11, "T5", datetime(2024, 1, 6), _WITH_ACTION_ALT),
+    (12, "T6", datetime(2024, 1, 3), "Forwarded to the block officer."),
+    (13, "T6", datetime(2024, 1, 10), _BENEFIT),
+    (14, "T7", datetime(2024, 1, 8), "Forwarded to the collector."),
+    (15, "T7", datetime(2024, 1, 31), _OFF_LADDER),
+    # T8 has no action history at all.
+    (16, "T9", datetime(2024, 1, 5), "Pending with the block officer."),
+    # A stray action row whose ticket is not in complaints at all.
+    (17, "T404", datetime(2024, 1, 5), _BARE),
+]
+
+
+def _write_lake(path, complaints=_COMPLAINTS, actions=_ACTIONS, grievance=None):
+    schema = [
+        ("ticket_no", pl.Utf8),
+        ("created_on", pl.Datetime),
+        ("resolved_on", pl.Datetime),
+        ("benefitted", pl.Utf8),
+        ("category", pl.Utf8),
+        ("district", pl.Utf8),
+        ("dept", pl.Utf8),
+    ]
+    if grievance is not None:
+        # The real lake carries the citizen's own text. The mart must not read
+        # it even when it is right there.
+        complaints = [(*row, grievance) for row in complaints]
+        schema = [*schema, ("grievance", pl.Utf8)]
+    pl.DataFrame(complaints, schema=schema, orient="row").write_parquet(
+        path / "complaints.parquet"
+    )
+
+    pl.DataFrame(
+        [(i, t, d, r, "Disposed") for i, t, d, r in actions],
+        schema=[
+            ("id", pl.Int64),
+            ("ticket_no", pl.Utf8),
+            ("action_taken_date", pl.Datetime),
+            ("action_taken_remark", pl.Utf8),
+            ("action_status", pl.Utf8),
+        ],
+        orient="row",
+    ).write_parquet(path / "action_history.parquet")
+    return path
+
+
+@pytest.fixture
+def lake(tmp_path):
+    return _write_lake(tmp_path)
+
+
+# --- the mart loader --------------------------------------------------------
+
+
+def test_mart_sql_is_read_verbatim_from_the_sql_directory():
+    """The SQL is the deliverable, so nothing may rewrite it on the way out."""
+    assert closure.sql_text() == marts.mart_path("closure").read_text()
+    assert "CREATE OR REPLACE VIEW closure_finding_summary" in closure.sql_text()
+
+
+def test_unknown_mart_names_the_ones_that_exist():
+    with pytest.raises(FileNotFoundError, match="closure"):
+        marts.mart_sql("no_such_mart")
+
+
+def test_open_lake_installs_the_mart_over_the_lake_tables(lake):
+    con = marts.open_lake("closure", lake_dir=lake)
+    try:
+        assert con.execute("SELECT count(*) FROM closure_rung").fetchone()[0] == 8
+    finally:
+        con.close()
+
+
+def test_the_ladder_lives_only_in_the_sql(lake):
+    """Six templates, one source. They are not duplicated in Python."""
+    sql = closure.sql_text()
+    for template in (
+        "the grievance has been disposed",
+        "the grievance has been resolved",
+        "the grievance has been disposed with appropriate action",
+        "the grievance has been resolved with appropriate action",
+        "the grievance has been disposed & beneficiary benefited",
+        "the grievance has been resolved & beneficiary benefited",
+    ):
+        assert f"'{template}'" in sql
+
+    con = marts.open_lake("closure", lake_dir=lake)
+    try:
+        rungs = con.execute(
+            "SELECT rung, count(*) FROM closure_disposal_ladder GROUP BY rung"
+        ).fetchall()
+    finally:
+        con.close()
+    assert dict(rungs) == {"bare": 2, "with_action": 2, "benefit": 2}
+
+
+def test_the_mart_never_reads_the_citizen_text_column(tmp_path):
+    """Not reading `complaints.grievance` is why this finding needs no
+    redaction pass, no slice decision and no gold set. It is a scope claim the
+    whole issue rests on, so it is asserted rather than asserted-in-a-comment.
+
+    Checked twice: the SQL never names the column, and a lake that *has* the
+    column never surfaces it. The static half strips comments and string
+    literals first — the disposal templates themselves contain the word
+    "grievance", so a plain substring search would pass for the wrong reason.
+    """
+    sql = re.sub(r"--[^\n]*", "", closure.sql_text())
+    sql = re.sub(r"'[^']*'", "''", sql)
+    assert "grievance" not in sql.replace("closure_", "")
+
+    tables = closure.compute(_write_lake(tmp_path, grievance="My hand pump is broken"))
+    for frame in tables.values():
+        assert "grievance" not in frame.columns
+    assert "hand pump" not in closure.render_markdown(tables)
+
+
+# --- the headline -----------------------------------------------------------
+
+
+def test_headline_reports_both_denominators_and_they_differ(lake):
+    row = closure.compute(lake)["closure_finding_summary"].row(0, named=True)
+
+    assert row["resolved_complaints"] == 8  # the two pending rows are excluded
+    assert row["ladder_closures"] == 6
+    assert row["bare"] == 3
+    assert row["with_action"] == 2
+    assert row["benefit"] == 1
+    assert row["claims_action"] == 3
+    assert row["off_ladder"] == 2
+
+    # The whole point of the finding: the same 3 complaints, two denominators.
+    assert row["bare_share_of_ladder_pct"] == pytest.approx(50.0)
+    assert row["bare_share_of_resolved_pct"] == pytest.approx(37.5)
+    assert row["ladder_coverage_pct"] == pytest.approx(75.0)
+    assert row["off_ladder_share_pct"] == pytest.approx(25.0)
+
+    # Reconciliation, written independently of the SQL: the rungs partition the
+    # resolved complaints, and the ladder is exactly the non-off_ladder part.
+    assert row["bare"] + row["claims_action"] == row["ladder_closures"]
+    assert row["ladder_closures"] + row["off_ladder"] == row["resolved_complaints"]
+    assert row["with_action"] + row["benefit"] == row["claims_action"]
+
+
+def test_rung_assignment_normalizes_case_whitespace_and_trailing_stops(lake):
+    """T2's remark has no trailing stop; T5's has a doubled internal space."""
+    row = closure.compute(lake)["closure_finding_summary"].row(0, named=True)
+    assert row["bare"] == 3  # T1, T2, T3 — T2 only if normalization works
+    assert row["with_action"] == 2  # T4, T5 — T5 only if whitespace collapses
+
+
+def test_closing_remark_is_the_latest_action_not_the_first_row(lake):
+    """T4's disposal is stored ahead of its earlier steps in row order.
+
+    If the closing remark were taken by row order it would be the *forwarded*
+    remark and T4 would fall off the ladder entirely.
+    """
+    cell = (
+        closure.compute(lake)["closure_by_trajectory"]
+        .filter(
+            (pl.col("steps_bucket") == "3-5 steps")
+            & (pl.col("elapsed_bucket") == "8-30 days")
+        )
+        .row(0, named=True)
+    )
+    assert cell["ladder_closures"] == 1
+    assert cell["bare"] == 0
+
+
+def test_actions_for_unknown_tickets_do_not_invent_complaints(lake):
+    """T404's action row has no complaint. It must not reach any count."""
+    row = closure.compute(lake)["closure_finding_summary"].row(0, named=True)
+    assert row["resolved_complaints"] == 8
+
+
+# --- the required controls --------------------------------------------------
+
+
+def test_trajectory_conditioning_separates_two_day_closures_from_worked_cases(lake):
+    traj = closure.compute(lake)["closure_by_trajectory"]
+
+    fast = traj.filter(
+        (pl.col("steps_bucket") == "1 step") & (pl.col("elapsed_bucket") == "0-2 days")
+    ).row(0, named=True)
+    assert fast["resolved_complaints"] == 2  # T1, T2
+    assert fast["bare"] == 2
+    assert fast["bare_share_of_ladder_pct"] == pytest.approx(100.0)
+
+    worked = traj.filter(
+        (pl.col("steps_bucket") == "3-5 steps") & (pl.col("elapsed_bucket") == "31+ days")
+    ).row(0, named=True)
+    assert worked["resolved_complaints"] == 1  # T3: four steps, forty days
+    assert worked["bare"] == 1
+
+    # The buckets partition the resolved complaints, exactly once each.
+    assert traj["resolved_complaints"].sum() == 8
+
+    # A complaint with no action history lands in the zero-step bucket rather
+    # than being silently dropped.
+    none = traj.filter(
+        (pl.col("steps_bucket") == "1 step") & (pl.col("elapsed_bucket") == "3-7 days")
+    ).row(0, named=True)
+    assert none["resolved_complaints"] == 1  # T8, zero actions
+
+
+def test_two_day_bare_subfinding(lake):
+    row = closure.compute(lake)["closure_two_day_bare"].row(0, named=True)
+
+    assert row["two_day_bare"] == 2  # T1 (1 day), T2 (2 days)
+    assert row["two_day_bare_single_step"] == 2
+    assert row["bare"] == 3
+    assert row["share_of_bare_pct"] == pytest.approx(200.0 / 3)
+    assert row["share_of_ladder_pct"] == pytest.approx(200.0 / 6)
+    assert row["share_of_resolved_pct"] == pytest.approx(25.0)
+
+    # T3 is a bare disposal too, but it took forty days over four steps. If the
+    # boundary leaked it would show up here.
+    assert row["two_day_bare"] < row["bare"]
+
+
+def test_benefitted_overlap_is_reported_so_the_third_rung_is_not_claimed_novel(lake):
+    pairs = {
+        (r["rung"], r["benefitted_value"]): r["resolved_complaints"]
+        for r in closure.compute(lake)["closure_benefitted_overlap"].iter_rows(named=True)
+    }
+    assert pairs[("benefit", "yes")] == 1  # T6 carries both signals
+    assert pairs[("bare", "(null)")] == 2  # T1, T3
+    assert pairs[("bare", "no")] == 1  # T2
+    assert sum(pairs.values()) == 8
+
+
+# --- the guards -------------------------------------------------------------
+
+
+def test_off_ladder_templates_never_leak_low_frequency_text(lake):
+    """The coverage check is bounded to templates used 1,000+ times.
+
+    The fixture's off-ladder remark appears twice, so the view must be empty: a
+    string used twice is not a dropdown template, it is somebody's writing.
+    """
+    assert closure.compute(lake)["closure_off_ladder_templates"].height == 0
+
+
+def test_template_drift_is_reported_rather_than_silently_shrinking_the_base(tmp_path):
+    """An unmatched ladder string does not error — it moves complaints into
+    `off_ladder` and quietly shrinks the denominator the headline divides by."""
+    drifted = [(i, t, d, r.replace("grievance", "petition")) for i, t, d, r in _ACTIONS]
+    tables = closure.compute(_write_lake(tmp_path, actions=drifted))
+    assert tables["closure_finding_summary"].row(0, named=True)["ladder_closures"] == 0
+    warning = closure.check_ladder_coverage(tables)
+    assert warning is not None
+    assert "drifted" in warning
+
+
+def test_healthy_coverage_raises_no_drift_warning(lake):
+    assert closure.check_ladder_coverage(closure.compute(lake)) is None
+
+
+def test_markdown_never_states_the_headline_without_its_base(lake):
+    md = closure.render_markdown(closure.compute(lake))
+
+    assert "50.0%" in md  # the ladder share
+    assert "37.5%" in md  # and the all-resolved figure, not optional
+    assert "**not** a failure rate" in md
+    assert "300-500 closures adjudicated by hand" in md
+    assert "Insight" in md
+    # No citizen text, and no per-office breakdown, ever.
+    assert _OFF_LADDER not in md
+
+
+def test_write_emits_the_tables_the_markdown_and_the_handed_over_sql(lake, tmp_path):
+    written = closure.write(closure.compute(lake), tmp_path / "findings")
+
+    for view in closure.REPORT_VIEWS:
+        assert written[view].exists()
+    assert written["markdown"].read_text().startswith("## How cases are closed")
+    # The deliverable is the view definition, so it ships beside the numbers.
+    assert written["sql"].read_text() == closure.sql_text()
+
+    # The two complaint-level views stay intermediate: no per-complaint file.
+    names = {p.name for p in (tmp_path / "findings").iterdir()}
+    assert not {n for n in names if n.startswith(("closure_rung", "closure_closing"))}

--- a/tests/test_closure_finding.py
+++ b/tests/test_closure_finding.py
@@ -6,7 +6,7 @@ cannot tell a correct query from a query that happens to agree with today's
 corpus.
 
 The fixture is arranged so each headline figure has an independently countable
-answer, and so the two denominators genuinely differ — collapsing them is the
+answer, and so the two denominators genuinely differ. Collapsing them is the
 failure mode this finding is most exposed to.
 """
 
@@ -171,7 +171,7 @@ def test_the_mart_never_reads_the_citizen_text_column(tmp_path):
 
     Checked twice: the SQL never names the column, and a lake that *has* the
     column never surfaces it. The static half strips comments and string
-    literals first — the disposal templates themselves contain the word
+    literals first: the disposal templates themselves contain the word
     "grievance", so a plain substring search would pass for the wrong reason.
     """
     sql = re.sub(r"--[^\n]*", "", closure.sql_text())
@@ -214,8 +214,8 @@ def test_headline_reports_both_denominators_and_they_differ(lake):
 def test_rung_assignment_normalizes_case_whitespace_and_trailing_stops(lake):
     """T2's remark has no trailing stop; T5's has a doubled internal space."""
     row = closure.compute(lake)["closure_finding_summary"].row(0, named=True)
-    assert row["bare"] == 3  # T1, T2, T3 — T2 only if normalization works
-    assert row["with_action"] == 2  # T4, T5 — T5 only if whitespace collapses
+    assert row["bare"] == 3  # T1, T2, T3; T2 only if normalization works
+    assert row["with_action"] == 2  # T4, T5; T5 only if whitespace collapses
 
 
 def test_closing_remark_is_the_latest_action_not_the_first_row(lake):
@@ -389,7 +389,7 @@ def test_off_ladder_templates_never_leak_low_frequency_text(lake):
 
 
 def test_template_drift_is_reported_rather_than_silently_shrinking_the_base(tmp_path):
-    """An unmatched ladder string does not error — it moves complaints into
+    """An unmatched ladder string does not error. It moves complaints into
     `off_ladder` and quietly shrinks the denominator the headline divides by."""
     drifted = [(i, t, d, r.replace("grievance", "petition")) for i, t, d, r in _ACTIONS]
     tables = closure.compute(_write_lake(tmp_path, actions=drifted))


### PR DESCRIPTION
Closes #76.

## What is delivered

A new `janasunani/analytics` package, split the way `sams` splits `marts/` from `analysis/`:

- **`sql/`** — the **marts**: governed derived tables as portable SQL views. The SQL *is* the deliverable, so `marts.py` only locates and installs it. No mart's logic is duplicated in Python. It runs unmodified on our DuckDB lake and on the department's PostgreSQL.
- **`findings/`** — what goes in front of an audience: the aggregates, the reconciliation, and the Markdown fragment carrying each number's caveats.

`janasunani-closure-finding` runs the mart over the lake and writes the tables, the fragment and the SQL itself to `outputs/findings/`. `--print-sql` gives the handover artifact without touching data.

## Against the issue's checklist

| Done when | Where |
|---|---|
| View definition, tested, handed over | `janasunani/analytics/sql/closure.sql`, 17 fixture tests, `--print-sql` |
| Denominator stated **every time** | Both come out of one row of `closure_finding_summary`; `render_markdown` cannot emit one without the other, and a test asserts it |
| Conditioned on trajectory | `closure_by_trajectory` (action steps × elapsed days), carried on the base view rather than bolted on |
| Cases created and closed within two days, as their own figure | `closure_two_day_bare`, including the single-action-step subset |
| Overlap with `complaints.benefitted` checked | `closure_benefitted_overlap` |

The ⚠️ that the 61% is descriptive and never a failure rate is in the SQL header, the module docstring, the package README, and `DESCRIPTIVE_CAVEAT`, which the renderer emits unconditionally.

## Two things worth review

**It did not need #75 after all.** ROADMAP §5.6 A lists disposal-template labelling as gating this view, on the assumption the ladder had to come out of the top-500 pass. The ladder is six strings, already enumerated in §5.3, and the mart matches them directly. #75 still gates the other action-type work. I updated §5.3 to say so.

**Template drift is the failure mode.** An unmatched ladder string does not error, it moves complaints into `off_ladder` and silently shrinks the denominator the headline divides by. `check_ladder_coverage` warns below 50% (expect roughly two thirds) and `closure_off_ladder_templates` lists what stopped matching, bounded to strings used 1,000+ times so the free-text tail never surfaces.

The six template strings are reconstructed from the ROADMAP §5.3 table, where the shared prefix is elided as `…`. **Run the coverage check against the real lake before quoting anything** — that is the step that confirms them, and it is the one thing here I could not verify without lake access.

## Privacy

Reads `action_taken_remark` and structured `complaints` columns. **Never `complaints.grievance`**, which is why this needs no redaction pass, no dedup index, no gold set and no backlog slice. Asserted both statically over the SQL (comments and string literals stripped first, since the templates themselves contain the word) and behaviourally over a fixture lake that carries the column.

Every output is a count or a share. `closure_rung` and `closure_closing_action` are complaint-level and stay intermediate; a test asserts neither becomes an output file.

## Tests

`tests/test_closure_finding.py`, 17 tests, all against a hand-built fixture lake, never the real one. The fixture is arranged so the two denominators genuinely differ (50.0% of templated closures vs 37.5% of resolved), which is the collapse this finding is most exposed to.

Full suite: **550 passed, 14 skipped**.

## Not in this PR

The ED decision on whether the finding is shown on 14 August (DELIVERY.md Table 4) is still open. Per the issue, this is prepared either way.