### PR TITLE
fix(dedup): batch pair verification, which OOM-killed the Sambalpur run

### DIFF
--- a/janasunani/pipeline/dedup_index.py
+++ b/janasunani/pipeline/dedup_index.py
@@ -144,6 +144,12 @@ from janasunani.pipeline.export import _dialect_upsert
 
 BATCH_SIZE = 500
 
+# Candidate pairs verified per round trip. Bounds peak memory: only the
+# redacted text and shingle sets for the tickets in one chunk are held, rather
+# than every ticket involved in any candidate pair. 20,000 pairs touch at most
+# 40,000 tickets and in practice far fewer, since sorting clusters them.
+VERIFY_CHUNK_PAIRS = 20_000
+
 # Time-window blocking width. Campaigns and resubmissions cluster within
 # days to a few weeks of each other (a citizen re-files, or many filers
 # submit the same near-identical text in a burst); a filing from January
@@ -544,18 +550,35 @@ async def _group_duplicates(
         rows
     )
 
-    involved = sorted({ticket for pair in candidate_pairs for ticket in pair})
-    async with engine.begin() as conn:
-        text_by_ticket = await _load_redacted_text(conn, involved)
+    # Verification is batched, and this is a memory fix rather than a
+    # preference. Loading every involved ticket's redacted text at once put
+    # the Sambalpur 2024 run at 7.4 GB RSS and the kernel OOM-killed it on an
+    # 8 GB box after all 55,544 signatures had been written. Candidate
+    # generation above is safe to keep global -- it touches only band hashes
+    # and identity hashes, which are small, and identity pairs legitimately
+    # cross blocks so partitioning there would change the answer.
+    #
+    # Pairs are sorted first so both members of consecutive pairs tend to
+    # repeat, which makes the per-chunk shingle cache actually hit.
+    verified_pairs: list[tuple[str, str]] = []
+    ordered_pairs = sorted(candidate_pairs)
+    for start in range(0, len(ordered_pairs), VERIFY_CHUNK_PAIRS):
+        chunk = ordered_pairs[start : start + VERIFY_CHUNK_PAIRS]
+        tickets = sorted({ticket for pair in chunk for ticket in pair})
+        async with engine.begin() as conn:
+            text_by_ticket = await _load_redacted_text(conn, tickets)
 
-    verified_pairs = [
-        (a, b)
-        for a, b in candidate_pairs
-        if jaccard_similarity(
-            shingles(text_by_ticket.get(a, "")), shingles(text_by_ticket.get(b, ""))
-        )
-        >= threshold
-    ]
+        # Shingling dominates the CPU here and the same ticket appears in many
+        # pairs, so cache within the chunk. The cache is rebound each
+        # iteration rather than accumulated, which is what keeps the ceiling
+        # flat instead of growing across the run.
+        shingle_cache: dict[str, set[str]] = {}
+        for a, b in chunk:
+            for ticket in (a, b):
+                if ticket not in shingle_cache:
+                    shingle_cache[ticket] = shingles(text_by_ticket.get(ticket, ""))
+            if jaccard_similarity(shingle_cache[a], shingle_cache[b]) >= threshold:
+                verified_pairs.append((a, b))
 
     all_tickets = [row.ticket_no for row in rows]
     groups = union_find_groups(verified_pairs, items=all_tickets)

--- a/tests/test_dedup_index.py
+++ b/tests/test_dedup_index.py
@@ -730,3 +730,38 @@ def _index_version_for_test() -> str:
     from janasunani.pipeline.dedup_index import _index_version
 
     return _index_version(30, 0.5, "s")
+
+
+class TestVerificationIsBatched:
+    """The Sambalpur 2024 run OOM-killed at 7.4 GB on an 8 GB box after all
+    55,544 signatures were written: verification loaded every involved ticket's
+    redacted text at once. Candidate generation stays global -- it touches only
+    band and identity hashes, and identity pairs legitimately cross blocks."""
+
+    def test_grouping_is_unchanged_by_chunking(self, dup_oltp, monkeypatch):
+        """A chunk size of 1 must produce exactly the same groups as one big
+        chunk, or the fix changed the answer rather than the memory profile."""
+        import janasunani.pipeline.dedup_index as di
+
+        async_url, sync_url = dup_oltp
+        big = build_dedup_index("Sambalpur", 2024, oltp_url=async_url, salt="s")
+
+        engine = create_engine(sync_url)
+        with engine.begin() as conn:
+            conn.execute(text("DELETE FROM dedup_groups"))
+            conn.execute(text("DELETE FROM dedup_signatures"))
+        engine.dispose()
+
+        monkeypatch.setattr(di, "VERIFY_CHUNK_PAIRS", 1)
+        small = build_dedup_index("Sambalpur", 2024, oltp_url=async_url, salt="s")
+
+        assert small["groups"] == big["groups"]
+        assert small["verified_pairs"] == big["verified_pairs"]
+
+    def test_the_chunk_size_is_a_real_bound(self):
+        """A chunk larger than the pair count would silently restore the old
+        all-at-once behaviour."""
+        import janasunani.pipeline.dedup_index as di
+
+        assert isinstance(di.VERIFY_CHUNK_PAIRS, int)
+        assert 0 < di.VERIFY_CHUNK_PAIRS <= 100_000


### PR DESCRIPTION
Refs #71. The dedup index build died on the demo slice tonight.

## What happened

```
Out of memory: Killed process 2330874 (python) total-vm:7955372kB, anon-rss:7390724kB
```

All **55,544 signatures were written** and persisted. The kernel killed the process during grouping, on an 8 GB box, at 7.4 GB RSS. No traceback — the log simply stops after the last signature batch, which is what an OOM looks like from the application side.

## Cause

`_group_duplicates` loaded the redacted text for **every ticket involved in any candidate pair** into one dict, then shingled from it. The expensive half of the job survived; the cheap half is what fell over.

## Fix

Verification runs in chunks of 20,000 pairs. Only the text and shingle sets for the tickets in one chunk are held, and the cache is rebound each iteration rather than accumulated. Pairs are sorted first so consecutive pairs share members and the cache actually hits.

**Candidate generation is deliberately left global.** It touches only band hashes and identity hashes, which are small — and identity pairs legitimately cross blocks, so partitioning there would change the answer rather than the memory profile. Blocking already caps the real work: **26 blocks over this slice, largest 9,405**.

## The test that matters

A chunk size of 1 must produce identical groups and verified pairs to one big chunk. **A memory fix that changes the result is not a memory fix.**

## Why the suite did not catch it

The unit tests pass at every chunk size because the fixtures are small enough that the old code never allocated anything. Found by running it at scale, the same way #139 was.

- `pytest` — **695 passed, 7 skipped**
- `ruff check .` — clean

CI is down, so local is the gate.