### PR TITLE
fix(pii): redact bank account and scheme IDs, recover landline shapes, add --refresh-stale

### DIFF
--- a/janasunani/pipeline/pii_eval.py
+++ b/janasunani/pipeline/pii_eval.py
@@ -321,6 +321,18 @@ def _overlaps(gold: PIISpan, predicted: PIISpan) -> bool:
 
 
 def _format_metrics(entity: str, metrics: EntityMetrics) -> str:
+    # An entity the gold never labels has no recall to report. Printing
+    # 0.0000 there reads as total failure when it means the measurement
+    # cannot see the class at all -- and this table is published (#67).
+    # BANK_ACCOUNT and SCHEME_ID (#139) are exactly this case: the n50 gold
+    # predates them, so the tagger is scored as missing everything while
+    # actually redacting identifiers the gold never asked about.
+    if metrics.gold == 0:
+        return (
+            f"{entity} {metrics.gold} {metrics.predicted} "
+            f"{metrics.overlap_hits} {metrics.exact_hits} "
+            "n/a n/a  (not labelled in this gold)"
+        )
     return (
         f"{entity} {metrics.gold} {metrics.predicted} "
         f"{metrics.overlap_hits} {metrics.exact_hits} "

--- a/janasunani/pipeline/redact_grievance.py
+++ b/janasunani/pipeline/redact_grievance.py
@@ -98,18 +98,29 @@ def _analyzer_version() -> str:
 
 
 async def _load_pending_batch(
-    conn, district: str, year: int, limit: int
+    conn,
+    district: str,
+    year: int,
+    limit: int,
+    version: str | None = None,
 ) -> list[tuple[str, str]]:
-    """Complaints in the slice with grievance text and no redaction row yet.
+    """Complaints in the slice with grievance text and no current redaction.
 
     The pending predicate *is* the resume mechanism, so it must stay a NOT
     EXISTS against the output table rather than an offset: rows land in
     ``grievance_redactions`` as the run proceeds, and an offset would skip
     unprocessed rows once earlier ones stopped matching.
+
+    When ``version`` is given, a row stamped with a *different*
+    ``analyzer_version`` also counts as pending (#130). Without this the
+    stamp is write-only: a completed slice is excluded forever, so a better
+    analyzer can never reach the rows it was built to fix.
     """
     done = select(GrievanceRedaction.ticket_no).where(
         GrievanceRedaction.ticket_no == Complaint.ticket_no
     )
+    if version is not None:
+        done = done.where(GrievanceRedaction.analyzer_version == version)
     stmt = (
         select(Complaint.ticket_no, Complaint.grievance)
         .where(
@@ -150,18 +161,41 @@ async def _count_slice(conn, district: str, year: int) -> tuple[int, int]:
     return int(total or 0), int(done or 0)
 
 
+async def _count_stale(conn, district: str, year: int, version: str) -> int:
+    """Rows in the slice redacted by a different analyzer than the current one.
+
+    Reported by every run whether or not it acts on them, so the need for a
+    refresh is visible rather than something you have to think to check.
+    """
+    return int(
+        await conn.scalar(
+            select(func.count())
+            .select_from(GrievanceRedaction)
+            .join(Complaint, Complaint.ticket_no == GrievanceRedaction.ticket_no)
+            .where(
+                Complaint.district == district,
+                Complaint.created_year == year,
+                GrievanceRedaction.analyzer_version != version,
+            )
+        )
+        or 0
+    )
+
+
 async def _redact_slice(
     engine: AsyncEngine,
     district: str,
     year: int,
     redact: Any,
     limit: Optional[int] = None,
+    refresh_stale: bool = False,
 ) -> dict[str, int]:
     version = _analyzer_version()
     processed = 0
 
     async with engine.begin() as conn:
         total, already = await _count_slice(conn, district, year)
+        stale = await _count_stale(conn, district, year, version)
     logger.info(
         "slice {}/{}: {} complaints with grievance text, {} already redacted",
         district,
@@ -169,6 +203,15 @@ async def _redact_slice(
         total,
         already,
     )
+    if stale:
+        logger.warning(
+            "{} row(s) were redacted by a different analyzer than this one. "
+            "{}",
+            stale,
+            "Reprocessing them (--refresh-stale)."
+            if refresh_stale
+            else "Leaving them as they are; pass --refresh-stale to reprocess.",
+        )
 
     while True:
         remaining = None if limit is None else limit - processed
@@ -177,7 +220,9 @@ async def _redact_slice(
         size = BATCH_SIZE if remaining is None else min(BATCH_SIZE, remaining)
 
         async with engine.begin() as conn:
-            batch = await _load_pending_batch(conn, district, year, size)
+            batch = await _load_pending_batch(
+                conn, district, year, size, version=version if refresh_stale else None
+            )
             if not batch:
                 break
 
@@ -205,7 +250,12 @@ async def _redact_slice(
         processed += len(batch)
         logger.info("redacted {} of {} ({} this batch)", processed + already, total, len(batch))
 
-    return {"total": total, "already_redacted": already, "processed": processed}
+    return {
+        "total": total,
+        "already_redacted": already,
+        "processed": processed,
+        "stale_at_start": stale,
+    }
 
 
 def redact_grievances(
@@ -213,6 +263,7 @@ def redact_grievances(
     year: int,
     oltp_url: Optional[str] = None,
     limit: Optional[int] = None,
+    refresh_stale: bool = False,
 ) -> dict[str, int]:
     """Redact one district-year slice. Returns per-run counts."""
     # Imported here, not at module scope: pipeline-core is an optional extra,
@@ -224,7 +275,14 @@ def redact_grievances(
 
     async def run() -> dict[str, int]:
         try:
-            return await _redact_slice(engine, district, year, redact_text, limit=limit)
+            return await _redact_slice(
+                engine,
+                district,
+                year,
+                redact_text,
+                limit=limit,
+                refresh_stale=refresh_stale,
+            )
         finally:
             await engine.dispose()
 
@@ -249,10 +307,23 @@ def main() -> None:
         type=int,
         help="Stop after this many complaints. For a smoke test before the full run.",
     )
+    parser.add_argument(
+        "--refresh-stale",
+        action="store_true",
+        help=(
+            "Also reprocess rows redacted by a different analyzer version. "
+            "Off by default: a backfill over citizen text should not silently "
+            "change scope because an unrelated commit landed."
+        ),
+    )
     args = parser.parse_args()
 
     counts = redact_grievances(
-        args.district, args.year, oltp_url=args.oltp_url, limit=args.limit
+        args.district,
+        args.year,
+        oltp_url=args.oltp_url,
+        limit=args.limit,
+        refresh_stale=args.refresh_stale,
     )
     logger.info(
         "done: {} processed this run, {} of {} redacted in slice {}/{}",

--- a/janasunani/pipeline/stages/pii_tagger.py
+++ b/janasunani/pipeline/stages/pii_tagger.py
@@ -51,6 +51,8 @@ ENTITY_TOKENS = {
     "IN_LANDLINE": "[PHONE]",
     "IN_AADHAAR": "[AADHAAR]",
     "IN_PAN": "[PAN]",
+    "IN_BANK_ACCOUNT": "[ACCOUNT]",
+    "IN_SCHEME_ID": "[ID]",
     "EMAIL_ADDRESS": "[EMAIL]",
 }
 
@@ -65,6 +67,10 @@ ENTITY_ALIASES = {
     "AADHAAR": "AADHAAR",
     "IN_PAN": "PAN",
     "PAN": "PAN",
+    "IN_BANK_ACCOUNT": "BANK_ACCOUNT",
+    "BANK_ACCOUNT": "BANK_ACCOUNT",
+    "IN_SCHEME_ID": "SCHEME_ID",
+    "SCHEME_ID": "SCHEME_ID",
     "EMAIL_ADDRESS": "EMAIL",
     "EMAIL": "EMAIL",
 }
@@ -159,6 +165,105 @@ def _ascii_digits(text: str) -> str:
 _engines: tuple | None = None
 
 
+# Identifier classes with no distinctive shape of their own (#139). Each maps
+# a set of context words to the digit lengths that class plausibly takes.
+#
+# Lengths are deliberately generous. Indian bank account numbers run 9-18
+# digits across banks; ration, job-card and registration numbers vary by
+# scheme and district. Over-redaction is the documented safe failure direction
+# here -- an extra [ACCOUNT] where a case number stood is visible and
+# harmless, an un-redacted account number is not.
+_IDENTIFIER_CLASSES = (
+    (
+        "IN_BANK_ACCOUNT",
+        re.compile(
+            r"(?:a/?c|acc(?:oun)?t|account|bank|ifsc|passbook|khata)"
+            # Qualifiers repeat: "account no.", "bank a/c number", "khata no".
+            r"(?:[^0-9A-Za-z]{0,4}(?:a/?c|n[o0]\.?|number|num|is))*"
+            r"[^0-9A-Za-z]{0,4}$",
+            re.IGNORECASE,
+        ),
+        (9, 18),
+    ),
+    (
+        "IN_SCHEME_ID",
+        re.compile(
+            r"(?:ration|job\s*card|jobcard|mgnrega|nrega|registration|regd|"
+            r"epic|voter|udise|pension|scholarship|beneficiary|applicant)"
+            # Qualifiers repeat and stack: "ration card no", "job card number".
+            r"(?:[^0-9A-Za-z]{0,4}(?:i?d|n[o0]\.?|number|num|card|is))*"
+            r"[^0-9A-Za-z]{0,4}$",
+            re.IGNORECASE,
+        ),
+        (8, 18),
+    ),
+)
+
+# A bare run this long is an identifier whatever it is called. Nothing in a
+# grievance subject line is legitimately a 14+ digit number except an account
+# or a scheme id, and requiring a keyword would miss every one written without
+# a label. Below this length the keyword is required, or case numbers would be
+# redacted wholesale.
+_BARE_ACCOUNT_MIN = 14
+_BARE_ACCOUNT_MAX = 18
+
+_DIGIT_RUN_RE = re.compile(r"(?<!\d)\d{8,18}(?!\d)")
+
+# How far back to look for the context word. Long enough to span "bank account
+# number is", short enough that an unrelated earlier mention does not leak in.
+_CONTEXT_WINDOW = 40
+
+
+class _IndianIdentifierRecognizer:
+    """Bank account and scheme-identifier numbers, anchored on context.
+
+    Subclasses Presidio's EntityRecognizer at construction time rather than at
+    import, so this module stays importable without presidio installed (the
+    lazy-import philosophy the rest of the file follows).
+    """
+
+    def __new__(cls):
+        from presidio_analyzer import EntityRecognizer, RecognizerResult
+
+        class _Impl(EntityRecognizer):
+            def __init__(self) -> None:
+                super().__init__(
+                    supported_entities=[name for name, _, _ in _IDENTIFIER_CLASSES],
+                    name="in_identifier_recognizer",
+                    supported_language="en",
+                )
+
+            def load(self) -> None:  # pragma: no cover - presidio hook
+                pass
+
+            def analyze(self, text, entities, nlp_artifacts=None):
+                results = []
+                for match in _DIGIT_RUN_RE.finditer(text):
+                    start, end = match.start(), match.end()
+                    length = end - start
+                    before = text[max(0, start - _CONTEXT_WINDOW) : start]
+
+                    entity = None
+                    score = 0.0
+                    for name, context_re, (low, high) in _IDENTIFIER_CLASSES:
+                        if low <= length <= high and context_re.search(before):
+                            entity, score = name, 0.7
+                            break
+                    if entity is None and _BARE_ACCOUNT_MIN <= length <= _BARE_ACCOUNT_MAX:
+                        entity, score = "IN_BANK_ACCOUNT", 0.6
+
+                    if entity is None or (entities and entity not in entities):
+                        continue
+                    results.append(
+                        RecognizerResult(
+                            entity_type=entity, start=start, end=end, score=score
+                        )
+                    )
+                return results
+
+        return _Impl()
+
+
 def _get_engines():
     """Build (analyzer, anonymizer) once per process. Heavy imports live here
     so importing this module stays light (lazy-import philosophy)."""
@@ -247,6 +352,28 @@ def _get_engines():
             context=["pan", "income tax", "permanent account"],
         )
     )
+    # Bank accounts and government scheme identifiers (#139).
+    #
+    # Found in the Sambalpur 2024 redaction pass: 579 digit runs of 11-18
+    # characters survived, because nothing looked for them. ENTITY_TOKENS
+    # covered NAME/PHONE/EMAIL/AADHAAR/PAN, and Aadhaar is exactly 12 digits,
+    # so every other identifier length passed straight through. In a corpus
+    # about pensions, rations and scholarships, the numbers citizens quote are
+    # account numbers, ration cards and job cards -- removing someone's name
+    # while leaving their bank account is not a redaction.
+    #
+    # These are shape-PLUS-context problems, unlike Aadhaar and PAN which have
+    # a distinctive shape of their own. A bare 11-digit run could be a job card
+    # or a case number and nothing about the digits distinguishes them, so the
+    # context word is load-bearing rather than a confidence nudge -- which is
+    # why this is a custom recognizer instead of a PatternRecognizer with a
+    # `context` list. Presidio's `context` only boosts a score; here its
+    # absence must mean no match at all.
+    #
+    # The returned span covers the DIGITS ONLY. Matching the keyword too would
+    # redact "account no." along with the number and destroy the sentence for
+    # the officer reading it.
+    analyzer.registry.add_recognizer(_IndianIdentifierRecognizer())
     # Landline: STD code (2-4 digits after the leading 0) plus a 6-8 digit
     # subscriber number, e.g. Bhubaneswar "0674 2536789". Presidio's built-in
     # PhoneRecognizer used to be the only thing catching these, at the same
@@ -294,6 +421,23 @@ def _get_engines():
                     "in_landline_split_subscriber",
                     r"(?<!\d)0\d{2,4}[\s-]\d{3}[\s-]\d{4}(?!\d)",
                     0.6,
+                ),
+                # #120: two shapes the Sambalpur scan and the n50 gold both
+                # showed surviving. Written without the leading 0 ("674-2536789"
+                # for Bhubaneswar), and split 6-4 rather than at the STD
+                # boundary ("025612 3456"). Both are separator-bearing, so
+                # they cannot be confused with a bare mobile, and the
+                # citation guard in _postfilter still exempts "Letter No."
+                # style references that happen to take the same shape.
+                Pattern(
+                    "in_landline_no_leading_zero",
+                    r"(?<!\d)[1-9]\d{2,3}[\s-]\d{6,8}(?!\d)",
+                    0.55,
+                ),
+                Pattern(
+                    "in_landline_split_six_four",
+                    r"(?<!\d)0\d{4,5}[\s-]\d{4}(?!\d)",
+                    0.55,
                 ),
             ],
             context=["landline", "office", "std code", "telephone"],

--- a/tests/test_pii_eval.py
+++ b/tests/test_pii_eval.py
@@ -241,3 +241,26 @@ def test_cli_gate_exits_nonzero_when_below_baseline(tmp_path, capsys, monkeypatc
 
     assert code == 1
     assert "passed=false" in capsys.readouterr().out
+
+
+def test_an_entity_absent_from_the_gold_reports_na_not_zero():
+    """#139/#67. An entity the gold never labels has no recall to report.
+    Printing 0.0000 reads as total failure when it means the measurement
+    cannot see the class -- and this table gets published."""
+    from janasunani.pipeline.pii_eval import EntityMetrics, _format_metrics
+
+    row = _format_metrics(
+        "BANK_ACCOUNT", EntityMetrics(gold=0, predicted=7, overlap_hits=0, exact_hits=0)
+    )
+    assert "0.0000" not in row
+    assert "n/a" in row
+    assert "not labelled in this gold" in row
+
+
+def test_a_labelled_entity_still_reports_numeric_recall():
+    from janasunani.pipeline.pii_eval import EntityMetrics, _format_metrics
+
+    row = _format_metrics(
+        "NAME", EntityMetrics(gold=404, predicted=497, overlap_hits=176, exact_hits=106)
+    )
+    assert "0.4356" in row

--- a/tests/test_pii_redaction.py
+++ b/tests/test_pii_redaction.py
@@ -315,3 +315,91 @@ def test_redact_text_and_detect_pii_spans_agree_on_government_email():
     assert "citizen@gmail.com" not in red and "[EMAIL]" in red  # citizen: redacted
     assert len(email_spans) == 1
     assert text[email_spans[0].start : email_spans[0].end] == "citizen@gmail.com"
+
+
+class TestSchemeAndAccountIdentifiers:
+    """#139. Found in the Sambalpur 2024 pass: 579 digit runs of 11-18 chars
+    survived because nothing looked for them. In a corpus about pensions,
+    rations and scholarships, removing a citizen's name while leaving their
+    bank account is not a redaction.
+
+    Synthetic numbers only.
+    """
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "my account no. 123456789012345 not credited",
+            "bank a/c 987654321098 pension pending",
+            "account number is 123456789012 wrong",
+            "khata no 1234567890123 blocked",
+        ],
+    )
+    def test_context_anchored_account_numbers_are_redacted(self, text):
+        assert "[ACCOUNT]" in redact_text(text)
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "ration card no 12345678901 not working",
+            "my ration card 12345678901 blocked",
+            "job card number 98765432101 wrong",
+            "registration no 123456789012 rejected",
+        ],
+    )
+    def test_context_anchored_scheme_ids_are_redacted(self, text):
+        assert "[ID]" in redact_text(text)
+
+    def test_a_long_bare_run_is_redacted_without_a_keyword(self):
+        """Nothing in a grievance subject is legitimately a 14+ digit number
+        except an account or scheme id, and requiring a keyword would miss
+        every one written without a label."""
+        assert "[ACCOUNT]" in redact_text("12345678901234567 credited late")
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "Letter No. 1234567890 dated 05.06.2024",
+            "case no 12345678 pending review",
+        ],
+    )
+    def test_cited_reference_numbers_are_not_redacted(self, text):
+        """Below the bare-run threshold a keyword is required, or case and
+        letter numbers would be redacted wholesale."""
+        assert "[ACCOUNT]" not in redact_text(text)
+        assert "[ID]" not in redact_text(text)
+
+    def test_the_surrounding_words_survive(self):
+        """The span covers the digits only. Redacting 'account no.' along with
+        the number would destroy the sentence for the officer reading it."""
+        out = redact_text("my account no. 123456789012345 not credited")
+        assert "account no." in out
+        assert "not credited" in out
+
+    def test_aadhaar_still_wins_on_its_own_shape(self):
+        assert "[AADHAAR]" in redact_text("aadhaar 234567890123 mismatch")
+
+    def test_a_mobile_is_still_a_phone_not_an_identifier(self):
+        out = redact_text("call me on 9876543210 about the water supply")
+        assert "[PHONE]" in out
+        assert "[ACCOUNT]" not in out and "[ID]" not in out
+
+
+class TestLandlineShapesFromTheSambalpurScan:
+    """#120. Two shapes the n50 gold and the 55,544-row Sambalpur scan both
+    showed surviving after PHONE_NUMBER was dropped in #55."""
+
+    def test_std_written_without_the_leading_zero(self):
+        assert "[PHONE]" in redact_text("std 674-2536789 office")
+
+    def test_split_six_four_rather_than_at_the_std_boundary(self):
+        assert "[PHONE]" in redact_text("landline 025612 3456 ward")
+
+    def test_the_citation_guard_still_protects_reference_numbers(self):
+        """These shapes are structurally identical to zero-prefixed file
+        numbers, so the textual citation signal is what separates them."""
+        assert "[PHONE]" not in redact_text("Letter No. 1234567890 dated 05.06.2024")
+        assert "[PHONE]" not in redact_text("case no 123-4567890 pending")
+
+    def test_dates_are_still_not_phones(self):
+        assert "[PHONE]" not in redact_text("on 06.05.2025 we filed the complaint")

--- a/tests/test_redact_grievance.py
+++ b/tests/test_redact_grievance.py
@@ -112,13 +112,13 @@ class TestResumability:
     def test_counts_report_the_slice(self, oltp):
         async_url, _ = oltp
         counts = redact_grievances("Khordha", 2024, oltp_url=async_url)
-        assert counts == {"total": 3, "already_redacted": 0, "processed": 3}
+        assert counts == {"total": 3, "already_redacted": 0, "processed": 3, "stale_at_start": 0}
 
     def test_second_run_is_a_no_op(self, oltp):
         async_url, _ = oltp
         redact_grievances("Khordha", 2024, oltp_url=async_url)
         second = redact_grievances("Khordha", 2024, oltp_url=async_url)
-        assert second == {"total": 3, "already_redacted": 3, "processed": 0}
+        assert second == {"total": 3, "already_redacted": 3, "processed": 0, "stale_at_start": 0}
 
     def test_an_interrupted_run_resumes_where_it_stopped(self, oltp):
         async_url, sync_url = oltp
@@ -259,3 +259,64 @@ class TestRealAnalyzer:
         out = redactions(sync_url)["T1"]
         assert "9876543210" not in out
         assert "water supply" in out
+
+
+class TestRefreshStale:
+    """#130. Without this the analyzer_version stamp is write-only: a completed
+    slice is excluded forever, so a better analyzer can never reach the rows it
+    was built to fix. #139 and #120 are exactly that case."""
+
+    def _restamp(self, sync_url: str, version: str) -> None:
+        engine = create_engine(sync_url)
+        with engine.begin() as conn:
+            conn.execute(
+                text("UPDATE grievance_redactions SET analyzer_version = :v"),
+                {"v": version},
+            )
+        engine.dispose()
+
+    def test_stale_rows_are_counted_even_when_not_reprocessed(self, oltp):
+        """Reported by every run, so the need is visible rather than something
+        you have to think to check."""
+        async_url, sync_url = oltp
+        redact_grievances("Khordha", 2024, oltp_url=async_url)
+        self._restamp(sync_url, "presidio-analyzer=0.0.1 an-older-build")
+
+        counts = redact_grievances("Khordha", 2024, oltp_url=async_url)
+        assert counts["stale_at_start"] == 3
+        assert counts["processed"] == 0
+
+    def test_stale_rows_are_not_reprocessed_by_default(self, oltp):
+        """A backfill over citizen text must not change scope because an
+        unrelated commit landed."""
+        async_url, sync_url = oltp
+        redact_grievances("Khordha", 2024, oltp_url=async_url)
+        self._restamp(sync_url, "presidio-analyzer=0.0.1 an-older-build")
+
+        counts = redact_grievances("Khordha", 2024, oltp_url=async_url)
+        assert counts["processed"] == 0
+
+    def test_refresh_stale_reprocesses_them(self, oltp):
+        async_url, sync_url = oltp
+        redact_grievances("Khordha", 2024, oltp_url=async_url)
+        self._restamp(sync_url, "presidio-analyzer=0.0.1 an-older-build")
+
+        counts = redact_grievances("Khordha", 2024, oltp_url=async_url, refresh_stale=True)
+        assert counts["processed"] == 3
+
+        engine = create_engine(sync_url)
+        with engine.begin() as conn:
+            stamps = conn.execute(
+                select(GrievanceRedaction.analyzer_version).distinct()
+            ).scalars().all()
+        engine.dispose()
+        assert len(stamps) == 1 and "0.0.1" not in stamps[0]
+
+    def test_refresh_stale_leaves_current_rows_alone(self, oltp):
+        """Rows already on the current analyzer are not rewritten, so a refresh
+        run costs only what actually changed."""
+        async_url, _ = oltp
+        redact_grievances("Khordha", 2024, oltp_url=async_url)
+        counts = redact_grievances("Khordha", 2024, oltp_url=async_url, refresh_stale=True)
+        assert counts["processed"] == 0
+        assert counts["stale_at_start"] == 0


### PR DESCRIPTION
Closes #139. Closes #120. Closes #130.

Three fixes that together make the demo slice properly redacted. They are on one branch because each is useless without the others: the recognizers fix what is missed, and `--refresh-stale` is the only way those fixes reach the 55,544 rows already written.

## #139 — identifiers nothing was looking for

The Sambalpur 2024 pass left **579 digit runs of 11-18 characters** unredacted. `ENTITY_TOKENS` covered NAME/PHONE/EMAIL/AADHAAR/PAN, and Aadhaar is exactly 12 digits, so every other identifier length passed straight through. Context check on those runs: **122** beside ration or job-card keywords, **26** beside account or bank.

This is a corpus about pensions, rations and scholarships. Removing a citizen's name while leaving their bank account is not a redaction.

**Why a custom recognizer rather than a `PatternRecognizer`.** These are shape-*plus*-context problems. A bare 11-digit run is a job card or a case number and the digits do not say which, so the context word has to be load-bearing — but Presidio's `context=` only boosts a score, it cannot make absence mean no-match. Bare runs of 14+ digits match without a keyword, because nothing in a grievance subject is legitimately that long except an account or scheme id, and requiring a label would miss every unlabelled one.

**The span covers the digits only.** Matching the keyword too would redact "account no." along with the number and destroy the sentence for the officer reading it.

## #120 — two landline shapes

Added the shapes the n50 gold and the 55,544-row scan both showed surviving: STD written without the leading zero (`674-2536789`) and split 6-4 rather than at the STD boundary (`025612 3456`). **PHONE overlap recall 0.7931 → 0.8276.** Both are separator-bearing so they cannot be confused with a bare mobile, and the citation guard still exempts `Letter No.` references of the same shape.

## #130 — the stamp was write-only

The pending predicate was an unconditional `NOT EXISTS`, so a completed slice was excluded forever and `analyzer_version` could never be acted on. `--refresh-stale` treats a version mismatch as pending.

**Explicit flag, not an implicit predicate.** A backfill over citizen text should not silently change scope because an unrelated commit touched `pii_tagger`, and someone resuming a run expecting a no-op should get one. The stale count is reported by **every** run whether or not it acts, so the need is visible rather than something you have to remember to check.

## Also: the scorecard was about to publish a misleading zero

`BANK_ACCOUNT` has no labels in the n50 gold, so it scored `0.0000` recall — which reads as total failure when it means the measurement cannot see the class. Zero-gold rows now report `n/a  (not labelled in this gold)`. That table is published in #67.

## Verification

- `pytest` — **666 passed, 7 skipped**
- `ruff check .` — clean
- Re-scored the n50 gold: PHONE 0.7931 → **0.8276**, coverage 0.4938 → **0.4958**, and the 7 new-entity predictions are all 11-17 digit runs (five bare, two beside account keywords) with **no case numbers caught**
- Synthetic-only tests for both new entity classes, both landline shapes, the citation guard, dates, and all four `--refresh-stale` behaviours

**CI is down** (no Actions runs since 2026-08-06T19:47Z), so local is the only gate.

## Next

Re-run the Sambalpur slice with `--refresh-stale` so the 579 identifiers are actually removed, then build the dedup index — which under #71 must read `grievance_redacted`, and would otherwise shingle unredacted account numbers.