### PR TITLE
fix(pipeline): refresh progress counts current rows in a mixed slice

### DIFF
--- a/janasunani/pipeline/redact_grievance.py
+++ b/janasunani/pipeline/redact_grievance.py
@@ -248,11 +248,16 @@ async def _redact_slice(
             )
 
         processed += len(batch)
-        # In a refresh run `already` is the whole slice, so adding it to
-        # `processed` reports more rows than exist ("62544 of 55544"). Count
-        # rows carrying a current redaction instead: that is what the progress
-        # figure means in both modes.
-        current = processed if refresh_stale else processed + already
+        # Rows carrying a *current* redaction. One definition for both modes.
+        #
+        # `already + processed` double-counts in a refresh, because `already`
+        # includes the stale rows being reprocessed ("62544 of 55544"). Bare
+        # `processed` is wrong the other way: a slice of 48,544 current plus
+        # 7,000 stale rows would finish at "7000 of 55544" and read as a run
+        # that gave up. Subtracting the stale rows from `already` gives the
+        # ones that were current at the start, and `processed` adds the ones
+        # made current since.
+        current = already - stale + processed
         logger.info("redacted {} of {} ({} this batch)", current, total, len(batch))
 
     return {

--- a/tests/test_redact_grievance.py
+++ b/tests/test_redact_grievance.py
@@ -352,3 +352,45 @@ def test_refresh_progress_does_not_exceed_the_slice(oltp, caplog):
         done = int(line.split("redacted ")[1].split(" of ")[0])
         total = int(line.split(" of ")[1].split(" ")[0])
         assert done <= total, line
+
+
+def test_refresh_progress_counts_current_rows_in_a_mixed_slice(oltp, capsys):
+    """A slice that is part current and part stale must not finish at the stale
+    count alone: 48,544 current plus 7,000 stale ending at '7000 of 55544'
+    reads as a run that gave up (Codex on #141)."""
+    from loguru import logger as _logger
+
+    async_url, sync_url = oltp
+    redact_grievances("Khordha", 2024, oltp_url=async_url)
+
+    # Make exactly one of the three rows stale.
+    engine = create_engine(sync_url)
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "UPDATE grievance_redactions SET analyzer_version = :v "
+                "WHERE ticket_no = 'T1'"
+            ),
+            {"v": "presidio-analyzer=0.0.1 an-older-build"},
+        )
+    engine.dispose()
+
+    records: list[str] = []
+    sink = _logger.add(lambda m: records.append(str(m)), level="INFO", format="{message}")
+    try:
+        counts = redact_grievances(
+            "Khordha", 2024, oltp_url=async_url, refresh_stale=True
+        )
+    finally:
+        _logger.remove(sink)
+
+    assert counts["stale_at_start"] == 1
+    assert counts["processed"] == 1
+
+    progress = [r for r in records if "redacted" in r and " of " in r]
+    assert progress
+    final = progress[-1]
+    done = int(final.split("redacted ")[1].split(" of ")[0])
+    total = int(final.split(" of ")[1].split(" ")[0])
+    # Two rows were already current, one was made current: all three.
+    assert done == total == 3, final


### PR DESCRIPTION
Codex on #141. My fix there handled the all-stale case and broke the mixed one.

A slice of 48,544 current plus 7,000 stale rows would have finished at `7000 of 55544` — **a complete run reading as one that gave up**, on the line an operator watches to decide whether to intervene.

## One definition for both modes

```
current = already - stale + processed
```

The rows carrying a *current* redaction.

- `already + processed` double-counts in a refresh, because `already` includes the stale rows being reprocessed — that was the original `62544 of 55544`
- bare `processed` undercounts, because it ignores rows that were already current — that was my fix

Subtracting stale from `already` gives the rows current at the start; `processed` adds the ones made current since. Works unchanged in a plain resume, where `stale` is zero.

## Why neither bug showed up tonight

The Sambalpur refresh was **entirely** stale — every row predated the recognizer change — so `already - stale` was zero and bare `processed` happened to be right. The mixed case is the normal one from here: every future analyzer change makes some rows stale and leaves the rest.

- `pytest` — 680 passed, 7 skipped
- `ruff check .` — clean
- New test builds exactly that mixed slice (2 current, 1 stale) and asserts the final line reads `3 of 3`

CI is down, so local is the gate.