### PR TITLE
docs(terraform): runbook for the stale admin_cidr lockout

### DIFF
--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -82,23 +82,42 @@ To unblock immediately without running an apply against production:
 ```bash
 NEW_CIDR="$(curl -4 -s ifconfig.me)/32"
 
-# Add first, verify, and only then remove the old rule. Doing it in this order
-# means a wrong CIDR cannot lock you out of the box.
+# Do this for EVERY Janasunani security group, not just the CPU box. gpu.tf
+# applies the same admin_cidr, so a GPU box that is up gets locked out too, and
+# a GPU box that is down keeps the stale rule waiting for whoever inherits that
+# address. Groups: sg-0321058ce58a24322 (cpu), sg-0356bbc5c5ff9f7c6 (gpu).
+GROUP=sg-0321058ce58a24322
+
+# Add first, verify, and only then remove the old rule. In this order a wrong
+# CIDR cannot lock you out.
 aws ec2 authorize-security-group-ingress --region ap-south-1 \
-  --group-id sg-0321058ce58a24322 \
+  --group-id "$GROUP" \
   --ip-permissions "IpProtocol=tcp,FromPort=22,ToPort=22,IpRanges=[{CidrIp=$NEW_CIDR,Description=\"SSH from the maintainer IP only\"}]"
 
-nc -z -w 8 52.66.116.80 22   # must succeed before the next step
+# If this fails, the address you just authorized is NOT the one your SSH
+# actually egresses from -- split-tunnel VPN, a proxy, or a wrong answer from
+# ifconfig.me. REVOKE IT before doing anything else: leaving it means an
+# unrelated address holds SSH access to a host with citizen data.
+if ! nc -z -w 8 52.66.116.80 22; then
+  aws ec2 revoke-security-group-ingress --region ap-south-1 \
+    --group-id "$GROUP" \
+    --ip-permissions "IpProtocol=tcp,FromPort=22,ToPort=22,IpRanges=[{CidrIp=$NEW_CIDR}]"
+  echo "wrong CIDR, revoked; find your real egress address before retrying" >&2
+  exit 1
+fi
 
+# Only now remove the stale rule.
 aws ec2 revoke-security-group-ingress --region ap-south-1 \
-  --group-id sg-0321058ce58a24322 \
+  --group-id "$GROUP" \
   --ip-permissions 'IpProtocol=tcp,FromPort=22,ToPort=22,IpRanges=[{CidrIp=<OLD_CIDR>}]'
 ```
 
 **Revoke the old rule; do not just leave it.** An address you have stopped using
 goes back to the ISP pool and gets handed to someone else, and until it is
-revoked that stranger has SSH exposure to a host holding citizen data. Sweep for
-leftovers across the account, since the GPU group carries the same CIDR:
+revoked that stranger has SSH exposure to a host holding citizen data.
+
+Then confirm the old CIDR is gone from **every** group in the account, not just
+the one you were working on:
 
 ```bash
 aws ec2 describe-security-groups --region ap-south-1 \
@@ -106,9 +125,21 @@ aws ec2 describe-security-groups --region ap-south-1 \
   --query 'SecurityGroups[].{Id:GroupId,Name:GroupName}'
 ```
 
-If a `terraform apply` is the route instead, **abort if the plan shows destroy or
-replace on `aws_instance.cpu_box` or `aws_security_group.cpu_box`.** A CIDR change
-is an in-place rule update; anything more than that is the line that loses the box.
+Anything this lists still needs the add/verify/revoke sequence above. It should
+return an empty list when you are done.
+
+### If you use `terraform apply` instead
+
+⚠️ **Check that no `Deploy demo` job is running first, and wait for it if one
+is.** The deploy workflow authorizes a temporary runner `/32` on
+`aws_security_group.cpu_box`; an apply reconciles that rule away and severs the
+SSH session executing `deploy.sh` mid-deploy, and a severed session can skip
+rollback. This collision is documented in
+[docs/DEPLOY.md](../../docs/DEPLOY.md) under the deploy-workflow hazards.
+
+**Abort if the plan shows destroy or replace on `aws_instance.cpu_box` or
+`aws_security_group.cpu_box`.** A CIDR change is an in-place rule update;
+anything more than that is the line that loses the box.
 
 Longer term this recurs by design. SSM Session Manager needs no inbound rule at
 all and is worth considering once the demo is past.

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -46,6 +46,73 @@ terraform plan
 terraform apply
 ```
 
+## When SSH to the box times out
+
+Almost always a stale `admin_cidr`, not a broken box. The security group allows
+SSH from one `/32`, so a new office, a new ISP or a DHCP lease change locks you
+out — and it fails as a **TCP timeout before any handshake**, which reads like a
+dead instance rather than a firewall.
+
+Diagnose in this order. The first two rule out the box itself:
+
+```bash
+# 1. Is the instance actually up, and is the IP still the one you think?
+aws ec2 describe-instances --region ap-south-1 \
+  --instance-ids i-0ef24e15a80ba7128 \
+  --query 'Reservations[].Instances[].{State:State.Name,PublicIp:PublicIpAddress}'
+
+# 2. What does the security group allow, and what is your IP now?
+aws ec2 describe-security-groups --region ap-south-1 \
+  --group-ids sg-0321058ce58a24322 \
+  --query 'SecurityGroups[].IpPermissions'
+curl -4 -s ifconfig.me      # -4 matters: plain curl returns IPv6 on some networks
+```
+
+If the instance is running on the expected IP and your address is not in the
+group, that is the whole diagnosis.
+
+### Fixing it
+
+Terraform is the source of truth — `admin_cidr` in `terraform.tfvars`, consumed
+by both the CPU and GPU security groups. Update it there **always**, so the next
+apply does not revoke whatever you did by hand.
+
+To unblock immediately without running an apply against production:
+
+```bash
+NEW_CIDR="$(curl -4 -s ifconfig.me)/32"
+
+# Add first, verify, and only then remove the old rule. Doing it in this order
+# means a wrong CIDR cannot lock you out of the box.
+aws ec2 authorize-security-group-ingress --region ap-south-1 \
+  --group-id sg-0321058ce58a24322 \
+  --ip-permissions "IpProtocol=tcp,FromPort=22,ToPort=22,IpRanges=[{CidrIp=$NEW_CIDR,Description=\"SSH from the maintainer IP only\"}]"
+
+nc -z -w 8 52.66.116.80 22   # must succeed before the next step
+
+aws ec2 revoke-security-group-ingress --region ap-south-1 \
+  --group-id sg-0321058ce58a24322 \
+  --ip-permissions 'IpProtocol=tcp,FromPort=22,ToPort=22,IpRanges=[{CidrIp=<OLD_CIDR>}]'
+```
+
+**Revoke the old rule; do not just leave it.** An address you have stopped using
+goes back to the ISP pool and gets handed to someone else, and until it is
+revoked that stranger has SSH exposure to a host holding citizen data. Sweep for
+leftovers across the account, since the GPU group carries the same CIDR:
+
+```bash
+aws ec2 describe-security-groups --region ap-south-1 \
+  --filters "Name=ip-permission.cidr,Values=<OLD_CIDR>" \
+  --query 'SecurityGroups[].{Id:GroupId,Name:GroupName}'
+```
+
+If a `terraform apply` is the route instead, **abort if the plan shows destroy or
+replace on `aws_instance.cpu_box` or `aws_security_group.cpu_box`.** A CIDR change
+is an in-place rule update; anything more than that is the line that loses the box.
+
+Longer term this recurs by design. SSM Session Manager needs no inbound rule at
+all and is worth considering once the demo is past.
+
 Then, following `docs/ROADMAP.md` (Week 1). The repo **and** its `dpic` dependency
 (pyproject.toml) are private, and the box holds no GitHub credential by design —
 connect with **SSH agent forwarding** (`-A`) so the clone and `uv sync` authenticate

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -73,9 +73,16 @@ Outputs: `public_ip`, `instance_id`, `ssh_command`, and (when the GPU box is up)
 `gpu_box_ip` / `gpu_ssh_command`.
 
 > **SSH times out later?** `admin_cidr` pins SSH to your IP, which rotates
-> (VPN on/off, ISP). Re-run `echo "$(curl -4 -s ifconfig.me)/32"`, update
-> `terraform.tfvars`, `terraform apply`. Use plain **`curl -4`** — bare curl may
-> return IPv6, which won't match the /32.
+> (VPN on/off, ISP), and the failure looks like a dead box: a TCP timeout
+> before any handshake. Use plain **`curl -4`** — bare curl may return IPv6,
+> which won't match the /32.
+>
+> **Do not reach for `terraform apply` first.** An apply during a running
+> `Deploy demo` job reconciles away CI's temporary runner rule and severs the
+> SSH session executing `deploy.sh`. Follow the add/verify/revoke procedure in
+> [deploy/terraform/README.md](../deploy/terraform/README.md#when-ssh-to-the-box-times-out),
+> which also covers revoking the stale rule from **every** group — leaving it
+> means whoever next receives that address has SSH access to citizen data.
 
 ## 2 · CPU box — first-time bring-up
 


### PR DESCRIPTION
SSH to the CPU box timed out tonight with the redaction backfill on the critical path. Cause was a changed maintainer IP.

## Why this needed writing down

It presents as a **TCP timeout before any handshake**, which reads like a dead instance rather than a firewall. The first instinct is to check whether the box is up, and the actual diagnosis takes three AWS queries. It also recurs by design — the group allows exactly one `/32`, so any new location breaks it.

## What was actually wrong

| | |
|---|---|
| Instance `i-0ef24e15a80ba7128` | **running**, `52.66.116.80`, t3.large — all fine |
| `sg-0321058ce58a24322` allowed | `106.202.96.145/32` |
| Current egress | `49.37.116.250/32` |

Different ISPs entirely, so not a DHCP lease change.

## Fixed

- Authorized the new CIDR on `sg-0321058ce58a24322`, verified port 22, **then** revoked the stale rule. That order matters: a wrong CIDR cannot lock you out if the old rule is still live when you test.
- Swept the account for the old CIDR and found it on `janasunani-gpu-box` (`sg-0356bbc5c5ff9f7c6`) too. Fixed there as well — no instance attached (`gpu_box_count = 0`), so no exposure today, but it would have allowlisted a stranger the moment that box is provisioned in week 2.
- `admin_cidr` updated in `terraform.tfvars` (gitignored, so not in this diff) so the next apply does not revoke the manual rules.
- Confirmed the old CIDR now appears in **zero** security groups in the account.

## The part worth arguing with

The runbook insists on **revoking** the old rule rather than leaving it as a harmless spare. A released address goes back to the ISP pool and is handed to someone else, and until it is revoked that stranger has SSH exposure to a host holding 1.37M citizen records. Leaving stale `/32`s accumulating is the failure mode here, not the inconvenience of re-adding one.

It also keeps the existing abort condition: a CIDR change is an in-place rule update, so a plan showing destroy or replace on `aws_instance.cpu_box` or `aws_security_group.cpu_box` is the signal to stop.

## Longer term

This will keep happening. SSM Session Manager needs no inbound rule at all and is worth considering once the demo is past — noted in the runbook rather than filed, since it is a post-14-August change.

**CI is down** (no Actions runs since 2026-08-06T19:47Z), so this is docs-only and unverified by CI. No code paths touched.