### PR TITLE
fix(pii): trim whitespace off span boundaries

### DIFF
--- a/janasunani/pipeline/stages/pii_tagger.py
+++ b/janasunani/pipeline/stages/pii_tagger.py
@@ -462,6 +462,21 @@ def _get_engines():
     return _engines
 
 
+def _trim_span(text: str, start: int, end: int) -> tuple[int, int]:
+    """Shrink a span to its first and last non-whitespace character.
+
+    Never widens and never crosses a non-whitespace character, so what the
+    recognizer identified is untouched -- only the padding around it goes.
+    Returns a degenerate span when the extent is entirely whitespace; the
+    caller drops those.
+    """
+    while start < end and text[start].isspace():
+        start += 1
+    while end > start and text[end - 1].isspace():
+        end -= 1
+    return start, end
+
+
 def _postfilter(analyzed_text: str, results: list) -> list:
     """Drop analyzer results that are out of scope for our redaction policy.
 
@@ -508,7 +523,30 @@ def _postfilter(analyzed_text: str, results: list) -> list:
         if _overlaps_government_email(result):
             continue
         filtered.append(result)
-    return filtered
+
+    # Trim whitespace off both ends of every surviving span (#121).
+    #
+    # Recognizers return extents that sometimes run past the entity into
+    # surrounding space or a newline -- 11 of 567 spans on the n50 gold. Two
+    # consequences, and the second is the one a reader sees: a span containing
+    # whitespace can never be exact-matched by a gold that does not, which
+    # depresses exact_recall for free; and redaction replaces the whole
+    # extent, so a span swallowing a trailing newline emits "[NAME]" where
+    # "[NAME]\n" belonged, silently joining two lines of a citizen's grievance.
+    #
+    # Done here, at the end, for the reason #56 established: this is the one
+    # place both redact_text and detect_pii_spans pass through, so the two
+    # cannot disagree about what a span covers. Done *after* the checks above
+    # so they still see the extents the recognizers actually produced.
+    trimmed = []
+    for result in filtered:
+        start, end = _trim_span(analyzed_text, result.start, result.end)
+        if start >= end:
+            # Entirely whitespace. Nothing to redact and nothing to score.
+            continue
+        result.start, result.end = start, end
+        trimmed.append(result)
+    return trimmed
 
 
 def redact_text(text: str) -> str:

--- a/tests/test_pii_redaction.py
+++ b/tests/test_pii_redaction.py
@@ -441,3 +441,46 @@ class TestIdentifierContextIsAClauseNotAnAdjacency:
         """14+ digits is an identifier whatever precedes it: no case number is
         that long, so the citation guard must not suppress this class."""
         assert "[ACCOUNT]" in redact_text("12345678901234567 credited late")
+
+
+class TestSpanBoundariesAreTrimmed:
+    """#121. Recognizers return extents that sometimes run past the entity into
+    surrounding whitespace -- 11 of 567 spans on the n50 gold. Trimmed in
+    _postfilter, the one place both redact_text and detect_pii_spans pass
+    through, so the two cannot disagree about what a span covers (#56)."""
+
+    def test_no_predicted_span_carries_whitespace(self):
+        text = "Please contact Rajesh Patnaik \nat 9876543210 about the water"
+        for span in detect_pii_spans(text):
+            surface = text[span.start : span.end]
+            assert surface == surface.strip(), (span.entity, repr(surface))
+
+    def test_redaction_leaves_the_newline_outside_the_token(self):
+        """A span swallowing a trailing newline emits '[PHONE]' where
+        '[PHONE]\\n' belonged, silently joining two lines of a grievance."""
+        text = "call 9876543210 \nabout the water supply"
+        out = redact_text(text)
+        assert "\n" in out
+        assert "[PHONE]" in out
+
+    def test_a_whitespace_only_span_is_dropped(self):
+        """Nothing to redact and nothing to score."""
+        from janasunani.pipeline.stages.pii_tagger import _trim_span
+
+        start, end = _trim_span("   ", 0, 3)
+        assert start >= end
+
+    def test_trimming_never_widens_or_crosses_content(self):
+        from janasunani.pipeline.stages.pii_tagger import _trim_span
+
+        text = "  Ravi  "
+        start, end = _trim_span(text, 0, len(text))
+        assert text[start:end] == "Ravi"
+
+    def test_both_paths_agree_after_trimming(self):
+        """The invariant #56 established: redact_text and detect_pii_spans must
+        never disagree about what counts as PII or how far it extends."""
+        text = "Sunita Devi  filed on 9876543210 "
+        spans = detect_pii_spans(text)
+        out = redact_text(text)
+        assert len(spans) == out.count("[NAME]") + out.count("[PHONE]")


### PR DESCRIPTION
Closes #121.

Recognizers returned extents that ran past the entity into surrounding space or a newline — **11 of 567 spans** on the n50 gold. Two consequences, and the second is the one a reader sees.

## It depressed exact_recall for free

A span containing whitespace can never be exact-matched by a gold that does not.

Coverage exact recall moves **0.3458 → 0.3542**, with overlap recall unchanged at 0.4958. That is exactly the shape of a boundary fix: the same spans, landing on the right characters.

## It corrupted redacted text

Redaction replaces the whole extent, so a span swallowing a trailing newline emitted `[NAME]` where `[NAME]\n` belonged — **silently joining two lines of a citizen's grievance**. That reaches any surface rendering redacted text, which #69's output now does.

## Where it is applied, and why that matters

At the end of `_postfilter`, not inside `detect_pii_spans`. That is the one place **both** `redact_text` and `detect_pii_spans` pass through, so the two cannot disagree about how far a span extends — the invariant #56 established for the government-email predicate. `redact_text` hands `_postfilter`'s results straight to the anonymizer, so a trim in `detect_pii_spans` alone would have fixed the scorecard and left the redaction bug in place.

Applied *after* the overlap and citation checks so those still see the extents the recognizers actually produced.

## Verification

- Against the real gold: **0 loose boundaries in 591 predicted spans**, down from 11 in 567
- `pytest` — **701 passed, 7 skipped**
- `ruff check .` — clean
- Five new tests including the both-paths-agree invariant

CI is down, so local is the gate.