### PR TITLE
fix(pipeline): the done line had the same double-count as the progress line

### DIFF
--- a/janasunani/pipeline/redact_grievance.py
+++ b/janasunani/pipeline/redact_grievance.py
@@ -335,10 +335,14 @@ def main() -> None:
         limit=args.limit,
         refresh_stale=args.refresh_stale,
     )
+    # Same arithmetic as the per-batch progress line: rows carrying a *current*
+    # redaction. The batch line was fixed in #141/#147 and this one was not, so
+    # tonight's refresh ended on "111088 of 55544" -- the number that gets
+    # pasted into a run record, which is worse than the one that scrolls past.
     logger.info(
         "done: {} processed this run, {} of {} redacted in slice {}/{}",
         counts["processed"],
-        counts["already_redacted"] + counts["processed"],
+        counts["already_redacted"] - counts["stale_at_start"] + counts["processed"],
         counts["total"],
         args.district,
         args.year,

--- a/tests/test_redact_grievance.py
+++ b/tests/test_redact_grievance.py
@@ -9,7 +9,7 @@ import pytest
 from sqlalchemy import create_engine, insert, select, text
 
 from janasunani.db.models import Base, Complaint, GrievanceRedaction
-from janasunani.pipeline.redact_grievance import redact_grievances
+from janasunani.pipeline.redact_grievance import main, redact_grievances
 
 # Deliberately not real PII: these tests assert plumbing, not detection.
 ROWS = [
@@ -394,3 +394,49 @@ def test_refresh_progress_counts_current_rows_in_a_mixed_slice(oltp, capsys):
     total = int(final.split(" of ")[1].split(" ")[0])
     # Two rows were already current, one was made current: all three.
     assert done == total == 3, final
+
+
+def test_done_line_does_not_exceed_the_slice(oltp, monkeypatch):
+    """The per-batch progress line was fixed in #141/#147 and this one was not,
+    so the refresh ended on '111088 of 55544'. It is the line that gets pasted
+    into a run record, which is worse than the one that scrolls past."""
+    import sys
+
+    from loguru import logger as _logger
+
+    async_url, sync_url = oltp
+    redact_grievances("Khordha", 2024, oltp_url=async_url)
+    engine = create_engine(sync_url)
+    with engine.begin() as conn:
+        conn.execute(
+            text("UPDATE grievance_redactions SET analyzer_version = :v"),
+            {"v": "presidio-analyzer=0.0.1 an-older-build"},
+        )
+    engine.dispose()
+
+    records: list[str] = []
+    sink = _logger.add(lambda m: records.append(str(m)), level="INFO", format="{message}")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "redact_grievance.py",
+            "--district",
+            "Khordha",
+            "--year",
+            "2024",
+            "--oltp-url",
+            async_url,
+            "--refresh-stale",
+        ],
+    )
+    try:
+        main()
+    finally:
+        _logger.remove(sink)
+
+    done = [r for r in records if r.startswith("done:")]
+    assert done, "expected a done line"
+    counted = int(done[-1].split("this run, ")[1].split(" of ")[0])
+    total = int(done[-1].split(" of ")[1].split(" ")[0])
+    assert counted == total == 3, done[-1]


### PR DESCRIPTION
The per-batch progress line was fixed in #141 and corrected again in #147. **The final summary line in `main()` has the identical arithmetic and was left alone**, so tonight's refresh ended on:

```
done: 55544 processed this run, 111088 of 55544 redacted in slice Sambalpur/2024
```

This is the worse of the two to get wrong. The progress line scrolls past; **the done line is what gets pasted into a run record** and read later by someone deciding whether the job completed.

Now uses the same expression as the batch line — `already - stale + processed`, the rows carrying a current redaction — so the two cannot disagree.

## How it survived two fixes

Both earlier fixes were verified against tests that exercise `redact_grievances()` and never call `main()`. The new test drives `main()` through `argv` so the line is actually produced.

Found by reading the output of a real run rather than by review — the same way #139 surfaced.

- `pytest` — 688 passed, 7 skipped
- `ruff check .` — clean

CI is down, so local is the gate.