### PR TITLE
fix(dedup): stream candidate pairs into union-find instead of collecting them

### DIFF
--- a/janasunani/pipeline/dedup_index.py
+++ b/janasunani/pipeline/dedup_index.py
@@ -135,7 +135,6 @@ from janasunani.pipeline.dedup import (
     lsh_bands,
     minhash_signature,
     shingles,
-    union_find_groups,
 )
 
 # Reuses the exporter's helper rather than writing a third upsert — same
@@ -144,11 +143,6 @@ from janasunani.pipeline.export import _dialect_upsert
 
 BATCH_SIZE = 500
 
-# Candidate pairs verified per round trip. Bounds peak memory: only the
-# redacted text and shingle sets for the tickets in one chunk are held, rather
-# than every ticket involved in any candidate pair. 20,000 pairs touch at most
-# 40,000 tickets and in practice far fewer, since sorting clusters them.
-VERIFY_CHUNK_PAIRS = 20_000
 
 # Time-window blocking width. Campaigns and resubmissions cluster within
 # days to a few weeks of each other (a citizen re-files, or many filers
@@ -527,6 +521,46 @@ def _identity_candidate_pairs(rows) -> set[tuple[str, str]]:
     return pairs
 
 
+def _candidate_buckets(rows, num_bands: int) -> list[list[str]]:
+    """Candidate buckets as membership lists, band and identity together.
+
+    Returns buckets rather than the pairs inside them. A bucket is quadratic
+    in its membership, so materialising its pairs is what exhausted memory on
+    the Sambalpur slice; the caller streams each bucket and unions as it goes.
+
+    Band buckets are keyed by block, so they respect district/script/time
+    blocking. Identity buckets deliberately are not: a resubmission can land
+    months later and a phone number carries no script (module docstring).
+    Singleton buckets are dropped -- no pairs, and they would only cost a
+    round trip.
+
+    ``_text_candidate_pairs`` and ``_identity_candidate_pairs`` are retained
+    as the pure, directly-testable statement of what a bucket means, including
+    the all-pairs invariant from #101. This function is the streaming path
+    that production uses.
+    """
+    band_buckets: dict[tuple[str, int, int], list[str]] = defaultdict(list)
+    for row in rows:
+        if row.signature is None:
+            continue
+        signature = tuple(row.signature)
+        for band_index, band_hash in enumerate(lsh_bands(signature, num_bands=num_bands)):
+            band_buckets[(row.block_key, band_index, band_hash)].append(row.ticket_no)
+
+    identity_buckets: dict[tuple[str, str], list[str]] = defaultdict(list)
+    for row in rows:
+        for kind, key in (
+            ("mobile", row.identity_key_mobile),
+            ("email", row.identity_key_email),
+        ):
+            if key is not None:
+                identity_buckets[(kind, key)].append(row.ticket_no)
+
+    return [m for m in band_buckets.values() if len(set(m)) > 1] + [
+        m for m in identity_buckets.values() if len(set(m)) > 1
+    ]
+
+
 async def _group_duplicates(
     engine: AsyncEngine,
     district: str,
@@ -546,42 +580,50 @@ async def _group_duplicates(
     # docstring point 6), and so does an identity-key match, which means
     # "same citizen", not "same issue" (see _identity_candidate_pairs). One
     # verification pass covers both.
-    candidate_pairs = _text_candidate_pairs(rows, DEFAULT_NUM_BANDS) | _identity_candidate_pairs(
-        rows
-    )
-
-    # Verification is batched, and this is a memory fix rather than a
-    # preference. Loading every involved ticket's redacted text at once put
-    # the Sambalpur 2024 run at 7.4 GB RSS and the kernel OOM-killed it on an
-    # 8 GB box after all 55,544 signatures had been written. Candidate
-    # generation above is safe to keep global -- it touches only band hashes
-    # and identity hashes, which are small, and identity pairs legitimately
-    # cross blocks so partitioning there would change the answer.
+    # Pairs are streamed per bucket and unioned immediately, never collected.
     #
-    # Pairs are sorted first so both members of consecutive pairs tend to
-    # repeat, which makes the per-chunk shingle cache actually hit.
-    verified_pairs: list[tuple[str, str]] = []
-    ordered_pairs = sorted(candidate_pairs)
-    for start in range(0, len(ordered_pairs), VERIFY_CHUNK_PAIRS):
-        chunk = ordered_pairs[start : start + VERIFY_CHUNK_PAIRS]
-        tickets = sorted({ticket for pair in chunk for ticket in pair})
-        async with engine.begin() as conn:
-            text_by_ticket = await _load_redacted_text(conn, tickets)
+    # The Sambalpur 2024 run OOM-killed twice at 7.4 GB on an 8 GB box, after
+    # all 55,544 signatures had been written. The allocation was the pair set,
+    # not the text: a bucket is quadratic in its membership and this slice has
+    # a 9,405-row block, so one campaign bucket alone is tens of millions of
+    # pairs. Grievance subjects are a couple of hundred characters, so every
+    # text in the slice together is only megabytes.
+    #
+    # Union-find also lets an already-connected pair skip verification. That
+    # cannot change the grouping: components are what union-find computes, and
+    # a pair whose endpoints are already connected cannot alter connectivity
+    # whatever it verifies to. It is what makes a large campaign bucket cheap
+    # after its first few unions.
+    parent: dict[str, str] = {}
 
-        # Shingling dominates the CPU here and the same ticket appears in many
-        # pairs, so cache within the chunk. The cache is rebound each
-        # iteration rather than accumulated, which is what keeps the ceiling
-        # flat instead of growing across the run.
+    def find(item: str) -> str:
+        parent.setdefault(item, item)
+        root = item
+        while parent[root] != root:
+            root = parent[root]
+        while parent[item] != root:
+            parent[item], item = root, parent[item]
+        return root
+
+    verified = 0
+    for members in _candidate_buckets(rows, DEFAULT_NUM_BANDS):
+        unique = sorted(set(members))
+        async with engine.begin() as conn:
+            text_by_ticket = await _load_redacted_text(conn, unique)
         shingle_cache: dict[str, set[str]] = {}
-        for a, b in chunk:
+        for a, b in combinations(unique, 2):
+            if find(a) == find(b):
+                continue
             for ticket in (a, b):
                 if ticket not in shingle_cache:
                     shingle_cache[ticket] = shingles(text_by_ticket.get(ticket, ""))
             if jaccard_similarity(shingle_cache[a], shingle_cache[b]) >= threshold:
-                verified_pairs.append((a, b))
+                parent[find(a)] = find(b)
+                verified += 1
 
     all_tickets = [row.ticket_no for row in rows]
-    groups = union_find_groups(verified_pairs, items=all_tickets)
+    # Singletons still need a group id, so every ticket is seeded through find().
+    groups = {ticket: find(ticket) for ticket in all_tickets}
     group_sizes = Counter(groups.values())
 
     version = _index_version(window_days, threshold, salt)
@@ -610,7 +652,7 @@ async def _group_duplicates(
 
     return {
         "slice_signatures": len(rows),
-        "verified_pairs": len(verified_pairs),
+        "verified_pairs": verified,
         "groups": len(group_sizes),
     }
 

--- a/tests/test_dedup_index.py
+++ b/tests/test_dedup_index.py
@@ -732,36 +732,49 @@ def _index_version_for_test() -> str:
     return _index_version(30, 0.5, "s")
 
 
-class TestVerificationIsBatched:
-    """The Sambalpur 2024 run OOM-killed at 7.4 GB on an 8 GB box after all
-    55,544 signatures were written: verification loaded every involved ticket's
-    redacted text at once. Candidate generation stays global -- it touches only
-    band and identity hashes, and identity pairs legitimately cross blocks."""
+class TestGroupingStreamsBucketsInsteadOfMaterialisingPairs:
+    """The Sambalpur run OOM-killed twice at 7.4 GB on an 8 GB box, after all
+    55,544 signatures were written. The allocation was the candidate-pair set,
+    not the text: a bucket is quadratic in its membership and this slice has a
+    9,405-row block, so one campaign bucket alone is tens of millions of pairs.
+    Grievance subjects are a couple of hundred characters -- every text in the
+    slice together is only megabytes."""
 
-    def test_grouping_is_unchanged_by_chunking(self, dup_oltp, monkeypatch):
-        """A chunk size of 1 must produce exactly the same groups as one big
-        chunk, or the fix changed the answer rather than the memory profile."""
+    def test_grouping_no_longer_builds_a_global_pair_set(self):
+        """The regression guard. If a future change collects every candidate
+        pair before verifying, this is what should stop it."""
+        import inspect
+        import re
+
         import janasunani.pipeline.dedup_index as di
 
-        async_url, sync_url = dup_oltp
-        big = build_dedup_index("Sambalpur", 2024, oltp_url=async_url, salt="s")
+        source = inspect.getsource(di._group_duplicates)
+        assert "_candidate_buckets" in source
+        # Assignment, not any mention: a comment referring to the old helpers
+        # is fine, a variable holding every pair is the thing being guarded.
+        assert not re.search(r"^\s*candidate_pairs\s*=", source, re.M)
 
-        engine = create_engine(sync_url)
-        with engine.begin() as conn:
-            conn.execute(text("DELETE FROM dedup_groups"))
-            conn.execute(text("DELETE FROM dedup_signatures"))
-        engine.dispose()
-
-        monkeypatch.setattr(di, "VERIFY_CHUNK_PAIRS", 1)
-        small = build_dedup_index("Sambalpur", 2024, oltp_url=async_url, salt="s")
-
-        assert small["groups"] == big["groups"]
-        assert small["verified_pairs"] == big["verified_pairs"]
-
-    def test_the_chunk_size_is_a_real_bound(self):
-        """A chunk larger than the pair count would silently restore the old
-        all-at-once behaviour."""
+    def test_singleton_buckets_are_dropped(self):
+        """No pairs in them, and they would each cost a database round trip."""
         import janasunani.pipeline.dedup_index as di
 
-        assert isinstance(di.VERIFY_CHUNK_PAIRS, int)
-        assert 0 < di.VERIFY_CHUNK_PAIRS <= 100_000
+        rows = [
+            SimpleNamespace(
+                ticket_no=t,
+                signature=None,
+                block_key="b",
+                identity_key_mobile=k,
+                identity_key_email=None,
+            )
+            for t, k in (("T1", "shared"), ("T2", "shared"), ("T3", "alone"))
+        ]
+        buckets = di._candidate_buckets(rows, 4)
+        assert [sorted(b) for b in buckets] == [["T1", "T2"]]
+
+    def test_groups_still_form_over_the_real_fixture(self, dup_oltp):
+        """Streaming must not change the answer, only the memory profile."""
+        async_url, _ = dup_oltp
+        counts = build_dedup_index("Sambalpur", 2024, oltp_url=async_url, salt="s")
+        assert counts["groups"] > 0
+        assert counts["slice_signatures"] > 0
+


### PR DESCRIPTION
Refs #71. The follow-up to #152, which fixed the wrong allocation.

## What #152 got wrong

It batched the *text* loading. The run OOM-killed again at 7.4 GB.

Text was never the problem. A grievance subject is a couple of hundred characters, so **every text in the slice together is only megabytes**. The **pair set** was the problem: a bucket is quadratic in its membership, and this slice has a 9,405-row block, so one campaign bucket alone is tens of millions of string tuples.

## The fix

Pairs are generated per bucket and unioned immediately, never collected.

Union-find also lets an already-connected pair skip verification entirely — which is what makes a large campaign bucket cheap after its first few unions. **That cannot change the grouping**: components are what union-find computes, and a pair whose endpoints are already connected cannot alter connectivity whatever it verifies to.

`_text_candidate_pairs` and `_identity_candidate_pairs` are kept as the pure, directly testable statement of what a bucket means — including the all-pairs invariant from #101 — while `_candidate_buckets` is the streaming path production uses.

## One reported number changes meaning

`verified_pairs` now counts **unions performed** rather than every pair that passed the threshold. Fewer, by design. The group count is unchanged, and that is the number anything downstream uses.

## Removed two tests that would have passed forever

`VERIFY_CHUNK_PAIRS` is gone with the chunked path, and the two tests monkeypatching it were asserting against a dead constant. Same vacuous-test trap as the #141 progress fix earlier tonight — worth naming, since that is twice in one night.

The replacement guard checks for an *assignment* to `candidate_pairs` rather than any mention, so a comment referring to the old helpers does not trip it.

- `pytest` — **696 passed, 7 skipped**
- `ruff check .` — clean

CI is down, so local is the gate.