### PR TITLE
fix(dvc): narrow pipeline-sample deps to the code it actually runs

### DIFF
--- a/dvc.lock
+++ b/dvc.lock
@@ -39,11 +39,40 @@ stages:
       md5: d4a066e526da37ae5d8e8ecf1777af68.dir
       size: 167765
       nfiles: 2
-    - path: janasunani/pipeline
+    - path: janasunani/pipeline/cli.py
       hash: md5
-      md5: 094d70d918c86af84dd9075a7aeea509.dir
-      size: 391304
-      nfiles: 65
+      md5: 00c2a54e86da52fe2eb2353930102f69
+      size: 4761
+    - path: janasunani/pipeline/config.py
+      hash: md5
+      md5: e508043ffe368506a97889aa950097de
+      size: 1303
+    - path: janasunani/pipeline/db.py
+      hash: md5
+      md5: 58a2065f49b310e21662075e7fafd1a8
+      size: 2721
+    - path: janasunani/pipeline/pipeline.py
+      hash: md5
+      md5: 0d7db5d06824fe6182e62189887d4c40
+      size: 2513
+    - path: janasunani/pipeline/stages/format_classifier
+      hash: md5
+      md5: 703c1c4d60b4fa0eba72d1d14a90cecd.dir
+      size: 89848
+      nfiles: 12
+    - path: janasunani/pipeline/stages/ocr_extraction
+      hash: md5
+      md5: aa8bb78d11a87f59e07f48b365408ca1.dir
+      size: 59037
+      nfiles: 11
+    - path: janasunani/pipeline/stages/pii_tagger.py
+      hash: md5
+      md5: a2208c0a7707bdb2a01fca1369fd46c3
+      size: 25139
+    - path: janasunani/pipeline/ticket.py
+      hash: md5
+      md5: d50437cc4d295c76e90d74bca601eec5
+      size: 3639
     - path: models/format_classifier/page_split_v3.0_doc_split.pkl
       hash: md5
       md5: a428d2b7b057c53e94890d1bc2ec69ce
@@ -51,5 +80,5 @@ stages:
     outs:
     - path: data/processed/pipeline-sample.sqlite
       hash: md5
-      md5: dd1d06328327de49ee9206015dc79cae
+      md5: 4a6c9f27c88b75d1d5d51781b8ef1006
       size: 81920

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -30,10 +30,35 @@ stages:
       --ocr-engine pytesseract
       --stages format_classifier ocr_extraction pii_tagger
       --workers 1
+    # File-level deps, not the whole `janasunani/pipeline` tree (#87). The
+    # directory hash changed on every merge into that package -- dedup, the
+    # exporter, the evaluator, the grievance redactor -- none of which this
+    # stage runs, so the cached artifact read as stale when it was fine, and
+    # nothing distinguished that from genuinely stale. CI only runs `dvc dag`,
+    # which validates structure and never compares anything.
+    #
+    # Listed here: the entrypoint and its plumbing, plus exactly the three
+    # stages named in `--stages` above. Adding a stage to that flag means
+    # adding it here, which is the point -- the dep list and the command
+    # should disagree loudly rather than silently.
+    #
+    # cli.py imports the summarizer, categorizer and page-type stages too, and
+    # they are deliberately NOT deps: they do not execute under this --stages
+    # list, so they cannot change the artifact. If one of them breaks the
+    # import the run fails outright, which is the loud failure. What DVC deps
+    # exist to prevent is the quiet one -- a cached artifact that looks current
+    # and was produced by different code.
     deps:
       - data/raw/documents-sample
       - models/format_classifier/page_split_v3.0_doc_split.pkl
-      - janasunani/pipeline
+      - janasunani/pipeline/cli.py
+      - janasunani/pipeline/pipeline.py
+      - janasunani/pipeline/config.py
+      - janasunani/pipeline/db.py
+      - janasunani/pipeline/ticket.py
+      - janasunani/pipeline/stages/format_classifier
+      - janasunani/pipeline/stages/ocr_extraction
+      - janasunani/pipeline/stages/pii_tagger.py
     outs:
       - data/processed/pipeline-sample.sqlite
 


### PR DESCRIPTION
Closes #87.

The stage depended on the whole `janasunani/pipeline` tree, recorded as one directory hash. **Every merge into that package invalidated it** — tonight alone that was dedup, dedup_index, the exporter, the evaluator and the grievance redactor, none of which this stage runs.

So the cached artifact read as stale when it was fine, and nothing distinguished that from genuinely stale. CI runs only `dvc dag`, which validates structure and never compares anything, so the signal was invisible in both directions.

## What it depends on now

The entrypoint and its plumbing, plus exactly the three stages `--stages` names. Adding a stage to that flag means adding it here, which is the point — the dep list and the command should disagree loudly rather than silently.

**The summarizer, categorizer and page-type stages are imported by `cli.py` and deliberately excluded.** They do not execute under this `--stages` list so they cannot change the artifact, and if one breaks the import the run fails outright. That is the loud failure. What DVC deps exist to prevent is the quiet one — a cached artifact that looks current and came from different code.

## The lock, and a live example of the bug

A `dvc repro` ran with the first commit and regenerated the artifact, replacing the directory hash with file-level entries. Pushed to the remote.

Worth stating what that changed: the previous sample predated tonight's recognizer work, so its redactions were missing bank account and scheme ID coverage (#139) and the two landline shapes (#120). **Anyone who pulled it before now has pre-fix redactions** — which is exactly the failure #87 describes, happening one last time on the way to being fixed.

`dvc status` now reports `pipeline-sample` clean. `materialize` still shows a changed dep, but that stage reads the local SQLite OLTP and per the file's own note only applies to the SQLite dev setup.

CI is down, so `dvc dag` was run locally.