### PR TITLE
fix(dedup): reject an empty MinHash signature before banding

### DIFF
--- a/janasunani/pipeline/dedup.py
+++ b/janasunani/pipeline/dedup.py
@@ -299,6 +299,18 @@ def lsh_bands(
             "None for an empty shingle set; treat that as low-signal/spam, "
             "not a duplicate candidate, and do not call lsh_bands() on it"
         )
+    if not signature:
+        # An empty signature passes the divisibility check below (0 % n == 0),
+        # every band then hashes the same empty tuple, and every empty-signature
+        # record band-matches every other -- collapsing the indexed slice into
+        # one duplicate group. The num_hashes <= 0 guard upstream protects the
+        # producer; a signature read back from `dedup_signatures` or built by
+        # hand never passes through minhash_signature() at all, which is the
+        # path that matters once signatures are persisted for the backfill.
+        raise ValueError(
+            "cannot band an empty signature — every band would hash the same "
+            "empty tuple, so unrelated records would all become candidates"
+        )
     if num_bands <= 0 or len(signature) % num_bands != 0:
         raise ValueError(
             f"num_bands ({num_bands}) must evenly divide the signature "

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -618,3 +618,29 @@ def test_cross_script_lsh_bands_never_collide():
     bands_odia = set(lsh_bands(sig_odia, num_bands=8))
     bands_romanized = set(lsh_bands(sig_romanized, num_bands=8))
     assert not (bands_odia & bands_romanized)
+
+
+class TestEmptySignatureIsRejected:
+    """#100. An empty signature passes the divisibility check (0 % n == 0),
+    every band hashes the same empty tuple, and every such record band-matches
+    every other — collapsing the slice into one duplicate group."""
+
+    def test_empty_tuple_is_rejected(self):
+        with pytest.raises(ValueError, match="empty signature"):
+            lsh_bands((), num_bands=4)
+
+    def test_none_is_still_rejected_separately(self):
+        with pytest.raises(ValueError, match="None signature"):
+            lsh_bands(None, num_bands=4)
+
+    def test_two_empty_signatures_cannot_become_candidates(self):
+        """The failure this guards: without it both calls return identical band
+        tuples and the records match on every band."""
+        for signature in ((), ()):
+            with pytest.raises(ValueError):
+                lsh_bands(signature, num_bands=4)
+
+    def test_a_real_signature_still_bands(self):
+        signature = minhash_signature({"abc", "bcd", "cde"}, num_hashes=8)
+        assert signature is not None
+        assert len(lsh_bands(signature, num_bands=4)) == 4


### PR DESCRIPTION
Closes #100.

An empty signature passed the divisibility check, because `0 % n == 0`. Every band then hashed the same empty tuple, so **every empty-signature record band-matched every other** — collapsing the indexed slice into one duplicate group.

## Why the existing guard did not cover it

The `num_hashes <= 0` guard protects the **producer**. This is the **consumer**: a signature read back from `dedup_signatures`, or built by a caller that never went through `minhash_signature()`, reaches `lsh_bands()` directly.

That path is live now rather than theoretical — #135 persists signatures and the grouping stage reads them back.

## Kept separate from the `None` guard

`None` is `minhash_signature()` abstaining on an empty shingle set, which the caller is supposed to branch on. An empty tuple is a malformed value that should never have been constructed. Same outcome, different diagnosis, so different messages.

- `pytest` — 679 passed, 7 skipped
- `ruff check .` — clean
- Four tests including the failure this guards: two empty signatures must not become candidates

CI is down, so local is the gate.