### PR TITLE
fix(dvc): narrow pipeline-sample deps and add dvc.lock guard (closes #87)

### DIFF
--- a/.github/workflows/data-check.yml
+++ b/.github/workflows/data-check.yml
@@ -72,3 +72,26 @@ jobs:
         run: |
           test -f .dvc/config
           test -f dvc.yaml
+
+      - name: Check DVC lock is updated when deps change
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Cheap check that would have caught f890120: if a commit touches a
+          # stage's declared deps (dvc.yaml) without updating dvc.lock, the
+          # artifact in the DVC remote goes stale silently. dvc status cannot
+          # do this without the data, so we compare changed paths against the
+          # deps list in dvc.yaml.
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            git fetch origin main --depth=1 2>/dev/null || true
+            base="${{ github.event.pull_request.base.sha }}"
+            head="${{ github.sha }}"
+            # Fallback when base sha is empty (local act)
+            if [ -z "$base" ]; then
+              base="origin/main"
+            fi
+          else
+            base="HEAD~1"
+            head="HEAD"
+          fi
+          python3 scripts/check_dvc_lock.py --base "$base" --head "$head" 

--- a/dvc.lock
+++ b/dvc.lock
@@ -39,15 +39,40 @@ stages:
       md5: d4a066e526da37ae5d8e8ecf1777af68.dir
       size: 167765
       nfiles: 2
-    - path: janasunani/pipeline
-      hash: md5
-      md5: 094d70d918c86af84dd9075a7aeea509.dir
-      size: 391304
-      nfiles: 65
     - path: models/format_classifier/page_split_v3.0_doc_split.pkl
       hash: md5
       md5: a428d2b7b057c53e94890d1bc2ec69ce
       size: 7227944
+    - path: janasunani/pipeline/pipeline.py
+      hash: md5
+      md5: 0d7db5d06824fe6182e62189887d4c40
+      size: 2513
+    - path: janasunani/pipeline/config.py
+      hash: md5
+      md5: e508043ffe368506a97889aa950097de
+      size: 1303
+    - path: janasunani/pipeline/db.py
+      hash: md5
+      md5: 58a2065f49b310e21662075e7fafd1a8
+      size: 2721
+    - path: janasunani/pipeline/cli.py
+      hash: md5
+      md5: 00c2a54e86da52fe2eb2353930102f69
+      size: 4761
+    - path: janasunani/pipeline/stages/format_classifier
+      hash: md5
+      md5: 5d5f5394ddfc8fb538fdfd79ff4a93cb.dir
+      size: 41034
+      nfiles: 6
+    - path: janasunani/pipeline/stages/ocr_extraction
+      hash: md5
+      md5: 3dd7b71caffe314dd2e92592d2e67978.dir
+      size: 29312
+      nfiles: 6
+    - path: janasunani/pipeline/stages/pii_tagger.py
+      hash: md5
+      md5: a2208c0a7707bdb2a01fca1369fd46c3
+      size: 25139
     outs:
     - path: data/processed/pipeline-sample.sqlite
       hash: md5

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -33,7 +33,17 @@ stages:
     deps:
       - data/raw/documents-sample
       - models/format_classifier/page_split_v3.0_doc_split.pkl
-      - janasunani/pipeline
+      # Narrowed from the whole janasunani/pipeline directory (issue #87):
+      # only the modules executed by --stages format_classifier ocr_extraction pii_tagger.
+      # Adding dedup.py / redact_grievance.py etc. no longer invalidates this artifact.
+      # If you touch any path below, run: uv run --extra pipeline-core dvc repro pipeline-sample && dvc push && git add dvc.lock
+      - janasunani/pipeline/pipeline.py
+      - janasunani/pipeline/config.py
+      - janasunani/pipeline/db.py
+      - janasunani/pipeline/cli.py
+      - janasunani/pipeline/stages/format_classifier
+      - janasunani/pipeline/stages/ocr_extraction
+      - janasunani/pipeline/stages/pii_tagger.py
     outs:
       - data/processed/pipeline-sample.sqlite
 

--- a/scripts/check_dvc_lock.py
+++ b/scripts/check_dvc_lock.py
@@ -1,0 +1,171 @@
+"""Fail when a DVC stage's declared deps change without a dvc.lock update.
+
+Parses dvc.yaml deps and checks git diff against origin/main. Cheap shell
+check that would have caught f890120 without needing data or the DVC remote.
+
+Stdlib only — runs on a bare runner before deps are installed.
+
+Usage:
+  python3 scripts/check_dvc_lock.py
+  python3 scripts/check_dvc_lock.py --base origin/main --head HEAD
+  git diff --name-only origin/main...HEAD | python3 scripts/check_dvc_lock.py --stdin
+
+Exits 0 when either no dep was touched or dvc.lock was updated alongside it,
+1 otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Fallback: if PyYAML is unavailable, parse dvc.yaml with a tiny regex.
+# This keeps the script stdlib-only on the bare runner.
+
+def _parse_deps_via_yaml(path: Path) -> list[str]:
+    try:
+        import yaml  # type: ignore
+
+        data = yaml.safe_load(path.read_text())
+        deps: list[str] = []
+        for stage in data.get("stages", {}).values():
+            for dep in stage.get("deps", []):
+                # deps can be str or {"path": str}
+                if isinstance(dep, str):
+                    deps.append(dep)
+                elif isinstance(dep, dict) and "path" in dep:
+                    deps.append(dep["path"])
+        return deps
+    except Exception:
+        return _parse_deps_via_regex(path)
+
+
+def _parse_deps_via_regex(path: Path) -> list[str]:
+    text = path.read_text()
+    # Find each "- <path>" under a "deps:" block. Good enough for dvc.yaml's
+    # flat stage structure.
+    deps: list[str] = []
+    in_deps = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if re.match(r"deps:\s*$", stripped):
+            in_deps = True
+            continue
+        if in_deps:
+            m = re.match(r"-\s+([^\s#]+)", stripped)
+            if m:
+                deps.append(m.group(1).strip())
+                continue
+            # Deps block ends at next top-level key (outs:, cmd:, etc.) or blank
+            if re.match(r"(outs|cmd|desc|params|metrics|plots|wdir):", stripped):
+                in_deps = False
+            elif stripped == "" or stripped.startswith("#"):
+                continue
+            elif not stripped.startswith("-"):
+                # likely next stage or outs
+                if "outs:" in stripped or "stages:" in stripped:
+                    in_deps = False
+    return deps
+
+
+def _changed_files(base: str, head: str) -> list[str]:
+    # Try git diff base...head, fall back to base..head
+    for sep in ["...", ".."]:
+        try:
+            out = subprocess.check_output(
+                ["git", "diff", "--name-only", f"{base}{sep}{head}"],
+                text=True,
+                stderr=subprocess.DEVNULL,
+            )
+            files = [f.strip() for f in out.splitlines() if f.strip()]
+            if files or sep == "..":
+                return files
+        except subprocess.CalledProcessError:
+            continue
+    return []
+
+
+def _is_dep_match(changed: str, dep: str) -> bool:
+    # Exact file match or directory prefix match. A dep that is a directory
+    # (no file extension or ends with /) matches any file under it.
+    # We treat both "janasunani/pipeline/stages/format_classifier" and
+    # "janasunani/pipeline/stages/format_classifier/" as directory prefixes.
+    if changed == dep:
+        return True
+    # Normalize: dep without trailing slash
+    dep_norm = dep.rstrip("/")
+    # If changed is under dep directory
+    if changed == dep_norm or changed.startswith(dep_norm + "/"):
+        return True
+    return False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check dvc.lock updated with deps")
+    parser.add_argument("--base", default=None, help="git base ref (default: origin/main or GITHUB_BASE_SHA)")
+    parser.add_argument("--head", default="HEAD", help="git head ref")
+    parser.add_argument("--stdin", action="store_true", help="read changed files from stdin instead of git")
+    parser.add_argument("--dvc-yaml", default="dvc.yaml")
+    parser.add_argument("--dvc-lock", default="dvc.lock")
+    args = parser.parse_args()
+
+    dvc_yaml = Path(args.dvc_yaml)
+    if not dvc_yaml.exists():
+        print(f"{dvc_yaml} not found, skipping", file=sys.stderr)
+        return 0
+
+    deps = _parse_deps_via_yaml(dvc_yaml)
+    # Filter to janasunani/pipeline and other file deps that are code;
+    # data/raw and models are also deps but we care about pipeline code.
+    # We check all deps — if any dep file changed without lock, fail.
+
+    if args.stdin:
+        changed = [line.strip() for line in sys.stdin if line.strip()]
+    else:
+        base = args.base
+        if not base:
+            # In GitHub Actions PR, GITHUB_BASE_SHA is the merge base
+            base = os.environ.get("GITHUB_BASE_SHA") or "origin/main"
+            # If origin/main doesn't exist locally, try main
+            try:
+                subprocess.check_output(["git", "rev-parse", "--verify", base], stderr=subprocess.DEVNULL)
+            except subprocess.CalledProcessError:
+                base = "main"
+                try:
+                    subprocess.check_output(["git", "rev-parse", "--verify", base], stderr=subprocess.DEVNULL)
+                except subprocess.CalledProcessError:
+                    base = "HEAD~1"
+        changed = _changed_files(base, args.head)
+
+    if not changed:
+        return 0
+
+    # dvc.lock must be in changed if any dep is
+    lock_changed = any(c == args.dvc_lock for c in changed)
+
+    # Find which changed files are deps
+    matched: list[str] = []
+    for c in changed:
+        for dep in deps:
+            if _is_dep_match(c, dep):
+                matched.append(c)
+                break
+
+    if matched and not lock_changed:
+        print("Error: the following DVC deps changed but dvc.lock was not updated:", file=sys.stderr)
+        for m in sorted(set(matched)):
+            print(f"  - {m}", file=sys.stderr)
+        print(f"\nDeps are declared in {args.dvc_yaml}.", file=sys.stderr)
+        print(f"Run: uv run --extra pipeline-core dvc repro <stage> && dvc push && git add {args.dvc_lock}", file=sys.stderr)
+        print("Or if the change intentionally does not affect the output, update dvc.yaml to narrow the dep.", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_check_dvc_lock.py
+++ b/tests/test_check_dvc_lock.py
@@ -1,0 +1,196 @@
+"""Tests for scripts/check_dvc_lock.py.
+
+Synthetic dvc.yaml / changed-files only; no DVC remote or data needed.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, _SCRIPTS / f"{name}.py")
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+check = _load("check_dvc_lock")
+
+
+class TestIsDepMatch:
+    def test_exact_file_match(self):
+        assert check._is_dep_match("janasunani/pipeline/pipeline.py", "janasunani/pipeline/pipeline.py")
+
+    def test_directory_prefix_match(self):
+        assert check._is_dep_match("janasunani/pipeline/stages/format_classifier/model.py", "janasunani/pipeline/stages/format_classifier")
+
+    def test_directory_with_trailing_slash(self):
+        assert check._is_dep_match("janasunani/pipeline/stages/format_classifier/model.py", "janasunani/pipeline/stages/format_classifier/")
+
+    def test_not_a_match(self):
+        assert not check._is_dep_match("janasunani/pipeline/dedup.py", "janasunani/pipeline/stages/pii_tagger.py")
+        assert not check._is_dep_match("janasunani/pipeline/dedup.py", "janasunani/pipeline/stages/format_classifier")
+        assert not check._is_dep_match("janasunani/olap/materialize.py", "janasunani/pipeline/pipeline.py")
+
+    def test_no_false_prefix(self):
+        # dedup.py should not match dedup_index.py prefix
+        assert not check._is_dep_match("janasunani/pipeline/dedup_index.py", "janasunani/pipeline/dedup.py")
+
+    def test_exact_dep_not_prefix_of_longer(self):
+        assert not check._is_dep_match("janasunani/pipeline/pipeline.py.bak", "janasunani/pipeline/pipeline.py")
+
+
+class TestParseDeps:
+    def test_parses_new_narrowed_deps(self, tmp_path):
+        yaml_text = """
+stages:
+  pipeline-sample:
+    deps:
+      - data/raw/documents-sample
+      - models/format_classifier/page_split_v3.0_doc_split.pkl
+      - janasunani/pipeline/pipeline.py
+      - janasunani/pipeline/stages/format_classifier
+      - janasunani/pipeline/stages/pii_tagger.py
+    outs:
+      - data/processed/pipeline-sample.sqlite
+"""
+        p = tmp_path / "dvc.yaml"
+        p.write_text(yaml_text)
+        deps = check._parse_deps_via_yaml(p)
+        # Should find all 5 deps via yaml or regex fallback
+        assert "janasunani/pipeline/pipeline.py" in deps
+        assert "janasunani/pipeline/stages/format_classifier" in deps
+
+    def test_covers_materialize_stage(self, tmp_path):
+        yaml_text = """
+stages:
+  materialize:
+    deps:
+      - data/oltp/janasunani.db
+      - janasunani/olap/materialize.py
+    outs:
+      - data/interim/complaints.parquet
+"""
+        p = tmp_path / "dvc.yaml"
+        p.write_text(yaml_text)
+        deps = check._parse_deps_via_yaml(p)
+        assert "janasunani/olap/materialize.py" in deps
+
+
+class TestMainLogic:
+    def _run(self, tmp_path, dvc_yaml_text, changed, lock_changed):
+        p = tmp_path / "dvc.yaml"
+        p.write_text(dvc_yaml_text)
+        # Mock _changed_files by passing via stdin simulation: we test the core
+        # matching logic directly
+        deps = check._parse_deps_via_yaml(p)
+        matched = []
+        for c in changed:
+            for dep in deps:
+                if check._is_dep_match(c, dep):
+                    matched.append(c)
+                    break
+        lock_in_changed = "dvc.lock" in changed if lock_changed is None else lock_changed
+        # Replicate main's decision
+        if matched and not lock_in_changed:
+            return 1
+        return 0
+
+    def test_pipeline_file_without_lock_fails(self, tmp_path):
+        yaml_text = """
+stages:
+  pipeline-sample:
+    deps:
+      - janasunani/pipeline/pipeline.py
+      - janasunani/pipeline/stages/format_classifier
+      - janasunani/pipeline/stages/pii_tagger.py
+"""
+        assert self._run(tmp_path, yaml_text, ["janasunani/pipeline/stages/pii_tagger.py"], False) == 1
+
+    def test_pipeline_file_with_lock_passes(self, tmp_path):
+        yaml_text = """
+stages:
+  pipeline-sample:
+    deps:
+      - janasunani/pipeline/stages/pii_tagger.py
+"""
+        assert self._run(tmp_path, yaml_text, ["janasunani/pipeline/stages/pii_tagger.py", "dvc.lock"], True) == 0
+
+    def test_format_classifier_subfile_without_lock_fails(self, tmp_path):
+        yaml_text = """
+stages:
+  pipeline-sample:
+    deps:
+      - janasunani/pipeline/stages/format_classifier
+"""
+        assert self._run(tmp_path, yaml_text, ["janasunani/pipeline/stages/format_classifier/model.py"], False) == 1
+
+    def test_unrelated_file_without_lock_passes(self, tmp_path):
+        yaml_text = """
+stages:
+  pipeline-sample:
+    deps:
+      - janasunani/pipeline/stages/pii_tagger.py
+      - janasunani/pipeline/stages/format_classifier
+"""
+        # dedup.py is NOT a dep after narrowing, so no failure
+        assert self._run(tmp_path, yaml_text, ["janasunani/pipeline/dedup.py"], False) == 0
+        assert self._run(tmp_path, yaml_text, ["janasunani/pipeline/redact_grievance.py"], False) == 0
+        assert self._run(tmp_path, yaml_text, ["janasunani/pipeline/dedup_index.py"], False) == 0
+
+    def test_no_changed_files_passes(self, tmp_path):
+        yaml_text = """
+stages:
+  pipeline-sample:
+    deps:
+      - janasunani/pipeline/pipeline.py
+"""
+        assert self._run(tmp_path, yaml_text, [], False) == 0
+
+    def test_cli_with_stdin_mode(self, tmp_path, capsys):
+        yaml_text = """
+stages:
+  pipeline-sample:
+    deps:
+      - janasunani/pipeline/stages/pii_tagger.py
+"""
+        p = tmp_path / "dvc.yaml"
+        p.write_text(yaml_text)
+        # Simulate stdin mode: changed files via stdin, lock not present -> should exit 1
+        import subprocess
+        import sys
+        proc = subprocess.run(
+            [sys.executable, str(_SCRIPTS / "check_dvc_lock.py"), "--stdin", "--dvc-yaml", str(p)],
+            input="janasunani/pipeline/stages/pii_tagger.py\n",
+            text=True,
+            capture_output=True,
+        )
+        assert proc.returncode == 1
+        # With lock, passes
+        proc2 = subprocess.run(
+            [sys.executable, str(_SCRIPTS / "check_dvc_lock.py"), "--stdin", "--dvc-yaml", str(p)],
+            input="janasunani/pipeline/stages/pii_tagger.py\ndvc.lock\n",
+            text=True,
+            capture_output=True,
+        )
+        assert proc2.returncode == 0
+
+    def test_new_narrowed_deps_are_detected(self, tmp_path):
+        yaml_text = Path("/tmp/janasunani-fix-87-work/dvc.yaml").read_text()
+        p = tmp_path / "dvc.yaml"
+        p.write_text(yaml_text)
+        deps = check._parse_deps_via_yaml(p)
+        assert "janasunani/pipeline/pipeline.py" in deps
+        assert "janasunani/pipeline/stages/format_classifier" in deps
+        assert "janasunani/pipeline/stages/ocr_extraction" in deps
+        assert "janasunani/pipeline/stages/pii_tagger.py" in deps
+        # Whole directory should NOT be a dep anymore
+        assert "janasunani/pipeline" not in deps


### PR DESCRIPTION
Closes #87.

## Summary

`dvc.yaml`'s `pipeline-sample` stage depended on the whole `janasunani/pipeline` directory, so any merge into that tree (whether it touched the executed stages or not) bumped the `.dir` hash and left `data/processed/pipeline-sample.sqlite` in the DVC remote stale. CI ran `uv run dvc dag` only — structural validation — so nothing caught it. This already happened at `f890120` (Codex P1 on #59).

## What Changed

- **Narrowed `dvc.yaml` deps** from `janasunani/pipeline` to the modules actually executed by `--stages format_classifier ocr_extraction pii_tagger` (issue's durable fix):
  `pipeline.py`, `config.py`, `db.py`, `cli.py`, `stages/format_classifier/`, `stages/ocr_extraction/`, `stages/pii_tagger.py`.
  Adding `dedup.py` / `redact_grievance.py` / `dedup_index.py` no longer invalidates the artifact; a real `pii_tagger` change now meaningfully does. Documented the repro obligation inline in `dvc.yaml`.

- **Updated `dvc.lock`** to per-file/dir hashes (dir hashes via `dvc_data` `Tree` digest, `5d5f5394...` and `3dd7b71c...`; file md5s `00c2a54e...` etc.). Output hash unchanged until the next engineer-owned `dvc repro` / `dvc push`.

- **Added `scripts/check_dvc_lock.py`** — cheap CI check that fails when a commit touches a declared dep without updating `dvc.lock`. Parses `dvc.yaml` (PyYAML or regex fallback, stdlib-only), compares `git diff` against `origin/main` (PR base via `github.event.pull_request.base.sha`), handles exact files and directory prefixes. Would have caught `f890120` before review. Wired into `.github/workflows/data-check.yml`.

- **Tests**: `tests/test_check_dvc_lock.py` (15 tests) covering exact vs directory prefix matching, `dedup.py` no-op after narrowing, and `--stdin` mode.

## Validation

- [x] `uv run ruff check .` — `All checks passed!`
- [x] `uv run pytest tests/test_check_dvc_lock.py` — `15 passed`
- [x] `uv run pytest tests/test_check_dvc_lock.py tests/test_check_provenance_sidecars.py` — `49 passed`
- [x] `python3 scripts/check_dvc_lock.py --stdin` manual checks:
  - `janasunani/pipeline/stages/pii_tagger.py` without `dvc.lock` → fails (exit 1)
  - same with `dvc.lock` → passes
  - `janasunani/pipeline/dedup.py` without `dvc.lock` → passes (cost trap closed)
  - `janasunani/pipeline/stages/format_classifier/model.py` without `dvc.lock` → fails
- [x] `python3 -c "import yaml; yaml.safe_load(open('dvc.yaml'))"` — deps list verified: `['data/raw/documents-sample', 'models/...pkl', 'janasunani/pipeline/pipeline.py', ...]`, whole `janasunani/pipeline` no longer present
- [x] Notebooks have been stripped with `uv run nbstripout --install` or equivalent.
- [x] No proprietary data files are committed directly to Git.
- [x] DVC pointers / `dvc.lock` are updated when approved data or pipeline outputs changed.

## Review Expectations

- Keep this PR small enough to be reviewed by a human in a short sitting.
- Split unrelated changes into separate PRs before requesting review.
- Two-person review is required.
- Yashaswi is a mandatory reviewer.
- Add one additional reviewer who can assess the code, analysis, or domain impact.

## Data And Delivery Notes

- [x] This PR does not modify data.
- [ ] This PR ingests or versions data through DVC.
- [ ] This PR updates generated exhibits.
- [ ] This PR requires `make deliver` after merge.

Notes:

- Work done in a separate worktree (`/tmp/janasunani-fix-87-work`, branch `fix/dvc-pipeline-sample-deps`) due to sandbox `.git` read-only. Pushed from there; this is the PR that closes #87.
- The narrowed deps are intentionally more to maintain: adding a new executed stage requires editing `dvc.yaml`. The inline comment in `dvc.yaml` states the repro command.
- Next repro (`uv run --extra pipeline-core dvc repro pipeline-sample && dvc push && git add dvc.lock`) is still engineer-owned and serial (needs tesseract + DVC remote), but CI now enforces the lock update.

