### PR TITLE
fix(scripts): withhold record ids from verifier output by default

### DIFF
--- a/scripts/verify_pii_gold.py
+++ b/scripts/verify_pii_gold.py
@@ -218,6 +218,12 @@ def check(records: Iterable[Record]) -> Report:
     return report
 
 
+# Keys in the human-pass report that hold raw record ids. Ticket numbers are
+# not citizen text, but they are the join key to it: a public comment listing
+# them says which specific grievances are in the labelled sample.
+_ID_ARRAYS = ("records_only_in_draft", "records_only_in_gold", "text_mismatches")
+
+
 def _changed_spans(human: dict[str, Any]) -> int:
     """How many spans the human pass actually touched, in any way."""
     return (
@@ -361,28 +367,50 @@ def main() -> None:
 
     if args.draft:
         human = diff(load(args.draft), gold)
-        payload["human_pass"] = human
+        # The checks below read the raw ids; only what gets *published* is
+        # sanitized. --json dumped all three arrays in full, and ids are ticket
+        # numbers -- the join key to citizen text -- in output written to be
+        # pasted into a PR (#96).
+        if args.show_samples:
+            payload["human_pass"] = human
+        else:
+            payload["human_pass"] = {
+                (f"{k}_count" if k in _ID_ARRAYS else k): (
+                    len(v) if k in _ID_ARRAYS else v
+                )
+                for k, v in human.items()
+            }
         # Completeness is part of correctness: a gold file missing pages, or whose
         # text was edited out from under its offsets, scores wrong rather than
         # failing. Both are hard errors so a pre-merge gate catches them.
+        # Record ids are not opaque: bootstrap builds them as
+        # f"{ticket}_p{page}", so an id is a real grievance ticket number.
+        # This report exists to be pasted into a PR, and the failure mode is
+        # exactly the one where someone pastes it -- the arrays fill, the tool
+        # exits 1, and the natural next step is to ask for help in public.
+        # Counts here; identities only behind --show-samples (#96).
+        hint = "" if args.show_samples else " Pass --show-samples to list them."
         if human["records_only_in_draft"]:
             missing = human["records_only_in_draft"]
+            shown = f" ({missing[:3]})" if args.show_samples else ""
             report.fail(
-                f"{len(missing)} draft record(s) absent from gold "
-                f"(first: {missing[:3]}). Every drafted page must be adjudicated."
+                f"{len(missing)} draft record(s) absent from gold{shown}. "
+                f"Every drafted page must be adjudicated.{hint}"
             )
         if human["records_only_in_gold"]:
             extra = human["records_only_in_gold"]
+            shown = f" ({extra[:3]})" if args.show_samples else ""
             report.fail(
-                f"{len(extra)} gold record(s) not present in the draft "
-                f"(first: {extra[:3]}). Ids must match the drafted set."
+                f"{len(extra)} gold record(s) not present in the draft{shown}. "
+                f"Ids must match the drafted set.{hint}"
             )
         if human["text_mismatches"]:
             bad = human["text_mismatches"]
+            shown = f" ({bad[:3]})" if args.show_samples else ""
             report.fail(
-                f"{len(bad)} record(s) whose text differs between draft and gold "
-                f"(first: {bad[:3]}). Offsets index into the text, so editing it "
-                f"silently invalidates every span in that record."
+                f"{len(bad)} record(s) whose text differs between draft and "
+                f"gold{shown}. Offsets index into the text, so editing it "
+                f"silently invalidates every span in that record.{hint}"
             )
         # No adjudication at all means the "gold" is analyzer output, which
         # scores ~100% recall against itself. That is a void measurement, not a

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -9,6 +9,8 @@ it is the one real code-path CI coverage the whole intelligence layer
 Synthetic strings only — no real grievance text, no `data/` access.
 """
 
+from itertools import combinations
+
 import pytest
 
 from janasunani.pipeline.dedup import (
@@ -377,8 +379,14 @@ def test_union_find_groups_end_to_end_campaign_vs_unrelated():
     candidate_pairs = set()
     for bucket_docs in buckets.values():
         if len(bucket_docs) > 1:
-            first = bucket_docs[0]
-            candidate_pairs.update((first, other) for other in bucket_docs[1:])
+            # Every unordered pair, not star edges from an arbitrary first
+            # member (#101). Exact Jaccard verification is not transitive: in
+            # a bucket of three the first can fall below the threshold against
+            # both others while those two exceed it against each other, and if
+            # that bucket is their only shared band the duplicate is lost.
+            # This block is the pattern people copy, so it has to be the right
+            # one -- janasunani/pipeline/dedup_index.py does the same.
+            candidate_pairs.update(combinations(sorted(bucket_docs), 2))
 
     verified_pairs = [
         (doc_a, doc_b)

--- a/tests/test_verify_pii_gold.py
+++ b/tests/test_verify_pii_gold.py
@@ -451,3 +451,61 @@ class TestVoidMeasurementsFail:
         )
         with pytest.raises(ValueError, match="duplicate record ids"):
             verify.diff(draft, gold)
+
+
+class TestRecordIdsAreNotPublishedByDefault:
+    """#96. Record ids are `{ticket}_p{page}` — not citizen text, but the join
+    key to it. This report exists to be pasted into a PR, and the failure mode
+    is exactly the one where someone pastes it: the arrays fill, the tool exits
+    1, and the natural next step is to ask for help in public."""
+
+    TICKET = "CMOFF-D-2021-01956_p2"
+
+    def _run(self, monkeypatch, capsys, gold: Path, draft: Path, *extra: str):
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["verify_pii_gold.py", "--gold", str(gold), "--draft", str(draft), *extra],
+        )
+        try:
+            verify.main()
+        except SystemExit:
+            pass
+        return capsys.readouterr().out
+
+    def _mismatched_pair(self, tmp_path):
+        gold = write_jsonl(
+            tmp_path / "gold.jsonl",
+            [{"id": self.TICKET, "text": TEXT, "entities": []}],
+        )
+        draft = write_jsonl(
+            tmp_path / "draft.jsonl",
+            [{"id": "some-other-page_p1", "text": TEXT, "entities": []}],
+        )
+        return gold, draft
+
+    def test_ticket_ids_absent_from_default_output(self, tmp_path, monkeypatch, capsys):
+        gold, draft = self._mismatched_pair(tmp_path)
+        out = self._run(monkeypatch, capsys, gold, draft)
+        assert self.TICKET not in out
+        assert "--show-samples" in out
+
+    def test_ticket_ids_absent_from_json_output(self, tmp_path, monkeypatch, capsys):
+        gold, draft = self._mismatched_pair(tmp_path)
+        out = self._run(monkeypatch, capsys, gold, draft, "--json")
+        assert self.TICKET not in out
+        assert "records_only_in_gold_count" in out
+
+    def test_counts_are_still_reported(self, tmp_path, monkeypatch, capsys):
+        gold, draft = self._mismatched_pair(tmp_path)
+        out = self._run(monkeypatch, capsys, gold, draft, "--json")
+        payload = json.loads(out)
+        human = payload["human_pass"]
+        assert human["records_only_in_gold_count"] == 1
+        assert human["records_only_in_draft_count"] == 1
+
+    def test_show_samples_still_lists_them(self, tmp_path, monkeypatch, capsys):
+        """The flag that already guards citizen text guards identities too."""
+        gold, draft = self._mismatched_pair(tmp_path)
+        out = self._run(monkeypatch, capsys, gold, draft, "--show-samples")
+        assert self.TICKET in out


### PR DESCRIPTION
Closes #96. Closes #101.

## #96 — the verifier published ticket numbers

Record ids are built as `{ticket}_p{page}`, so each is a real grievance ticket number. Not citizen text, but **the join key to it**: a public comment listing them says which specific grievances are in the labelled sample.

They appeared in four places — the two completeness errors, the text-mismatch error, and all three id arrays in full under `--json`. None was gated on `--show-samples`, despite the module docstring promising nothing prints without it.

**The failure mode is the realistic one.** Those arrays only fill when the draft and gold do not line up. The tool exits 1, and the natural next step is to paste the whole report and ask why. That is precisely when the ids are there — I pasted verifier output into #54 twice today.

Counts and a pointer to `--show-samples` by default; identities behind the same flag that already guards citizen text. The checks still read the raw ids — only what gets *published* is sanitized, so nothing about detection changes.

## #101 — the example pattern taught the bug

The end-to-end block in `tests/test_dedup.py` compared each LSH bucket's first member against the rest. Exact Jaccard is not transitive: in a bucket of three, the first can fall below the threshold against both others while those two exceed it against each other, and if that bucket is their only shared band the duplicate is silently lost.

`dedup_index.py` already does all-pairs after the #135 review round. This is the block people copy, so it has to be right too.

## Verification

- `pytest` — **671 passed, 7 skipped**
- `ruff check .` — clean
- Four new tests: ids absent from default output, absent from `--json`, counts still reported, and `--show-samples` still lists them

CI is down, so local is the gate.