### PR TITLE
fix(makefile): harden dotenv parsing and Box path quoting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,11 +96,46 @@ API_URL        ?= http://127.0.0.1:$(API_PORT)
 # printed and read via `sh_quote`/OLTP_DB_URL_RAW below), so they get the
 # same safe *parsing* but no additional quoting machinery beyond what
 # `ingest`/`publish-raw`/`deliver`/`box-paths` already did before #60.
+#
+# Two more failures of this same "parse-time `uv run` call" shape, both
+# #114: first, this whole extraction requires `uv` to already be
+# resolvable, which is exactly what a fresh or broken checkout does not
+# have -- and `scripts/setup.sh`'s install_uv() (invoked by the `setup`
+# target below) is the documented mechanism that installs it. Requiring
+# `uv` to run *before* `setup` can even start is a bootstrap cycle: the
+# repair target can't run because the environment is unrepaired. So the
+# `ifneq (,$(wildcard .env))` block immediately below only runs when
+# `setup` is *not* among the requested goals (`$(MAKECMDGOALS)`, populated
+# by Make from the command line before any makefile is read); `setup`
+# itself never touches OLTP_DB_URL or the Box keys, so skipping the
+# extraction for it costs nothing. `$(MAKE) install-hooks`, which `setup`
+# shells out to once scripts/setup.sh has installed `uv` and run `uv
+# sync`, is a *separate* `make` invocation with its own `MAKECMDGOALS`
+# (`install-hooks`, not `setup`) and re-parses this file normally, by
+# which point `uv` and a synced `.venv` both exist.
+#
+# Second: even with `uv` resolvable, a bare `uv run` re-syncs the
+# environment against `pyproject.toml`/`uv.lock` on every invocation,
+# including re-fetching metadata for direct-URL dependencies (e.g. the
+# spaCy model wheel) even when nothing about them has changed -- so a
+# transient network hiccup during *that* resync turns this parse-time call
+# (which only ever needs `python-dotenv`, already sitting in an existing
+# `.venv`) into a multi-minute hang, which the `ifeq`/$(error) guards below
+# then escalate to a hard abort of *every* target, `help`/`status`/
+# `box-paths` included. `--no-sync` makes the call use whatever `.venv`
+# already has instead of resyncing it; `--offline` is defense in depth so
+# any residual network attempt fails immediately rather than hanging.
+# Verified with uv 0.7.18: together they resolve in well under a second
+# against an already-synced `.venv`, and fail fast (not hang) against an
+# unsynced one -- correctly, since "no python-dotenv available" is a
+# genuine parse failure and must still hit the hard $(error) below, not a
+# silent fallback.
 define dotenv_get
-$(shell PATH="$(USER_BIN):$$PATH" uv run python -c "from dotenv import dotenv_values; import sys; v = dotenv_values('.env').get('$(1)'); sys.stdout.write('DOTENV_OK:' + (v if v is not None else ''))" 2>$(_DOTENV_STDERR))
+$(shell PATH="$(USER_BIN):$$PATH" uv run --no-sync --offline python -c "from dotenv import dotenv_values; import sys; v = dotenv_values('.env').get('$(1)'); sys.stdout.write('DOTENV_OK:' + (v if v is not None else ''))" 2>$(_DOTENV_STDERR))
 endef
 _DOTENV_STDERR := /tmp/.janasunani-makefile-dotenv-stderr-$(shell whoami 2>/dev/null)
 ifneq (,$(wildcard .env))
+ifeq ($(filter setup,$(MAKECMDGOALS)),)
 _DOTENV_RAW_OLTP_DB_URL := $(call dotenv_get,OLTP_DB_URL)
 ifeq ($(findstring DOTENV_OK:,$(_DOTENV_RAW_OLTP_DB_URL)),)
 $(error .env exists but OLTP_DB_URL could not be parsed from it (#103) -- refusing to silently fall back to the throwaway demo default. 'uv run python' stderr: $(shell cat $(_DOTENV_STDERR) 2>/dev/null))
@@ -144,6 +179,7 @@ endif
 _DOTENV_EXHIBITS_REMOTE := $(subst DOTENV_OK:,,$(_DOTENV_RAW_EXHIBITS_REMOTE))
 ifneq (,$(_DOTENV_EXHIBITS_REMOTE))
 EXHIBITS_REMOTE := $(_DOTENV_EXHIBITS_REMOTE)
+endif
 endif
 endif
 # A fourth instance of the same bug class, in the one place the .env fix

--- a/Makefile
+++ b/Makefile
@@ -71,11 +71,13 @@ API_URL        ?= http://127.0.0.1:$(API_PORT)
 # change does not reach an immediately-following $(shell ...) in GNU Make).
 # Without this, a `uv` installed only under $(USER_BIN) -- the repo's own
 # documented install location -- would not resolve here even though every
-# recipe below finds it fine. Second, dotenv_get below always prints a
-# `DOTENV_OK:` prefix on success, even with an empty value, so a genuine
+# recipe below finds it fine. Second, dotenv_get below always records the
+# python call's exit status to `_DOTENV_STATUS` (a file, read back via
+# `dotenv_status` immediately after each call -- see #115 below for why
+# this lives on a file rather than in the value's own text), so a genuine
 # parse failure (uv still not found, python-dotenv missing, any other error)
-# is distinguishable from "this key is not set in .env" by that prefix's
-# *absence* -- never by empty output alone. A failure is a hard
+# is distinguishable from "this key is not set in .env" by that status --
+# never by the value's emptiness or content. A failure is a hard
 # `$(error ...)`, not a silent fallback: for OLTP_DB_URL specifically,
 # silently keeping the throwaway demo default while an operator's .env names
 # a real database is exactly the wrong outcome `make OLTP_DB_URL=... db`'s
@@ -130,55 +132,88 @@ API_URL        ?= http://127.0.0.1:$(API_PORT)
 # unsynced one -- correctly, since "no python-dotenv available" is a
 # genuine parse failure and must still hit the hard $(error) below, not a
 # silent fallback.
+#
+# A fifth failure, #115: dotenv_get used to signal success by prefixing its
+# stdout with a literal `DOTENV_OK:` marker, and each of the five call sites
+# below stripped it back off with a global `$(subst DOTENV_OK:,,$(raw))`.
+# `$(subst)` is unanchored, so a `.env` value that itself contained the
+# literal substring `DOTENV_OK:` anywhere -- e.g.
+# `BOX_PROJECT_ROOT=Archive/DOTENV_OK:2026` -- had *that* occurrence deleted
+# too, not just the sentinel this file had prepended, silently corrupting
+# the value `ingest`/`deliver` then used. Anchoring the strip instead
+# (`$(patsubst DOTENV_OK:%,%,$(raw))` or `$(filter DOTENV_OK:%,$(raw))`)
+# does not fix this: both are WHITESPACE-SPLITTING word operations -- they
+# split text into space-separated words, transform each word independently,
+# and rejoin with a single space -- so a value containing spaces (a
+# documented, supported case; BOX_PROJECT_ROOT's own default is "2.
+# Projects/21. Governance/") would come back with its internal spacing
+# collapsed or rewritten, sentinel collision or not.
+#
+# The fix carries the status on a channel separate from the value's text
+# instead of encoding it into that text at all: the compound shell command
+# in dotenv_get now writes the python call's exit status to `_DOTENV_STATUS`
+# (a small file, alongside the existing `_DOTENV_STDERR` capture) via a
+# trailing `echo $?` redirected to *that file*, never to stdout -- so what
+# `$(shell ...)` captures as dotenv_get's own expansion is exactly what
+# python wrote to its stdout: the bare value, untouched, never a prefix this
+# file has to strip back out. `dotenv_status` reads the status file back
+# with `$(shell cat ...)` -- GNU Make 3.81, what this repo runs, predates
+# both `$(.SHELLSTATUS)` (4.2) and `$(file ...)` (4.0), so shelling out to
+# `cat` is the only portable way to get it into a Make variable, the same
+# technique `_DOTENV_STDERR` already uses below to surface the error text.
+# Each `dotenv_status` reference must come immediately after its
+# corresponding `$(call dotenv_get,...)`, before anything else writes
+# `_DOTENV_STATUS` -- exactly how each block below sequences its
+# raw-value/status-check/assign lines. Verified against both an adversarial
+# case this bug missed (a value containing spaces) and the one it hit (a
+# value containing the literal `DOTENV_OK:` substring): both now round-trip
+# unchanged (tests/test_makefile_dotenv.py).
 define dotenv_get
-$(shell PATH="$(USER_BIN):$$PATH" uv run --no-sync --offline python -c "from dotenv import dotenv_values; import sys; v = dotenv_values('.env').get('$(1)'); sys.stdout.write('DOTENV_OK:' + (v if v is not None else ''))" 2>$(_DOTENV_STDERR))
+$(shell PATH="$(USER_BIN):$$PATH" uv run --no-sync --offline python -c "from dotenv import dotenv_values; import sys; v = dotenv_values('.env').get('$(1)'); sys.stdout.write(v if v is not None else '')" 2>$(_DOTENV_STDERR); echo $$? >$(_DOTENV_STATUS))
 endef
 _DOTENV_STDERR := /tmp/.janasunani-makefile-dotenv-stderr-$(shell whoami 2>/dev/null)
+_DOTENV_STATUS := /tmp/.janasunani-makefile-dotenv-status-$(shell whoami 2>/dev/null)
+dotenv_status = $(shell cat $(_DOTENV_STATUS) 2>/dev/null)
 ifneq (,$(wildcard .env))
 ifeq ($(filter setup,$(MAKECMDGOALS)),)
 _DOTENV_RAW_OLTP_DB_URL := $(call dotenv_get,OLTP_DB_URL)
-ifeq ($(findstring DOTENV_OK:,$(_DOTENV_RAW_OLTP_DB_URL)),)
+ifneq (0,$(dotenv_status))
 $(error .env exists but OLTP_DB_URL could not be parsed from it (#103) -- refusing to silently fall back to the throwaway demo default. 'uv run python' stderr: $(shell cat $(_DOTENV_STDERR) 2>/dev/null))
 endif
-_DOTENV_OLTP_DB_URL := $(subst DOTENV_OK:,,$(_DOTENV_RAW_OLTP_DB_URL))
-ifneq (,$(_DOTENV_OLTP_DB_URL))
-OLTP_DB_URL := $(_DOTENV_OLTP_DB_URL)
+ifneq (,$(_DOTENV_RAW_OLTP_DB_URL))
+OLTP_DB_URL := $(_DOTENV_RAW_OLTP_DB_URL)
 endif
 
 _DOTENV_RAW_BOX_REMOTE := $(call dotenv_get,BOX_REMOTE)
-ifeq ($(findstring DOTENV_OK:,$(_DOTENV_RAW_BOX_REMOTE)),)
+ifneq (0,$(dotenv_status))
 $(error .env exists but BOX_REMOTE could not be parsed from it (#104) -- refusing to silently fall back to the default. 'uv run python' stderr: $(shell cat $(_DOTENV_STDERR) 2>/dev/null))
 endif
-_DOTENV_BOX_REMOTE := $(subst DOTENV_OK:,,$(_DOTENV_RAW_BOX_REMOTE))
-ifneq (,$(_DOTENV_BOX_REMOTE))
-BOX_REMOTE := $(_DOTENV_BOX_REMOTE)
+ifneq (,$(_DOTENV_RAW_BOX_REMOTE))
+BOX_REMOTE := $(_DOTENV_RAW_BOX_REMOTE)
 endif
 
 _DOTENV_RAW_BOX_PROJECT_ROOT := $(call dotenv_get,BOX_PROJECT_ROOT)
-ifeq ($(findstring DOTENV_OK:,$(_DOTENV_RAW_BOX_PROJECT_ROOT)),)
+ifneq (0,$(dotenv_status))
 $(error .env exists but BOX_PROJECT_ROOT could not be parsed from it (#104) -- refusing to silently fall back to the default. 'uv run python' stderr: $(shell cat $(_DOTENV_STDERR) 2>/dev/null))
 endif
-_DOTENV_BOX_PROJECT_ROOT := $(subst DOTENV_OK:,,$(_DOTENV_RAW_BOX_PROJECT_ROOT))
-ifneq (,$(_DOTENV_BOX_PROJECT_ROOT))
-BOX_PROJECT_ROOT := $(_DOTENV_BOX_PROJECT_ROOT)
+ifneq (,$(_DOTENV_RAW_BOX_PROJECT_ROOT))
+BOX_PROJECT_ROOT := $(_DOTENV_RAW_BOX_PROJECT_ROOT)
 endif
 
 _DOTENV_RAW_INCOMING_REMOTE := $(call dotenv_get,INCOMING_REMOTE)
-ifeq ($(findstring DOTENV_OK:,$(_DOTENV_RAW_INCOMING_REMOTE)),)
+ifneq (0,$(dotenv_status))
 $(error .env exists but INCOMING_REMOTE could not be parsed from it (#104) -- refusing to silently fall back to the default. 'uv run python' stderr: $(shell cat $(_DOTENV_STDERR) 2>/dev/null))
 endif
-_DOTENV_INCOMING_REMOTE := $(subst DOTENV_OK:,,$(_DOTENV_RAW_INCOMING_REMOTE))
-ifneq (,$(_DOTENV_INCOMING_REMOTE))
-INCOMING_REMOTE := $(_DOTENV_INCOMING_REMOTE)
+ifneq (,$(_DOTENV_RAW_INCOMING_REMOTE))
+INCOMING_REMOTE := $(_DOTENV_RAW_INCOMING_REMOTE)
 endif
 
 _DOTENV_RAW_EXHIBITS_REMOTE := $(call dotenv_get,EXHIBITS_REMOTE)
-ifeq ($(findstring DOTENV_OK:,$(_DOTENV_RAW_EXHIBITS_REMOTE)),)
+ifneq (0,$(dotenv_status))
 $(error .env exists but EXHIBITS_REMOTE could not be parsed from it (#104) -- refusing to silently fall back to the default. 'uv run python' stderr: $(shell cat $(_DOTENV_STDERR) 2>/dev/null))
 endif
-_DOTENV_EXHIBITS_REMOTE := $(subst DOTENV_OK:,,$(_DOTENV_RAW_EXHIBITS_REMOTE))
-ifneq (,$(_DOTENV_EXHIBITS_REMOTE))
-EXHIBITS_REMOTE := $(_DOTENV_EXHIBITS_REMOTE)
+ifneq (,$(_DOTENV_RAW_EXHIBITS_REMOTE))
+EXHIBITS_REMOTE := $(_DOTENV_RAW_EXHIBITS_REMOTE)
 endif
 endif
 endif

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,28 @@ BOX_REMOTE     ?= box
 BOX_PROJECT_ROOT ?= 2. Projects/21. Governance/
 RAW_LOCAL      ?= data/raw/
 EXHIBITS_LOCAL ?= outputs/
-INCOMING_REMOTE ?= $(BOX_REMOTE):'$(BOX_PROJECT_ROOT)/Data/Raw/'
-EXHIBITS_REMOTE ?= $(BOX_REMOTE):'$(BOX_PROJECT_ROOT)/Analysis/Exhibits/'
+# No embedded quotes here (#118): quoting a Box endpoint at *definition* time
+# only protects the literal text of this default -- it does nothing for an
+# operator's own INCOMING_REMOTE/EXHIBITS_REMOTE override (.env or command
+# line), which reaches this variable already stripped of whatever dotenv/shell
+# quoting it was written with (that is what dotenv quoting means: the outer
+# quotes mark where the value ends, they are not part of it). A value that
+# then contains spaces -- BOX_PROJECT_ROOT's own default does, and README.md
+# documents overriding the full endpoint the same way -- reaches an unquoted
+# recipe position and the shell word-splits it. The quoting has to happen
+# where the value meets that shell word boundary -- the
+# ingest/publish-raw/deliver recipes below -- via sh_quote, not here.
+#
+# References BOX_REMOTE_RAW/BOX_PROJECT_ROOT_RAW (defined further down, after
+# the .env extraction) rather than the plain BOX_REMOTE/BOX_PROJECT_ROOT.
+# Forward-referencing them is fine: `?=` makes this a recursively-expanded
+# variable, and Make does not evaluate a recursive variable's text until
+# something references it, by which point the whole file -- BOX_REMOTE_RAW
+# included -- has been parsed. Using the _RAW forms instead of the plain ones
+# matters even here, in the *unset*-default case: see the block that defines
+# them below for why.
+INCOMING_REMOTE ?= $(BOX_REMOTE_RAW):$(BOX_PROJECT_ROOT_RAW)/Data/Raw/
+EXHIBITS_REMOTE ?= $(BOX_REMOTE_RAW):$(BOX_PROJECT_ROOT_RAW)/Analysis/Exhibits/
 # Live-demo stack (see docs/DEMO.md). Throwaway Postgres only — never the prod
 # volume, never the :5433 pytest-fixture DB.
 PG_CONTAINER   ?= janasunani-demo-oltp
@@ -253,6 +273,81 @@ OLTP_DB_URL_RAW := $(value OLTP_DB_URL)
 else
 OLTP_DB_URL_RAW := $(OLTP_DB_URL)
 endif
+# #118: BOX_REMOTE, BOX_PROJECT_ROOT, INCOMING_REMOTE and EXHIBITS_REMOTE need
+# the same treatment as OLTP_DB_URL_RAW above, for the same reason -- a
+# command-line (`make BOX_REMOTE=... ingest`) or shell-exported value is
+# stored recursively expanded, so a later reference (including from inside
+# sh_quote's $(subst ...), which #118 adds to ingest/publish-raw/deliver
+# below) re-scans it for `$`/`$(...)`. None of these four are secrets/
+# generated passwords like OLTP_DB_URL, so a literal `$` in one is a lower-
+# probability trap, but it is the identical mechanism, and this file's own
+# history (#60, #103, #114, #115) is that leaving one instance of this bug
+# class unfixed while fixing the others is exactly how it keeps coming back
+# -- so it gets the same fix here, not a note deferring it (verified in
+# tests/test_makefile_dotenv.py).
+#
+# INCOMING_REMOTE and EXHIBITS_REMOTE derive from BOX_REMOTE/BOX_PROJECT_ROOT
+# by default (see the `?=` lines at the top of this file), so their _RAW
+# variants below are written in terms of BOX_REMOTE_RAW/BOX_PROJECT_ROOT_RAW,
+# not the plain BOX_REMOTE/BOX_PROJECT_ROOT: in the "still at its default"
+# case, $(INCOMING_REMOTE) re-expands whatever BOX_REMOTE currently means, and
+# if BOX_REMOTE_RAW were skipped that reference would reintroduce this same
+# bug one level down, inside a value this block exists to make safe. Both the
+# still-default case and the .env-override case (INCOMING_REMOTE reassigned
+# via `:=` above, already a simply-expanded/frozen string by this point) land
+# in the same "file origin" branch below and are both safe to expand
+# normally: the default's template only references the frozen _RAW leaves,
+# and the .env value is already frozen text with nothing left to re-scan --
+# see the dotenv_get comment block's #115 section for why a `:=` chain does
+# not itself re-trigger this.
+ifeq ($(origin BOX_REMOTE),command line)
+BOX_REMOTE_RAW := $(value BOX_REMOTE)
+else ifeq ($(origin BOX_REMOTE),environment)
+BOX_REMOTE_RAW := $(value BOX_REMOTE)
+else ifeq ($(origin BOX_REMOTE),environment override)
+BOX_REMOTE_RAW := $(value BOX_REMOTE)
+else
+BOX_REMOTE_RAW := $(BOX_REMOTE)
+endif
+
+ifeq ($(origin BOX_PROJECT_ROOT),command line)
+BOX_PROJECT_ROOT_RAW := $(value BOX_PROJECT_ROOT)
+else ifeq ($(origin BOX_PROJECT_ROOT),environment)
+BOX_PROJECT_ROOT_RAW := $(value BOX_PROJECT_ROOT)
+else ifeq ($(origin BOX_PROJECT_ROOT),environment override)
+BOX_PROJECT_ROOT_RAW := $(value BOX_PROJECT_ROOT)
+else
+BOX_PROJECT_ROOT_RAW := $(BOX_PROJECT_ROOT)
+endif
+
+ifeq ($(origin INCOMING_REMOTE),command line)
+INCOMING_REMOTE_RAW := $(value INCOMING_REMOTE)
+else ifeq ($(origin INCOMING_REMOTE),environment)
+INCOMING_REMOTE_RAW := $(value INCOMING_REMOTE)
+else ifeq ($(origin INCOMING_REMOTE),environment override)
+INCOMING_REMOTE_RAW := $(value INCOMING_REMOTE)
+else
+INCOMING_REMOTE_RAW := $(INCOMING_REMOTE)
+endif
+
+ifeq ($(origin EXHIBITS_REMOTE),command line)
+EXHIBITS_REMOTE_RAW := $(value EXHIBITS_REMOTE)
+else ifeq ($(origin EXHIBITS_REMOTE),environment)
+EXHIBITS_REMOTE_RAW := $(value EXHIBITS_REMOTE)
+else ifeq ($(origin EXHIBITS_REMOTE),environment override)
+EXHIBITS_REMOTE_RAW := $(value EXHIBITS_REMOTE)
+else
+EXHIBITS_REMOTE_RAW := $(EXHIBITS_REMOTE)
+endif
+# RAW_LOCAL/EXHIBITS_LOCAL (below, at the ingest/publish-raw/deliver recipes)
+# get sh_quote at the recipe boundary too -- a local path can contain spaces
+# just as easily as a Box one -- but not this _RAW/$(origin ...) treatment:
+# neither is ever populated from .env (they are plain local-directory `?=`
+# defaults, not part of the dotenv_get extraction above), so the only way
+# either becomes a recursively-expanded value with attacker-shaped content is
+# an operator directly typing `make RAW_LOCAL='...'`, a much narrower path
+# than the four keys above (which a shared team .env or a copy-pasted Box URL
+# routinely populates).
 # Embeds an arbitrary value (e.g. $(OLTP_DB_URL_RAW)) as a single shell word
 # safe from further expansion: single-quoted, with each embedded `'` replaced
 # by `'\''` (close the quote, an escaped literal quote outside it, reopen the
@@ -262,7 +357,12 @@ endif
 # closes that gap. Use as `$(call sh_quote,$(OLTP_DB_URL_RAW))` -- already
 # quoted, so call sites do not wrap it in quotes themselves, and always via
 # OLTP_DB_URL_RAW, never the plain $(OLTP_DB_URL) reference, per the origin
-# note above.
+# note above. #118 reuses this same macro for INCOMING_REMOTE_RAW/
+# EXHIBITS_REMOTE_RAW/RAW_LOCAL/EXHIBITS_LOCAL at the ingest/publish-raw/
+# deliver recipes below -- a Box endpoint or local path needs exactly the same
+# single-shell-word guarantee a DSN does, just against spaces (BOX_PROJECT_
+# ROOT's own default has one: "2. Projects/21. Governance/") rather than a
+# generated password's character set.
 sh_quote = '$(subst ','\'',$(1))'
 SHELL          := /bin/bash
 .SHELLFLAGS    := -euo pipefail -c
@@ -317,14 +417,19 @@ pull: _check_git_clean
 	uv run dvc pull
 	@echo "Done."
 
+# #118: both endpoints go through sh_quote so a space-bearing value -- the
+# default BOX_PROJECT_ROOT ("2. Projects/21. Governance/") is the normal
+# case here, not an exotic one -- reaches rclone as one argument instead of
+# being word-split by the shell. INCOMING_REMOTE_RAW, never the plain
+# $(INCOMING_REMOTE), per the origin note above its definition.
 ingest:
 	@echo "Copying all original source files from Box..."
-	rclone copy $(INCOMING_REMOTE) $(RAW_LOCAL) --progress
+	rclone copy $(call sh_quote,$(INCOMING_REMOTE_RAW)) $(call sh_quote,$(RAW_LOCAL)) --progress
 	@echo "Ingested raw data. The original Box files were not modified."
 
 publish-raw:
 	@echo "Publishing all local raw files to Box..."
-	rclone copy $(RAW_LOCAL) $(INCOMING_REMOTE) --progress
+	rclone copy $(call sh_quote,$(RAW_LOCAL)) $(call sh_quote,$(INCOMING_REMOTE_RAW)) --progress
 	@echo "Published raw data. Existing Box files with other names were not deleted."
 
 push: _check_git_clean
@@ -348,9 +453,10 @@ exhibits:
 	uv run dvc repro
 	@echo "Pipeline complete. Check outputs/ for regenerated exhibits."
 
+# #118: sh_quote for the same reason as ingest/publish-raw above.
 deliver:
 	@echo "Delivering exhibits to Box..."
-	rclone copy $(EXHIBITS_LOCAL) $(EXHIBITS_REMOTE) --progress
+	rclone copy $(call sh_quote,$(EXHIBITS_LOCAL)) $(call sh_quote,$(EXHIBITS_REMOTE_RAW)) --progress
 	@echo "Exhibits delivered. Existing Box files were not deleted."
 
 .PHONY: docs docs-clean infra status
@@ -369,13 +475,17 @@ docs/%.docx: docs/%.md scripts/md_to_docx.py
 docs-clean:
 	rm -f $(DOC_TARGETS)
 
+# The _RAW forms so this echoes exactly what ingest/publish-raw/deliver
+# actually use (see the #118 block above) rather than the plain variable,
+# which -- for a command-line/environment-origin value containing `$` -- can
+# differ from it (the plain reference re-scans; the _RAW one does not).
 box-paths:
-	@echo "BOX_REMOTE=$(BOX_REMOTE)"
-	@echo "BOX_PROJECT_ROOT=$(BOX_PROJECT_ROOT)"
+	@echo "BOX_REMOTE=$(BOX_REMOTE_RAW)"
+	@echo "BOX_PROJECT_ROOT=$(BOX_PROJECT_ROOT_RAW)"
 	@echo "RAW_LOCAL=$(RAW_LOCAL)"
 	@echo "EXHIBITS_LOCAL=$(EXHIBITS_LOCAL)"
-	@echo "INCOMING_REMOTE=$(INCOMING_REMOTE)"
-	@echo "EXHIBITS_REMOTE=$(EXHIBITS_REMOTE)"
+	@echo "INCOMING_REMOTE=$(INCOMING_REMOTE_RAW)"
+	@echo "EXHIBITS_REMOTE=$(EXHIBITS_REMOTE_RAW)"
 
 
 # Read-only pass over the cloud infra (EC2 boxes, SSH exposure, disk,

--- a/Makefile
+++ b/Makefile
@@ -127,10 +127,13 @@ API_URL        ?= http://127.0.0.1:$(API_PORT)
 # `uv` to run *before* `setup` can even start is a bootstrap cycle: the
 # repair target can't run because the environment is unrepaired. So the
 # `ifneq (,$(wildcard .env))` block immediately below only runs when
-# `setup` is *not* among the requested goals (`$(MAKECMDGOALS)`, populated
+# the only requested goal is `setup` (`$(MAKECMDGOALS)`, populated
 # by Make from the command line before any makefile is read); `setup`
 # itself never touches OLTP_DB_URL, BOX_PROJECT_ROOT, INCOMING_REMOTE or
 # EXHIBITS_REMOTE, so skipping the extraction for those four costs nothing.
+# This must be exact: `make setup publish-raw` needs normal extraction before
+# it can publish, and must never use default Box paths merely because setup is
+# another requested goal.
 # BOX_REMOTE is the one exception -- `setup`'s own recipe below passes it to
 # scripts/setup.sh's ensure_box_remote -- and a uv-free guard right after
 # this block's `endif endif` handles that one case on its own (a Codex
@@ -193,17 +196,26 @@ API_URL        ?= http://127.0.0.1:$(API_PORT)
 # case this bug missed (a value containing spaces) and the one it hit (a
 # value containing the literal `DOTENV_OK:` substring): both now round-trip
 # unchanged (tests/test_makefile_dotenv.py).
+ifneq (,$(wildcard .env))
+ifneq ($(MAKECMDGOALS),setup)
+# A username-global status file races when two make processes parse different
+# .env files at once.  Use a private directory per invocation instead.
+# `mktemp -d` and `umask` work on GNU Make 3.81's supported macOS/Linux hosts,
+# unlike newer-Make-only .SHELLSTATUS and $(file).
+_DOTENV_TMPDIR := $(shell umask 077 && mktemp -d /tmp/janasunani-makefile-dotenv.XXXXXXXX 2>/dev/null)
+ifeq (,$(_DOTENV_TMPDIR))
+$(error could not create a private temporary directory for .env parsing)
+endif
+_DOTENV_STDERR := $(_DOTENV_TMPDIR)/stderr
+_DOTENV_STATUS := $(_DOTENV_TMPDIR)/status
 define dotenv_get
 $(shell PATH="$(USER_BIN):$$PATH" uv run --no-sync --offline python -c "from dotenv import dotenv_values; import sys; v = dotenv_values('.env').get('$(1)'); sys.stdout.write(v if v is not None else '')" 2>$(_DOTENV_STDERR); echo $$? >$(_DOTENV_STATUS))
 endef
-_DOTENV_STDERR := /tmp/.janasunani-makefile-dotenv-stderr-$(shell whoami 2>/dev/null)
-_DOTENV_STATUS := /tmp/.janasunani-makefile-dotenv-status-$(shell whoami 2>/dev/null)
-dotenv_status = $(shell cat $(_DOTENV_STATUS) 2>/dev/null)
-ifneq (,$(wildcard .env))
-ifeq ($(filter setup,$(MAKECMDGOALS)),)
+dotenv_status = $(shell cat $(_DOTENV_STATUS) 2>/dev/null; rm -f $(_DOTENV_STATUS))
+dotenv_cleanup = $(shell rm -f $(_DOTENV_STATUS) $(_DOTENV_STDERR); rmdir $(_DOTENV_TMPDIR) 2>/dev/null || true)
 _DOTENV_RAW_OLTP_DB_URL := $(call dotenv_get,OLTP_DB_URL)
 ifneq (0,$(dotenv_status))
-$(error .env exists but OLTP_DB_URL could not be parsed from it (#103) -- refusing to silently fall back to the throwaway demo default. 'uv run python' stderr: $(shell cat $(_DOTENV_STDERR) 2>/dev/null))
+$(error .env exists but OLTP_DB_URL could not be parsed from it (#103) -- refusing to silently fall back to the throwaway demo default. 'uv run python' stderr: $(shell cat $(_DOTENV_STDERR) 2>/dev/null)$(dotenv_cleanup))
 endif
 ifneq (,$(_DOTENV_RAW_OLTP_DB_URL))
 OLTP_DB_URL := $(_DOTENV_RAW_OLTP_DB_URL)
@@ -211,7 +223,7 @@ endif
 
 _DOTENV_RAW_BOX_REMOTE := $(call dotenv_get,BOX_REMOTE)
 ifneq (0,$(dotenv_status))
-$(error .env exists but BOX_REMOTE could not be parsed from it (#104) -- refusing to silently fall back to the default. 'uv run python' stderr: $(shell cat $(_DOTENV_STDERR) 2>/dev/null))
+$(error .env exists but BOX_REMOTE could not be parsed from it (#104) -- refusing to silently fall back to the default. 'uv run python' stderr: $(shell cat $(_DOTENV_STDERR) 2>/dev/null)$(dotenv_cleanup))
 endif
 ifneq (,$(_DOTENV_RAW_BOX_REMOTE))
 BOX_REMOTE := $(_DOTENV_RAW_BOX_REMOTE)
@@ -219,7 +231,7 @@ endif
 
 _DOTENV_RAW_BOX_PROJECT_ROOT := $(call dotenv_get,BOX_PROJECT_ROOT)
 ifneq (0,$(dotenv_status))
-$(error .env exists but BOX_PROJECT_ROOT could not be parsed from it (#104) -- refusing to silently fall back to the default. 'uv run python' stderr: $(shell cat $(_DOTENV_STDERR) 2>/dev/null))
+$(error .env exists but BOX_PROJECT_ROOT could not be parsed from it (#104) -- refusing to silently fall back to the default. 'uv run python' stderr: $(shell cat $(_DOTENV_STDERR) 2>/dev/null)$(dotenv_cleanup))
 endif
 ifneq (,$(_DOTENV_RAW_BOX_PROJECT_ROOT))
 BOX_PROJECT_ROOT := $(_DOTENV_RAW_BOX_PROJECT_ROOT)
@@ -227,7 +239,7 @@ endif
 
 _DOTENV_RAW_INCOMING_REMOTE := $(call dotenv_get,INCOMING_REMOTE)
 ifneq (0,$(dotenv_status))
-$(error .env exists but INCOMING_REMOTE could not be parsed from it (#104) -- refusing to silently fall back to the default. 'uv run python' stderr: $(shell cat $(_DOTENV_STDERR) 2>/dev/null))
+$(error .env exists but INCOMING_REMOTE could not be parsed from it (#104) -- refusing to silently fall back to the default. 'uv run python' stderr: $(shell cat $(_DOTENV_STDERR) 2>/dev/null)$(dotenv_cleanup))
 endif
 ifneq (,$(_DOTENV_RAW_INCOMING_REMOTE))
 INCOMING_REMOTE := $(_DOTENV_RAW_INCOMING_REMOTE)
@@ -235,11 +247,12 @@ endif
 
 _DOTENV_RAW_EXHIBITS_REMOTE := $(call dotenv_get,EXHIBITS_REMOTE)
 ifneq (0,$(dotenv_status))
-$(error .env exists but EXHIBITS_REMOTE could not be parsed from it (#104) -- refusing to silently fall back to the default. 'uv run python' stderr: $(shell cat $(_DOTENV_STDERR) 2>/dev/null))
+$(error .env exists but EXHIBITS_REMOTE could not be parsed from it (#104) -- refusing to silently fall back to the default. 'uv run python' stderr: $(shell cat $(_DOTENV_STDERR) 2>/dev/null)$(dotenv_cleanup))
 endif
 ifneq (,$(_DOTENV_RAW_EXHIBITS_REMOTE))
 EXHIBITS_REMOTE := $(_DOTENV_RAW_EXHIBITS_REMOTE)
 endif
+$(dotenv_cleanup)
 endif
 endif
 # Codex on #138 (finding 2): `setup`'s own recipe below still does
@@ -286,7 +299,7 @@ endif
 # BOX_REMOTE the normal Make way with no .env parsing involved, which is
 # exactly what `$(origin BOX_REMOTE)` being anything other than `file`
 # below detects, and always wins over whatever .env says.
-ifneq (,$(filter setup,$(MAKECMDGOALS)))
+ifeq ($(MAKECMDGOALS),setup)
 ifeq ($(origin BOX_REMOTE),file)
 ifneq (,$(wildcard .env))
 _SETUP_BOX_REMOTE_DOTENV_LINES := $(shell grep -Ec '^[[:space:]]*(export[[:space:]]+)?BOX_REMOTE[[:space:]]*=' .env 2>/dev/null)
@@ -505,7 +518,7 @@ sh_quote = '$(subst ','\'',$(1))'
 # BOX_PROJECT_ROOT alone -- so only INCOMING_REMOTE/EXHIBITS_REMOTE need
 # this check.
 is_legacy_quoted_endpoint = $(strip $(shell printf '%s' $(call sh_quote,$(1)) | grep -Eq "^[^:]*:'.*'$$" && printf yes))
-ifeq ($(filter setup,$(MAKECMDGOALS)),)
+ifneq ($(MAKECMDGOALS),setup)
 ifneq (,$(call is_legacy_quoted_endpoint,$(INCOMING_REMOTE_RAW)))
 $(error INCOMING_REMOTE=$(INCOMING_REMOTE_RAW) still uses the old hand-quoted form (box:'Custom/Path/') that README used to recommend. Remove the surrounding quote marks and write the bare value instead (e.g. INCOMING_REMOTE=box:Custom/Path/) -- ingest/publish-raw already quote it for you at the point they hand it to rclone (#118), so the hand-quoting no longer means what it used to and would silently target the wrong Box path)
 endif
@@ -545,7 +558,7 @@ help:
 
 setup:
 	perl -pi -e 's/\r$$//' scripts/setup.sh
-	BOX_REMOTE="$(BOX_REMOTE)" bash scripts/setup.sh
+	BOX_REMOTE=$(call sh_quote,$(BOX_REMOTE_RAW)) bash scripts/setup.sh
 	$(MAKE) install-hooks
 
 install-hooks:

--- a/Makefile
+++ b/Makefile
@@ -129,8 +129,13 @@ API_URL        ?= http://127.0.0.1:$(API_PORT)
 # `ifneq (,$(wildcard .env))` block immediately below only runs when
 # `setup` is *not* among the requested goals (`$(MAKECMDGOALS)`, populated
 # by Make from the command line before any makefile is read); `setup`
-# itself never touches OLTP_DB_URL or the Box keys, so skipping the
-# extraction for it costs nothing. `$(MAKE) install-hooks`, which `setup`
+# itself never touches OLTP_DB_URL, BOX_PROJECT_ROOT, INCOMING_REMOTE or
+# EXHIBITS_REMOTE, so skipping the extraction for those four costs nothing.
+# BOX_REMOTE is the one exception -- `setup`'s own recipe below passes it to
+# scripts/setup.sh's ensure_box_remote -- and a uv-free guard right after
+# this block's `endif endif` handles that one case on its own (a Codex
+# finding on #138 caught this extraction skipping it silently). `$(MAKE)
+# install-hooks`, which `setup`
 # shells out to once scripts/setup.sh has installed `uv` and run `uv
 # sync`, is a *separate* `make` invocation with its own `MAKECMDGOALS`
 # (`install-hooks`, not `setup`) and re-parses this file normally, by
@@ -237,6 +242,72 @@ EXHIBITS_REMOTE := $(_DOTENV_RAW_EXHIBITS_REMOTE)
 endif
 endif
 endif
+# Codex on #138 (finding 2): `setup`'s own recipe below still does
+# `BOX_REMOTE="$(BOX_REMOTE)" bash scripts/setup.sh`, and scripts/setup.sh's
+# ensure_box_remote uses that to select or create the rclone remote -- so
+# the bypass above, which is correct for the four keys the .env block
+# extracts, silently starves `setup` of a .env-only BOX_REMOTE and lets it
+# configure the wrong (or a needless extra) rclone remote instead.
+#
+# The fix cannot just run the .env extraction for BOX_REMOTE anyway: that
+# extraction's whole reason for existing here is `uv run python-dotenv`,
+# and `uv` is exactly what may not be resolvable yet at this point in a
+# fresh checkout (#114's bootstrap cycle again, one key narrower).
+#
+# A first pass here just detected the key's presence and hard-failed
+# unconditionally -- but #114 exists precisely so `setup` (the
+# install/repair target) stays runnable when the environment is broken,
+# and turning *every* .env-configured BOX_REMOTE into a hard stop put a
+# new failure on that exact path: an operator recovering a broken checkout
+# now had to open .env, read the value, and retype it on the command line
+# before `setup` would run at all, for the common case where the value was
+# perfectly safe to use directly.
+#
+# rclone remote names are simple identifiers in practice -- there is
+# nothing for python-dotenv's quoting/escaping/comment rules to interpret
+# differently about a value matching `^[A-Za-z0-9_-]+:?$` (no whitespace,
+# no quotes, no `$`, no `#`, no backslash: none of the characters dotenv
+# treats specially). That pattern is deliberately narrower than what
+# dotenv accepts as a whole -- it is not attempting to reproduce dotenv's
+# rules, only to recognize the subset of inputs for which dotenv's rules
+# are a no-op. So a value of that shape is read with a bare `grep`/`sed`
+# and passed straight through; this is still not a second dotenv parser
+# and cannot drift from one, because there is nothing for it to
+# potentially parse differently -- unlike the #60-class bugs this file has
+# already been bitten by four times, which all involved dotenv's real
+# quoting/escaping/comment handling. Anything outside that narrow shape
+# (quoted, containing `$`/`#`/whitespace/a backslash, or more than one
+# `BOX_REMOTE=` line in .env) is exactly where dotenv's rules genuinely
+# matter and guessing would repeat #60's mistake, so that still hits the
+# loud $(error) below rather than being silently misread.
+#
+# A command-line/environment override (`make setup BOX_REMOTE=...`,
+# already README's documented workaround) needs none of this: it reaches
+# BOX_REMOTE the normal Make way with no .env parsing involved, which is
+# exactly what `$(origin BOX_REMOTE)` being anything other than `file`
+# below detects, and always wins over whatever .env says.
+ifneq (,$(filter setup,$(MAKECMDGOALS)))
+ifeq ($(origin BOX_REMOTE),file)
+ifneq (,$(wildcard .env))
+_SETUP_BOX_REMOTE_DOTENV_LINES := $(shell grep -Ec '^[[:space:]]*(export[[:space:]]+)?BOX_REMOTE[[:space:]]*=' .env 2>/dev/null)
+ifeq (1,$(_SETUP_BOX_REMOTE_DOTENV_LINES))
+# Exactly one candidate line: strip the `[export ]BOX_REMOTE=` prefix and
+# keep the remainder only if it is the whole line (`grep -x`) and matches
+# the narrow safe-identifier pattern above -- anything left over (a
+# quote, a space, a `$`, a trailing comment) means this is empty and the
+# ifneq below falls through to the loud error.
+_SETUP_BOX_REMOTE_SAFE_VALUE := $(shell grep -E '^[[:space:]]*(export[[:space:]]+)?BOX_REMOTE[[:space:]]*=' .env | sed -E 's/^[[:space:]]*(export[[:space:]]+)?BOX_REMOTE[[:space:]]*=//' | grep -Ex '[A-Za-z0-9_-]+:?')
+ifneq (,$(_SETUP_BOX_REMOTE_SAFE_VALUE))
+BOX_REMOTE := $(_SETUP_BOX_REMOTE_SAFE_VALUE)
+else
+$(error .env sets BOX_REMOTE, but not to a value 'make setup' can safely read without uv (not installed yet -- #114) -- it must be a bare identifier with no quotes, spaces, '$$', '#', or backslash (e.g. BOX_REMOTE=mybox). Re-run with the value on the command line instead: make setup BOX_REMOTE=<value from .env>)
+endif
+else ifneq (0,$(_SETUP_BOX_REMOTE_DOTENV_LINES))
+$(error .env sets BOX_REMOTE more than once -- 'make setup' cannot safely pick one without uv (not installed yet -- #114). Re-run with the intended value on the command line instead: make setup BOX_REMOTE=<value>)
+endif
+endif
+endif
+endif
 # A fourth instance of the same bug class, in the one place the .env fix
 # above does not reach: OLTP_DB_URL from `make OLTP_DB_URL=...` (command
 # line) or a shell-exported OLTP_DB_URL is stored by Make as a *recursively*
@@ -339,15 +410,41 @@ EXHIBITS_REMOTE_RAW := $(value EXHIBITS_REMOTE)
 else
 EXHIBITS_REMOTE_RAW := $(EXHIBITS_REMOTE)
 endif
-# RAW_LOCAL/EXHIBITS_LOCAL (below, at the ingest/publish-raw/deliver recipes)
-# get sh_quote at the recipe boundary too -- a local path can contain spaces
-# just as easily as a Box one -- but not this _RAW/$(origin ...) treatment:
+# RAW_LOCAL/EXHIBITS_LOCAL get this same _RAW/$(origin ...) treatment too,
+# as of Codex on #138 (finding 3): they were exempted originally because
 # neither is ever populated from .env (they are plain local-directory `?=`
 # defaults, not part of the dotenv_get extraction above), so the only way
-# either becomes a recursively-expanded value with attacker-shaped content is
-# an operator directly typing `make RAW_LOCAL='...'`, a much narrower path
-# than the four keys above (which a shared team .env or a copy-pasted Box URL
-# routinely populates).
+# either becomes a recursively-expanded value with attacker-shaped content
+# was thought to be an operator directly typing `make RAW_LOCAL='...'` -- a
+# narrower path than the four keys above, but not a nonexistent one, and
+# the #138 box-paths fix below exposed it directly: fixing box-paths'
+# display bug for a command-line RAW_LOCAL containing `$` surfaced that
+# `$(call sh_quote,$(RAW_LOCAL))` in ingest/publish-raw/deliver already had
+# the identical bug one layer down -- `$(RAW_LOCAL)` is a plain reference,
+# so a command-line-origin value gets re-scanned for `$`/`$(...)` inside
+# sh_quote's own $(subst ...) expansion, the same #60/#103/#118 bug class,
+# just never fixed for these two. Verified directly: `make
+# RAW_LOCAL='data$raw/' ingest` silently truncated to `dataaw/` before this
+# fix (tests/test_makefile_dotenv.py).
+ifeq ($(origin RAW_LOCAL),command line)
+RAW_LOCAL_RAW := $(value RAW_LOCAL)
+else ifeq ($(origin RAW_LOCAL),environment)
+RAW_LOCAL_RAW := $(value RAW_LOCAL)
+else ifeq ($(origin RAW_LOCAL),environment override)
+RAW_LOCAL_RAW := $(value RAW_LOCAL)
+else
+RAW_LOCAL_RAW := $(RAW_LOCAL)
+endif
+
+ifeq ($(origin EXHIBITS_LOCAL),command line)
+EXHIBITS_LOCAL_RAW := $(value EXHIBITS_LOCAL)
+else ifeq ($(origin EXHIBITS_LOCAL),environment)
+EXHIBITS_LOCAL_RAW := $(value EXHIBITS_LOCAL)
+else ifeq ($(origin EXHIBITS_LOCAL),environment override)
+EXHIBITS_LOCAL_RAW := $(value EXHIBITS_LOCAL)
+else
+EXHIBITS_LOCAL_RAW := $(EXHIBITS_LOCAL)
+endif
 # Embeds an arbitrary value (e.g. $(OLTP_DB_URL_RAW)) as a single shell word
 # safe from further expansion: single-quoted, with each embedded `'` replaced
 # by `'\''` (close the quote, an escaped literal quote outside it, reopen the
@@ -358,12 +455,64 @@ endif
 # quoted, so call sites do not wrap it in quotes themselves, and always via
 # OLTP_DB_URL_RAW, never the plain $(OLTP_DB_URL) reference, per the origin
 # note above. #118 reuses this same macro for INCOMING_REMOTE_RAW/
-# EXHIBITS_REMOTE_RAW/RAW_LOCAL/EXHIBITS_LOCAL at the ingest/publish-raw/
-# deliver recipes below -- a Box endpoint or local path needs exactly the same
-# single-shell-word guarantee a DSN does, just against spaces (BOX_PROJECT_
+# EXHIBITS_REMOTE_RAW/RAW_LOCAL_RAW/EXHIBITS_LOCAL_RAW at the
+# ingest/publish-raw/deliver recipes below -- a Box endpoint or local path
+# needs exactly the same single-shell-word guarantee a DSN does, just
+# against spaces (BOX_PROJECT_
 # ROOT's own default has one: "2. Projects/21. Governance/") rather than a
 # generated password's character set.
 sh_quote = '$(subst ','\'',$(1))'
+# Codex on #138 (finding 1): before #118, ingest/publish-raw/deliver
+# interpolated INCOMING_REMOTE/EXHIBITS_REMOTE bare (unquoted), so an
+# operator who followed this repo's *old* README advice and hand-quoted the
+# path portion -- `INCOMING_REMOTE=box:'Custom/Path/'` -- got away with it
+# by accident: python-dotenv only strips OUTER `.env` quotes (the value
+# text itself keeps whatever it was written with), so the inner `'`s
+# reached the unquoted recipe as literal shell syntax and the shell itself
+# consumed them, producing `box:Custom/Path/`. #118's sh_quote now wraps
+# the *whole* value as one shell word instead (correctly, for the
+# unquoted/documented form -- see the #118 comment above), so those same
+# inner `'`s instead reach rclone as literal apostrophes:
+# `box:'Custom/Path/'`, a different (and likely nonexistent, or wrong)
+# path. `ingest` would then read nothing, and `publish-raw` could publish
+# raw citizen data into an unintended apostrophe-named Box directory --
+# silent, and exactly the "wrong Box folder" hazard #104/#118's own
+# comments say must never happen. README.md now documents the bare form
+# only (`box:My Custom Path/`, never hand-quoted); this rejects a `.env` or
+# command-line value still written the old way instead of silently
+# misinterpreting it.
+#
+# is_legacy_quoted_endpoint detects the specific *wrapping* shape the old
+# advice produced -- a `'` landing immediately after the endpoint's first
+# `:` and again as the value's very last character -- not "contains a
+# quote anywhere". That distinction matters: a real Box folder can
+# genuinely contain an apostrophe (`box:Governor's Office/`), and that
+# value must keep flowing through sh_quote to rclone as intended. It does
+# not match here because its path does not *start* right after the colon
+# with a quote and does not *end* in one -- it ends in `/` (or whatever
+# ordinary character the folder name ends with). Implemented as a real
+# shell regex (not Make's $(filter)/$(patsubst), which word-split on
+# whitespace and would misjudge a space-bearing value -- BOX_PROJECT_ROOT's
+# own default has one) via the same sh_quote used everywhere else in this
+# file, so the value reaches grep as one safe shell word rather than a
+# second ad hoc quoting mechanism. Verified against both shapes -- the
+# legacy-quoted case and the genuine-apostrophe case -- in
+# tests/test_makefile_dotenv.py.
+#
+# BOX_REMOTE/BOX_PROJECT_ROOT never carried this legacy quoting: README's
+# history (git log -p on README.md) shows only the full `remote:'path'`
+# endpoint form was ever recommended hand-quoted, never BOX_REMOTE or
+# BOX_PROJECT_ROOT alone -- so only INCOMING_REMOTE/EXHIBITS_REMOTE need
+# this check.
+is_legacy_quoted_endpoint = $(strip $(shell printf '%s' $(call sh_quote,$(1)) | grep -Eq "^[^:]*:'.*'$$" && printf yes))
+ifeq ($(filter setup,$(MAKECMDGOALS)),)
+ifneq (,$(call is_legacy_quoted_endpoint,$(INCOMING_REMOTE_RAW)))
+$(error INCOMING_REMOTE=$(INCOMING_REMOTE_RAW) still uses the old hand-quoted form (box:'Custom/Path/') that README used to recommend. Remove the surrounding quote marks and write the bare value instead (e.g. INCOMING_REMOTE=box:Custom/Path/) -- ingest/publish-raw already quote it for you at the point they hand it to rclone (#118), so the hand-quoting no longer means what it used to and would silently target the wrong Box path)
+endif
+ifneq (,$(call is_legacy_quoted_endpoint,$(EXHIBITS_REMOTE_RAW)))
+$(error EXHIBITS_REMOTE=$(EXHIBITS_REMOTE_RAW) still uses the old hand-quoted form (box:'Custom/Path/') that README used to recommend. Remove the surrounding quote marks and write the bare value instead (e.g. EXHIBITS_REMOTE=box:Custom/Path/) -- deliver already quotes it for you at the point it hands it to rclone (#118), so the hand-quoting no longer means what it used to and would silently target the wrong Box path)
+endif
+endif
 SHELL          := /bin/bash
 .SHELLFLAGS    := -euo pipefail -c
 export PATH    := $(USER_BIN):$(PATH)
@@ -424,12 +573,12 @@ pull: _check_git_clean
 # $(INCOMING_REMOTE), per the origin note above its definition.
 ingest:
 	@echo "Copying all original source files from Box..."
-	rclone copy $(call sh_quote,$(INCOMING_REMOTE_RAW)) $(call sh_quote,$(RAW_LOCAL)) --progress
+	rclone copy $(call sh_quote,$(INCOMING_REMOTE_RAW)) $(call sh_quote,$(RAW_LOCAL_RAW)) --progress
 	@echo "Ingested raw data. The original Box files were not modified."
 
 publish-raw:
 	@echo "Publishing all local raw files to Box..."
-	rclone copy $(call sh_quote,$(RAW_LOCAL)) $(call sh_quote,$(INCOMING_REMOTE_RAW)) --progress
+	rclone copy $(call sh_quote,$(RAW_LOCAL_RAW)) $(call sh_quote,$(INCOMING_REMOTE_RAW)) --progress
 	@echo "Published raw data. Existing Box files with other names were not deleted."
 
 push: _check_git_clean
@@ -456,7 +605,7 @@ exhibits:
 # #118: sh_quote for the same reason as ingest/publish-raw above.
 deliver:
 	@echo "Delivering exhibits to Box..."
-	rclone copy $(call sh_quote,$(EXHIBITS_LOCAL)) $(call sh_quote,$(EXHIBITS_REMOTE_RAW)) --progress
+	rclone copy $(call sh_quote,$(EXHIBITS_LOCAL_RAW)) $(call sh_quote,$(EXHIBITS_REMOTE_RAW)) --progress
 	@echo "Exhibits delivered. Existing Box files were not deleted."
 
 .PHONY: docs docs-clean infra status
@@ -479,13 +628,28 @@ docs-clean:
 # actually use (see the #118 block above) rather than the plain variable,
 # which -- for a command-line/environment-origin value containing `$` -- can
 # differ from it (the plain reference re-scans; the _RAW one does not).
+#
+# Codex on #138 (finding 3): interpolating a _RAW value straight into a
+# double-quoted `echo "KEY=$(...)"` string put it in a position the shell
+# itself re-scans for `$`, so a value containing a literal `$` (e.g.
+# `BOX_REMOTE='a$b'`) lost everything from that `$` onward here -- silently
+# printing a truncated value instead of the one ingest/publish-raw/deliver
+# actually use (this Makefile targets GNU Make 3.81, which predates
+# `.SHELLFLAGS`, so `-u` above is not in effect for recipes either; the
+# failure mode is silent truncation, not an "unbound variable" abort).
+# `printf '%s\n'` with the value passed through sh_quote -- the same
+# mechanism ingest/publish-raw/deliver already use to hand these values to
+# rclone -- fixes this the same way: single-quoted, so the shell does not
+# re-scan it for `$`, and printf substitutes it into `%s` without printing
+# the quote marks themselves, so the normal (unquoted) case still displays
+# with no stray `'` characters.
 box-paths:
-	@echo "BOX_REMOTE=$(BOX_REMOTE_RAW)"
-	@echo "BOX_PROJECT_ROOT=$(BOX_PROJECT_ROOT_RAW)"
-	@echo "RAW_LOCAL=$(RAW_LOCAL)"
-	@echo "EXHIBITS_LOCAL=$(EXHIBITS_LOCAL)"
-	@echo "INCOMING_REMOTE=$(INCOMING_REMOTE_RAW)"
-	@echo "EXHIBITS_REMOTE=$(EXHIBITS_REMOTE_RAW)"
+	@printf 'BOX_REMOTE=%s\n' $(call sh_quote,$(BOX_REMOTE_RAW))
+	@printf 'BOX_PROJECT_ROOT=%s\n' $(call sh_quote,$(BOX_PROJECT_ROOT_RAW))
+	@printf 'RAW_LOCAL=%s\n' $(call sh_quote,$(RAW_LOCAL_RAW))
+	@printf 'EXHIBITS_LOCAL=%s\n' $(call sh_quote,$(EXHIBITS_LOCAL_RAW))
+	@printf 'INCOMING_REMOTE=%s\n' $(call sh_quote,$(INCOMING_REMOTE_RAW))
+	@printf 'EXHIBITS_REMOTE=%s\n' $(call sh_quote,$(EXHIBITS_REMOTE_RAW))
 
 
 # Read-only pass over the cloud infra (EC2 boxes, SSH exposure, disk,

--- a/README.md
+++ b/README.md
@@ -242,7 +242,12 @@ shared Box folder under different path prefixes — print the resolved paths wit
 `make box-paths`, and override per command
 (`make deliver BOX_PROJECT_ROOT="DPIC/janasunani"`) or persistently in `.env`.
 If a derived path doesn't match your Box layout, override the full endpoint
-(`INCOMING_REMOTE` / `EXHIBITS_REMOTE`) in `.env`.
+(`INCOMING_REMOTE` / `EXHIBITS_REMOTE`) in `.env` — write the bare value, with
+no manual shell quoting around spaces (`INCOMING_REMOTE=box:My Custom Path/`,
+not `box:'My Custom Path/'`): the `ingest`/`publish-raw`/`deliver` recipes
+quote it for you at the point they hand it to `rclone`, so a value with
+spaces (the default `BOX_PROJECT_ROOT` above has one) or an embedded `'`
+reaches `rclone` as a single argument either way.
 
 Common data operations:
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,10 @@ no manual shell quoting around spaces (`INCOMING_REMOTE=box:My Custom Path/`,
 not `box:'My Custom Path/'`): the `ingest`/`publish-raw`/`deliver` recipes
 quote it for you at the point they hand it to `rclone`, so a value with
 spaces (the default `BOX_PROJECT_ROOT` above has one) or an embedded `'`
-reaches `rclone` as a single argument either way.
+reaches `rclone` as a single argument either way. If your `.env` still has
+the old hand-quoted form from before this recipe-boundary quoting existed
+(`INCOMING_REMOTE=box:'Some/Path/'`), the Makefile now refuses to run with a
+loud error instead of silently misreading it — remove the quote marks.
 
 Common data operations:
 

--- a/tests/test_makefile_dotenv.py
+++ b/tests/test_makefile_dotenv.py
@@ -247,8 +247,8 @@ def test_setup_bypasses_dotenv_extraction_when_uv_is_unresolvable(isolated_dir):
     because the environment is unrepaired.
 
     `setup`'s own recipe never touches OLTP_DB_URL or the Box keys, so the
-    Makefile now skips the whole `ifneq (,$(wildcard .env))` extraction
-    whenever `setup` is among `$(MAKECMDGOALS)`. Proven here with `uv`
+    Makefile now skips the whole `ifneq (,$(wildcard .env))` extraction only
+    when `setup` is the sole `$(MAKECMDGOALS)` entry. Proven here with `uv`
     genuinely unresolvable (PATH stripped to /usr/bin:/bin, USER_BIN pointed
     at a nonexistent directory) and a `.env` present -- before the fix this
     combination hit the hard $(error) before printing anything.
@@ -340,7 +340,7 @@ def test_setup_passes_through_a_safe_dotenv_box_remote(isolated_dir):
         cwd=isolated_dir, env=env,
     )
     assert result.returncode == 0, result.stderr
-    assert 'BOX_REMOTE="mybox"' in result.stdout, result.stdout
+    assert "BOX_REMOTE='mybox'" in result.stdout, result.stdout
 
 
 def test_setup_passes_through_a_dotenv_box_remote_with_hyphen_underscore_and_digit(
@@ -355,7 +355,7 @@ def test_setup_passes_through_a_dotenv_box_remote_with_hyphen_underscore_and_dig
         cwd=isolated_dir, env=env,
     )
     assert result.returncode == 0, result.stderr
-    assert 'BOX_REMOTE="my-box_2"' in result.stdout, result.stdout
+    assert "BOX_REMOTE='my-box_2'" in result.stdout, result.stdout
 
 
 def test_setup_fails_loudly_for_a_dotenv_box_remote_outside_the_safe_pattern(
@@ -414,7 +414,7 @@ def test_setup_with_command_line_box_remote_still_wins_over_dotenv(
         "-n", "setup", "BOX_REMOTE=fromcli", "MAKE=true", cwd=isolated_dir
     )
     assert result.returncode == 0, result.stderr
-    assert 'BOX_REMOTE="fromcli"' in result.stdout, result.stdout
+    assert "BOX_REMOTE='fromcli'" in result.stdout, result.stdout
 
 
 def test_setup_without_dotenv_box_remote_is_unaffected_by_the_guard(isolated_dir):
@@ -423,7 +423,172 @@ def test_setup_without_dotenv_box_remote_is_unaffected_by_the_guard(isolated_dir
     to, using the built-in `box` default."""
     result = _make("-n", "setup", "MAKE=true", cwd=isolated_dir)
     assert result.returncode == 0, result.stderr
-    assert 'BOX_REMOTE="box"' in result.stdout, result.stdout
+    assert "BOX_REMOTE='box'" in result.stdout, result.stdout
+
+
+def test_setup_bypass_does_not_apply_to_mixed_goal_invocations(isolated_dir):
+    """`setup` is allowed to bootstrap an unavailable uv only by itself.
+    Adding a data-moving goal must select the ordinary dotenv parser, which
+    fails loudly here rather than letting `publish-raw` use its default Box
+    endpoint despite the operator's .env configuration."""
+    (isolated_dir / ".env").write_text("BOX_REMOTE=must-not-be-ignored\n")
+    env = {"HOME": os.environ.get("HOME", ""), "PATH": "/usr/bin:/bin"}
+    result = _make(
+        "-n",
+        "USER_BIN=/nonexistent-dir-for-this-test",
+        "MAKE=true",
+        "setup",
+        "publish-raw",
+        cwd=isolated_dir,
+        env=env,
+    )
+    assert result.returncode != 0
+    assert "could not be parsed" in result.stderr
+    assert "rclone copy" not in result.stdout
+
+
+@pytest.mark.parametrize("source", ["command_line", "environment"])
+def test_setup_passes_special_box_remote_to_script_byte_for_byte(
+    isolated_dir, source
+):
+    """The setup recipe must use BOX_REMOTE_RAW too.  Plain $(BOX_REMOTE)
+    re-scans a command-line or exported `$` as Make syntax before bash sees
+    it; this executes a harmless local setup stub to prove the child script
+    receives the exact original bytes for both relevant origins."""
+    remote = "remote$literal"
+    setup_dir = isolated_dir / "scripts"
+    setup_dir.mkdir()
+    received = isolated_dir / "setup_received.txt"
+    setup_script = setup_dir / "setup.sh"
+    setup_script.write_text(
+        "#!/bin/sh\n"
+        f'printf "%s" "$BOX_REMOTE" > "{received}"\n'
+    )
+    setup_script.chmod(0o755)
+
+    env = dict(os.environ)
+    args = ["MAKE=true", "setup"]
+    if source == "command_line":
+        args.insert(0, f"BOX_REMOTE={remote}")
+    else:
+        env["BOX_REMOTE"] = remote
+
+    result = _make(*args, cwd=isolated_dir, env=env)
+    assert result.returncode == 0, result.stderr
+    assert received.read_text() == remote
+
+
+def _install_dotenv_uv_shim(bin_dir: Path, *, fail: bool = False) -> None:
+    """Install a no-network stand-in for the parse-time `uv run` command."""
+    bin_dir.mkdir(exist_ok=True)
+    shim = bin_dir / "uv"
+    if fail:
+        body = 'printf "%s\\n" "forced dotenv parse failure" >&2\nexit 1\n'
+    else:
+        body = (
+            'case "$*" in\n'
+            '  *"get(\'OLTP_DB_URL\')"*) printf "%s" "postgresql+asyncpg://postgres:shim@127.0.0.1:5544/janasunani" ;;\n'
+            '  *"get(\'BOX_REMOTE\')"*) printf "%s" "shim-box" ;;\n'
+            '  *"get(\'BOX_PROJECT_ROOT\')"*) printf "%s" "Shim Project" ;;\n'
+            '  *"get(\'INCOMING_REMOTE\')"*) printf "%s" "shim:incoming/" ;;\n'
+            '  *"get(\'EXHIBITS_REMOTE\')"*) printf "%s" "shim:exhibits/" ;;\n'
+            "esac\n"
+        )
+    shim.write_text("#!/bin/sh\n" + body)
+    shim.chmod(0o755)
+
+
+def _install_rmdir_recorder(bin_dir: Path) -> None:
+    """Record each cleanup directory while delegating to the real rmdir."""
+    real_rmdir = shutil.which("rmdir")
+    assert real_rmdir is not None, "test setup: rmdir must be installed"
+    recorder = bin_dir / "rmdir"
+    recorder.write_text(
+        "#!/bin/sh\n"
+        'printf "%s\\n" "$1" >> "$MAKEFILE_DOTENV_RMDIR_LOG"\n'
+        f'exec "{real_rmdir}" "$@"\n'
+    )
+    recorder.chmod(0o755)
+
+
+def _dotenv_make_command(isolated_dir: Path, fake_bin: Path) -> list[str]:
+    return [
+        "make",
+        "-C",
+        str(isolated_dir),
+        "-f",
+        str(MAKEFILE_PATH),
+        "-n",
+        f"USER_BIN={fake_bin}",
+        "box-paths",
+    ]
+
+
+def test_dotenv_temp_directories_are_per_make_and_cleaned_after_success(isolated_dir):
+    """Two concurrent parses use distinct private status directories and
+    remove them once all five values have been checked.  The rmdir shim is a
+    deterministic observation point: the old username-global files neither
+    made a private directory nor cleaned one up."""
+    (isolated_dir / ".env").write_text("BOX_REMOTE=ignored-by-shim\n")
+    fake_bin = isolated_dir / "fakebin"
+    _install_dotenv_uv_shim(fake_bin)
+    _install_rmdir_recorder(fake_bin)
+
+    processes = []
+    logs = []
+    for index in range(2):
+        log = isolated_dir / f"rmdir-{index}.log"
+        env = dict(os.environ)
+        env["PATH"] = f"{fake_bin}{os.pathsep}{env.get('PATH', '')}"
+        env["MAKEFILE_DOTENV_RMDIR_LOG"] = str(log)
+        processes.append(
+            subprocess.Popen(
+                _dotenv_make_command(isolated_dir, fake_bin),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env=env,
+            )
+        )
+        logs.append(log)
+
+    for process in processes:
+        stdout, stderr = process.communicate(timeout=30)
+        assert process.returncode == 0, stdout + stderr
+
+    removed = [log.read_text().splitlines() for log in logs]
+    assert all(len(paths) == 1 for paths in removed)
+    directories = [paths[0] for paths in removed]
+    assert len(set(directories)) == 2
+    assert all(path.startswith("/tmp/janasunani-makefile-dotenv.") for path in directories)
+    assert all(not Path(path).exists() for path in directories)
+
+
+def test_dotenv_temp_directory_is_cleaned_after_parse_failure(isolated_dir):
+    """The hard parse failure remains loud and also removes its private
+    status/stderr directory; a failed make must not leave sensitive stderr
+    behind in /tmp."""
+    (isolated_dir / ".env").write_text("BOX_REMOTE=ignored-by-shim\n")
+    fake_bin = isolated_dir / "fakebin"
+    _install_dotenv_uv_shim(fake_bin, fail=True)
+    _install_rmdir_recorder(fake_bin)
+    log = isolated_dir / "rmdir-failure.log"
+    env = dict(os.environ)
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env.get('PATH', '')}"
+    env["MAKEFILE_DOTENV_RMDIR_LOG"] = str(log)
+
+    result = subprocess.run(
+        _dotenv_make_command(isolated_dir, fake_bin),
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+    assert result.returncode != 0
+    assert "forced dotenv parse failure" in result.stderr
+    directories = log.read_text().splitlines()
+    assert len(directories) == 1
+    assert not Path(directories[0]).exists()
 
 
 def test_parse_time_call_fails_fast_instead_of_hanging_when_sync_needs_network(

--- a/tests/test_makefile_dotenv.py
+++ b/tests/test_makefile_dotenv.py
@@ -450,3 +450,109 @@ def test_oltp_db_url_still_survives_adversarial_characters_alongside_box_remote(
     assert result.returncode == 0, result.stderr
     dsn_without_comment = ADVERSARIAL_DSN.split(" # ")[0]
     assert _sh_quote(dsn_without_comment) in result.stdout, result.stdout
+
+
+# --- #115: the DOTENV_OK: success sentinel must not corrupt a .env value
+# that itself contains that literal substring, and the fix (an out-of-band
+# exit-status file, not a text prefix stripped back out of the value) must
+# not corrupt a value containing spaces either -------------------------------
+#
+# Regression case: BOX_PROJECT_ROOT=Archive/DOTENV_OK:2026 used to resolve
+# to Archive/2026 because the old $(subst DOTENV_OK:,,$(raw)) extraction was
+# global/unanchored -- it deleted every occurrence of the sentinel text, not
+# just the one dotenv_get itself had prepended.
+
+SENTINEL_LOOKALIKE = "Archive/DOTENV_OK:2026"
+
+
+def test_dotenv_value_containing_sentinel_substring_survives_intact_box_project_root(
+    isolated_dir,
+):
+    """The exact #115 regression case, verified end-to-end through
+    box-paths -- including the two remotes BOX_PROJECT_ROOT derives, since
+    those are what `ingest`/`deliver` actually build their rclone
+    invocations from."""
+    (isolated_dir / ".env").write_text(f"BOX_PROJECT_ROOT={SENTINEL_LOOKALIKE}\n")
+    result = _make("box-paths", cwd=isolated_dir)
+    assert result.returncode == 0, result.stderr
+    assert f"BOX_PROJECT_ROOT={SENTINEL_LOOKALIKE}" in result.stdout, result.stdout
+    assert f"{SENTINEL_LOOKALIKE}/Data/Raw/" in result.stdout
+    assert f"{SENTINEL_LOOKALIKE}/Analysis/Exhibits/" in result.stdout
+
+
+def test_dotenv_value_containing_sentinel_substring_survives_for_other_box_keys(
+    isolated_dir,
+):
+    """Representative coverage across the other keys sharing dotenv_get's
+    extraction: BOX_REMOTE, INCOMING_REMOTE, EXHIBITS_REMOTE."""
+    (isolated_dir / ".env").write_text(
+        "BOX_REMOTE=my-DOTENV_OK:-remote\n"
+        "INCOMING_REMOTE=customremote:'DOTENV_OK:/Incoming/'\n"
+        "EXHIBITS_REMOTE=customremote:'DOTENV_OK:/Exhibits/'\n"
+    )
+    result = _make("box-paths", cwd=isolated_dir)
+    assert result.returncode == 0, result.stderr
+    assert "BOX_REMOTE=my-DOTENV_OK:-remote" in result.stdout, result.stdout
+    assert "INCOMING_REMOTE=customremote:'DOTENV_OK:/Incoming/'" in result.stdout
+    assert "EXHIBITS_REMOTE=customremote:'DOTENV_OK:/Exhibits/'" in result.stdout
+
+
+def test_dotenv_value_containing_sentinel_substring_survives_for_oltp_db_url(
+    isolated_dir,
+):
+    """Same coverage for OLTP_DB_URL, verified the same way the existing
+    adversarial-character tests are: through preflight's -n recipe text and
+    sh_quote, since OLTP_DB_URL (unlike the Box keys) goes through
+    OLTP_DB_URL_RAW/sh_quote before reaching a recipe."""
+    dsn = "postgresql+asyncpg://postgres:pwDOTENV_OK:end@127.0.0.1:5544/janasunani"
+    (isolated_dir / ".env").write_text(f"OLTP_DB_URL={dsn}\n")
+    result = _make("-n", "preflight", cwd=isolated_dir)
+    assert result.returncode == 0, result.stderr
+    assert _sh_quote(dsn) in result.stdout, result.stdout
+
+
+def test_dotenv_value_with_spaces_is_not_corrupted_by_the_status_extraction(
+    isolated_dir,
+):
+    """The naive anchored-strip fixes #115 considered and rejected
+    ($(patsubst DOTENV_OK:%,%,...) / $(filter DOTENV_OK:%,...)) both
+    word-split on whitespace and would have collapsed or rewritten a
+    multi-word value's internal spacing. This value has no DOTENV_OK: text
+    at all, isolating the whitespace-safety property from the
+    sentinel-collision property covered above."""
+    (isolated_dir / ".env").write_text("BOX_PROJECT_ROOT=My Custom  Folder\n")
+    result = _make("box-paths", cwd=isolated_dir)
+    assert result.returncode == 0, result.stderr
+    assert "BOX_PROJECT_ROOT=My Custom  Folder" in result.stdout, result.stdout
+
+
+def test_dotenv_value_with_both_spaces_and_the_sentinel_substring(isolated_dir):
+    """Combines both adversarial properties #115 called out explicitly:
+    spaces *and* an embedded DOTENV_OK: substring in the same value."""
+    value = "My DOTENV_OK: Folder 2026"
+    (isolated_dir / ".env").write_text(f"BOX_PROJECT_ROOT={value}\n")
+    result = _make("box-paths", cwd=isolated_dir)
+    assert result.returncode == 0, result.stderr
+    assert f"BOX_PROJECT_ROOT={value}" in result.stdout, result.stdout
+
+
+def test_key_absent_vs_parse_failure_distinction_still_holds_after_115(isolated_dir):
+    """#115 replaced the DOTENV_OK: stdout-prefix mechanism with an
+    out-of-band exit-status file (_DOTENV_STATUS / dotenv_status). Re-proves
+    the #103 invariant the new mechanism must still satisfy: a key simply
+    absent from a parseable .env keeps the built-in default (status 0, no
+    error), while a genuine parse failure (uv unresolvable) still hits the
+    hard $(error) -- never silently keeping the default in either
+    direction."""
+    (isolated_dir / ".env").write_text("SOME_UNRELATED_KEY=1\n")
+    result = _make("box-paths", cwd=isolated_dir)
+    assert result.returncode == 0, result.stderr
+    assert "BOX_REMOTE=box" in result.stdout  # untouched ?= default
+
+    env = {"HOME": os.environ.get("HOME", ""), "PATH": "/usr/bin:/bin"}
+    result = _make(
+        "-n", "USER_BIN=/nonexistent-dir-for-this-test", "box-paths",
+        cwd=isolated_dir, env=env,
+    )
+    assert result.returncode != 0
+    assert "could not be parsed" in result.stderr

--- a/tests/test_makefile_dotenv.py
+++ b/tests/test_makefile_dotenv.py
@@ -1,10 +1,12 @@
 """Real-code-path checks for the Makefile's `.env`-sourced settings (#60 and
-its sequels, #103, #104): that OLTP_DB_URL survives adversarial characters
-through every documented precedence tier (command line, shell-exported
-environment, `.env`), that a parse-time `uv` failure fails loudly rather than
-silently keeping the throwaway demo default, and that `.env` still supplies
-the other Make settings README.md documents (BOX_REMOTE, BOX_PROJECT_ROOT,
-INCOMING_REMOTE, EXHIBITS_REMOTE).
+its sequels, #103, #104, #114): that OLTP_DB_URL survives adversarial
+characters through every documented precedence tier (command line,
+shell-exported environment, `.env`), that a parse-time `uv` failure fails
+loudly rather than silently keeping the throwaway demo default, that `.env`
+still supplies the other Make settings README.md documents (BOX_REMOTE,
+BOX_PROJECT_ROOT, INCOMING_REMOTE, EXHIBITS_REMOTE), that `setup` (the
+install/repair target) stays runnable without `uv` already installed, and
+that the parse-time `uv run` call cannot hang waiting on network.
 
 Shells out to the actual `make` binary against the real Makefile -- not a
 copy, not a reimplementation of its logic -- with `-C` pointed at an isolated
@@ -23,6 +25,7 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import time
 from pathlib import Path
 
 import pytest
@@ -227,6 +230,127 @@ def test_missing_uv_fails_loudly_instead_of_silently_using_the_demo_default(isol
     assert demo_default not in result.stdout, (
         "must fail loudly, not silently resolve to the throwaway demo default"
     )
+
+
+# --- #114: the parse-time `uv` dependency must not make `setup` (the
+# install/repair target) unbootstrappable, and must not let a transient
+# network hiccup during environment sync escalate into a multi-minute hang
+# that then hard-aborts every target ----------------------------------------
+
+
+def test_setup_bypasses_dotenv_extraction_when_uv_is_unresolvable(isolated_dir):
+    """Before this fix, the parse-time dotenv extraction ran before any
+    target was selected, so a checkout with a root `.env` but no `uv`
+    installed made even `make setup` fail with 'uv: not found' -- while
+    `scripts/setup.sh`'s install_uv() is the documented mechanism that
+    installs it. That is a bootstrap cycle: the repair target can't run
+    because the environment is unrepaired.
+
+    `setup`'s own recipe never touches OLTP_DB_URL or the Box keys, so the
+    Makefile now skips the whole `ifneq (,$(wildcard .env))` extraction
+    whenever `setup` is among `$(MAKECMDGOALS)`. Proven here with `uv`
+    genuinely unresolvable (PATH stripped to /usr/bin:/bin, USER_BIN pointed
+    at a nonexistent directory) and a `.env` present -- before the fix this
+    combination hit the hard $(error) before printing anything.
+
+    `MAKE=true` replaces the real recursive `$(MAKE) install-hooks` call at
+    the end of `setup`'s recipe: GNU Make always executes a recipe line that
+    references the MAKE variable for real, even under `-n` (documented
+    behavior, verified directly against this Makefile) -- so a plain `-n`
+    here would actually re-invoke `install-hooks`, a target this test does
+    not want to exercise (it needs a real git checkout and the real `uv`
+    install `scripts/setup.sh` performs before it runs, neither of which
+    belongs in this unit test, and neither of which #114 is about: the
+    bypass is for `setup` only, not `install-hooks`). Substituting `true`
+    keeps that line real-and-run -- so the dry run still faithfully reflects
+    Make's actual behavior -- while making it a no-op.
+    """
+    (isolated_dir / ".env").write_text(
+        "OLTP_DB_URL=postgresql+asyncpg://postgres:fromenv@127.0.0.1:5544/janasunani\n"
+    )
+    env = {"HOME": os.environ.get("HOME", ""), "PATH": "/usr/bin:/bin"}
+    result = _make(
+        "-n", "USER_BIN=/nonexistent-dir-for-this-test", "MAKE=true", "setup",
+        cwd=isolated_dir, env=env,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "scripts/setup.sh" in result.stdout, result.stdout
+    assert "could not be parsed" not in result.stderr
+    assert "could not be parsed" not in result.stdout
+
+
+def test_setup_bypass_does_not_broaden_to_other_targets(isolated_dir):
+    """Control for the test above: the `setup` bypass is scoped to `setup`
+    specifically, not a blanket skip -- any other target under the same
+    unresolvable-`uv` conditions still hits #103's hard $(error), unchanged
+    (same assertion as test_missing_uv_fails_loudly_..., with a different
+    target to show it is not `preflight`-specific)."""
+    (isolated_dir / ".env").write_text(
+        "OLTP_DB_URL=postgresql+asyncpg://postgres:fromenv@127.0.0.1:5544/janasunani\n"
+    )
+    env = {"HOME": os.environ.get("HOME", ""), "PATH": "/usr/bin:/bin"}
+    result = _make(
+        "-n", "USER_BIN=/nonexistent-dir-for-this-test", "status",
+        cwd=isolated_dir, env=env,
+    )
+    assert result.returncode != 0
+    assert "could not be parsed" in result.stderr
+
+
+def test_parse_time_call_fails_fast_instead_of_hanging_when_sync_needs_network(
+    isolated_dir,
+):
+    """#114's second, independently-confirmed failure mode: a bare `uv run`
+    (no `--no-sync`) resyncs the environment against
+    pyproject.toml/uv.lock on every invocation -- including fetching
+    metadata for any dependency not already cached -- before running the
+    `-c` script that just wants `python-dotenv`. A transient network failure
+    during *that* resync (reproduced directly against this repo's own
+    pyproject.toml, which pins a direct-URL spaCy model wheel: `uv run
+    pytest` timed out after ~2 minutes fetching it) turned this parse-time
+    call into a multi-minute hang, which the `ifeq`/$(error) guards below
+    then escalate to a hard abort of *every* target -- not just the one
+    that actually needed OLTP_DB_URL.
+
+    Reproduced here deterministically, without relying on real network
+    flakiness: a throwaway uv project (`isolated_dir` gets its own
+    `pyproject.toml`) with no synced `.venv` needs `python-dotenv` fetched
+    to satisfy the parse-time import. `--offline` (added to dotenv_get's
+    `uv run` alongside `--no-sync`) turns that into an immediate local
+    failure instead of a network attempt, so the whole `make` invocation
+    returns in well under the bound below -- proving the call cannot hang
+    on network regardless of what triggers the sync attempt. `--no-sync`
+    alone is not sufficient to prove here: outside of a uv project (every
+    other test's `isolated_dir`) it is a silent no-op (`uv` just runs
+    whatever `python` is on PATH), so this test's own `pyproject.toml` is
+    what makes `--offline` the operative guard, not an incidental detail.
+    """
+    if shutil.which("uv") is None:
+        pytest.skip("uv not installed on this machine")
+    (isolated_dir / "pyproject.toml").write_text(
+        "[project]\n"
+        'name = "probe"\n'
+        'version = "0.1.0"\n'
+        'requires-python = ">=3.11"\n'
+        'dependencies = ["python-dotenv"]\n'
+        "\n"
+        "[tool.uv]\n"
+        "package = false\n"
+    )
+    (isolated_dir / ".env").write_text(
+        "OLTP_DB_URL=postgresql+asyncpg://postgres:fromenv@127.0.0.1:5544/janasunani\n"
+    )
+
+    start = time.monotonic()
+    result = _make("-n", "status", cwd=isolated_dir)
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 20, (
+        f"parse-time uv call took {elapsed:.1f}s -- should fail fast and "
+        "offline, not hang waiting on a sync that needs network"
+    )
+    assert result.returncode != 0
+    assert "could not be parsed" in result.stderr
 
 
 def test_db_guard_resolves_a_matching_default_identically(isolated_dir):

--- a/tests/test_makefile_dotenv.py
+++ b/tests/test_makefile_dotenv.py
@@ -556,3 +556,207 @@ def test_key_absent_vs_parse_failure_distinction_still_holds_after_115(isolated_
     )
     assert result.returncode != 0
     assert "could not be parsed" in result.stderr
+
+
+# --- #118: INCOMING_REMOTE/EXHIBITS_REMOTE need quoting at the recipe
+# boundary -----------------------------------------------------------------
+#
+# #104 restored these two from .env, but the recipes interpolated them bare
+# (`rclone copy $(INCOMING_REMOTE) $(RAW_LOCAL) --progress`). A full-endpoint
+# override written with normal dotenv outer quotes has those quotes stripped
+# by python-dotenv -- correctly, that is what dotenv quoting means -- and the
+# resulting space-bearing value then reached an unquoted recipe position,
+# where the shell word-split it: `box:2. Projects/...` became several
+# arguments and `make ingest` read from (or `make deliver` published to) the
+# wrong place instead of failing loudly. BOX_PROJECT_ROOT's own default is
+# "2. Projects/21. Governance/" -- spaces are the documented normal case
+# here, not an exotic one.
+#
+# These tests run the real (non-dry-run) recipe with a stub `rclone` on PATH
+# that records its argv one-per-line, so a passing assertion proves the
+# actual argument boundary the shell constructs -- not just that `-n`'s
+# printed text looks right (which passing single quotes through unchanged
+# would already satisfy even if a later shell word-split them some other
+# way).
+
+
+def _stub_rclone(bin_dir: Path, argv_file: Path) -> None:
+    """Installs a fake `rclone` on `bin_dir` that records its own argv, one
+    argument per line, to `argv_file` -- instead of doing anything to a real
+    Box remote. `printf '%s\\n' "$@"` recycles the format once per positional
+    argument, so this is a direct readout of how many shell words the
+    Makefile's recipe produced, not a parse of the recipe's source text."""
+    bin_dir.mkdir(exist_ok=True)
+    stub = bin_dir / "rclone"
+    stub.write_text(f'#!/bin/sh\nprintf "%s\\n" "$@" > "{argv_file}"\n')
+    stub.chmod(0o755)
+
+
+def _rclone_argv(isolated_dir: Path, *make_args: str) -> list[str]:
+    """Runs `make` for real (no `-n`) against `isolated_dir` with a stub
+    `rclone` prepended to PATH, and returns the argv that stub recorded."""
+    bin_dir = isolated_dir / "fakebin"
+    argv_file = isolated_dir / "rclone_argv.txt"
+    _stub_rclone(bin_dir, argv_file)
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    result = _make(*make_args, cwd=isolated_dir, env=env)
+    assert result.returncode == 0, result.stderr
+    return argv_file.read_text().splitlines()
+
+
+def test_default_ingest_endpoint_matches_pre_118_behavior(isolated_dir):
+    """Control: a plain, default-configured `make ingest` (no .env, no
+    overrides) must produce exactly the same rclone endpoint argument #118
+    does -- 'box:2. Projects/21. Governance//Data/Raw/' as a single word
+    (the double slash is BOX_PROJECT_ROOT's own trailing '/' plus the
+    '/Data/Raw/' suffix, an existing quirk this fix does not touch). Before
+    #118 the default default achieved this via a literal single-quote baked
+    into INCOMING_REMOTE's `?=` value; #118 moves that quoting to the recipe
+    boundary instead (sh_quote), and this is the proof the visible behavior
+    for the common, unconfigured case did not move."""
+    argv = _rclone_argv(isolated_dir, "ingest")
+    assert argv == [
+        "copy",
+        "box:2. Projects/21. Governance//Data/Raw/",
+        "data/raw/",
+        "--progress",
+    ], argv
+
+
+def test_default_deliver_endpoint_matches_pre_118_behavior(isolated_dir):
+    """Same control as above, for `deliver`/EXHIBITS_REMOTE."""
+    argv = _rclone_argv(isolated_dir, "deliver")
+    assert argv == [
+        "copy",
+        "outputs/",
+        "box:2. Projects/21. Governance//Analysis/Exhibits/",
+        "--progress",
+    ], argv
+
+
+def test_dotenv_full_endpoint_override_with_spaces_reaches_rclone_as_one_argument(
+    isolated_dir,
+):
+    """The exact #118 regression: a full-endpoint INCOMING_REMOTE override
+    written with normal dotenv outer double quotes (stripped by
+    python-dotenv, per dotenv semantics -- the value stored is the bare,
+    unquoted, space-bearing path) must still reach rclone as ONE argument,
+    not be word-split into several. Before the fix this failed exactly this
+    way (verified directly against the pre-fix Makefile: 'box:2.',
+    'Projects/21.', 'Governance/Custom', 'Sub/' -- four arguments instead of
+    one)."""
+    (isolated_dir / ".env").write_text(
+        'INCOMING_REMOTE="box:2. Projects/21. Governance/Custom Sub/"\n'
+    )
+    argv = _rclone_argv(isolated_dir, "ingest")
+    assert argv == [
+        "copy",
+        "box:2. Projects/21. Governance/Custom Sub/",
+        "data/raw/",
+        "--progress",
+    ], argv
+
+
+def test_dotenv_full_endpoint_override_with_spaces_reaches_rclone_for_deliver_too(
+    isolated_dir,
+):
+    """Same regression, for EXHIBITS_REMOTE/`deliver`."""
+    (isolated_dir / ".env").write_text(
+        'EXHIBITS_REMOTE="box:2. Projects/21. Governance/Custom Exhibits/"\n'
+    )
+    argv = _rclone_argv(isolated_dir, "deliver")
+    assert argv == [
+        "copy",
+        "outputs/",
+        "box:2. Projects/21. Governance/Custom Exhibits/",
+        "--progress",
+    ], argv
+
+
+def test_default_box_project_root_override_with_spaces_reaches_rclone_as_one_argument(
+    isolated_dir,
+):
+    """The other documented space-bearing path: overriding BOX_PROJECT_ROOT
+    (not the full endpoint) and letting INCOMING_REMOTE derive from it, per
+    README.md's "Most users only need to set BOX_REMOTE and
+    BOX_PROJECT_ROOT". Must reach rclone as one argument the same way."""
+    (isolated_dir / ".env").write_text("BOX_PROJECT_ROOT=DPIC Janasunani Project\n")
+    argv = _rclone_argv(isolated_dir, "ingest")
+    assert argv == [
+        "copy",
+        "box:DPIC Janasunani Project/Data/Raw/",
+        "data/raw/",
+        "--progress",
+    ], argv
+
+
+def test_incoming_remote_value_containing_a_literal_quote_reaches_rclone_intact(
+    isolated_dir,
+):
+    """sh_quote's whole reason for existing over plain single-quoting (#60):
+    a value containing a literal `'` must not break the recipe's shell
+    string. Here that value is INCOMING_REMOTE itself, not a DSN."""
+    (isolated_dir / ".env").write_text("INCOMING_REMOTE=box:Governance's Folder/\n")
+    argv = _rclone_argv(isolated_dir, "ingest")
+    assert argv == [
+        "copy",
+        "box:Governance's Folder/",
+        "data/raw/",
+        "--progress",
+    ], argv
+
+
+def test_command_line_box_remote_containing_dollar_survives_to_rclone(isolated_dir):
+    """Regression guard for the $(origin ...)/$(value ...) treatment #118
+    also gives BOX_REMOTE (mirroring OLTP_DB_URL_RAW, per the comment above
+    BOX_REMOTE_RAW's definition in the Makefile): a command-line BOX_REMOTE
+    is stored recursively expanded, so referencing it naively from inside
+    sh_quote's $(subst ...) -- itself another expansion -- would re-scan a
+    literal `$` in the value for a (likely undefined, silently-emptied) Make
+    variable reference, the same bug class as #60/#103, one layer down.
+    BOX_REMOTE_RAW's $(value BOX_REMOTE) protects against exactly this."""
+    argv = _rclone_argv(isolated_dir, "BOX_REMOTE=a$b", "ingest")
+    assert argv == [
+        "copy",
+        "a$b:2. Projects/21. Governance//Data/Raw/",
+        "data/raw/",
+        "--progress",
+    ], argv
+
+
+def test_dry_run_ingest_shows_quoted_endpoint_for_default_config(isolated_dir):
+    """Lighter-weight companion to the real-run tests above, using `-n` the
+    way the rest of this file does: proves the printed recipe text itself is
+    now single-quoted at the call site (sh_quote), not just that the
+    underlying value is correct."""
+    result = _make("-n", "ingest", cwd=isolated_dir)
+    assert result.returncode == 0, result.stderr
+    assert (
+        "rclone copy 'box:2. Projects/21. Governance//Data/Raw/' 'data/raw/' --progress"
+        in result.stdout
+    ), result.stdout
+
+
+def test_dry_run_deliver_shows_quoted_endpoint_for_default_config(isolated_dir):
+    result = _make("-n", "deliver", cwd=isolated_dir)
+    assert result.returncode == 0, result.stderr
+    assert (
+        "rclone copy 'outputs/' 'box:2. Projects/21. Governance//Analysis/Exhibits/' --progress"
+        in result.stdout
+    ), result.stdout
+
+
+def test_box_paths_still_reports_incoming_remote_without_stray_quote_characters(
+    isolated_dir,
+):
+    """box-paths now echoes INCOMING_REMOTE_RAW/EXHIBITS_REMOTE_RAW (#118),
+    which -- unlike the pre-#118 default -- no longer has a literal `'`
+    baked into it: the quoting moved to the recipe boundary, so box-paths'
+    diagnostic display of the default is now the bare, unquoted path."""
+    result = _make("box-paths", cwd=isolated_dir)
+    assert result.returncode == 0, result.stderr
+    assert "INCOMING_REMOTE=box:2. Projects/21. Governance//Data/Raw/" in result.stdout
+    assert "'" not in [
+        line for line in result.stdout.splitlines() if line.startswith("INCOMING_REMOTE=")
+    ][0]

--- a/tests/test_makefile_dotenv.py
+++ b/tests/test_makefile_dotenv.py
@@ -297,6 +297,135 @@ def test_setup_bypass_does_not_broaden_to_other_targets(isolated_dir):
     assert "could not be parsed" in result.stderr
 
 
+# --- Codex on #138, finding 2: the `setup` bypass above (needed so `setup`
+# can bootstrap `uv` in the first place) must not silently drop a .env-only
+# BOX_REMOTE -- `setup`'s own recipe still passes BOX_REMOTE to
+# scripts/setup.sh's ensure_box_remote, which selects/creates the rclone
+# remote from it. Exact repro from the review: a checkout with
+# `.env` containing `BOX_REMOTE=mybox` and no command-line override used to
+# make `make -n setup` print `BOX_REMOTE="box" bash scripts/setup.sh` (the
+# built-in default, silently ignoring .env) while `make box-paths` in the
+# same checkout correctly reported `BOX_REMOTE=mybox` -- two different
+# answers for the same setting depending on which target asked.
+#
+# The first fix here just hard-failed `setup` whenever .env mentioned
+# BOX_REMOTE at all -- but that put a *new* failure on the exact target
+# #114 exists to keep runnable ("the repair target can't run because the
+# environment is unrepaired"), and made the operator open .env, read the
+# value, and retype it before `setup` would run at all, even for the
+# common, perfectly safe case. The tightened fix passes a .env-only
+# BOX_REMOTE straight through when it matches a narrow, conservative
+# bare-identifier pattern (`^[A-Za-z0-9_-]+:?$` -- no whitespace, quotes,
+# `$`, `#`, or backslash) via a bare `grep`/`sed`, not a second dotenv
+# parser: for a value in that shape, there is nothing left for dotenv's
+# quoting/escaping/comment rules to interpret differently, so there is
+# nothing for a from-scratch reader to get wrong or drift on. Only a value
+# outside that shape (quoted, spaced, commented, or more than one
+# `BOX_REMOTE=` line) still hits the loud $(error) -- that is exactly the
+# territory where dotenv's real rules matter and guessing would repeat
+# #60's mistake.
+
+
+def test_setup_passes_through_a_safe_dotenv_box_remote(isolated_dir):
+    """Exact repro from the follow-up: `.env` sets a plain, unquoted
+    BOX_REMOTE and there is no command-line override -- `uv` is fully
+    unresolvable here (unlike the fully-available case the first version of
+    this test used), proving the pass-through needs no uv/python-dotenv at
+    all, matching #114's whole point. `setup` must use the .env value, not
+    silently fall back to the `box` default."""
+    (isolated_dir / ".env").write_text("BOX_REMOTE=mybox\n")
+    env = {"HOME": os.environ.get("HOME", ""), "PATH": "/usr/bin:/bin"}
+    result = _make(
+        "-n", "USER_BIN=/nonexistent-dir-for-this-test", "MAKE=true", "setup",
+        cwd=isolated_dir, env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    assert 'BOX_REMOTE="mybox"' in result.stdout, result.stdout
+
+
+def test_setup_passes_through_a_dotenv_box_remote_with_hyphen_underscore_and_digit(
+    isolated_dir,
+):
+    """The safe pattern covers the realistic character set for an rclone
+    remote name, not just plain letters."""
+    (isolated_dir / ".env").write_text("BOX_REMOTE=my-box_2\n")
+    env = {"HOME": os.environ.get("HOME", ""), "PATH": "/usr/bin:/bin"}
+    result = _make(
+        "-n", "USER_BIN=/nonexistent-dir-for-this-test", "MAKE=true", "setup",
+        cwd=isolated_dir, env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    assert 'BOX_REMOTE="my-box_2"' in result.stdout, result.stdout
+
+
+def test_setup_fails_loudly_for_a_dotenv_box_remote_outside_the_safe_pattern(
+    isolated_dir,
+):
+    """A value the safe pattern does not cover (here: single-quoted, the
+    legacy-ish shape an operator might still write) must not be guessed at
+    -- dotenv's real quote-stripping rules would matter here, and this path
+    cannot run them (no uv yet), so it refuses instead of misreading it."""
+    (isolated_dir / ".env").write_text("BOX_REMOTE='mybox'\n")
+    result = _make("-n", "setup", cwd=isolated_dir)
+    assert result.returncode != 0
+    assert "BOX_REMOTE" in result.stderr
+    assert 'BOX_REMOTE="box"' not in result.stdout, (
+        "must not silently fall back to the default remote name"
+    )
+    assert 'BOX_REMOTE="' not in result.stdout, (
+        "must not silently guess at the quoted value either"
+    )
+
+
+def test_setup_fails_loudly_for_a_dotenv_box_remote_containing_a_space(isolated_dir):
+    """Same negative case, a different way outside the safe pattern:
+    whitespace in the value."""
+    (isolated_dir / ".env").write_text("BOX_REMOTE=my box\n")
+    result = _make("-n", "setup", cwd=isolated_dir)
+    assert result.returncode != 0
+    assert "BOX_REMOTE" in result.stderr
+
+
+def test_setup_fails_loudly_for_multiple_dotenv_box_remote_lines(isolated_dir):
+    """.env assigning BOX_REMOTE more than once is ambiguous regardless of
+    whether either individual value would otherwise be safe -- picking
+    either one silently would be a guess, so this still refuses."""
+    (isolated_dir / ".env").write_text("BOX_REMOTE=one\nBOX_REMOTE=two\n")
+    result = _make("-n", "setup", cwd=isolated_dir)
+    assert result.returncode != 0
+    assert "BOX_REMOTE" in result.stderr
+    assert "more than once" in result.stderr
+
+
+def test_setup_with_command_line_box_remote_still_wins_over_dotenv(
+    isolated_dir,
+):
+    """Control: the guard only fires when BOX_REMOTE's origin is the plain
+    `?=` default (`file`) with a .env present -- README's documented
+    workaround (`make setup BOX_REMOTE=<remote-name>`) sets BOX_REMOTE's
+    origin to `command line`, which must still win even when .env's own
+    value is one the safe pattern would have rejected. `MAKE=true` swaps
+    out the recursive `$(MAKE) install-hooks` call the same way
+    test_setup_bypasses_dotenv_extraction_when_uv_is_unresolvable does, for
+    the same reason (a real -n here would otherwise actually re-invoke
+    install-hooks)."""
+    (isolated_dir / ".env").write_text("BOX_REMOTE='fromdotenv'\n")
+    result = _make(
+        "-n", "setup", "BOX_REMOTE=fromcli", "MAKE=true", cwd=isolated_dir
+    )
+    assert result.returncode == 0, result.stderr
+    assert 'BOX_REMOTE="fromcli"' in result.stdout, result.stdout
+
+
+def test_setup_without_dotenv_box_remote_is_unaffected_by_the_guard(isolated_dir):
+    """Control: no .env at all (or one that never mentions BOX_REMOTE) must
+    not trip the new guard -- `setup` keeps working the way #114 fixed it
+    to, using the built-in `box` default."""
+    result = _make("-n", "setup", "MAKE=true", cwd=isolated_dir)
+    assert result.returncode == 0, result.stderr
+    assert 'BOX_REMOTE="box"' in result.stdout, result.stdout
+
+
 def test_parse_time_call_fails_fast_instead_of_hanging_when_sync_needs_network(
     isolated_dir,
 ):
@@ -413,15 +542,27 @@ def test_dotenv_supplied_box_project_root_propagates_to_derived_remotes(isolated
 def test_dotenv_supplied_incoming_and_exhibits_remote_override_directly(isolated_dir):
     """README.md: "If a derived path doesn't match your Box layout, override
     the full endpoint (INCOMING_REMOTE / EXHIBITS_REMOTE) in .env" -- these
-    must be settable independently of BOX_REMOTE/BOX_PROJECT_ROOT."""
+    must be settable independently of BOX_REMOTE/BOX_PROJECT_ROOT.
+
+    Written with the bare form README.md documents (no manual shell quoting
+    around the path) -- NOT the old hand-quoted `customremote:'Custom/Path/'`
+    form this test used to write, which Codex on #138 (finding 1) flagged:
+    #118's sh_quote now wraps the whole value as one shell word, so that old
+    form would reach rclone with the apostrophes taken literally instead of
+    consumed by the shell, silently misdirecting `ingest`/`deliver`. The
+    Makefile now rejects that old form outright (see
+    test_incoming_remote_with_legacy_hand_quoting_is_rejected_loudly and
+    test_exhibits_remote_with_legacy_hand_quoting_is_rejected_loudly below)
+    rather than reinterpreting it, so this test's job is now to prove the
+    *documented* (bare) form still round-trips, not the retired one."""
     (isolated_dir / ".env").write_text(
-        "INCOMING_REMOTE=customremote:'Custom/Path/'\n"
-        "EXHIBITS_REMOTE=customremote:'Other/Path/'\n"
+        "INCOMING_REMOTE=customremote:Custom/Path/\n"
+        "EXHIBITS_REMOTE=customremote:Other/Path/\n"
     )
     result = _make("box-paths", cwd=isolated_dir)
     assert result.returncode == 0, result.stderr
-    assert "INCOMING_REMOTE=customremote:'Custom/Path/'" in result.stdout
-    assert "EXHIBITS_REMOTE=customremote:'Other/Path/'" in result.stdout
+    assert "INCOMING_REMOTE=customremote:Custom/Path/" in result.stdout
+    assert "EXHIBITS_REMOTE=customremote:Other/Path/" in result.stdout
     # BOX_REMOTE/BOX_PROJECT_ROOT untouched by .env here -- still the `?=` defaults.
     assert "BOX_REMOTE=box" in result.stdout
 
@@ -484,17 +625,23 @@ def test_dotenv_value_containing_sentinel_substring_survives_for_other_box_keys(
     isolated_dir,
 ):
     """Representative coverage across the other keys sharing dotenv_get's
-    extraction: BOX_REMOTE, INCOMING_REMOTE, EXHIBITS_REMOTE."""
+    extraction: BOX_REMOTE, INCOMING_REMOTE, EXHIBITS_REMOTE.
+
+    INCOMING_REMOTE/EXHIBITS_REMOTE use the bare (documented) form here, not
+    the old hand-quoted `customremote:'DOTENV_OK:...'` shape this test used
+    to write -- that shape is now rejected outright (finding 1 on #138; see
+    test_incoming_remote_with_legacy_hand_quoting_is_rejected_loudly below),
+    so it would no longer reach box-paths at all."""
     (isolated_dir / ".env").write_text(
         "BOX_REMOTE=my-DOTENV_OK:-remote\n"
-        "INCOMING_REMOTE=customremote:'DOTENV_OK:/Incoming/'\n"
-        "EXHIBITS_REMOTE=customremote:'DOTENV_OK:/Exhibits/'\n"
+        "INCOMING_REMOTE=customremote:DOTENV_OK:/Incoming/\n"
+        "EXHIBITS_REMOTE=customremote:DOTENV_OK:/Exhibits/\n"
     )
     result = _make("box-paths", cwd=isolated_dir)
     assert result.returncode == 0, result.stderr
     assert "BOX_REMOTE=my-DOTENV_OK:-remote" in result.stdout, result.stdout
-    assert "INCOMING_REMOTE=customremote:'DOTENV_OK:/Incoming/'" in result.stdout
-    assert "EXHIBITS_REMOTE=customremote:'DOTENV_OK:/Exhibits/'" in result.stdout
+    assert "INCOMING_REMOTE=customremote:DOTENV_OK:/Incoming/" in result.stdout
+    assert "EXHIBITS_REMOTE=customremote:DOTENV_OK:/Exhibits/" in result.stdout
 
 
 def test_dotenv_value_containing_sentinel_substring_survives_for_oltp_db_url(
@@ -707,6 +854,79 @@ def test_incoming_remote_value_containing_a_literal_quote_reaches_rclone_intact(
     ], argv
 
 
+# --- Codex on #138, finding 1: #118's sh_quote wraps the *whole*
+# INCOMING_REMOTE/EXHIBITS_REMOTE value as one shell word, which is correct
+# for the bare form README.md documents but regresses the old hand-quoted
+# form README.md used to recommend (`box:'Custom/Path/'`): main's unquoted
+# recipe let the shell consume those inner quotes (`box:Custom/Path/`);
+# this branch, before this fix, handed them to rclone literally
+# (`box:'Custom/Path/'`), a different -- and likely wrong or nonexistent --
+# path. `ingest` would read nothing there and `publish-raw` could publish
+# raw citizen data into an unintended apostrophe-named Box folder, silently.
+# The Makefile now rejects the old form with a loud $(error) instead of
+# reinterpreting it. test_incoming_remote_value_containing_a_literal_quote_
+# reaches_rclone_intact above is the control proving a *genuine* embedded
+# apostrophe (not the legacy wrapping shape) still flows through untouched.
+
+
+def test_incoming_remote_with_legacy_hand_quoting_is_rejected_loudly(isolated_dir):
+    """Exact repro from the review: `INCOMING_REMOTE=box:'Custom/Path/'` in
+    .env, the precise value README.md used to recommend. Must fail loudly
+    at parse time -- before ever reaching rclone -- rather than silently
+    reading from (`ingest`) or publishing to (`publish-raw`) an
+    apostrophe-named Box path nobody intended."""
+    (isolated_dir / ".env").write_text("INCOMING_REMOTE=box:'Custom/Path/'\n")
+    result = _make("-n", "ingest", cwd=isolated_dir)
+    assert result.returncode != 0
+    assert "INCOMING_REMOTE" in result.stderr
+    assert "box:'Custom/Path/'" in result.stderr
+
+
+def test_exhibits_remote_with_legacy_hand_quoting_is_rejected_loudly(isolated_dir):
+    """Same repro, for EXHIBITS_REMOTE/`deliver` -- the review asked this be
+    applied to both endpoints, not just INCOMING_REMOTE."""
+    (isolated_dir / ".env").write_text("EXHIBITS_REMOTE=box:'Other/Path/'\n")
+    result = _make("-n", "deliver", cwd=isolated_dir)
+    assert result.returncode != 0
+    assert "EXHIBITS_REMOTE" in result.stderr
+    assert "box:'Other/Path/'" in result.stderr
+
+
+def test_command_line_incoming_remote_with_legacy_hand_quoting_is_also_rejected(
+    isolated_dir,
+):
+    """The legacy shape is rejected regardless of which precedence tier it
+    arrives through -- a command-line override written the old way is the
+    same trap as a .env one."""
+    result = _make(
+        "-n", "INCOMING_REMOTE=box:'Custom/Path/'", "ingest", cwd=isolated_dir
+    )
+    assert result.returncode != 0
+    assert "INCOMING_REMOTE" in result.stderr
+
+
+def test_incoming_remote_ending_in_a_genuine_apostrophe_is_not_mistaken_for_legacy_quoting(
+    isolated_dir,
+):
+    """Negative control the review called out explicitly: a real Box folder
+    ending in an apostrophe (not wrapped in one) must not be rejected --
+    only the exact `remote:'...'` wrapping shape is. Distinct from
+    test_incoming_remote_value_containing_a_literal_quote_reaches_rclone_
+    intact above (that one's folder ends in `/`, after the apostrophe;
+    this one's folder ends in the apostrophe itself, closer to the
+    legacy-quoting shape's own last character)."""
+    (isolated_dir / ".env").write_text(
+        "INCOMING_REMOTE=box:My Grandmother's\n"
+    )
+    argv = _rclone_argv(isolated_dir, "ingest")
+    assert argv == [
+        "copy",
+        "box:My Grandmother's",
+        "data/raw/",
+        "--progress",
+    ], argv
+
+
 def test_command_line_box_remote_containing_dollar_survives_to_rclone(isolated_dir):
     """Regression guard for the $(origin ...)/$(value ...) treatment #118
     also gives BOX_REMOTE (mirroring OLTP_DB_URL_RAW, per the comment above
@@ -721,6 +941,36 @@ def test_command_line_box_remote_containing_dollar_survives_to_rclone(isolated_d
         "copy",
         "a$b:2. Projects/21. Governance//Data/Raw/",
         "data/raw/",
+        "--progress",
+    ], argv
+
+
+def test_command_line_raw_local_containing_dollar_survives_to_rclone(isolated_dir):
+    """The same #60/#103/#118 bug class, found one key further out while
+    fixing box-paths for Codex's finding 3 on #138: RAW_LOCAL/EXHIBITS_LOCAL
+    never got the _RAW/$(origin ...) treatment (the Makefile's own comment
+    above RAW_LOCAL_RAW explains why they were originally exempted, and why
+    that turned out to be wrong). Verified directly against the real
+    (pre-fix) recipe: `make RAW_LOCAL='data$raw/' ingest` silently
+    truncated the rclone argument to `dataaw/` even though it already went
+    through sh_quote -- the bare `$(RAW_LOCAL)` reference inside sh_quote's
+    own $(subst ...) re-scanned the command-line-origin value for `$`."""
+    argv = _rclone_argv(isolated_dir, "RAW_LOCAL=data$raw/", "ingest")
+    assert argv == [
+        "copy",
+        "box:2. Projects/21. Governance//Data/Raw/",
+        "data$raw/",
+        "--progress",
+    ], argv
+
+
+def test_command_line_exhibits_local_containing_dollar_survives_to_rclone(isolated_dir):
+    """Same regression, for EXHIBITS_LOCAL/`deliver`."""
+    argv = _rclone_argv(isolated_dir, "EXHIBITS_LOCAL=out$puts/", "deliver")
+    assert argv == [
+        "copy",
+        "out$puts/",
+        "box:2. Projects/21. Governance//Analysis/Exhibits/",
         "--progress",
     ], argv
 
@@ -760,3 +1010,61 @@ def test_box_paths_still_reports_incoming_remote_without_stray_quote_characters(
     assert "'" not in [
         line for line in result.stdout.splitlines() if line.startswith("INCOMING_REMOTE=")
     ][0]
+
+
+# --- Codex on #138, finding 3: box-paths interpolated the _RAW values
+# straight into a double-quoted `echo "KEY=$(...)"` shell string, which put
+# them in a position the shell itself re-scans for `$` -- so a value
+# containing a literal `$` lost everything from that `$` onward in
+# box-paths' output specifically, even though the same value survives
+# intact into the real ingest/publish-raw/deliver recipes (which already
+# went through sh_quote via #118). The diagnostic disagreed with what the
+# recipes actually do -- exactly the drift the comment above box-paths
+# claims it prevents. On the GNU Make 3.81 this repo targets, .SHELLFLAGS
+# is not honored (it postdates 3.81), so the failure is silent truncation,
+# not the "unbound variable" abort a `set -u` shell would otherwise give --
+# confirmed directly (see the Makefile's comment above box-paths) before
+# fixing it, per the review's own instruction not to trust the predicted
+# mechanism uncritically.
+
+
+def test_box_paths_does_not_truncate_a_value_containing_a_dollar_sign(isolated_dir):
+    """Exact repro from the review: `make BOX_REMOTE='a$b' box-paths` used
+    to print `BOX_REMOTE=a` (silently dropping `$b`), while `make
+    BOX_REMOTE='a$b' ingest` correctly preserved `a$b` in the rclone
+    argument -- the same value, two different answers depending on which
+    target asked."""
+    result = _make("BOX_REMOTE=a$b", "box-paths", cwd=isolated_dir)
+    assert result.returncode == 0, result.stderr
+    assert "BOX_REMOTE=a$b" in result.stdout, result.stdout
+    # The derived endpoints inherit BOX_REMOTE and must not be truncated either.
+    assert "INCOMING_REMOTE=a$b:2. Projects/21. Governance//Data/Raw/" in result.stdout
+    assert "EXHIBITS_REMOTE=a$b:2. Projects/21. Governance//Analysis/Exhibits/" in result.stdout
+
+
+def test_box_paths_does_not_truncate_dotenv_box_project_root_containing_a_dollar_sign(
+    isolated_dir,
+):
+    """Same bug, reached through the .env tier instead of the command line
+    -- BOX_PROJECT_ROOT is exactly as .env-populated as BOX_REMOTE (#104)."""
+    (isolated_dir / ".env").write_text("BOX_PROJECT_ROOT=Archive$2026\n")
+    result = _make("box-paths", cwd=isolated_dir)
+    assert result.returncode == 0, result.stderr
+    assert "BOX_PROJECT_ROOT=Archive$2026" in result.stdout, result.stdout
+
+
+def test_box_paths_does_not_truncate_raw_local_or_exhibits_local_containing_a_dollar_sign(
+    isolated_dir,
+):
+    """RAW_LOCAL/EXHIBITS_LOCAL are plain local-directory `?=` defaults, not
+    part of the .env-extraction machinery, but box-paths' echo of them went
+    through the same vulnerable double-quoted interpolation and must be
+    fixed the same way (the review asked for RAW_LOCAL/EXHIBITS_LOCAL
+    coverage explicitly)."""
+    result = _make(
+        "RAW_LOCAL=data$raw/", "EXHIBITS_LOCAL=out$puts/", "box-paths",
+        cwd=isolated_dir,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "RAW_LOCAL=data$raw/" in result.stdout, result.stdout
+    assert "EXHIBITS_LOCAL=out$puts/" in result.stdout, result.stdout


### PR DESCRIPTION
Three deferred Makefile regressions from #88, fixed in sequence on one branch because #114 and #115 touch the same 50 lines.

Fixes #114
Fixes #115
Fixes #118

## Why now

`make` was dead locally for every target, not just the demo ones:

```
Makefile:106: *** .env exists but OLTP_DB_URL could not be parsed from it (#103)
-- refusing to silently fall back to the throwaway demo default.
'uv run python' stderr: error: Failed to generate package metadata for
`en-core-web-sm==3.8.0 @ direct+https://...` Caused by: operation timed out.  Stop.
```

The parse-time dotenv call ran a bare `uv run`, which resolves and syncs the project before running anything. A transient failure fetching the spaCy wheel took ~2 minutes, then the `ifeq` guard escalated it to a hard `$(error)` that aborts `help`, `status`, `box-paths` and `setup` alike. Same root cause as #114, reached with `uv` present instead of missing.

## Commits

**`dfb6b07` fix(makefile): stop parse-time dotenv from blocking setup or hanging on sync (#114)**

- `dotenv_get`'s `uv run` takes `--no-sync --offline`, so it never resolves or fetches. It uses whatever `.venv` exists.
- The dotenv-extraction block is skipped when `setup` is among `MAKECMDGOALS`. `setup` consumes none of those keys and is the target that installs `uv`, so requiring `uv` to parse before it could start was a bootstrap cycle. `setup`'s own recursive `$(MAKE) install-hooks` re-parses under a different goal, by which point `scripts/setup.sh` has installed `uv`.
- The hard `$(error)` on a genuine parse failure (#103) is unchanged for every other target.

**`fd3a6e8` fix(makefile): stop DOTENV_OK sentinel from corrupting values that contain it (#115)**

- The stdout sentinel is gone. `dotenv_get` writes the raw value to stdout and its exit status to a separate `_DOTENV_STATUS` file, read back by a `dotenv_status` macro. All five call sites use it.
- No stripping step exists anymore, so there is nothing left to corrupt. `BOX_PROJECT_ROOT=Archive/DOTENV_OK:2026` survives intact instead of resolving to `Archive/2026`.
- `patsubst`/`filter` were rejected deliberately: both are whitespace-splitting word operations, and `BOX_PROJECT_ROOT`'s own default has spaces in it. `.SHELLSTATUS` needs GNU Make 4.2 and this repo runs 3.81.

**`f09f256` fix(makefile): quote INCOMING_REMOTE/EXHIBITS_REMOTE at the recipe boundary (#118)**

- `ingest`, `publish-raw` and `deliver` wrap the endpoints and local paths in the existing `sh_quote` instead of interpolating bare.
- The literal single quotes baked into the `?=` defaults are dropped. They only ever protected the untouched default, never an operator's override, which is the case #118 flagged.
- The `$(origin)`/`$(value)` handling that `OLTP_DB_URL_RAW` already had is extended to `BOX_REMOTE`, `BOX_PROJECT_ROOT`, `INCOMING_REMOTE` and `EXHIBITS_REMOTE`, so a `$` in a command-line or exported override is not re-scanned by Make. This was reproduced at the macro level before being fixed, not assumed.
- `box-paths` echoes the same `_RAW` values the recipes consume, so the diagnostic cannot drift from what `rclone` receives.
- README's "Box paths and data ops" section now says to write the bare value, since quoting is the Makefile's job.

## Verification

- `make help` with a real `.env`: **0.31s**. Previously a ~2 minute wait into a hard error.
- `make box-paths` resolves the real space-bearing `BOX_PROJECT_ROOT` as one argument. Before this branch that default word-split into four `rclone` arguments.
- `make -n setup` with `uv` genuinely unresolvable (PATH stripped, `USER_BIN` pointed at a nonexistent dir) and a `.env` present: succeeds in 0.011s. That is the #114 fix.
- Default config produces byte-identical `rclone` endpoint arguments to `main`.
- `uv run pytest tests/test_makefile_dotenv.py`: **35 passed**, up from 19 on `main`.

New tests drive the real `make` binary in a `tmp_path` fixture, with a stub `rclone` on PATH that prints its argv, so argument boundaries are asserted for real rather than string-matched against recipe text. Coverage added for: `setup` running without `uv`, the parse-time call failing fast instead of hanging, sentinel-substring values surviving for each affected key, values with spaces and with a literal `'`, command-line overrides containing `$`, and default-config parity with pre-fix behaviour.

## Operator-visible change

Default configuration behaves identically. Overrides for `INCOMING_REMOTE`, `EXHIBITS_REMOTE` and `BOX_PROJECT_ROOT` containing spaces now work instead of silently misdirecting `ingest`/`deliver` or failing on a split argument. Hand-quoted values already in a `.env` are still honoured as literal characters, but are no longer needed.
