### PR TITLE
feat(pii): find names written in ALL CAPS

### DIFF
--- a/janasunani/pipeline/stages/pii_tagger.py
+++ b/janasunani/pipeline/stages/pii_tagger.py
@@ -162,6 +162,29 @@ def _ascii_digits(text: str) -> str:
     return text.translate(_INDIC_DIGITS_TO_ASCII)
 
 
+# Runs of two or more ALL-CAPS words. Government correspondence writes names
+# this way constantly ("APPLICANT SMT SUNITA DEVI"), and spaCy's NER leans on
+# capitalisation as a feature, so all-caps defeats it: 53 of the 228 NAME
+# spans it missed on the n50 gold are all-caps (#92).
+_CAPS_RUN_RE = re.compile(r"\b[A-Z][A-Z'.-]*(?:\s+[A-Z][A-Z'.-]*)+\b")
+
+
+def _soften_caps(text: str) -> str:
+    """Title-case ALL-CAPS runs so the NER can see them as names.
+
+    **Length-preserving by construction**, which is what makes it safe: every
+    replacement is `str.title()` of the same span, so offsets carry over 1:1
+    and the caller can analyze this copy while redacting the original. Same
+    contract as :func:`_ascii_digits`, and the reason both are applied to a
+    throwaway copy rather than to the text anyone reads.
+
+    Only runs of two or more capitalised words are touched. A single
+    all-caps token is as likely to be an acronym (BDO, PHED, ATR) as a name,
+    and title-casing those would create names out of department codes.
+    """
+    return _CAPS_RUN_RE.sub(lambda m: m.group(0).title(), text)
+
+
 _engines: tuple | None = None
 
 
@@ -556,7 +579,7 @@ def redact_text(text: str) -> str:
     analyzer, anonymizer = _get_engines()
     # Analyze the digit-normalized copy (Indic numerals -> ASCII, same length),
     # anonymize the original: offsets carry over 1:1.
-    analyzed_text = _ascii_digits(text)
+    analyzed_text = _soften_caps(_ascii_digits(text))
     results = analyzer.analyze(
         text=analyzed_text, language="en", entities=list(ENTITY_TOKENS)
     )
@@ -585,7 +608,7 @@ def detect_pii_spans(text: str) -> list[PIISpan]:
     recognizers, not a parallel implementation.
     """
     analyzer, _ = _get_engines()
-    analyzed_text = _ascii_digits(text)
+    analyzed_text = _soften_caps(_ascii_digits(text))
     results = analyzer.analyze(
         text=analyzed_text, language="en", entities=list(ENTITY_TOKENS)
     )

--- a/tests/test_pii_redaction.py
+++ b/tests/test_pii_redaction.py
@@ -484,3 +484,50 @@ class TestSpanBoundariesAreTrimmed:
         spans = detect_pii_spans(text)
         out = redact_text(text)
         assert len(spans) == out.count("[NAME]") + out.count("[PHONE]")
+
+
+class TestAllCapsNamesAreFound:
+    """#92. spaCy's NER leans on capitalisation as a feature, so ALL-CAPS text
+    defeats it: 53 of the 228 NAME spans missed on the n50 gold were all-caps.
+    Government correspondence writes names that way constantly."""
+
+    def test_softening_is_length_preserving(self):
+        """The whole safety argument. Offsets carry over 1:1 to the original,
+        which is what lets us analyze a copy and redact the untouched text --
+        the same contract as _ascii_digits."""
+        from janasunani.pipeline.stages.pii_tagger import _soften_caps
+
+        for text in [
+            "APPLICANT SMT SUNITA DEVI aged 45",
+            "RAMESH KUMAR SAHOO filed on 06.05.2024",
+            "no caps here at all",
+        ]:
+            assert len(_soften_caps(text)) == len(text)
+
+    def test_single_acronyms_are_left_alone(self):
+        """A lone all-caps token is as likely an acronym as a name, and
+        title-casing those would invent names out of department codes."""
+        from janasunani.pipeline.stages.pii_tagger import _soften_caps
+
+        assert _soften_caps("the BDO office and PHED dept") == "the BDO office and PHED dept"
+
+    def test_all_caps_is_detected_the_same_as_title_case(self):
+        """The mechanism, not spaCy's vocabulary. Whatever the model finds in
+        title-cased text it must now also find in the all-caps form -- and
+        whether it knows a given Indian name at all is #92's separate problem,
+        which softening cannot fix.
+        """
+        title = "The petitioner Michael Anderson lives in the ward"
+        caps = "The petitioner MICHAEL ANDERSON lives in the ward"
+        assert len(title) == len(caps)
+
+        title_spans = {(s.entity, s.start, s.end) for s in detect_pii_spans(title)}
+        caps_spans = {(s.entity, s.start, s.end) for s in detect_pii_spans(caps)}
+        assert title_spans, "fixture must produce at least one span to be meaningful"
+        assert caps_spans == title_spans
+
+    def test_the_original_text_is_what_gets_redacted(self):
+        """Softening happens on the analysis copy only; everything not redacted
+        must come back exactly as written, caps included."""
+        out = redact_text("WATER SUPPLY BROKEN since June in the WARD")
+        assert "WATER SUPPLY BROKEN" in out


### PR DESCRIPTION
Refs #92. **NAME overlap recall 0.4356 → 0.5074, coverage 0.4958 → 0.5563.**

## Measured before changing anything

Of the 228 missed NAME spans on the n50 gold, **53 are ALL CAPS**. spaCy's NER leans on capitalisation as a feature, so all-caps defeats it — and government correspondence writes names that way constantly (`APPLICANT SMT SUNITA DEVI`).

Word-count distribution of missed and found spans is nearly identical, so it is not a length problem. Capitalisation is a real, separable cause.

## The fix, and why it is safe

Runs of two or more capitalised words are title-cased **on the analysis copy only**.

**Length-preserving by construction** — every replacement is `str.title()` of the same span, so offsets carry over 1:1 and the original text is what gets redacted. Same contract as `_ascii_digits`, and the reason both operate on a throwaway copy rather than the text anyone reads.

**Single all-caps tokens are left alone.** A lone one is as likely an acronym as a name (BDO, PHED, ATR), and title-casing those would invent names out of department codes.

## Isolated, and verified so

Predicted counts for AADHAAR, EMAIL, PHONE, BANK_ACCOUNT and SCHEME_ID are **identical with and without** softening — only NAME moves (497 → 563 predicted, 176 → 205 hits). 29 of the 66 additional predictions land on gold, and recall is the release-critical metric per ROADMAP §5.1.

The `BANK_ACCOUNT` 7 → 20 change visible in the same scorecard is from **#148's context window**, not this. I chased it down rather than assuming.

## What it does not fix

The test asserts the *mechanism*, not spaCy's vocabulary: whatever the model finds in title-cased text it must also find in all-caps. It cannot help where the model does not know the name at all — `RAMESH KUMAR SAHOO` is still missed after softening, which is #92's separate and larger problem.

- `pytest` — **705 passed, 7 skipped**
- `ruff check .` — clean

CI is down, so local is the gate.