### PR TITLE
fix(pipeline): refresh-run progress no longer exceeds the slice size

### DIFF
--- a/janasunani/pipeline/redact_grievance.py
+++ b/janasunani/pipeline/redact_grievance.py
@@ -248,7 +248,12 @@ async def _redact_slice(
             )
 
         processed += len(batch)
-        logger.info("redacted {} of {} ({} this batch)", processed + already, total, len(batch))
+        # In a refresh run `already` is the whole slice, so adding it to
+        # `processed` reports more rows than exist ("62544 of 55544"). Count
+        # rows carrying a current redaction instead: that is what the progress
+        # figure means in both modes.
+        current = processed if refresh_stale else processed + already
+        logger.info("redacted {} of {} ({} this batch)", current, total, len(batch))
 
     return {
         "total": total,

--- a/tests/test_redact_grievance.py
+++ b/tests/test_redact_grievance.py
@@ -320,3 +320,35 @@ class TestRefreshStale:
         counts = redact_grievances("Khordha", 2024, oltp_url=async_url, refresh_stale=True)
         assert counts["processed"] == 0
         assert counts["stale_at_start"] == 0
+
+
+def test_refresh_progress_does_not_exceed_the_slice(oltp, caplog):
+    """In a refresh run every row is already redacted, so adding `already` to
+    `processed` reported more rows than the slice contains."""
+    from loguru import logger as _logger
+
+    async_url, sync_url = oltp
+    redact_grievances("Khordha", 2024, oltp_url=async_url)
+    # Force a version mismatch, or there is nothing stale to reprocess and the
+    # run emits no progress lines at all.
+    engine = create_engine(sync_url)
+    with engine.begin() as conn:
+        conn.execute(
+            text("UPDATE grievance_redactions SET analyzer_version = :v"),
+            {"v": "presidio-analyzer=0.0.1 an-older-build"},
+        )
+    engine.dispose()
+
+    records: list[str] = []
+    sink = _logger.add(lambda m: records.append(str(m)), level="INFO", format="{message}")
+    try:
+        redact_grievances("Khordha", 2024, oltp_url=async_url, refresh_stale=True)
+    finally:
+        _logger.remove(sink)
+
+    progress = [r for r in records if "redacted" in r and " of " in r]
+    assert progress, "expected at least one progress line"
+    for line in progress:
+        done = int(line.split("redacted ")[1].split(" of ")[0])
+        total = int(line.split(" of ")[1].split(" ")[0])
+        assert done <= total, line


### PR DESCRIPTION
Spotted watching tonight's refresh run, which logged `redacted 62544 of 55544`.

The progress line added `already` to `processed`. That is correct for a resume, where `already` is what a previous run finished, and wrong for a refresh, where `already` is the entire slice and `processed` counts the same rows again.

Cosmetic — no data effect — but it is the line an operator watches to judge whether a long job is healthy, and a count past the total reads like a bug in the job rather than in the message.

## On the test

The first version passed vacuously. A refresh run with nothing stale processes nothing and emits **no progress lines at all**, so `assert progress` was the only thing standing between a green test and a meaningless one. It now forces a version mismatch first, then asserts every progress line satisfies `done <= total`.

- `pytest` — 667 passed, 7 skipped
- `ruff check .` — clean

CI is still down, so local is the gate.