### PR TITLE
fix(pii): match identifier context across a clause, not adjacent to the digits

### DIFF
--- a/janasunani/pipeline/stages/pii_tagger.py
+++ b/janasunani/pipeline/stages/pii_tagger.py
@@ -177,10 +177,7 @@ _IDENTIFIER_CLASSES = (
     (
         "IN_BANK_ACCOUNT",
         re.compile(
-            r"(?:a/?c|acc(?:oun)?t|account|bank|ifsc|passbook|khata)"
-            # Qualifiers repeat: "account no.", "bank a/c number", "khata no".
-            r"(?:[^0-9A-Za-z]{0,4}(?:a/?c|n[o0]\.?|number|num|is))*"
-            r"[^0-9A-Za-z]{0,4}$",
+            r"(?:a/?c|acc(?:oun)?t|account|bank|ifsc|passbook|khata)",
             re.IGNORECASE,
         ),
         (9, 18),
@@ -189,10 +186,7 @@ _IDENTIFIER_CLASSES = (
         "IN_SCHEME_ID",
         re.compile(
             r"(?:ration|job\s*card|jobcard|mgnrega|nrega|registration|regd|"
-            r"epic|voter|udise|pension|scholarship|beneficiary|applicant)"
-            # Qualifiers repeat and stack: "ration card no", "job card number".
-            r"(?:[^0-9A-Za-z]{0,4}(?:i?d|n[o0]\.?|number|num|card|is))*"
-            r"[^0-9A-Za-z]{0,4}$",
+            r"epic|voter|udise|pension|scholarship|beneficiary|applicant)",
             re.IGNORECASE,
         ),
         (8, 18),
@@ -209,9 +203,28 @@ _BARE_ACCOUNT_MAX = 18
 
 _DIGIT_RUN_RE = re.compile(r"(?<!\d)\d{8,18}(?!\d)")
 
-# How far back to look for the context word. Long enough to span "bank account
+# How far back to look for the context word.
+#
+# The keyword is matched anywhere in this window rather than adjacent to the
+# digits. Requiring adjacency missed 48 of the 304 identifiers left after the
+# first pass over Sambalpur 2024: real text separates the two ("ration card
+# issued 2019, number 12345678901"), and no adjacency rule survives contact
+# with how people actually write.
+#
+# 40 characters is roughly one clause -- long enough to span "bank account
 # number is", short enough that an unrelated earlier mention does not leak in.
 _CONTEXT_WINDOW = 40
+
+# ...but a keyword in the window is not enough on its own, because a case or
+# letter number can sit in the same clause as a scheme word ("ration shop
+# complaint, letter no 12345678901"). The same citation convention the PHONE
+# postfilter uses (#55/#91) wins over the keyword when it immediately precedes
+# the digits. Cited numbers are being quoted, not identified with.
+_CITATION_BEFORE_RE = re.compile(
+    r"(letter|case|file|order|reference|ref|memo|receipt|regd)\.?\s*"
+    r"(no|number)?\.?\s*[:\-]?\s*$",
+    re.IGNORECASE,
+)
 
 
 class _IndianIdentifierRecognizer:
@@ -245,8 +258,9 @@ class _IndianIdentifierRecognizer:
 
                     entity = None
                     score = 0.0
+                    cited = _CITATION_BEFORE_RE.search(before) is not None
                     for name, context_re, (low, high) in _IDENTIFIER_CLASSES:
-                        if low <= length <= high and context_re.search(before):
+                        if low <= length <= high and context_re.search(before) and not cited:
                             entity, score = name, 0.7
                             break
                     if entity is None and _BARE_ACCOUNT_MIN <= length <= _BARE_ACCOUNT_MAX:

--- a/tests/test_pii_redaction.py
+++ b/tests/test_pii_redaction.py
@@ -403,3 +403,41 @@ class TestLandlineShapesFromTheSambalpurScan:
 
     def test_dates_are_still_not_phones(self):
         assert "[PHONE]" not in redact_text("on 06.05.2025 we filed the complaint")
+
+
+class TestIdentifierContextIsAClauseNotAnAdjacency:
+    """Requiring the keyword adjacent to the digits missed 48 of the 304
+    identifiers left after the first Sambalpur pass. Real text separates them,
+    and no adjacency rule survives contact with how people write."""
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "ration card issued 2019, number 12345678901 blocked",
+            "my account details, the number 123456789012 is wrong",
+            "pension not received, id 12345678901 since March",
+        ],
+    )
+    def test_a_keyword_earlier_in_the_clause_still_anchors(self, text):
+        out = redact_text(text)
+        assert "[ACCOUNT]" in out or "[ID]" in out
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "ration shop complaint, letter no 12345678901 pending",
+            "case no 12345678901 about pension arrears",
+            "file no 123456789012 regarding scholarship",
+        ],
+    )
+    def test_a_cited_number_wins_over_a_keyword_in_the_same_clause(self, text):
+        """A case or letter number can share a clause with a scheme word. The
+        citation convention immediately before the digits means they are being
+        quoted, not identified with."""
+        out = redact_text(text)
+        assert "[ACCOUNT]" not in out and "[ID]" not in out
+
+    def test_the_bare_long_run_rule_is_unaffected_by_citation(self):
+        """14+ digits is an identifier whatever precedes it: no case number is
+        that long, so the citation guard must not suppress this class."""
+        assert "[ACCOUNT]" in redact_text("12345678901234567 credited late")


### PR DESCRIPTION
Refs #139. Second pass, driven by measuring the first one against the real slice.

## What the first pass achieved

Unredacted identifiers in Sambalpur 2024 went **579 → 304 occurrences**, and **every 14-18 digit run is gone** — the bank-account-shaped class is fully covered.

## What it missed, and why

**48 of the remaining 304 had a recognised keyword within 40 characters** and were still not caught. The pattern required the keyword *adjacent* to the digits, with only qualifier words ("no.", "number") between. Real text separates them:

> ration card issued 2019, number 12345678901

No adjacency rule survives contact with how people actually write.

## The fix, and the false positive it would have created

The keyword now matches anywhere in the preceding clause. On its own that would redact case numbers sharing a clause with a scheme word:

> ration shop complaint, letter no 12345678901 pending

So the citation convention already used by the PHONE postfilter (#55/#91) wins when it immediately precedes the digits — a cited number is being quoted, not identified with. Verified in both directions.

**The bare 14+ digit rule is deliberately exempt from the citation guard.** No case number is that long, so a citation word before one does not make it a reference.

## Verification

- `pytest` — **687 passed, 7 skipped**
- `ruff check .` — clean
- Seven new tests: three separated-keyword cases now caught, three cited numbers still protected, and the bare-run rule unaffected
- Gold re-scored: coverage unchanged at **0.4958**, and the new entities still report `n/a` rather than a misleading zero

## What remains after this

The residual class is bare 11-13 digit runs with no keyword anywhere in the clause. Redacting those on shape alone would take case numbers wholesale, which is why they are left — a deliberate boundary, not an oversight. Worth a note on #139 with the final count once the slice is re-run.

CI is down, so local is the gate.