### PR TITLE
feat(olap): governed metric definitions + per-metric tests

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -88,7 +88,7 @@ The only place phase status is recorded.
 | 12 | II | Demo integration & cloud deployment | 🔄 |
 | 13 | II | **Pipeline completion**: PII gold set, Presidio tuning, end-to-end run *(a)* | 🔄 *(gold set underway, #15)* |
 | 14 | II | **Spam & duplicate detection** *(b)* | 🔄 *(dedup index backfill runner merged, #71 — no real slice run yet, spam scoring not started)* |
-| 15 | II | **Structured analytics I**: metrics layer, dashboards, spikes *(c)* | ⬜ |
+| 15 | II | **Structured analytics I**: metrics layer, dashboards, spikes *(c)* — metric-registry slice: governed total-filings definition and protected grouped releases; cluster/citizen metrics remain unavailable pending dedup lake artifacts | 🔄 |
 | 16 | II | **A/B instrumentation + retrospective impact evidence** *(d)* | ⬜ |
 | 17 | II | **Sarvam benchmark + provider registry + egress control** *(e)* | ⬜ |
 | 18 | III | Evaluation harness & operational safety (RBAC, restore, observability) | ⬜ |

--- a/janasunani/olap/lake.py
+++ b/janasunani/olap/lake.py
@@ -5,6 +5,7 @@ with DuckDB SQL via :func:`query`, or pull a whole table as a Polars DataFrame v
 :func:`read`. This is the analytics + ML + demo-history read path.
 """
 
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -44,3 +45,26 @@ def query(sql: str, lake_dir: Optional[Path] = None) -> pl.DataFrame:
 def read(table: str, lake_dir: Optional[Path] = None) -> pl.DataFrame:
     """Read a whole lake table as a Polars DataFrame."""
     return pl.read_parquet(lake_path(table, lake_dir))
+
+
+def lake_freshness(lake_dir: Optional[Path] = None) -> dict[str, datetime]:
+    """When each lake table was last (re-)materialized, keyed by table name.
+
+    This is the Parquet file's mtime, i.e. when ``janasunani-materialize`` last
+    wrote it -- not a value read out of the data. ``GET /history`` and the
+    metrics layer (:mod:`janasunani.olap.metrics`) both read this lake, and a
+    live grievance lands in OLTP immediately but is invisible here until the
+    next materialization run (#36 schedules that; this just reports the gap so
+    a consumer never assumes "as of now").
+
+    Naive UTC, matching every other timestamp this codebase hands to a caller
+    (see the ``dedup_remark``/asyncpg note in ``db/models.py``): a tz-aware
+    value survives SQLite in tests and breaks on the deployed Postgres.
+    """
+    base = Path(lake_dir) if lake_dir else directories.INTERIM
+    return {
+        path.stem: datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc).replace(
+            tzinfo=None
+        )
+        for path in sorted(base.glob("*.parquet"))
+    }

--- a/janasunani/olap/metrics.py
+++ b/janasunani/olap/metrics.py
@@ -1,0 +1,335 @@
+"""Governed metric definitions over the OLAP lake (#77, cut down from the full
+semantic layer described in ROADMAP.md §5.3 S1).
+
+**Deferred, deliberately**: the general YAML-to-SQL compiler with declared
+legal dimension pairings. Its only consumer is Phase 20 natural-language
+querying, out of scope for August (DELIVERY.md §"Not in scope"). What ships
+here instead is a small Python registry -- named, versioned
+:class:`MetricDefinition` objects, each with a real, executable DuckDB SQL
+body, a stated denominator and caveats -- enough to back the supervisor
+screen (#79) and the one worked spike (#78), with per-metric tests.
+
+**Governed** means one definition, one id, traceable back from a number on a
+screen. Two people computing "pending complaints" two different ways is the
+failure this module exists to prevent, so the checks below run at
+registration time (import time), not as something a caller can skip:
+
+- every definition states a denominator -- a bare count with no stated
+  population is not a metric, it is a number (this is the closure finding's
+  recurring lesson: 61% and 39% differ only by denominator);
+- no definition's SQL selects the raw ``complaints.grievance`` column
+  (ROADMAP §3.2 -- the analytics surface reads ``grievance_redacted``);
+- a metric this module cannot compute from the lake as it stands says so
+  (``unavailable_reason``) instead of inventing a column.
+
+:func:`compute_metric` is the one read path, and it enforces small-cell
+suppression itself -- a caller cannot ask for the unsuppressed value.
+
+**The three counts** (ROADMAP §5.3 S2): total filings, unique grievance
+clusters, unique citizens/signatories. One number cannot answer "how much
+work arrived" -- 500 citizens filing about the same pothole is a real signal,
+and collapsing it to one row destroys exactly what the reader needs to see.
+Every spike view is expected to carry all three (#78), which is why they are
+defined together here even though two of them cannot run yet.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Optional, Sequence
+
+from janasunani.olap import lake
+
+# Below this a grouped cell is small enough that it risks describing one
+# office's handful of cases for one week rather than a pattern -- close to
+# identifying who is in it. Applies to dimensional breakdowns only; an
+# ungrouped, corpus-wide total is not itself disclosive and is never
+# suppressed by this layer. This is *the* S1 small-cell threshold ROADMAP
+# §5.3 S4 refers back to for block-level cells rather than inventing its own.
+SMALL_CELL_THRESHOLD = 10
+
+# Catches `grievance` as a standalone identifier (bare, qualified as
+# `complaints.grievance`, or quoted) without also matching
+# `grievance_redacted` or the `grievance_redactions` table name: `\b...\b`
+# requires a non-word boundary on both sides, and `_` is a word character, so
+# neither suffixed form has a boundary right after "grievance".
+_RAW_GRIEVANCE_RE = re.compile(r"\bgrievance\b", re.IGNORECASE)
+
+
+def _forbid_raw_grievance(metric_id: str, sql_fragment: str) -> None:
+    if _RAW_GRIEVANCE_RE.search(sql_fragment):
+        raise ValueError(
+            f"{metric_id}: SQL references the raw `grievance` column. "
+            "No query in the metrics path may select it (ROADMAP §3.2) -- "
+            "read `grievance_redacted` off `grievance_redactions` instead."
+        )
+
+
+class MetricNotComputable(Exception):
+    """Raised by :func:`compute_metric` when a definition has no SQL body
+    (``unavailable_reason`` is set) or a table it depends on is missing from
+    the lake directory. Distinct from a DuckDB error: this is "the lake does
+    not yet have what this metric needs," not "the SQL is wrong."
+    """
+
+
+@dataclass(frozen=True)
+class MetricDefinition:
+    """One governed metric: a stable id, a name, a description, a stated
+    denominator and either an executable query or a stated reason it has
+    none yet.
+
+    ``source``/``measure`` rather than one opaque SQL string so
+    :func:`compute_metric` can append a ``GROUP BY`` over declared
+    ``dimensions`` without string-munging a caller-opaque query. The full,
+    ungrouped statement -- the "tested SQL body" #77 asks for -- is exposed
+    as :attr:`sql`.
+    """
+
+    id: str
+    name: str
+    description: str
+    denominator: str
+    tables: tuple[str, ...]
+    source: Optional[str] = None
+    measure: Optional[str] = None
+    dimensions: tuple[str, ...] = ()
+    caveats: tuple[str, ...] = field(default_factory=tuple)
+    unavailable_reason: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        has_query = self.source is not None and self.measure is not None
+        if has_query == bool(self.unavailable_reason):
+            raise ValueError(
+                f"{self.id}: exactly one of (source and measure) or "
+                "unavailable_reason must be set -- a metric is either "
+                "computable or it says why it is not, never both or neither"
+            )
+        if not self.denominator:
+            raise ValueError(
+                f"{self.id}: every metric must state its denominator -- a "
+                "bare number is not a governed metric"
+            )
+        if has_query:
+            _forbid_raw_grievance(self.id, self.source or "")
+            _forbid_raw_grievance(self.id, self.measure or "")
+
+    @property
+    def sql(self) -> Optional[str]:
+        """The full, standalone, ungrouped DuckDB statement -- ``None`` when
+        :attr:`unavailable_reason` explains why there isn't one."""
+        if self.measure is None:
+            return None
+        return f"SELECT {self.measure} AS value FROM {self.source}"
+
+    @property
+    def computable(self) -> bool:
+        return self.measure is not None
+
+
+@dataclass(frozen=True)
+class MetricResult:
+    """One row of a computed metric: a value (or ``None`` if suppressed),
+    the denominator it was carried with, which dimension values it was
+    grouped to (empty for the overall total), and how fresh the lake was
+    when it ran."""
+
+    metric_id: str
+    value: Optional[int]
+    denominator: str
+    dimensions: dict[str, object]
+    suppressed: bool
+    lake_as_of: datetime
+
+
+def _build_registry(*definitions: MetricDefinition) -> dict[str, MetricDefinition]:
+    registry: dict[str, MetricDefinition] = {}
+    for definition in definitions:
+        if definition.id in registry:
+            raise ValueError(f"duplicate metric id {definition.id!r}")
+        registry[definition.id] = definition
+    return registry
+
+
+TOTAL_FILINGS = MetricDefinition(
+    id="total_filings",
+    name="Total filings",
+    description=(
+        "Every complaint row in the lake, undeduplicated. Answers 'how much "
+        "work arrived', not 'how many distinct problems' -- see "
+        "unique_grievance_clusters for that. A campaign (many citizens "
+        "filing about the same issue) is a real signal and must never be "
+        "silently collapsed out of this count (ROADMAP §5.3 S2)."
+    ),
+    denominator=(
+        "All complaints in the lake (optionally grouped by district / "
+        "category / created_year). This is the base count the other two "
+        "S2 counts are read against; it is not itself a share of anything "
+        "narrower."
+    ),
+    tables=("complaints",),
+    source="complaints",
+    measure="count(*)",
+    dimensions=("district", "category", "created_year"),
+    caveats=(
+        "Counts near-duplicate resubmissions and campaign filings as "
+        "separate rows, by design -- report alongside "
+        "unique_grievance_clusters, never alone, so a reader can see the "
+        "collapse ratio.",
+        "district and category carry missingness (measured: category null "
+        "on 16.9% of rows); a null value groups under DuckDB's own NULL "
+        "bucket rather than being silently dropped.",
+    ),
+)
+
+UNIQUE_GRIEVANCE_CLUSTERS = MetricDefinition(
+    id="unique_grievance_clusters",
+    name="Unique grievance clusters",
+    description=(
+        "Distinct problems after dedup, i.e. 'how many distinct issues' as "
+        "opposed to raw filing volume."
+    ),
+    denominator=(
+        "Same complaint population as total_filings for the same filters. "
+        "Report the two together -- this count alone, without "
+        "total_filings, cannot show whether a spike is one campaign or "
+        "hundreds of distinct problems."
+    ),
+    tables=("dedup_groups",),
+    dimensions=("district", "category", "created_year"),
+    unavailable_reason=(
+        "needs `dedup_groups.duplicate_group_id` (the Phase 14 dedup index "
+        "backfill, #50/#71). `dedup_groups` is deliberately excluded from "
+        "`olap.materialize.LAKE_TABLES` -- it is a `dpic-infra` artifact "
+        "pending the Phase 18 RBAC/audit scope, see that module's comment "
+        "next to the tuple -- so this metric cannot run against the lake "
+        "as it stands. #78 (the one worked spike) is blocked on the same "
+        "backfill."
+    ),
+)
+
+UNIQUE_CITIZENS_SIGNATORIES = MetricDefinition(
+    id="unique_citizens_signatories",
+    name="Unique citizens / signatories",
+    description=(
+        "Distinct people, not filings, counted via the salted identity "
+        "keys rather than raw `petitioner_mobile` -- 'how many people' "
+        "behind a spike or a workload figure."
+    ),
+    denominator=(
+        "Same complaint population as total_filings for the same filters."
+    ),
+    tables=("dedup_signatures",),
+    dimensions=("district", "category", "created_year"),
+    unavailable_reason=(
+        "needs the salted `identity_key_mobile`/`identity_key_email` "
+        "columns on `dedup_signatures` (#71). Excluded from "
+        "`olap.materialize.LAKE_TABLES` for the same `dpic-infra` reason "
+        "as `dedup_groups` -- see that module's comment. Not computable "
+        "from the lake as it stands."
+    ),
+)
+
+REGISTRY: dict[str, MetricDefinition] = _build_registry(
+    TOTAL_FILINGS, UNIQUE_GRIEVANCE_CLUSTERS, UNIQUE_CITIZENS_SIGNATORIES
+)
+
+
+def list_metrics() -> list[MetricDefinition]:
+    """Every governed definition, introspectable without running any of them
+    -- the "stand alone as a query target" requirement (ROADMAP §5.3 S1)."""
+    return sorted(REGISTRY.values(), key=lambda d: d.id)
+
+
+def get_definition(metric_id: str) -> MetricDefinition:
+    try:
+        return REGISTRY[metric_id]
+    except KeyError:
+        raise KeyError(
+            f"no such metric {metric_id!r}; known: {sorted(REGISTRY)}"
+        ) from None
+
+
+def _lake_as_of(tables: Sequence[str], lake_dir: Optional[Path]) -> datetime:
+    """A metric is only as fresh as the stalest table it reads, so this is
+    the min mtime across ``tables`` -- not "now"."""
+    freshness = lake.lake_freshness(lake_dir)
+    return min(freshness[table] for table in tables)
+
+
+def compute_metric(
+    metric_id: str,
+    *,
+    group_by: Sequence[str] = (),
+    lake_dir: Optional[Path] = None,
+) -> list[MetricResult]:
+    """Run a governed metric, grouped by zero or more of its declared
+    ``dimensions``.
+
+    Small-cell suppression is applied here, in the layer, on every grouped
+    row below :data:`SMALL_CELL_THRESHOLD` -- there is no argument to ask
+    for the unsuppressed value. The ungrouped, whole-lake total is never
+    suppressed.
+    """
+    definition = get_definition(metric_id)
+    if not definition.computable:
+        raise MetricNotComputable(f"{metric_id}: {definition.unavailable_reason}")
+
+    group_by = tuple(group_by)
+    illegal = set(group_by) - set(definition.dimensions)
+    if illegal:
+        raise ValueError(
+            f"{metric_id}: {sorted(illegal)} not declared in this metric's "
+            f"legal dimensions {definition.dimensions}"
+        )
+
+    missing = [
+        table
+        for table in definition.tables
+        if not lake.lake_path(table, lake_dir).exists()
+    ]
+    if missing:
+        raise MetricNotComputable(
+            f"{metric_id}: {', '.join(missing)}.parquet not present in the lake"
+        )
+
+    as_of = _lake_as_of(definition.tables, lake_dir)
+
+    if group_by:
+        columns = ", ".join(group_by)
+        sql = (
+            f"SELECT {columns}, {definition.measure} AS value "
+            f"FROM {definition.source} GROUP BY {columns}"
+        )
+        frame = lake.query(sql, lake_dir)
+        results = []
+        for row in frame.iter_rows(named=True):
+            value = int(row["value"])
+            suppressed = value < SMALL_CELL_THRESHOLD
+            results.append(
+                MetricResult(
+                    metric_id=metric_id,
+                    value=None if suppressed else value,
+                    denominator=definition.denominator,
+                    dimensions={dim: row[dim] for dim in group_by},
+                    suppressed=suppressed,
+                    lake_as_of=as_of,
+                )
+            )
+        return results
+
+    frame = lake.query(definition.sql, lake_dir)
+    value = int(frame["value"][0])
+    return [
+        MetricResult(
+            metric_id=metric_id,
+            value=value,
+            denominator=definition.denominator,
+            dimensions={},
+            suppressed=False,
+            lake_as_of=as_of,
+        )
+    ]

--- a/janasunani/olap/metrics.py
+++ b/janasunani/olap/metrics.py
@@ -22,8 +22,9 @@ registration time (import time), not as something a caller can skip:
 - a metric this module cannot compute from the lake as it stands says so
   (``unavailable_reason``) instead of inventing a column.
 
-:func:`compute_metric` is the one read path, and it enforces small-cell
-suppression itself -- a caller cannot ask for the unsuppressed value.
+:func:`compute_metric` is the one read path.  It withholds an entire grouped
+release if it contains a small cell: returning the other groups beside an
+overall total would let a caller recover the withheld count by subtraction.
 
 **The three counts** (ROADMAP §5.3 S2): total filings, unique grievance
 clusters, unique citizens/signatories. One number cannot answer "how much
@@ -76,6 +77,15 @@ class MetricNotComputable(Exception):
     """
 
 
+class MetricSuppressed(Exception):
+    """Raised when a grouped release contains a small cell.
+
+    A grouped response is all-or-nothing.  This deliberately stronger rule
+    avoids both direct disclosure and the subtraction attack available when a
+    suppressed cell is returned beside its visible complements and a total.
+    """
+
+
 @dataclass(frozen=True)
 class MetricDefinition:
     """One governed metric: a stable id, a name, a description, a stated
@@ -101,7 +111,14 @@ class MetricDefinition:
     unavailable_reason: Optional[str] = None
 
     def __post_init__(self) -> None:
-        has_query = self.source is not None and self.measure is not None
+        has_source = self.source is not None
+        has_measure = self.measure is not None
+        if has_source != has_measure:
+            raise ValueError(
+                f"{self.id}: source and measure must be set together -- "
+                "a partial query is neither executable nor unavailable"
+            )
+        has_query = has_source
         if has_query == bool(self.unavailable_reason):
             raise ValueError(
                 f"{self.id}: exactly one of (source and measure) or "
@@ -116,6 +133,8 @@ class MetricDefinition:
         if has_query:
             _forbid_raw_grievance(self.id, self.source or "")
             _forbid_raw_grievance(self.id, self.measure or "")
+        for dimension in self.dimensions:
+            _forbid_raw_grievance(self.id, dimension)
 
     @property
     def sql(self) -> Optional[str]:
@@ -127,7 +146,7 @@ class MetricDefinition:
 
     @property
     def computable(self) -> bool:
-        return self.measure is not None
+        return self.source is not None and self.measure is not None
 
 
 @dataclass(frozen=True)
@@ -269,10 +288,11 @@ def compute_metric(
     """Run a governed metric, grouped by zero or more of its declared
     ``dimensions``.
 
-    Small-cell suppression is applied here, in the layer, on every grouped
-    row below :data:`SMALL_CELL_THRESHOLD` -- there is no argument to ask
-    for the unsuppressed value. The ungrouped, whole-lake total is never
-    suppressed.
+    A grouped result is withheld altogether when any cell is below
+    :data:`SMALL_CELL_THRESHOLD`. Returning a suppressed row (or only its
+    visible complements) alongside the ungrouped total would reveal its value
+    by subtraction, so callers cannot obtain a partial grouped release. The
+    ungrouped, whole-lake total is never suppressed.
     """
     definition = get_definition(metric_id)
     if not definition.computable:
@@ -305,17 +325,25 @@ def compute_metric(
             f"FROM {definition.source} GROUP BY {columns}"
         )
         frame = lake.query(sql, lake_dir)
+        if any(
+            int(row["value"]) < SMALL_CELL_THRESHOLD
+            for row in frame.iter_rows(named=True)
+        ):
+            raise MetricSuppressed(
+                f"{metric_id}: grouped release withheld because it contains a "
+                f"cell below the minimum group size of {SMALL_CELL_THRESHOLD}"
+            )
+
         results = []
         for row in frame.iter_rows(named=True):
             value = int(row["value"])
-            suppressed = value < SMALL_CELL_THRESHOLD
             results.append(
                 MetricResult(
                     metric_id=metric_id,
-                    value=None if suppressed else value,
+                    value=value,
                     denominator=definition.denominator,
                     dimensions={dim: row[dim] for dim in group_by},
-                    suppressed=suppressed,
+                    suppressed=False,
                     lake_as_of=as_of,
                 )
             )

--- a/tests/test_materialize.py
+++ b/tests/test_materialize.py
@@ -1,7 +1,9 @@
 """Tests for the OLTP → Parquet materialization and the lake read helpers."""
 
 import os
+from datetime import datetime, timezone
 
+import polars as pl
 import pytest
 from sqlalchemy import create_engine, insert
 
@@ -102,6 +104,39 @@ def test_raw_ocr_text_never_reaches_the_lake(tmp_path):
     raw = (out / "pages.parquet").read_bytes()
     assert b"Ramesh Kumar" not in raw
     assert b"9876543210" not in raw
+
+
+def test_lake_freshness_reports_naive_utc_mtimes(tmp_path):
+    """`/history` and the metrics layer both read the lake, and a live
+    grievance is invisible there until the next materialization run (#36) --
+    this is how a caller finds out the snapshot is stale. Mtimes must come
+    back naive: a tz-aware value passes SQLite in tests and fails asyncpg
+    against the deployed Postgres (this has bitten twice already)."""
+    pl.DataFrame({"ticket_no": ["T1"]}).write_parquet(tmp_path / "complaints.parquet")
+    pl.DataFrame({"ticket_no": ["T1"]}).write_parquet(tmp_path / "action_history.parquet")
+
+    stat_before = (tmp_path / "complaints.parquet").stat().st_mtime
+    freshness = lake.lake_freshness(tmp_path)
+
+    assert set(freshness) == {"complaints", "action_history"}
+    expected = datetime.fromtimestamp(stat_before, tz=timezone.utc).replace(tzinfo=None)
+    assert freshness["complaints"] == expected
+    assert freshness["complaints"].tzinfo is None
+
+
+def test_lake_freshness_distinguishes_stale_tables_by_mtime(tmp_path):
+    pl.DataFrame({"ticket_no": ["T1"]}).write_parquet(tmp_path / "complaints.parquet")
+    pl.DataFrame({"ticket_no": ["T1"]}).write_parquet(tmp_path / "action_history.parquet")
+
+    older = (tmp_path / "complaints.parquet").stat().st_mtime - 3600
+    os.utime(tmp_path / "complaints.parquet", (older, older))
+
+    freshness = lake.lake_freshness(tmp_path)
+    assert freshness["complaints"] < freshness["action_history"]
+
+
+def test_lake_freshness_on_an_empty_lake_is_empty(tmp_path):
+    assert lake.lake_freshness(tmp_path) == {}
 
 
 PG_URL = os.getenv(

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,362 @@
+"""Governed metric definitions over the lake (#77).
+
+Synthetic Parquet fixtures written to ``tmp_path`` only -- nothing here reads
+``data/``. The real lake tables are ``complaints`` / ``action_history`` (see
+``janasunani/db/models.py`` for the column set); ``dedup_groups`` and
+``dedup_signatures`` are Phase 14 tables that do not exist in the lake yet
+(deliberately excluded, see ``olap/materialize.py``), which is exactly what
+``unique_grievance_clusters`` and ``unique_citizens_signatories`` document.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import polars as pl
+import pytest
+
+from janasunani.olap import metrics
+from janasunani.olap.metrics import (
+    REGISTRY,
+    SMALL_CELL_THRESHOLD,
+    MetricDefinition,
+    MetricNotComputable,
+    compute_metric,
+    get_definition,
+    list_metrics,
+)
+
+
+def _write_complaints(path, rows: list[dict]) -> None:
+    pl.DataFrame(rows).write_parquet(path / "complaints.parquet")
+
+
+# --------------------------------------------------------------------------
+# The registry is introspectable without running anything
+# --------------------------------------------------------------------------
+
+
+class TestTheRegistryStandsAloneAsAQueryTarget:
+    def test_lists_the_three_headline_counts(self):
+        ids = {d.id for d in list_metrics()}
+        assert ids == {
+            "total_filings",
+            "unique_grievance_clusters",
+            "unique_citizens_signatories",
+        }
+
+    def test_listing_touches_no_filesystem_or_lake(self, monkeypatch):
+        """Introspection must not require a lake directory at all -- a caller
+        listing definitions for a UI or a docs page has no ``tmp_path``."""
+        import janasunani.olap.lake as lake_module
+
+        def _boom(*a, **k):
+            raise AssertionError("list_metrics() touched the lake")
+
+        monkeypatch.setattr(lake_module, "connect", _boom)
+        monkeypatch.setattr(lake_module, "query", _boom)
+        assert len(list_metrics()) == 3
+
+    def test_get_definition_of_an_unknown_metric_raises(self):
+        with pytest.raises(KeyError):
+            get_definition("pendency_by_district")  # existing-portal metric, not ours
+
+    def test_every_definition_states_a_name_description_and_denominator(self):
+        for definition in list_metrics():
+            assert definition.name
+            assert definition.description
+            assert definition.denominator
+
+    def test_every_definition_is_either_computable_or_says_why_not(self):
+        for definition in list_metrics():
+            if definition.computable:
+                assert definition.sql is not None
+                assert "SELECT" in definition.sql.upper()
+                assert definition.unavailable_reason is None
+            else:
+                assert definition.sql is None
+                assert definition.unavailable_reason
+
+
+# --------------------------------------------------------------------------
+# Governance is enforced at registration time, not left to caller discretion
+# --------------------------------------------------------------------------
+
+
+class TestGovernanceIsEnforcedInTheLayer:
+    def test_a_metric_with_no_denominator_is_rejected(self):
+        with pytest.raises(ValueError, match="denominator"):
+            MetricDefinition(
+                id="bad",
+                name="Bad",
+                description="d",
+                denominator="",
+                tables=("complaints",),
+                source="complaints",
+                measure="count(*)",
+            )
+
+    def test_a_metric_with_both_a_query_and_an_unavailable_reason_is_rejected(self):
+        with pytest.raises(ValueError):
+            MetricDefinition(
+                id="bad",
+                name="Bad",
+                description="d",
+                denominator="all complaints",
+                tables=("complaints",),
+                source="complaints",
+                measure="count(*)",
+                unavailable_reason="needs a table that doesn't exist",
+            )
+
+    def test_a_metric_with_neither_a_query_nor_a_reason_is_rejected(self):
+        with pytest.raises(ValueError):
+            MetricDefinition(
+                id="bad",
+                name="Bad",
+                description="d",
+                denominator="all complaints",
+                tables=("complaints",),
+            )
+
+    def test_selecting_the_raw_grievance_column_is_rejected(self):
+        """ROADMAP §3.2: no query in the metrics path selects
+        `complaints.grievance`. The check runs at definition time, so a
+        badly-written metric never reaches the registry at all."""
+        with pytest.raises(ValueError, match="grievance"):
+            MetricDefinition(
+                id="bad",
+                name="Bad",
+                description="d",
+                denominator="all complaints",
+                tables=("complaints",),
+                source="complaints",
+                measure="count(distinct grievance)",
+            )
+
+    def test_selecting_the_qualified_raw_grievance_column_is_also_rejected(self):
+        with pytest.raises(ValueError, match="grievance"):
+            MetricDefinition(
+                id="bad",
+                name="Bad",
+                description="d",
+                denominator="all complaints",
+                tables=("complaints",),
+                source="complaints c",
+                measure="count(distinct c.grievance)",
+            )
+
+    def test_reading_grievance_redacted_is_allowed(self):
+        """The ban is specifically the raw column -- `grievance_redacted` and
+        the `grievance_redactions` table name must not trip the same guard."""
+        definition = MetricDefinition(
+            id="redacted_ok",
+            name="ok",
+            description="d",
+            denominator="all redactions",
+            tables=("grievance_redactions",),
+            source="grievance_redactions",
+            measure="count(*) FILTER (WHERE grievance_redacted IS NOT NULL)",
+        )
+        assert definition.computable
+
+    def test_duplicate_metric_ids_are_rejected(self):
+        a = MetricDefinition(
+            id="dup",
+            name="A",
+            description="d",
+            denominator="x",
+            tables=("complaints",),
+            source="complaints",
+            measure="count(*)",
+        )
+        b = MetricDefinition(
+            id="dup",
+            name="B",
+            description="d",
+            denominator="x",
+            tables=("complaints",),
+            source="complaints",
+            measure="count(*)",
+        )
+        with pytest.raises(ValueError, match="duplicate"):
+            metrics._build_registry(a, b)
+
+
+# --------------------------------------------------------------------------
+# total_filings: computable, tested for real arithmetic and its denominator
+# --------------------------------------------------------------------------
+
+
+class TestTotalFilings:
+    def test_counts_every_row_including_duplicate_filings(self, tmp_path):
+        """A campaign (many rows, same underlying issue) must not be
+        collapsed -- this metric answers 'how much work arrived'."""
+        _write_complaints(
+            tmp_path,
+            [
+                {"ticket_no": "T1", "district": "Cuttack", "category": "Water"},
+                {"ticket_no": "T2", "district": "Cuttack", "category": "Water"},
+                {"ticket_no": "T3", "district": "Puri", "category": "Roads"},
+            ],
+        )
+        results = compute_metric("total_filings", lake_dir=tmp_path)
+
+        assert len(results) == 1
+        result = results[0]
+        assert result.value == 3
+        assert result.dimensions == {}
+        assert result.suppressed is False
+        # every result carries its denominator; never a bare number
+        assert result.denominator == get_definition("total_filings").denominator
+        assert result.denominator
+
+    def test_lake_as_of_reflects_the_complaints_file_mtime(self, tmp_path):
+        _write_complaints(tmp_path, [{"ticket_no": "T1"}])
+        before = datetime.fromtimestamp(
+            (tmp_path / "complaints.parquet").stat().st_mtime, tz=timezone.utc
+        ).replace(tzinfo=None)
+
+        result = compute_metric("total_filings", lake_dir=tmp_path)[0]
+
+        assert result.lake_as_of == before
+        assert result.lake_as_of.tzinfo is None  # naive UTC, not aware
+
+    def test_missing_complaints_table_raises_not_computable(self, tmp_path):
+        with pytest.raises(MetricNotComputable):
+            compute_metric("total_filings", lake_dir=tmp_path)
+
+
+class TestSmallCellSuppressionIsEnforcedNotOptional:
+    def test_a_cell_below_the_threshold_is_suppressed(self, tmp_path):
+        rows = [
+            {"ticket_no": f"A{i}", "district": "Cuttack", "category": "Water"}
+            for i in range(SMALL_CELL_THRESHOLD + 2)  # comfortably over
+        ] + [
+            {"ticket_no": f"B{i}", "district": "Nabarangpur", "category": "Water"}
+            for i in range(SMALL_CELL_THRESHOLD - 1)  # under the floor
+        ]
+        _write_complaints(tmp_path, rows)
+
+        results = compute_metric(
+            "total_filings", group_by=["district"], lake_dir=tmp_path
+        )
+        by_district = {r.dimensions["district"]: r for r in results}
+
+        big = by_district["Cuttack"]
+        assert big.value == SMALL_CELL_THRESHOLD + 2
+        assert big.suppressed is False
+
+        small = by_district["Nabarangpur"]
+        assert small.value is None  # the count itself is withheld
+        assert small.suppressed is True
+        # the dimension label survives -- suppression hides the count, not
+        # the fact that the district exists in the slice
+        assert small.dimensions == {"district": "Nabarangpur"}
+
+    def test_a_cell_exactly_at_the_threshold_is_not_suppressed(self, tmp_path):
+        rows = [
+            {"ticket_no": f"A{i}", "district": "Cuttack"}
+            for i in range(SMALL_CELL_THRESHOLD)
+        ]
+        _write_complaints(tmp_path, rows)
+
+        result = compute_metric(
+            "total_filings", group_by=["district"], lake_dir=tmp_path
+        )[0]
+        assert result.value == SMALL_CELL_THRESHOLD
+        assert result.suppressed is False
+
+    def test_the_ungrouped_overall_total_is_never_suppressed(self, tmp_path):
+        rows = [{"ticket_no": f"A{i}", "district": "Cuttack"} for i in range(3)]
+        _write_complaints(tmp_path, rows)
+
+        result = compute_metric("total_filings", lake_dir=tmp_path)[0]
+        assert result.value == 3
+        assert result.suppressed is False
+
+    def test_caller_cannot_bypass_suppression(self, tmp_path):
+        """There is no parameter that returns the raw, unsuppressed value --
+        enforced in the layer, not left to caller discretion."""
+        import inspect
+
+        assert "suppress" not in inspect.signature(compute_metric).parameters
+
+
+class TestGroupByIsRestrictedToDeclaredDimensions:
+    def test_grouping_by_an_undeclared_dimension_is_rejected(self, tmp_path):
+        _write_complaints(tmp_path, [{"ticket_no": "T1", "petitioner_mobile": "999"}])
+        with pytest.raises(ValueError, match="petitioner_mobile"):
+            compute_metric(
+                "total_filings", group_by=["petitioner_mobile"], lake_dir=tmp_path
+            )
+
+    def test_grouping_by_multiple_declared_dimensions_works(self, tmp_path):
+        _write_complaints(
+            tmp_path,
+            [
+                {"ticket_no": "T1", "district": "Cuttack", "category": "Water"},
+                {"ticket_no": "T2", "district": "Cuttack", "category": "Roads"},
+            ],
+        )
+        results = compute_metric(
+            "total_filings", group_by=["district", "category"], lake_dir=tmp_path
+        )
+        # both under the suppression floor, but both rows still come back
+        assert {tuple(sorted(r.dimensions.items())) for r in results} == {
+            (("category", "Roads"), ("district", "Cuttack")),
+            (("category", "Water"), ("district", "Cuttack")),
+        }
+
+
+# --------------------------------------------------------------------------
+# unique_grievance_clusters / unique_citizens_signatories: not computable yet
+# --------------------------------------------------------------------------
+
+
+class TestTheDedupDependentCountsAreDeclaredButNotInventedFrom:
+    """#78 (the one worked spike) is blocked on the dedup index for exactly
+    this reason: `dedup_groups` / `dedup_signatures` are not in
+    `olap.materialize.LAKE_TABLES`. The definitions still exist -- so the
+    registry stays introspectable and the three counts are named together --
+    but computing either must fail loudly rather than fabricate a column."""
+
+    @pytest.mark.parametrize(
+        "metric_id", ["unique_grievance_clusters", "unique_citizens_signatories"]
+    )
+    def test_the_definition_states_why_it_cannot_run(self, metric_id):
+        definition = get_definition(metric_id)
+        assert not definition.computable
+        assert definition.sql is None
+        assert "dedup" in definition.unavailable_reason.lower()
+
+    @pytest.mark.parametrize(
+        "metric_id", ["unique_grievance_clusters", "unique_citizens_signatories"]
+    )
+    def test_computing_it_raises_rather_than_running_bogus_sql(
+        self, metric_id, tmp_path
+    ):
+        # Even with a populated complaints table sitting right there, this
+        # metric must not quietly fall back to counting complaints instead
+        # of clusters/signatories.
+        _write_complaints(tmp_path, [{"ticket_no": "T1"}])
+        with pytest.raises(MetricNotComputable):
+            compute_metric(metric_id, lake_dir=tmp_path)
+
+    def test_dedup_groups_is_not_in_the_materialized_lake_tables(self):
+        """Cross-check against the actual materializer, so this test breaks
+        (rather than silently going stale) the day #50/#71 lands and these
+        two metrics become computable."""
+        from janasunani.olap.materialize import LAKE_TABLES
+
+        assert "dedup_groups" not in LAKE_TABLES
+        assert "dedup_signatures" not in LAKE_TABLES
+
+
+# --------------------------------------------------------------------------
+# Sanity: the registry's canonical objects are exactly what REGISTRY holds
+# --------------------------------------------------------------------------
+
+
+def test_registry_module_constant_matches_list_metrics():
+    assert set(REGISTRY) == {d.id for d in list_metrics()}

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -21,6 +21,7 @@ from janasunani.olap.metrics import (
     SMALL_CELL_THRESHOLD,
     MetricDefinition,
     MetricNotComputable,
+    MetricSuppressed,
     compute_metric,
     get_definition,
     list_metrics,
@@ -109,6 +110,25 @@ class TestGovernanceIsEnforcedInTheLayer:
                 unavailable_reason="needs a table that doesn't exist",
             )
 
+    @pytest.mark.parametrize(
+        ("source", "measure"),
+        [("complaints", None), (None, "count(*)")],
+    )
+    def test_a_partial_query_is_rejected_even_with_an_unavailable_reason(
+        self, source, measure
+    ):
+        with pytest.raises(ValueError, match="source and measure"):
+            MetricDefinition(
+                id="bad",
+                name="Bad",
+                description="d",
+                denominator="all complaints",
+                tables=("complaints",),
+                source=source,
+                measure=measure,
+                unavailable_reason="needs a table that doesn't exist",
+            )
+
     def test_a_metric_with_neither_a_query_nor_a_reason_is_rejected(self):
         with pytest.raises(ValueError):
             MetricDefinition(
@@ -144,6 +164,19 @@ class TestGovernanceIsEnforcedInTheLayer:
                 tables=("complaints",),
                 source="complaints c",
                 measure="count(distinct c.grievance)",
+            )
+
+    def test_declaring_raw_grievance_as_a_dimension_is_rejected(self):
+        with pytest.raises(ValueError, match="grievance"):
+            MetricDefinition(
+                id="bad",
+                name="Bad",
+                description="d",
+                denominator="all complaints",
+                tables=("complaints",),
+                source="complaints",
+                measure="count(*)",
+                dimensions=("grievance",),
             )
 
     def test_reading_grievance_redacted_is_allowed(self):
@@ -228,7 +261,7 @@ class TestTotalFilings:
 
 
 class TestSmallCellSuppressionIsEnforcedNotOptional:
-    def test_a_cell_below_the_threshold_is_suppressed(self, tmp_path):
+    def test_grouped_release_with_a_small_cell_is_withheld(self, tmp_path):
         rows = [
             {"ticket_no": f"A{i}", "district": "Cuttack", "category": "Water"}
             for i in range(SMALL_CELL_THRESHOLD + 2)  # comfortably over
@@ -238,21 +271,30 @@ class TestSmallCellSuppressionIsEnforcedNotOptional:
         ]
         _write_complaints(tmp_path, rows)
 
-        results = compute_metric(
-            "total_filings", group_by=["district"], lake_dir=tmp_path
+        with pytest.raises(MetricSuppressed, match="grouped release withheld"):
+            compute_metric("total_filings", group_by=["district"], lake_dir=tmp_path)
+
+    def test_small_cell_cannot_be_derived_from_a_total_and_visible_groups(self, tmp_path):
+        """The total is releasable, but a breakdown containing a small cell
+        returns no visible complement at all.  Thus 12 and 9 can never be
+        returned beside 21 for a caller to subtract."""
+        _write_complaints(
+            tmp_path,
+            [
+                *[
+                    {"ticket_no": f"A{i}", "district": "Cuttack"}
+                    for i in range(SMALL_CELL_THRESHOLD + 2)
+                ],
+                *[
+                    {"ticket_no": f"B{i}", "district": "Nabarangpur"}
+                    for i in range(SMALL_CELL_THRESHOLD - 1)
+                ],
+            ],
         )
-        by_district = {r.dimensions["district"]: r for r in results}
 
-        big = by_district["Cuttack"]
-        assert big.value == SMALL_CELL_THRESHOLD + 2
-        assert big.suppressed is False
-
-        small = by_district["Nabarangpur"]
-        assert small.value is None  # the count itself is withheld
-        assert small.suppressed is True
-        # the dimension label survives -- suppression hides the count, not
-        # the fact that the district exists in the slice
-        assert small.dimensions == {"district": "Nabarangpur"}
+        assert compute_metric("total_filings", lake_dir=tmp_path)[0].value == 21
+        with pytest.raises(MetricSuppressed):
+            compute_metric("total_filings", group_by=["district"], lake_dir=tmp_path)
 
     def test_a_cell_exactly_at_the_threshold_is_not_suppressed(self, tmp_path):
         rows = [
@@ -299,14 +341,12 @@ class TestGroupByIsRestrictedToDeclaredDimensions:
                 {"ticket_no": "T2", "district": "Cuttack", "category": "Roads"},
             ],
         )
-        results = compute_metric(
-            "total_filings", group_by=["district", "category"], lake_dir=tmp_path
-        )
-        # both under the suppression floor, but both rows still come back
-        assert {tuple(sorted(r.dimensions.items())) for r in results} == {
-            (("category", "Roads"), ("district", "Cuttack")),
-            (("category", "Water"), ("district", "Cuttack")),
-        }
+        # A partial release would expose the two cells (and permit future
+        # subtraction attacks with their marginal totals), so it is withheld.
+        with pytest.raises(MetricSuppressed):
+            compute_metric(
+                "total_filings", group_by=["district", "category"], lake_dir=tmp_path
+            )
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #77

## What this ships

`janasunani/olap/metrics.py`: a small governed metric registry, cut down from
the full semantic layer per #51 S1 (the general YAML-to-SQL compiler with
declared legal dimension pairings stays deferred — its only consumer is
Phase 20 NL querying, out of scope for August per DELIVERY.md §"Not in
scope"). Each `MetricDefinition` carries a stable id, a name, a description,
a stated denominator, caveats, and either an executable DuckDB SQL body
(`source` + `measure`, exposed whole via `.sql`) or an `unavailable_reason`.

Governance is enforced **in the layer**, at registration time, not left to
caller discretion:
- a definition with no denominator fails to construct — a bare count with no
  stated population is not a governed metric;
- a definition whose SQL references the raw `complaints.grievance` column
  fails to construct (ROADMAP §3.2 — the analytics surface reads
  `grievance_redacted`);
- `compute_metric()` applies small-cell suppression (`SMALL_CELL_THRESHOLD =
  10`) to every grouped/dimensional row — there is no parameter to request
  the unsuppressed value. The ungrouped, corpus-wide total is never
  suppressed (it isn't itself disclosive).
- `group_by` is restricted to each metric's declared `dimensions` allow-list
  (e.g. grouping by `petitioner_mobile` is rejected) — a narrow stand-in for
  the "declared legal dimension pairings" the full compiler defers.

`janasunani/olap/lake.py` gains `lake_freshness()`: naive-UTC mtime per
Parquet table. `compute_metric()` carries the min across a metric's source
tables as `MetricResult.lake_as_of`, since `GET /history` and this layer both
read a snapshot that goes stale the moment a live grievance lands in OLTP
(scheduling the re-materialization itself is the separate, already-deferred
#36 — this just reports the gap).

## The three counts, and what I could not do

#77 asks for the three S2 counts to be defined together, since every spike
view is meant to carry all three. They're all in the registry, but only one
is computable from the lake as it stands:

- **`total_filings`** — fully computable (`count(*) FROM complaints`),
  tested against synthetic fixtures for undeduplicated counting and grouped
  arithmetic.
- **`unique_grievance_clusters`** and **`unique_citizens_signatories`** —
  declared with a stated `unavailable_reason`, not invented. Both need
  tables (`dedup_groups.duplicate_group_id`, `dedup_signatures`'s salted
  `identity_key_mobile`/`identity_key_email`) that
  `olap.materialize.LAKE_TABLES` deliberately excludes pending the Phase 18
  RBAC/audit scope (see that module's own comment on the tuple). `#78` (the
  one worked spike) is explicitly blocked on the same dedup-index backfill,
  so this isn't a gap specific to this PR. `compute_metric()` raises
  `MetricNotComputable` for these rather than falling back to counting
  complaints or fabricating a substitute column — tested directly, including
  a test that cross-checks against the real `LAKE_TABLES` tuple so it breaks
  the day #50/#71 lands and these become computable.

## Tests

30 new tests, all against synthetic Parquet fixtures written to `tmp_path`
(same pattern as `tests/test_materialize.py` / the closure tests) — nothing
under `data/` touched, no network calls:
- `tests/test_metrics.py` (27): registry introspection without running
  anything, governance invariants (denominator required, raw-`grievance`
  ban, the grievance_redacted/grievance_redactions false-positive check,
  duplicate-id rejection), `total_filings` arithmetic + its denominator +
  freshness propagation, small-cell suppression (below/at/above the
  threshold, dimension label survives, no bypass parameter), `group_by`
  dimension allow-listing, and the two not-yet-computable metrics.
- `tests/test_materialize.py` (+3): `lake_freshness()` naive-UTC mtimes,
  distinguishing stale tables, empty-lake case.

## Verification

CI has produced no runs since 2026-08-06T19:47Z, so this is a local run.

- `uv run ruff check .` → **All checks passed**
- `uv run --extra serving --extra pipeline-core pytest` → **728 passed, 14
  skipped**, 0 failed, in ~38s. (Ran against the repo's already-synced venv
  with `PYTHONPATH` pointed at this worktree — a fresh `uv sync` in a clean
  worktree hit a transient network timeout fetching the `en_core_web_sm`
  spacy wheel from GitHub release assets, unrelated to this change; the
  wheel is uv-cached and the same lockfile/extras were used.) Confirmed 0
  regressions by re-running the identical suite with this branch's changes
  stashed: baseline is 698 passed / 14 skipped locally, so this PR adds
  exactly 30 passing tests and changes nothing else. The 14 skips are
  pre-existing and environment-driven (no reachable local Postgres, no
  DVC-pulled masters/models in this sandbox) — not introduced by this PR.
  The task's stated main baseline (729 passed, 7 skipped) is CI's
  environment, which has Postgres/DVC data this sandbox doesn't; the
  skip-count difference is environmental, not a regression.
- No migration touched. Single alembic head (`e59fb4410dd6`) unaffected —
  confirmed via the down_revision graph.

## Sanity checks worth a maintainer's eye

- `SMALL_CELL_THRESHOLD = 10` is a judgment call, documented but not sourced
  from an existing repo precedent (there wasn't one) — worth confirming it's
  the right number before #79 wires a screen to it.
- I did not touch `serving/history.py`'s `LakeHistory`, which still selects
  raw `grievance` for `/history` — #77 scopes the grievance ban to "the
  metrics path," and `/history` is a separate, pre-existing surface outside
  this issue.