### PR TITLE
fix(pii_eval): reject duplicate gold spans and report overlaps on the scoring path

### DIFF
--- a/janasunani/pipeline/pii_eval.py
+++ b/janasunani/pipeline/pii_eval.py
@@ -115,9 +115,56 @@ def load_gold_jsonl(path: Path) -> list[GoldExample]:
                 _parse_gold_span(span, text=text, path=path, line_number=line_number)
                 for span in raw_entities
             )
+            _reject_duplicate_spans(spans, example_id, path, line_number)
             examples.append(GoldExample(id=example_id, text=text, entities=spans))
     _require_unique_ids(examples)
     return examples
+
+
+def _reject_duplicate_spans(
+    spans: Sequence[PIISpan], example_id: str, path: Path, line_number: int
+) -> None:
+    """Fail closed on exact duplicate spans within a record (#89).
+
+    A duplicated gold span inflates the denominator by one while contributing
+    at most one hit, so recall is depressed and the output still looks
+    entirely plausible. That is worse than a crash: nothing downstream can
+    tell a corrupt gold from a bad model.
+
+    ``scripts/verify_pii_gold.py`` already caught this, but the verifier is a
+    review tool someone has to remember to run, while this is the path that
+    produces the published figure. The check belongs here too. It found 22
+    duplicates in one record of the n50 gold, which had already been scored.
+    """
+    seen: set[tuple[int, int, str]] = set()
+    for span in spans:
+        key = (span.start, span.end, normalize_entity(span.entity))
+        if key in seen:
+            raise ValueError(
+                f"{path}:{line_number}: record {example_id!r} has a duplicate span "
+                f"[{span.start},{span.end}) {key[2]}. A duplicated gold span "
+                f"inflates the denominator and silently depresses recall."
+            )
+        seen.add(key)
+
+
+def overlapping_spans(
+    spans: Sequence[PIISpan],
+) -> list[tuple[PIISpan, PIISpan]]:
+    """Pairs of distinct spans in one record whose extents overlap.
+
+    Warned about rather than rejected: unlike an exact duplicate, a nested
+    span is a labelling judgement, and adjudicating it needs a human. But a
+    gold set has to end up non-overlapping, because redaction produces
+    non-overlapping replacements and two overlapping gold spans can never both
+    be satisfied by a real redaction.
+    """
+    ordered = sorted(spans, key=lambda s: (s.start, s.end))
+    return [
+        (left, right)
+        for left, right in zip(ordered, ordered[1:])
+        if left.start < right.end and right.start < left.end
+    ]
 
 
 def score_examples(
@@ -248,10 +295,45 @@ def main(argv: Sequence[str] | None = None) -> int:
         action="store_true",
         help="Always exit 0 after printing the report.",
     )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help=(
+            "Also fail on overlapping (not identical) gold spans. Warned about "
+            "by default: a nested span is a labelling judgement, not file "
+            "corruption, and adjudicating it needs a human."
+        ),
+    )
     args = parser.parse_args(argv)
 
+    examples = load_gold_jsonl(args.gold)
+
+    # Overlaps are surfaced on the scoring path too, so a corrupt gold cannot
+    # be scored by accident just because nobody ran the verifier (#89). Offsets
+    # and record ids only, never the text they cover.
+    overlaps = [
+        (example.id, left, right)
+        for example in examples
+        for left, right in overlapping_spans(example.entities)
+    ]
+    if overlaps:
+        print(
+            f"WARNING: {len(overlaps)} overlapping gold span pair(s). A gold set "
+            "must end up non-overlapping: redaction produces non-overlapping "
+            "replacements, so two overlapping golds can never both be satisfied."
+        )
+        for example_id, left, right in overlaps[:10]:
+            print(
+                f"  {example_id}: [{left.start},{left.end}) {left.entity} "
+                f"vs [{right.start},{right.end}) {right.entity}"
+            )
+        if len(overlaps) > 10:
+            print(f"  ... and {len(overlaps) - 10} more")
+        if args.strict:
+            return 1
+
     report = score_examples(
-        load_gold_jsonl(args.gold),
+        examples,
         baseline_overlap_recall=args.baseline_overlap,
     )
     if args.json:

--- a/tests/test_pii_eval.py
+++ b/tests/test_pii_eval.py
@@ -264,3 +264,69 @@ def test_a_labelled_entity_still_reports_numeric_recall():
         "NAME", EntityMetrics(gold=404, predicted=497, overlap_hits=176, exact_hits=106)
     )
     assert "0.4356" in row
+
+
+class TestCorruptGoldIsRejectedOnTheScoringPath:
+    """#89. verify_pii_gold caught duplicate spans; pii_eval could not, and
+    pii_eval is the path that produces the published figure. A duplicated gold
+    span inflates the denominator while contributing at most one hit, so recall
+    is depressed and the output still looks plausible -- worse than a crash,
+    because nothing downstream can tell a corrupt gold from a bad model."""
+
+    TEXT = "Ravi Patra called 9876543210"
+
+    def _write(self, tmp_path, entities):
+        path = tmp_path / "gold.jsonl"
+        path.write_text(
+            json.dumps({"id": "t1_p1", "text": self.TEXT, "entities": entities}) + "\n",
+            encoding="utf-8",
+        )
+        return path
+
+    def test_exact_duplicate_span_is_rejected(self, tmp_path):
+        path = self._write(
+            tmp_path,
+            [
+                {"start": 0, "end": 10, "entity": "NAME"},
+                {"start": 0, "end": 10, "entity": "NAME"},
+            ],
+        )
+        with pytest.raises(ValueError, match="duplicate span"):
+            load_gold_jsonl(path)
+
+    def test_a_clean_file_still_loads(self, tmp_path):
+        path = self._write(
+            tmp_path,
+            [
+                {"start": 0, "end": 10, "entity": "NAME"},
+                {"start": 18, "end": 28, "entity": "PHONE"},
+            ],
+        )
+        assert len(load_gold_jsonl(path)) == 1
+
+    def test_nested_overlap_is_reported_not_rejected(self, tmp_path):
+        """A nested span is a labelling judgement, not file corruption."""
+        from janasunani.pipeline.pii_eval import overlapping_spans
+
+        path = self._write(
+            tmp_path,
+            [
+                {"start": 0, "end": 10, "entity": "NAME"},
+                {"start": 0, "end": 4, "entity": "NAME"},
+            ],
+        )
+        examples = load_gold_jsonl(path)
+        assert len(overlapping_spans(examples[0].entities)) == 1
+
+    def test_no_overlaps_reported_for_a_clean_file(self, tmp_path):
+        from janasunani.pipeline.pii_eval import overlapping_spans
+
+        path = self._write(
+            tmp_path,
+            [
+                {"start": 0, "end": 10, "entity": "NAME"},
+                {"start": 18, "end": 28, "entity": "PHONE"},
+            ],
+        )
+        examples = load_gold_jsonl(path)
+        assert overlapping_spans(examples[0].entities) == []


### PR DESCRIPTION
Closes #89.

`verify_pii_gold` caught duplicate spans. `pii_eval` could not — and `pii_eval` is the path that produces the **published** figure, while the verifier is a review tool someone has to remember to run.

## Why this is worse than a crash

A duplicated gold span inflates the denominator by one while contributing at most one hit. Recall is depressed and the output still looks entirely plausible, so nothing downstream can tell a corrupt gold from a bad model.

It is not hypothetical: 22 duplicates sat in one record of the n50 gold, and that gold had already been scored and the number posted.

## The split

**Duplicates fail closed**, naming the record id and the offsets. An exact duplicate is file corruption — `detect_pii_spans` dedupes by construction, so a draft cannot produce one.

**Overlaps warn**, with `--strict` to fail. A nested span is a labelling judgement rather than corruption, and adjudicating it needs a human. But a gold set has to end up non-overlapping, because redaction produces non-overlapping replacements and two overlapping golds can never both be satisfied by a real redaction.

Warning output carries offsets and record ids only, never the text they cover — same posture as #96.

## Verification

- `pytest` — **675 passed, 7 skipped**
- `ruff check .` — clean
- Ran against the real corrected gold: loads clean, no warnings, identical scorecard
- Four new tests on synthetic golds: exact duplicate rejected, clean file loads, nested overlap reported not rejected, no false positives on a clean file

CI is down, so local is the gate.