### PR TITLE
feat(ocr): add guarded Sarvam Vision adapter

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1143,12 +1143,12 @@ Sarvam is the most promising single quality lever available, because our weakest
 stage and their strongest capability are the same thing: Odia document
 understanding.
 
-**What Sarvam offers** (checked 2026-07-27 against their docs; re-check before
+**What Sarvam offers** (checked 2026-08-07 against their docs; re-check before
 building, this moves fast).
 
 | Model / API | ID | What it does | Price | Limits |
 |---|---|---|---|---|
-| Sarvam Vision | `sarvam-vision-v1` | 3B vision-language model for document digitisation. **Digitise** (text, tables, layout; HTML or Markdown out) and **Extract** (schema-driven structured fields; JSON, CSV or XLSX out) are separate endpoints and bill separately. In: PDF, PNG, JPG, ZIP | **₹0.50 / page digitise, ₹1.00 / page extract.** Per page, not per field | 10 pages per PDF, 200 MB, **10 req/min** |
+| Sarvam Vision 1.5 | Endpoint-selected; no request `model` field | Vision-language model for document digitisation. **Digitise** (text, tables, layout; HTML or Markdown out) and **Extract** (schema-driven structured fields; JSON, CSV or XLSX out) are separate endpoints and bill separately. In: PDF, PNG, JPG, ZIP | **₹0.50 / page digitise, ₹1.00 / page extract.** Per page, not per field | 10 pages per PDF, 200 MB, **10 req/min** |
 | ~~Sarvam-30B~~ | ~~`sarvam-30b`~~ | **Withdrawn.** Absent from the billing page as of 2026-08-07, so not callable. Superseded by 105B | — | — |
 | Sarvam-105B | `sarvam-105b` | Flagship, ~9B active, 128K context. Also `sarvam-105b-chat` | **₹29.28 / ₹10.98 / ₹73.20 per 1M tokens** (in / cached / out) | Tiered, below |
 | GLM 5.2 | third-party, billed via Sarvam | Available on the same account. **Not a Sarvam model** — see the authorization note below | ₹128.10 / ₹23.79 / ₹402.60 per 1M tokens | Tiered, below |
@@ -1218,17 +1218,18 @@ Four things to check before relying on any of it:
   separately** — not as a hedge against an unsupported case, but because the
   printed/handwritten split is the number nobody has published and the one our
   corpus turns on.
-- ⚠️ **"Akshar" is the product, `sarvam-vision` is still the model. Do not treat
-  them as the same thing when benchmarking.** Sarvam Akshar is a document
-  digitisation platform layered on Sarvam Vision, described as an intelligence
-  layer over it rather than a rename of it. The API model list still carries
-  Sarvam Vision for document intelligence and no Akshar entry. This matters for
-  what §Phase 17 actually measures: benchmarking the Akshar platform against
-  pytesseract compares a pipeline with its own reasoning and validation on top
-  against a bare OCR engine, which is not the comparison the scorecard claims to
-  make. **Benchmark the model, name the surface in the artifact, and state which
-  one was called.** The Doc AI endpoint takes `model: "sarvam-vision-v1"`, so the
-  model id is what the API accepts and Akshar is the surface around it.
+- ⚠️ **"Akshar" is the product surface; the current Doc AI API identifies the
+  underlying model as Sarvam Vision 1.5. Do not treat them as the same thing when
+  benchmarking.** Sarvam Akshar is a document digitisation platform layered on
+  Sarvam Vision, described as an intelligence layer over it rather than a rename
+  of it. This matters for what §Phase 17 actually measures: benchmarking the
+  Akshar platform against pytesseract compares a pipeline with its own reasoning
+  and validation on top against a bare OCR engine, which is not the comparison
+  the scorecard claims to make. **The async Doc AI Digitise and Extract request
+  contracts do not expose a caller-selected multipart `model` field.** Record
+  `Sarvam Vision 1.5` as reviewed provider provenance in the local audit and name
+  the called Doc AI surface in the benchmark artifact; do not send the stale
+  `sarvam-vision-v1` selector or imply that the endpoint is caller-pinned.
 - ⚠️ **Doc AI is an async job API with two distinct endpoints, not a drop-in OCR
   call.** `POST /doc-ai/v1/job/digitise` is the transcription path (`output_format`
   `html` default or `md`, no schema); `POST /doc-ai/v1/job/extract` is the
@@ -1244,7 +1245,9 @@ Four things to check before relying on any of it:
   `pages_failed`. An adapter that treats a job as success-or-failure silently
   drops the failed pages inside a partially completed job and reports the batch as
   done — at a 10-page cap, one bad page is a 10% loss. **Reconcile
-  `pages_succeeded` against `pages_total` per job and record the delta.**
+  `pages_succeeded` against `pages_total` per job and record the delta.** Until
+  the adapter exposes page-level result granularity, its safe contract is to
+  reject every `partially_completed` job and use the local fallback.
 - ⚠️ **Idempotency is undocumented, so our own submission log is the control.**
   The dashboard sample sends an `Idempotency-Key` header; the API reference
   documents no idempotency parameter. Send a deterministic key derived from

--- a/janasunani/egress/__init__.py
+++ b/janasunani/egress/__init__.py
@@ -1,0 +1,20 @@
+"""Declared routes that may carry citizen data beyond DPIC-controlled systems.
+
+Only :mod:`janasunani.egress.sarvam` contains an authorized-external HTTP
+client.  Callers use its provider interface; they must not create their own
+Sarvam clients.
+"""
+
+from .sarvam import (
+    PROVIDER_REGISTRY,
+    SarvamAuditContext,
+    SarvamVisionAdapter,
+    SqliteAuditLog,
+)
+
+__all__ = [
+    "PROVIDER_REGISTRY",
+    "SarvamAuditContext",
+    "SarvamVisionAdapter",
+    "SqliteAuditLog",
+]

--- a/janasunani/egress/sarvam.py
+++ b/janasunani/egress/sarvam.py
@@ -949,8 +949,8 @@ class SarvamVisionAdapter:
     def _digitise_form(language: str) -> dict[str, str]:
         return {"language": language, "output_format": "md"}
 
-    @staticmethod
     def _idempotency_key(
+        self,
         context: SarvamAuditContext,
         operation: str,
         document_bytes: bytes,
@@ -975,6 +975,9 @@ class SarvamVisionAdapter:
                 context.document_id,
                 context.stage,
                 operation,
+                self.route.provider,
+                self.route.model_id,
+                self.route.endpoint,
                 filename,
                 normalized_form,
                 content_hash,

--- a/janasunani/egress/sarvam.py
+++ b/janasunani/egress/sarvam.py
@@ -17,6 +17,7 @@ import os
 import sqlite3
 import time
 import zipfile
+from collections import deque
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from io import BytesIO
@@ -37,6 +38,10 @@ TRUST_TIER = "authorized-external"
 AUTHORIZATION_REFERENCE = "GoO-Sarvam MoU; ACS Vishal Dev (IT) sign-off"
 
 TERMINAL_STATUSES = frozenset({"completed", "partially_completed", "failed", "rejected"})
+VISION_SUBMISSIONS_PER_MINUTE = 10
+SUBMISSION_WINDOW_SECONDS = 60.0
+MAX_SUBMISSION_ATTEMPTS = 3
+MAX_RETRY_DELAY_SECONDS = 60.0
 
 
 @dataclass(frozen=True)
@@ -193,6 +198,7 @@ class HttpResponse(Protocol):
     status_code: int
     text: str
     content: bytes
+    headers: Any
 
     def json(self) -> Any: ...
 
@@ -270,12 +276,14 @@ class SqliteAuditLog:
     def submitted_job(
         self, context: SarvamAuditContext, operation: str, idempotency_key: str
     ) -> str | None:
-        """Return a previously recorded job before issuing a billable retry.
+        """Return a resumable recorded job before issuing a billable retry.
 
         Sarvam's Idempotency-Key semantics are undocumented.  This local log,
         not that header, is therefore the duplicate-billing control.  A
         completed job is also returned: its result can be downloaded again
-        without submitting the same document a second time.
+        without submitting the same document a second time.  Terminal
+        unsuccessful jobs are deliberately excluded so a later call may make
+        a fresh submission.
         """
         with sqlite3.connect(self.db_path) as connection:
             row = connection.execute(
@@ -295,7 +303,31 @@ class SqliteAuditLog:
                     idempotency_key,
                 ),
             ).fetchone()
-        return row[0] if row else None
+            if not row:
+                return None
+            job_id = row[0]
+            metadata_rows = connection.execute(
+                """
+                SELECT response_metadata
+                FROM authorized_external_audit
+                WHERE job_id = ? AND idempotency_key = ?
+                ORDER BY id DESC
+                """,
+                (job_id, idempotency_key),
+            ).fetchall()
+
+        for (raw_metadata,) in metadata_rows:
+            if not raw_metadata:
+                continue
+            try:
+                status = json.loads(raw_metadata).get("status")
+            except (AttributeError, json.JSONDecodeError):
+                continue
+            if status in {"failed", "rejected", "partially_completed"}:
+                return None
+            if status:
+                return job_id
+        return job_id
 
 
 class SarvamDocumentProvider(Protocol):
@@ -338,7 +370,14 @@ class SarvamVisionAdapter:
         poll_interval_seconds: float = 1.0,
         max_poll_attempts: int = 60,
         sleep: Callable[[float], None] = time.sleep,
+        monotonic: Callable[[], float] = time.monotonic,
+        max_submission_attempts: int = MAX_SUBMISSION_ATTEMPTS,
+        submission_backoff_seconds: float = 6.0,
     ) -> None:
+        if max_submission_attempts < 1:
+            raise ValueError("max_submission_attempts must be at least 1")
+        if submission_backoff_seconds < 0:
+            raise ValueError("submission_backoff_seconds must be non-negative")
         self.enabled = enabled
         self.api_key = api_key if api_key is not None else (
             os.getenv("SARVAM_API_KEY") or os.getenv("SARVAM_API_SUBSCRIPTION_KEY")
@@ -349,6 +388,10 @@ class SarvamVisionAdapter:
         self.poll_interval_seconds = poll_interval_seconds
         self.max_poll_attempts = max_poll_attempts
         self.sleep = sleep
+        self.monotonic = monotonic
+        self.max_submission_attempts = max_submission_attempts
+        self.submission_backoff_seconds = submission_backoff_seconds
+        self._submission_times: deque[float] = deque()
 
     def digitise(
         self,
@@ -663,37 +706,115 @@ class SarvamVisionAdapter:
         job_id: str | None,
         idempotency_key: str,
     ) -> dict[str, Any]:
-        try:
-            response = self._transport().post(url, headers=headers, files=files, data=data)
-            payload = self._json_response(response, label)
-        except Exception as exc:
+        for attempt in range(1, self.max_submission_attempts + 1):
+            self._wait_for_submission_slot()
+            try:
+                response = self._transport().post(
+                    url, headers=headers, files=files, data=data
+                )
+            except Exception as exc:
+                self._audit(
+                    context,
+                    operation,
+                    f"{label}_error",
+                    language,
+                    bytes_sent,
+                    job_id,
+                    {"error": type(exc).__name__, "attempt": attempt},
+                    idempotency_key,
+                )
+                raise SarvamError(f"Sarvam {label} request failed") from exc
+
+            if response.status_code == 429:
+                exhausted = attempt == self.max_submission_attempts
+                retry_delay = self._retry_delay_seconds(response, attempt)
+                self._audit(
+                    context,
+                    operation,
+                    f"{label}_rate_limit_exhausted"
+                    if exhausted
+                    else f"{label}_rate_limited",
+                    language,
+                    bytes_sent,
+                    job_id,
+                    {
+                        "http_status": 429,
+                        "attempt": attempt,
+                        "retry_after_seconds": retry_delay,
+                    },
+                    idempotency_key,
+                )
+                if exhausted:
+                    raise SarvamError(
+                        f"Sarvam {label} remained rate limited after "
+                        f"{self.max_submission_attempts} attempts"
+                    )
+                self.sleep(retry_delay)
+                continue
+
+            try:
+                payload = self._json_response(response, label)
+            except Exception as exc:
+                self._audit(
+                    context,
+                    operation,
+                    f"{label}_error",
+                    language,
+                    bytes_sent,
+                    job_id,
+                    {"error": type(exc).__name__, "attempt": attempt},
+                    idempotency_key,
+                )
+                if isinstance(exc, SarvamError):
+                    raise
+                raise SarvamError(f"Sarvam {label} request failed") from exc
+
+            returned_job_id = payload.get("job_id")
             self._audit(
                 context,
                 operation,
-                f"{label}_error",
+                label,
                 language,
                 bytes_sent,
-                job_id,
-                {"error": type(exc).__name__},
+                returned_job_id if isinstance(returned_job_id, str) else job_id,
+                {
+                    **self._response_metadata(payload, response.status_code),
+                    "attempt": attempt,
+                },
                 idempotency_key,
             )
-            if isinstance(exc, SarvamError):
-                raise
-            raise SarvamError(f"Sarvam {label} request failed") from exc
-        returned_job_id = payload.get("job_id")
-        self._audit(
-            context,
-            operation,
-            label,
-            language,
-            bytes_sent,
-            returned_job_id if isinstance(returned_job_id, str) else job_id,
-            self._response_metadata(payload, response.status_code),
-            idempotency_key,
-        )
-        if label == "submission" and not isinstance(returned_job_id, str):
-            raise SarvamError("Sarvam submission did not return a job_id")
-        return payload
+            if label == "submission" and not isinstance(returned_job_id, str):
+                raise SarvamError("Sarvam submission did not return a job_id")
+            return payload
+        raise AssertionError("bounded Sarvam submission loop did not return or raise")
+
+    def _wait_for_submission_slot(self) -> None:
+        """Enforce the documented ten Vision submissions per rolling minute."""
+        now = self.monotonic()
+        while self._submission_times and (
+            now - self._submission_times[0] >= SUBMISSION_WINDOW_SECONDS
+        ):
+            self._submission_times.popleft()
+        if len(self._submission_times) >= VISION_SUBMISSIONS_PER_MINUTE:
+            wait_seconds = SUBMISSION_WINDOW_SECONDS - (
+                now - self._submission_times[0]
+            )
+            self.sleep(max(0.0, wait_seconds))
+            now = self.monotonic()
+            while self._submission_times and (
+                now - self._submission_times[0] >= SUBMISSION_WINDOW_SECONDS
+            ):
+                self._submission_times.popleft()
+        self._submission_times.append(now)
+
+    def _retry_delay_seconds(self, response: HttpResponse, attempt: int) -> float:
+        headers = getattr(response, "headers", {})
+        retry_after = headers.get("Retry-After") if headers is not None else None
+        try:
+            delay = float(retry_after)
+        except (TypeError, ValueError):
+            delay = self.submission_backoff_seconds * (2 ** (attempt - 1))
+        return min(MAX_RETRY_DELAY_SECONDS, max(0.0, delay))
 
     def _get_json(
         self,

--- a/janasunani/egress/sarvam.py
+++ b/janasunani/egress/sarvam.py
@@ -1,0 +1,750 @@
+"""The sole authorized-external client for Sarvam document intelligence.
+
+The pipeline normally uses pytesseract on the same host.  Hosted Sarvam is an
+explicit, disabled-by-default exception: this module is the only place that
+may send document bytes to it, and records the approval relied upon before a
+submitted asynchronous job can be polled.
+
+This module deliberately has no credential default and does not create an HTTP
+client until an enabled adapter is used.  Tests supply recorded transports, so
+they never make a live network call.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+import time
+import zipfile
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from io import BytesIO
+from pathlib import Path
+from typing import Any, Callable, Protocol, TypeVar
+
+API_BASE_URL = "https://api.sarvam.ai"
+PROVIDER_ID = "sarvam-hosted"
+# The hosted job API chooses the Document AI model; it does not accept a
+# caller-selected model multipart field.  Record the reviewed provider model
+# locally instead of implying a request parameter that does not exist.
+MODEL_ID = "Sarvam Vision 1.5"
+TRUST_TIER = "authorized-external"
+
+# This is documentation of the settled authorization, not a runtime approval
+# gate.  Keeping the reference beside the route makes the boundary reviewable.
+AUTHORIZATION_REFERENCE = "GoO-Sarvam MoU; ACS Vishal Dev (IT) sign-off"
+
+TERMINAL_STATUSES = frozenset({"completed", "partially_completed", "failed", "rejected"})
+
+
+@dataclass(frozen=True)
+class ProviderRoute:
+    """The registered, reviewable declaration for a provider route."""
+
+    name: str
+    provider: str
+    model_id: str
+    endpoint: str
+    trust_tier: str
+    authorization_reference: str
+    fallback: str
+
+
+PROVIDER_REGISTRY = {
+    "sarvam-vision": ProviderRoute(
+        name="sarvam-vision",
+        provider=PROVIDER_ID,
+        model_id=MODEL_ID,
+        endpoint=API_BASE_URL,
+        trust_tier=TRUST_TIER,
+        authorization_reference=AUTHORIZATION_REFERENCE,
+        fallback="pytesseract",
+    )
+}
+
+
+class SarvamError(RuntimeError):
+    """A remote Sarvam request could not yield a usable result."""
+
+
+class SarvamDisabled(SarvamError):
+    """Raised internally when the configured kill switch blocks submission."""
+
+
+class SarvamPollTimeout(SarvamError):
+    """The job did not reach a terminal state within the bounded poll loop."""
+
+
+@dataclass(frozen=True)
+class SarvamAuditContext:
+    """Identity required to make a document egress call auditable."""
+
+    ticket: str
+    stage: str
+    document_id: str
+
+    def __post_init__(self) -> None:
+        if not self.ticket.strip() or not self.stage.strip() or not self.document_id.strip():
+            raise ValueError("ticket, stage, and document_id are required for Sarvam egress")
+
+
+@dataclass(frozen=True)
+class AuditRecord:
+    ticket: str
+    stage: str
+    document_id: str
+    provider: str
+    model_id: str
+    bytes_sent: int
+    timestamp: str
+    authorization_reference: str
+    operation: str
+    event: str
+    language: str
+    idempotency_key: str
+    job_id: str | None = None
+    response_metadata: dict[str, Any] | None = None
+
+
+class AuditLog(Protocol):
+    def append(self, record: AuditRecord) -> None: ...
+
+    def submitted_job(
+        self, context: SarvamAuditContext, operation: str, idempotency_key: str
+    ) -> str | None: ...
+
+
+class HttpResponse(Protocol):
+    status_code: int
+    text: str
+    content: bytes
+
+    def json(self) -> Any: ...
+
+
+class HttpTransport(Protocol):
+    def post(self, url: str, **kwargs: Any) -> HttpResponse: ...
+
+    def get(self, url: str, **kwargs: Any) -> HttpResponse: ...
+
+
+class SqliteAuditLog:
+    """Append-only audit records stored beside pipeline state.
+
+    The payload is JSON rather than a collection of optional columns so result
+    metadata can grow without silently dropping vendor fields.  Mandatory
+    governance fields remain indexed columns for review and reconciliation.
+    """
+
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = db_path
+        self._initialize()
+
+    def _initialize(self) -> None:
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        with sqlite3.connect(self.db_path) as connection:
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS authorized_external_audit (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    ticket TEXT NOT NULL,
+                    stage TEXT NOT NULL,
+                    document_id TEXT NOT NULL,
+                    provider TEXT NOT NULL,
+                    model_id TEXT NOT NULL,
+                    bytes_sent INTEGER NOT NULL,
+                    timestamp TEXT NOT NULL,
+                    authorization_reference TEXT NOT NULL,
+                    operation TEXT NOT NULL,
+                    event TEXT NOT NULL,
+                    language TEXT NOT NULL,
+                    idempotency_key TEXT NOT NULL,
+                    job_id TEXT,
+                    response_metadata TEXT
+                )
+                """
+            )
+            connection.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_authorized_external_audit_job
+                ON authorized_external_audit(job_id)
+                """
+            )
+
+    def append(self, record: AuditRecord) -> None:
+        payload = asdict(record)
+        payload["response_metadata"] = json.dumps(
+            payload["response_metadata"], sort_keys=True
+        )
+        with sqlite3.connect(self.db_path) as connection:
+            connection.execute(
+                """
+                INSERT INTO authorized_external_audit (
+                    ticket, stage, document_id, provider, model_id, bytes_sent,
+                    timestamp, authorization_reference, operation, event, language,
+                    idempotency_key, job_id, response_metadata
+                ) VALUES (
+                    :ticket, :stage, :document_id, :provider, :model_id, :bytes_sent,
+                    :timestamp, :authorization_reference, :operation, :event, :language,
+                    :idempotency_key, :job_id, :response_metadata
+                )
+                """,
+                payload,
+            )
+
+    def submitted_job(
+        self, context: SarvamAuditContext, operation: str, idempotency_key: str
+    ) -> str | None:
+        """Return a previously recorded job before issuing a billable retry.
+
+        Sarvam's Idempotency-Key semantics are undocumented.  This local log,
+        not that header, is therefore the duplicate-billing control.  A
+        completed job is also returned: its result can be downloaded again
+        without submitting the same document a second time.
+        """
+        with sqlite3.connect(self.db_path) as connection:
+            row = connection.execute(
+                """
+                SELECT job_id
+                FROM authorized_external_audit
+                WHERE ticket = ? AND stage = ? AND document_id = ?
+                  AND operation = ? AND event = 'submission'
+                  AND idempotency_key = ? AND job_id IS NOT NULL
+                ORDER BY id DESC LIMIT 1
+                """,
+                (
+                    context.ticket,
+                    context.stage,
+                    context.document_id,
+                    operation,
+                    idempotency_key,
+                ),
+            ).fetchone()
+        return row[0] if row else None
+
+
+class SarvamDocumentProvider(Protocol):
+    """Two-operation interface exposed by Sarvam Document Intelligence."""
+
+    def digitise(
+        self,
+        document_bytes: bytes,
+        filename: str,
+        language: str,
+        context: SarvamAuditContext,
+    ) -> str: ...
+
+    def extract(
+        self,
+        document_bytes: bytes,
+        filename: str,
+        language: str,
+        context: SarvamAuditContext,
+        *,
+        schema: dict[str, Any] | None = None,
+        config_id: str | None = None,
+    ) -> dict[str, Any]: ...
+
+
+_Result = TypeVar("_Result")
+
+
+class SarvamVisionAdapter:
+    """Submit/poll Sarvam jobs and route safe failures to a local counterpart."""
+
+    def __init__(
+        self,
+        *,
+        enabled: bool = False,
+        api_key: str | None = None,
+        audit_log: AuditLog,
+        transport: HttpTransport | None = None,
+        poll_interval_seconds: float = 1.0,
+        max_poll_attempts: int = 60,
+        sleep: Callable[[float], None] = time.sleep,
+    ) -> None:
+        self.enabled = enabled
+        self.api_key = api_key if api_key is not None else (
+            os.getenv("SARVAM_API_KEY") or os.getenv("SARVAM_API_SUBSCRIPTION_KEY")
+        )
+        self.audit_log = audit_log
+        self.transport = transport
+        self.poll_interval_seconds = poll_interval_seconds
+        self.max_poll_attempts = max_poll_attempts
+        self.sleep = sleep
+
+    def digitise(
+        self,
+        document_bytes: bytes,
+        filename: str,
+        language: str,
+        context: SarvamAuditContext,
+    ) -> str:
+        """Run the OCR/Digitise endpoint and return its Markdown output."""
+        return self._run_job(
+            operation="digitise",
+            document_bytes=document_bytes,
+            filename=filename,
+            language=language,
+            context=context,
+            form={"language": language, "output_format": "md"},
+            result_reader=self._read_digitise_result,
+        )
+
+    def extract(
+        self,
+        document_bytes: bytes,
+        filename: str,
+        language: str,
+        context: SarvamAuditContext,
+        *,
+        schema: dict[str, Any] | None = None,
+        config_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Run the separate structured Extract endpoint.
+
+        A benchmark pins exactly one of ``schema`` or ``config_id``.  The
+        operation is intentionally separate from digitise: they differ in
+        task, result shape, and billing.
+        """
+        if (schema is None) == (config_id is None):
+            raise ValueError("provide exactly one of schema or config_id for Sarvam Extract")
+        form: dict[str, Any] = {"language": language, "output_format": "json"}
+        if schema is not None:
+            form["schema"] = json.dumps(schema, sort_keys=True)
+        else:
+            form["config_id"] = config_id
+        return self._run_job(
+            operation="extract",
+            document_bytes=document_bytes,
+            filename=filename,
+            language=language,
+            context=context,
+            form=form,
+            result_reader=self._read_extract_result,
+        )
+
+    def digitise_or_fallback(
+        self,
+        document_bytes: bytes,
+        filename: str,
+        language: str,
+        context: SarvamAuditContext,
+        fallback: Callable[[], _Result],
+    ) -> str | _Result:
+        """Use Digitise only while enabled; otherwise preserve local OCR.
+
+        Disabled means no remote request of any kind, including a resume/poll.
+        Enabled runs may resume a recorded job rather than resubmitting it.
+        """
+        if not self.enabled:
+            self._audit(
+                context,
+                "digitise",
+                "disabled",
+                language,
+                0,
+                None,
+                {},
+                self._idempotency_key(context, "digitise", document_bytes),
+            )
+            return fallback()
+        try:
+            return self.digitise(document_bytes, filename, language, context)
+        except SarvamError as exc:
+            self._audit(
+                context,
+                "digitise",
+                "fallback",
+                language,
+                0,
+                None,
+                {"reason": type(exc).__name__},
+                self._idempotency_key(context, "digitise", document_bytes),
+            )
+            return fallback()
+
+    def _run_job(
+        self,
+        *,
+        operation: str,
+        document_bytes: bytes,
+        filename: str,
+        language: str,
+        context: SarvamAuditContext,
+        form: dict[str, Any],
+        result_reader: Callable[
+            [str, dict[str, Any], SarvamAuditContext, str, str, str], _Result
+        ],
+    ) -> _Result:
+        if not self.enabled:
+            raise SarvamDisabled("Sarvam hosted egress is disabled")
+        if not self.api_key:
+            raise SarvamError(
+                "SARVAM_API_KEY is required when Sarvam is enabled "
+                "(SARVAM_API_SUBSCRIPTION_KEY is accepted for compatibility)"
+            )
+
+        idempotency_key = self._idempotency_key(context, operation, document_bytes)
+        recorded_job = self.audit_log.submitted_job(context, operation, idempotency_key)
+        if recorded_job:
+            self._audit(
+                context,
+                operation,
+                "resume",
+                language,
+                0,
+                recorded_job,
+                {},
+                idempotency_key,
+            )
+            return self._finish_job(
+                recorded_job,
+                context,
+                operation,
+                language,
+                idempotency_key,
+                result_reader,
+            )
+        submitted = self._post_json(
+            url=f"{API_BASE_URL}/doc-ai/v1/job/{operation}",
+            headers={
+                "api-subscription-key": self.api_key,
+                "Idempotency-Key": idempotency_key,
+            },
+            files={"file": (filename, document_bytes)},
+            data=form,
+            label="submission",
+            context=context,
+            operation=operation,
+            language=language,
+            bytes_sent=len(document_bytes),
+            job_id=None,
+            idempotency_key=idempotency_key,
+        )
+        job_id = submitted["job_id"]
+
+        return self._finish_job(
+            job_id,
+            context,
+            operation,
+            language,
+            idempotency_key,
+            result_reader,
+        )
+
+    def _finish_job(
+        self,
+        job_id: str,
+        context: SarvamAuditContext,
+        operation: str,
+        language: str,
+        idempotency_key: str,
+        result_reader: Callable[
+            [str, dict[str, Any], SarvamAuditContext, str, str, str], _Result
+        ],
+    ) -> _Result:
+        status = self._poll(job_id, context, operation, language, idempotency_key)
+        final_status = status.get("status")
+        if final_status not in {"completed", "partially_completed"}:
+            raise SarvamError(f"Sarvam job {job_id!r} ended with status {final_status!r}")
+        result = result_reader(job_id, status, context, operation, language, idempotency_key)
+        return result
+
+    def _poll(
+        self,
+        job_id: str,
+        context: SarvamAuditContext,
+        operation: str,
+        language: str,
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        for attempt in range(self.max_poll_attempts):
+            if attempt:
+                self.sleep(self.poll_interval_seconds)
+            status = self._get_json(
+                url=f"{API_BASE_URL}/doc-ai/v1/job/{job_id}/status",
+                headers={"api-subscription-key": self.api_key},
+                label="poll",
+                context=context,
+                operation=operation,
+                language=language,
+                job_id=job_id,
+                idempotency_key=idempotency_key,
+            )
+            state = status.get("status")
+            if state in TERMINAL_STATUSES:
+                return status
+        raise SarvamPollTimeout(f"Sarvam job {job_id!r} did not reach a terminal state")
+
+    def _read_digitise_result(
+        self,
+        job_id: str,
+        _status: dict[str, Any],
+        context: SarvamAuditContext,
+        operation: str,
+        language: str,
+        idempotency_key: str,
+    ) -> str:
+        response = self._get_json(
+            url=f"{API_BASE_URL}/doc-ai/v1/job/{job_id}/download-url",
+            headers={"api-subscription-key": self.api_key},
+            label="result_lookup",
+            context=context,
+            operation=operation,
+            language=language,
+            job_id=job_id,
+            idempotency_key=idempotency_key,
+        )
+        download_url = response.get("download_url") or response.get("url")
+        if not isinstance(download_url, str) or not download_url:
+            raise SarvamError("Sarvam Digitise result did not return a download URL")
+        archive = self._get_binary(
+            url=download_url,
+            headers=None,
+            label="download",
+            context=context,
+            operation=operation,
+            language=language,
+            job_id=job_id,
+            idempotency_key=idempotency_key,
+        )
+        return self._primary_markdown(archive)
+
+    def _read_extract_result(
+        self,
+        job_id: str,
+        _status: dict[str, Any],
+        context: SarvamAuditContext,
+        operation: str,
+        language: str,
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        return self._get_json(
+            url=f"{API_BASE_URL}/doc-ai/v1/job/{job_id}/results",
+            headers={"api-subscription-key": self.api_key},
+            label="result_lookup",
+            context=context,
+            operation=operation,
+            language=language,
+            job_id=job_id,
+            idempotency_key=idempotency_key,
+        )
+
+    def _post_json(
+        self,
+        *,
+        url: str,
+        headers: dict[str, str],
+        files: dict[str, tuple[str, bytes]],
+        data: dict[str, Any],
+        label: str,
+        context: SarvamAuditContext,
+        operation: str,
+        language: str,
+        bytes_sent: int,
+        job_id: str | None,
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        try:
+            response = self._transport().post(url, headers=headers, files=files, data=data)
+            payload = self._json_response(response, label)
+        except Exception as exc:
+            self._audit(
+                context,
+                operation,
+                f"{label}_error",
+                language,
+                bytes_sent,
+                job_id,
+                {"error": type(exc).__name__},
+                idempotency_key,
+            )
+            if isinstance(exc, SarvamError):
+                raise
+            raise SarvamError(f"Sarvam {label} request failed") from exc
+        returned_job_id = payload.get("job_id")
+        self._audit(
+            context,
+            operation,
+            label,
+            language,
+            bytes_sent,
+            returned_job_id if isinstance(returned_job_id, str) else job_id,
+            self._response_metadata(payload, response.status_code),
+            idempotency_key,
+        )
+        if label == "submission" and not isinstance(returned_job_id, str):
+            raise SarvamError("Sarvam submission did not return a job_id")
+        return payload
+
+    def _get_json(
+        self,
+        *,
+        url: str,
+        headers: dict[str, str],
+        label: str,
+        context: SarvamAuditContext,
+        operation: str,
+        language: str,
+        job_id: str,
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        try:
+            response = self._transport().get(url, headers=headers)
+            payload = self._json_response(response, label)
+        except Exception as exc:
+            self._audit(
+                context,
+                operation,
+                f"{label}_error",
+                language,
+                0,
+                job_id,
+                {"error": type(exc).__name__},
+                idempotency_key,
+            )
+            if isinstance(exc, SarvamError):
+                raise
+            raise SarvamError(f"Sarvam {label} request failed") from exc
+        self._audit(
+            context,
+            operation,
+            label,
+            language,
+            0,
+            job_id,
+            self._response_metadata(payload, response.status_code),
+            idempotency_key,
+        )
+        return payload
+
+    def _get_binary(
+        self,
+        *,
+        url: str,
+        headers: dict[str, str] | None,
+        label: str,
+        context: SarvamAuditContext,
+        operation: str,
+        language: str,
+        job_id: str,
+        idempotency_key: str,
+    ) -> bytes:
+        try:
+            response = self._transport().get(url, headers=headers)
+            if not 200 <= response.status_code < 300:
+                raise SarvamError(f"Sarvam {label} returned HTTP {response.status_code}")
+        except Exception as exc:
+            self._audit(
+                context,
+                operation,
+                f"{label}_error",
+                language,
+                0,
+                job_id,
+                {"error": type(exc).__name__},
+                idempotency_key,
+            )
+            if isinstance(exc, SarvamError):
+                raise
+            raise SarvamError(f"Sarvam {label} request failed") from exc
+        self._audit(
+            context,
+            operation,
+            label,
+            language,
+            0,
+            job_id,
+            {"http_status": response.status_code},
+            idempotency_key,
+        )
+        return response.content
+
+    @staticmethod
+    def _primary_markdown(archive: bytes) -> str:
+        try:
+            with zipfile.ZipFile(BytesIO(archive)) as result_zip:
+                markdown_members = [
+                    member
+                    for member in result_zip.namelist()
+                    if not member.endswith("/") and Path(member).suffix.lower() == ".md"
+                ]
+                if len(markdown_members) != 1:
+                    raise SarvamError(
+                        "Sarvam Digitise ZIP must contain exactly one primary Markdown file"
+                    )
+                return result_zip.read(markdown_members[0]).decode("utf-8")
+        except zipfile.BadZipFile as exc:
+            raise SarvamError("Sarvam Digitise download was not a valid ZIP archive") from exc
+        except UnicodeDecodeError as exc:
+            raise SarvamError("Sarvam Digitise Markdown was not UTF-8") from exc
+
+    def _transport(self) -> HttpTransport:
+        if self.transport is None:
+            # The import is intentionally local: disabled/default installations
+            # must not construct a network client at import or startup.
+            import httpx
+
+            self.transport = httpx.Client(timeout=30.0)
+        return self.transport
+
+    @staticmethod
+    def _json_response(response: HttpResponse, label: str) -> dict[str, Any]:
+        if not 200 <= response.status_code < 300:
+            raise SarvamError(f"Sarvam {label} returned HTTP {response.status_code}")
+        payload = response.json()
+        if not isinstance(payload, dict):
+            raise SarvamError(f"Sarvam {label} response was not a JSON object")
+        return payload
+
+    @staticmethod
+    def _response_metadata(payload: dict[str, Any], http_status: int) -> dict[str, Any]:
+        """Keep auditable operational metadata, never provider document output."""
+        safe_keys = {"job_id", "status", "usage", "model", "request_id"}
+        return {
+            **{key: value for key, value in payload.items() if key in safe_keys},
+            "http_status": http_status,
+        }
+
+    @staticmethod
+    def _idempotency_key(
+        context: SarvamAuditContext, operation: str, document_bytes: bytes = b""
+    ) -> str:
+        content_hash = hashlib.sha256(document_bytes).hexdigest()
+        source = "\0".join(
+            (context.ticket, context.document_id, context.stage, operation, content_hash)
+        )
+        return hashlib.sha256(source.encode("utf-8")).hexdigest()
+
+    def _audit(
+        self,
+        context: SarvamAuditContext,
+        operation: str,
+        event: str,
+        language: str,
+        bytes_sent: int,
+        job_id: str | None,
+        metadata: dict[str, Any],
+        idempotency_key: str | None = None,
+    ) -> None:
+        self.audit_log.append(
+            AuditRecord(
+                ticket=context.ticket,
+                stage=context.stage,
+                document_id=context.document_id,
+                provider=PROVIDER_ID,
+                model_id=MODEL_ID,
+                bytes_sent=bytes_sent,
+                timestamp=datetime.now(UTC).isoformat(),
+                authorization_reference=AUTHORIZATION_REFERENCE,
+                operation=operation,
+                event=event,
+                language=language,
+                idempotency_key=idempotency_key
+                or self._idempotency_key(context, operation),
+                job_id=job_id,
+                response_metadata=metadata,
+            )
+        )

--- a/janasunani/egress/sarvam.py
+++ b/janasunani/egress/sarvam.py
@@ -29,6 +29,7 @@ PROVIDER_ID = "sarvam-hosted"
 # caller-selected model multipart field.  Record the reviewed provider model
 # locally instead of implying a request parameter that does not exist.
 MODEL_ID = "Sarvam Vision 1.5"
+SARVAM_OCR_MODEL = f"{PROVIDER_ID}:{MODEL_ID}"
 TRUST_TIER = "authorized-external"
 
 # This is documentation of the settled authorization, not a runtime approval
@@ -87,6 +88,14 @@ class SarvamAuditContext:
     def __post_init__(self) -> None:
         if not self.ticket.strip() or not self.stage.strip() or not self.document_id.strip():
             raise ValueError("ticket, stage, and document_id are required for Sarvam egress")
+
+
+@dataclass(frozen=True)
+class DigitiseOutcome:
+    """Digitise text paired with the OCR engine that actually produced it."""
+
+    text: str
+    ocr_model: str
 
 
 @dataclass(frozen=True)
@@ -331,9 +340,9 @@ class SarvamVisionAdapter:
         filename: str,
         language: str,
         context: SarvamAuditContext,
-        fallback: Callable[[], _Result],
-    ) -> str | _Result:
-        """Use Digitise only while enabled; otherwise preserve local OCR.
+        fallback: Callable[[], str],
+    ) -> DigitiseOutcome:
+        """Use Digitise only while enabled and report the actual OCR engine.
 
         Disabled means no remote request of any kind, including a resume/poll.
         Enabled runs may resume a recorded job rather than resubmitting it.
@@ -349,9 +358,12 @@ class SarvamVisionAdapter:
                 {},
                 self._idempotency_key(context, "digitise", document_bytes),
             )
-            return fallback()
+            return DigitiseOutcome(text=fallback(), ocr_model="pytesseract")
         try:
-            return self.digitise(document_bytes, filename, language, context)
+            return DigitiseOutcome(
+                text=self.digitise(document_bytes, filename, language, context),
+                ocr_model=SARVAM_OCR_MODEL,
+            )
         except SarvamError as exc:
             self._audit(
                 context,
@@ -363,7 +375,7 @@ class SarvamVisionAdapter:
                 {"reason": type(exc).__name__},
                 self._idempotency_key(context, "digitise", document_bytes),
             )
-            return fallback()
+            return DigitiseOutcome(text=fallback(), ocr_model="pytesseract")
 
     def _run_job(
         self,
@@ -447,7 +459,10 @@ class SarvamVisionAdapter:
     ) -> _Result:
         status = self._poll(job_id, context, operation, language, idempotency_key)
         final_status = status.get("status")
-        if final_status not in {"completed", "partially_completed"}:
+        # A partially completed archive cannot be reconciled to individual
+        # page results through the current adapter surface.  Treat the whole
+        # job as unusable rather than silently dropping failed pages.
+        if final_status != "completed":
             raise SarvamError(f"Sarvam job {job_id!r} ended with status {final_status!r}")
         result = result_reader(job_id, status, context, operation, language, idempotency_key)
         return result

--- a/janasunani/egress/sarvam.py
+++ b/janasunani/egress/sarvam.py
@@ -40,6 +40,14 @@ TERMINAL_STATUSES = frozenset({"completed", "partially_completed", "failed", "re
 
 
 @dataclass(frozen=True)
+class GovernanceControl:
+    """A provider control statement and whether repo evidence verifies it."""
+
+    statement: str
+    verified: bool
+
+
+@dataclass(frozen=True)
 class ProviderRoute:
     """The registered, reviewable declaration for a provider route."""
 
@@ -48,8 +56,43 @@ class ProviderRoute:
     model_id: str
     endpoint: str
     trust_tier: str
+    data_class: str
     authorization_reference: str
+    retention_terms: GovernanceControl
+    encryption_in_transit: GovernanceControl
+    encryption_at_rest: GovernanceControl
+    audit_policy: str
     fallback: str
+
+    @property
+    def unverified_controls(self) -> tuple[str, ...]:
+        controls = {
+            "retention_terms": self.retention_terms,
+            "encryption_in_transit": self.encryption_in_transit,
+            "encryption_at_rest": self.encryption_at_rest,
+        }
+        return tuple(name for name, control in controls.items() if not control.verified)
+
+    @property
+    def declared_controls_complete(self) -> bool:
+        """Whether the architecture-mandated registry fields are all declared."""
+        required_text = (
+            self.trust_tier,
+            self.data_class,
+            self.endpoint,
+            self.authorization_reference,
+            self.retention_terms.statement,
+            self.encryption_in_transit.statement,
+            self.encryption_at_rest.statement,
+            self.audit_policy,
+            self.fallback,
+        )
+        return all(value.strip() for value in required_text)
+
+    @property
+    def live_use_ready(self) -> bool:
+        """Whether every provider-held-data control has verified repo evidence."""
+        return self.declared_controls_complete and not self.unverified_controls
 
 
 PROVIDER_REGISTRY = {
@@ -59,7 +102,25 @@ PROVIDER_REGISTRY = {
         model_id=MODEL_ID,
         endpoint=API_BASE_URL,
         trust_tier=TRUST_TIER,
+        data_class="raw grievance document bytes, including citizen PII",
         authorization_reference=AUTHORIZATION_REFERENCE,
+        retention_terms=GovernanceControl(
+            statement="Sarvam provider retention terms are not verified in this repository.",
+            verified=False,
+        ),
+        encryption_in_transit=GovernanceControl(
+            statement="Sarvam transport-encryption guarantees are not verified in this repository.",
+            verified=False,
+        ),
+        encryption_at_rest=GovernanceControl(
+            statement="Sarvam at-rest encryption guarantees are not verified in this repository.",
+            verified=False,
+        ),
+        audit_policy=(
+            "Append one local record for every remote attempt and fallback with ticket, stage, "
+            "document, provider, model, bytes sent, timestamp, authorization reference, "
+            "operation, event, language, request key, job id, and safe response metadata."
+        ),
         fallback="pytesseract",
     )
 }
@@ -75,6 +136,10 @@ class SarvamDisabled(SarvamError):
 
 class SarvamPollTimeout(SarvamError):
     """The job did not reach a terminal state within the bounded poll loop."""
+
+
+class SarvamGovernanceError(SarvamError):
+    """The external route lacks verified provider-held-data controls."""
 
 
 @dataclass(frozen=True)
@@ -268,6 +333,7 @@ class SarvamVisionAdapter:
         enabled: bool = False,
         api_key: str | None = None,
         audit_log: AuditLog,
+        route: ProviderRoute | None = None,
         transport: HttpTransport | None = None,
         poll_interval_seconds: float = 1.0,
         max_poll_attempts: int = 60,
@@ -278,6 +344,7 @@ class SarvamVisionAdapter:
             os.getenv("SARVAM_API_KEY") or os.getenv("SARVAM_API_SUBSCRIPTION_KEY")
         )
         self.audit_log = audit_log
+        self.route = route or PROVIDER_REGISTRY["sarvam-vision"]
         self.transport = transport
         self.poll_interval_seconds = poll_interval_seconds
         self.max_poll_attempts = max_poll_attempts
@@ -291,13 +358,14 @@ class SarvamVisionAdapter:
         context: SarvamAuditContext,
     ) -> str:
         """Run the OCR/Digitise endpoint and return its Markdown output."""
+        form = self._digitise_form(language)
         return self._run_job(
             operation="digitise",
             document_bytes=document_bytes,
             filename=filename,
             language=language,
             context=context,
-            form={"language": language, "output_format": "md"},
+            form=form,
             result_reader=self._read_digitise_result,
         )
 
@@ -321,7 +389,13 @@ class SarvamVisionAdapter:
             raise ValueError("provide exactly one of schema or config_id for Sarvam Extract")
         form: dict[str, Any] = {"language": language, "output_format": "json"}
         if schema is not None:
-            form["schema"] = json.dumps(schema, sort_keys=True)
+            form["schema"] = json.dumps(
+                schema,
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=False,
+                allow_nan=False,
+            )
         else:
             form["config_id"] = config_id
         return self._run_job(
@@ -347,6 +421,14 @@ class SarvamVisionAdapter:
         Disabled means no remote request of any kind, including a resume/poll.
         Enabled runs may resume a recorded job rather than resubmitting it.
         """
+        form = self._digitise_form(language)
+        idempotency_key = self._idempotency_key(
+            context,
+            "digitise",
+            document_bytes,
+            filename=filename,
+            form=form,
+        )
         if not self.enabled:
             self._audit(
                 context,
@@ -356,13 +438,21 @@ class SarvamVisionAdapter:
                 0,
                 None,
                 {},
-                self._idempotency_key(context, "digitise", document_bytes),
+                idempotency_key,
             )
             return DigitiseOutcome(text=fallback(), ocr_model="pytesseract")
         try:
             return DigitiseOutcome(
-                text=self.digitise(document_bytes, filename, language, context),
-                ocr_model=SARVAM_OCR_MODEL,
+                text=self._run_job(
+                    operation="digitise",
+                    document_bytes=document_bytes,
+                    filename=filename,
+                    language=language,
+                    context=context,
+                    form=form,
+                    result_reader=self._read_digitise_result,
+                ),
+                ocr_model=f"{self.route.provider}:{self.route.model_id}",
             )
         except SarvamError as exc:
             self._audit(
@@ -373,7 +463,7 @@ class SarvamVisionAdapter:
                 0,
                 None,
                 {"reason": type(exc).__name__},
-                self._idempotency_key(context, "digitise", document_bytes),
+                idempotency_key,
             )
             return DigitiseOutcome(text=fallback(), ocr_model="pytesseract")
 
@@ -392,13 +482,24 @@ class SarvamVisionAdapter:
     ) -> _Result:
         if not self.enabled:
             raise SarvamDisabled("Sarvam hosted egress is disabled")
+        if not self.route.live_use_ready:
+            controls = ", ".join(self.route.unverified_controls)
+            raise SarvamGovernanceError(
+                f"Sarvam hosted egress is gated by unverified controls: {controls}"
+            )
         if not self.api_key:
             raise SarvamError(
                 "SARVAM_API_KEY is required when Sarvam is enabled "
                 "(SARVAM_API_SUBSCRIPTION_KEY is accepted for compatibility)"
             )
 
-        idempotency_key = self._idempotency_key(context, operation, document_bytes)
+        idempotency_key = self._idempotency_key(
+            context,
+            operation,
+            document_bytes,
+            filename=filename,
+            form=form,
+        )
         recorded_job = self.audit_log.submitted_job(context, operation, idempotency_key)
         if recorded_job:
             self._audit(
@@ -420,7 +521,7 @@ class SarvamVisionAdapter:
                 result_reader,
             )
         submitted = self._post_json(
-            url=f"{API_BASE_URL}/doc-ai/v1/job/{operation}",
+            url=f"{self.route.endpoint}/doc-ai/v1/job/{operation}",
             headers={
                 "api-subscription-key": self.api_key,
                 "Idempotency-Key": idempotency_key,
@@ -479,7 +580,7 @@ class SarvamVisionAdapter:
             if attempt:
                 self.sleep(self.poll_interval_seconds)
             status = self._get_json(
-                url=f"{API_BASE_URL}/doc-ai/v1/job/{job_id}/status",
+                url=f"{self.route.endpoint}/doc-ai/v1/job/{job_id}/status",
                 headers={"api-subscription-key": self.api_key},
                 label="poll",
                 context=context,
@@ -503,7 +604,7 @@ class SarvamVisionAdapter:
         idempotency_key: str,
     ) -> str:
         response = self._get_json(
-            url=f"{API_BASE_URL}/doc-ai/v1/job/{job_id}/download-url",
+            url=f"{self.route.endpoint}/doc-ai/v1/job/{job_id}/download-url",
             headers={"api-subscription-key": self.api_key},
             label="result_lookup",
             context=context,
@@ -537,7 +638,7 @@ class SarvamVisionAdapter:
         idempotency_key: str,
     ) -> dict[str, Any]:
         return self._get_json(
-            url=f"{API_BASE_URL}/doc-ai/v1/job/{job_id}/results",
+            url=f"{self.route.endpoint}/doc-ai/v1/job/{job_id}/results",
             headers={"api-subscription-key": self.api_key},
             label="result_lookup",
             context=context,
@@ -724,12 +825,39 @@ class SarvamVisionAdapter:
         }
 
     @staticmethod
+    def _digitise_form(language: str) -> dict[str, str]:
+        return {"language": language, "output_format": "md"}
+
+    @staticmethod
     def _idempotency_key(
-        context: SarvamAuditContext, operation: str, document_bytes: bytes = b""
+        context: SarvamAuditContext,
+        operation: str,
+        document_bytes: bytes,
+        *,
+        filename: str,
+        form: dict[str, Any],
     ) -> str:
+        try:
+            normalized_form = json.dumps(
+                form,
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=False,
+                allow_nan=False,
+            )
+        except (TypeError, ValueError) as exc:
+            raise ValueError("Sarvam request form must be canonical JSON data") from exc
         content_hash = hashlib.sha256(document_bytes).hexdigest()
         source = "\0".join(
-            (context.ticket, context.document_id, context.stage, operation, content_hash)
+            (
+                context.ticket,
+                context.document_id,
+                context.stage,
+                operation,
+                filename,
+                normalized_form,
+                content_hash,
+            )
         )
         return hashlib.sha256(source.encode("utf-8")).hexdigest()
 
@@ -742,23 +870,22 @@ class SarvamVisionAdapter:
         bytes_sent: int,
         job_id: str | None,
         metadata: dict[str, Any],
-        idempotency_key: str | None = None,
+        idempotency_key: str,
     ) -> None:
         self.audit_log.append(
             AuditRecord(
                 ticket=context.ticket,
                 stage=context.stage,
                 document_id=context.document_id,
-                provider=PROVIDER_ID,
-                model_id=MODEL_ID,
+                provider=self.route.provider,
+                model_id=self.route.model_id,
                 bytes_sent=bytes_sent,
                 timestamp=datetime.now(UTC).isoformat(),
-                authorization_reference=AUTHORIZATION_REFERENCE,
+                authorization_reference=self.route.authorization_reference,
                 operation=operation,
                 event=event,
                 language=language,
-                idempotency_key=idempotency_key
-                or self._idempotency_key(context, operation),
+                idempotency_key=idempotency_key,
                 job_id=job_id,
                 response_metadata=metadata,
             )

--- a/janasunani/pipeline/cli.py
+++ b/janasunani/pipeline/cli.py
@@ -127,6 +127,15 @@ def main() -> int:
             raise SystemExit(
                 f"--worker-id ({args.worker_id}) must be in [0, --num-workers={args.num_workers})"
             )
+        if (
+            args.ocr_engine == "sarvam"
+            and args.enable_sarvam
+            and args.num_workers != 1
+        ):
+            raise SystemExit(
+                "enabled Sarvam OCR requires --num-workers 1 because its "
+                "10-RPM limiter is process-local"
+            )
 
         config = PipelineConfig(
             input_dir=args.input,

--- a/janasunani/pipeline/cli.py
+++ b/janasunani/pipeline/cli.py
@@ -1,7 +1,7 @@
 import argparse
 from pathlib import Path
 
-from janasunani.pipeline.config import PipelineConfig
+from janasunani.pipeline.config import PipelineConfig, validate_sarvam_sharding
 from janasunani.pipeline.db import initialize_database
 from janasunani.pipeline.pipeline import STAGE_ORDER, run_pipeline
 
@@ -127,15 +127,14 @@ def main() -> int:
             raise SystemExit(
                 f"--worker-id ({args.worker_id}) must be in [0, --num-workers={args.num_workers})"
             )
-        if (
-            args.ocr_engine == "sarvam"
-            and args.enable_sarvam
-            and args.num_workers != 1
-        ):
-            raise SystemExit(
-                "enabled Sarvam OCR requires --num-workers 1 because its "
-                "10-RPM limiter is process-local"
+        try:
+            validate_sarvam_sharding(
+                ocr_engine=args.ocr_engine,
+                sarvam_enabled=args.enable_sarvam,
+                num_workers=args.num_workers,
             )
+        except ValueError as exc:
+            raise SystemExit(str(exc).replace("num_workers=1", "--num-workers 1")) from exc
 
         config = PipelineConfig(
             input_dir=args.input,

--- a/janasunani/pipeline/cli.py
+++ b/janasunani/pipeline/cli.py
@@ -35,8 +35,16 @@ def build_parser() -> argparse.ArgumentParser:
     )
     run.add_argument(
         "--ocr-engine",
-        choices=["pytesseract", "deepseek"],
+        choices=["pytesseract", "deepseek", "sarvam"],
         default="pytesseract",
+    )
+    run.add_argument(
+        "--enable-sarvam",
+        action="store_true",
+        help=(
+            "Permit the authorized-external Sarvam OCR route for this run. "
+            "Without this flag, --ocr-engine sarvam falls back to pytesseract."
+        ),
     )
     run.add_argument(
         "--page-type-model",
@@ -125,6 +133,7 @@ def main() -> int:
             db_path=args.db,
             models_dir=args.models,
             ocr_engine=args.ocr_engine,
+            sarvam_enabled=args.enable_sarvam,
             page_type_model_id=args.page_type_model,
             file_list=args.file_list,
             n_workers=args.workers,

--- a/janasunani/pipeline/config.py
+++ b/janasunani/pipeline/config.py
@@ -2,6 +2,22 @@ from dataclasses import dataclass
 from pathlib import Path
 
 
+def validate_sarvam_sharding(
+    *, ocr_engine: str, sarvam_enabled: bool, num_workers: int
+) -> None:
+    """Reject enabled hosted Sarvam runs whose limiter cannot be global.
+
+    Cross-machine workers are separate processes, while the adapter's rolling
+    10-RPM limiter is process-local. Disabled Sarvam is safe to shard because
+    it makes no remote calls and uses the maintained local fallback instead.
+    """
+    if ocr_engine == "sarvam" and sarvam_enabled and num_workers != 1:
+        raise ValueError(
+            "enabled Sarvam OCR requires num_workers=1 because its "
+            "10-RPM limiter is process-local"
+        )
+
+
 @dataclass(frozen=True)
 class PipelineConfig:
     input_dir: Path

--- a/janasunani/pipeline/config.py
+++ b/janasunani/pipeline/config.py
@@ -8,6 +8,10 @@ class PipelineConfig:
     db_path: Path
     models_dir: Path
     ocr_engine: str = "pytesseract"
+    # Hosted Sarvam is an authorized-external route and stays off unless a
+    # deliberate run enables it.  When ``ocr_engine == "sarvam"`` but this is
+    # false, the OCR stage uses its maintained pytesseract counterpart.
+    sarvam_enabled: bool = False
     # None -> resolved by the page-type stage: the DVC-mirrored copy under
     # models_dir/page_type_classifier/vit_type_classifier when present,
     # falling back to the (orphaned-org) HF repo. Set explicitly to override.

--- a/janasunani/pipeline/stages/ocr_extraction/executors.py
+++ b/janasunani/pipeline/stages/ocr_extraction/executors.py
@@ -86,7 +86,7 @@ def pick_executor(
 
     Pytesseract picks serial for small batches, multiprocessing otherwise.
     """
-    if backend == "deepseek":
+    if backend in {"deepseek", "sarvam"}:
         return SerialExecutor(initializer=initializer, initargs=initargs)
 
     # Pytesseract path

--- a/janasunani/pipeline/stages/ocr_extraction/stage.py
+++ b/janasunani/pipeline/stages/ocr_extraction/stage.py
@@ -49,6 +49,11 @@ def run_ocr_extraction(config: PipelineConfig) -> None:
             f"unknown ocr_engine: {backend!r}. "
             "must be 'pytesseract', 'deepseek', or 'sarvam'."
         )
+    if backend == "sarvam" and config.sarvam_enabled and config.num_workers != 1:
+        raise ValueError(
+            "enabled Sarvam OCR requires num_workers=1 because its "
+            "10-RPM limiter is process-local"
+        )
 
     work_items = _load_pending_pages(
         db_path=config.db_path,

--- a/janasunani/pipeline/stages/ocr_extraction/stage.py
+++ b/janasunani/pipeline/stages/ocr_extraction/stage.py
@@ -8,6 +8,8 @@ the configured OCR backend, and writes the extracted text back to the
 The choice of backend is driven by config.ocr_engine:
   - "pytesseract": CPU-only, multi-language with confidence picking
   - "deepseek":    GPU-only, vision-language model
+  - "sarvam":      authorized-external provider, disabled by default and
+                     routed to pytesseract until explicitly enabled
 
 The pytesseract path can use multiprocessing for parallelism. DeepSeek
 runs serial within one process; cross-machine parallelism uses the
@@ -42,10 +44,10 @@ def run_ocr_extraction(config: PipelineConfig) -> None:
     by language, OCRs each one, and writes the results back.
     """
     backend = config.ocr_engine
-    if backend not in ("pytesseract", "deepseek"):
+    if backend not in ("pytesseract", "deepseek", "sarvam"):
         raise ValueError(
             f"unknown ocr_engine: {backend!r}. "
-            "must be 'pytesseract' or 'deepseek'."
+            "must be 'pytesseract', 'deepseek', or 'sarvam'."
         )
 
     work_items = _load_pending_pages(
@@ -80,7 +82,13 @@ def run_ocr_extraction(config: PipelineConfig) -> None:
         + (f" (filter_language={config.filter_language})" if config.filter_language else "")
     )
 
-    _run(backend=backend, work_items=work_items, db_path=config.db_path, n_workers=config.n_workers)
+    _run(
+        backend=backend,
+        work_items=work_items,
+        db_path=config.db_path,
+        n_workers=config.n_workers,
+        sarvam_enabled=config.sarvam_enabled,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -103,8 +111,10 @@ def _load_pending_pages(
     # Known-bad pages (already in unreadable_pages for this stage) are
     # excluded — otherwise every resume re-grinds the same failures forever.
     sql = """
-        SELECT page_id, doc_id, page_number, full_path, language
+        SELECT pages.page_id, pages.doc_id, pages.page_number, pages.full_path,
+               pages.language, pages.ticket_number, documents.ticket_number
         FROM pages
+        LEFT JOIN documents ON documents.doc_id = pages.doc_id
         WHERE extracted_text IS NULL
           AND NOT EXISTS (
               SELECT 1 FROM unreadable_pages u
@@ -126,7 +136,7 @@ def _load_pending_pages(
         conn.close()
 
     items: list[dict[str, Any]] = []
-    for page_id, doc_id, page_number, full_path, language in rows:
+    for page_id, doc_id, page_number, full_path, language, page_ticket, document_ticket in rows:
         # full_path in `pages` is stored relative to the original input_dir.
         # If the user passed --input, resolve against it. Otherwise treat
         # as absolute.
@@ -140,6 +150,7 @@ def _load_pending_pages(
                 "page_number": page_number,
                 "file_path": str(p),
                 "language": language,
+                "ticket": page_ticket or document_ticket,
             }
         )
     return items
@@ -152,20 +163,30 @@ def _load_pending_pages(
 _worker_backend: str = ""
 _worker_ds_tokenizer: Any = None
 _worker_ds_model: Any = None
+_worker_sarvam: Any = None
 
 
-def _worker_init(backend: str) -> None:
+def _worker_init(backend: str, sarvam_enabled: bool = False, db_path: Path | None = None) -> None:
     """Per-worker initializer.
 
     For deepseek, loads the GPU model (slow, multi-GB) once per worker.
     For pytesseract, just configures the tesseract binary path.
     """
-    global _worker_backend, _worker_ds_tokenizer, _worker_ds_model
+    global _worker_backend, _worker_ds_tokenizer, _worker_ds_model, _worker_sarvam
     _worker_backend = backend
 
     if backend == "deepseek":
         from .deepseek_backend import load_model
         _worker_ds_tokenizer, _worker_ds_model = load_model()
+    elif backend == "sarvam":
+        if db_path is None:
+            raise ValueError("Sarvam OCR requires the pipeline audit database path")
+        from janasunani.egress.sarvam import SarvamVisionAdapter, SqliteAuditLog
+
+        _worker_sarvam = SarvamVisionAdapter(
+            enabled=sarvam_enabled,
+            audit_log=SqliteAuditLog(db_path),
+        )
     else:
         from .pytesseract_backend import _configure_tesseract
         _configure_tesseract()
@@ -206,6 +227,38 @@ def _process_page(item: dict[str, Any]) -> dict[str, Any]:
                     f"(top-trigram share {top_trigram_share(text):.2f})"
                 )
                 return result
+        elif _worker_backend == "sarvam":
+            from io import BytesIO
+
+            from janasunani.egress.sarvam import SarvamAuditContext
+            from .pytesseract_backend import (
+                extract_text as pt_extract,
+                pipeline_lang_to_tesseract,
+            )
+
+            ticket = item.get("ticket")
+            if not ticket:
+                # A call without the required audit identity would be an
+                # untraceable egress route.  Preserve OCR behavior locally.
+                text = pt_extract(image, force_lang=pipeline_lang_to_tesseract(item.get("language")))
+            else:
+                encoded = BytesIO()
+                image.save(encoded, format="PNG")
+                language = _pipeline_lang_to_sarvam(item.get("language"))
+                text = _worker_sarvam.digitise_or_fallback(
+                    encoded.getvalue(),
+                    f"{item['doc_id']}-{item['page_number']}.png",
+                    language,
+                    SarvamAuditContext(
+                        ticket=ticket,
+                        stage="ocr_extraction",
+                        document_id=f"{item['doc_id']}:{item['page_number']}",
+                    ),
+                    lambda: pt_extract(
+                        image,
+                        force_lang=pipeline_lang_to_tesseract(item.get("language")),
+                    ),
+                )
         else:
             from .pytesseract_backend import (
                 extract_text as pt_extract,
@@ -219,6 +272,15 @@ def _process_page(item: dict[str, Any]) -> dict[str, Any]:
 
     result["text"] = text
     return result
+
+
+def _pipeline_lang_to_sarvam(pipeline_language: str | None) -> str:
+    """Map the format stage's labels to Sarvam's documented language codes."""
+    if pipeline_language == "Odia":
+        return "od-IN"
+    # Mixed/unknown pages remain explicitly English for the current adapter;
+    # language routing is audited so a benchmark can surface that limitation.
+    return "en-IN"
 
 
 # ---------------------------------------------------------------------------
@@ -306,6 +368,7 @@ def _run(
     work_items: list[dict[str, Any]],
     db_path: Path,
     n_workers: int | None,
+    sarvam_enabled: bool = False,
 ) -> None:
     n = len(work_items)
     today_iso = datetime.now().isoformat()
@@ -315,7 +378,7 @@ def _run(
         n_items=n,
         n_workers=n_workers,
         initializer=_worker_init,
-        initargs=(backend,),
+        initargs=(backend, sarvam_enabled, db_path),
     )
 
     # For serial execution, the executor's __init__ already ran _worker_init.

--- a/janasunani/pipeline/stages/ocr_extraction/stage.py
+++ b/janasunani/pipeline/stages/ocr_extraction/stage.py
@@ -23,7 +23,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from ...config import PipelineConfig
+from ...config import PipelineConfig, validate_sarvam_sharding
 from ...db import connect
 from .executors import pick_executor, shard_work_items
 from .page_renderer import render_page
@@ -49,11 +49,11 @@ def run_ocr_extraction(config: PipelineConfig) -> None:
             f"unknown ocr_engine: {backend!r}. "
             "must be 'pytesseract', 'deepseek', or 'sarvam'."
         )
-    if backend == "sarvam" and config.sarvam_enabled and config.num_workers != 1:
-        raise ValueError(
-            "enabled Sarvam OCR requires num_workers=1 because its "
-            "10-RPM limiter is process-local"
-        )
+    validate_sarvam_sharding(
+        ocr_engine=backend,
+        sarvam_enabled=config.sarvam_enabled,
+        num_workers=config.num_workers,
+    )
 
     work_items = _load_pending_pages(
         db_path=config.db_path,

--- a/janasunani/pipeline/stages/ocr_extraction/stage.py
+++ b/janasunani/pipeline/stages/ocr_extraction/stage.py
@@ -200,6 +200,7 @@ def _process_page(item: dict[str, Any]) -> dict[str, Any]:
         "page_number": item["page_number"],
         "file_path": item["file_path"],
         "text": None,
+        "ocr_model": None,
         "error": None,
     }
     try:
@@ -217,6 +218,7 @@ def _process_page(item: dict[str, Any]) -> dict[str, Any]:
             )
             from .deepseek_backend import extract_text as ds_extract
             text = ds_extract(image, tokenizer=_worker_ds_tokenizer, model=_worker_ds_model)
+            result["ocr_model"] = "deepseek"
             # DeepSeek's signature failure mode (per the DSI report): the
             # generation loops and one phrase fills the page. Store nothing —
             # record the page in unreadable_pages so resumes skip it.
@@ -241,11 +243,12 @@ def _process_page(item: dict[str, Any]) -> dict[str, Any]:
                 # A call without the required audit identity would be an
                 # untraceable egress route.  Preserve OCR behavior locally.
                 text = pt_extract(image, force_lang=pipeline_lang_to_tesseract(item.get("language")))
+                result["ocr_model"] = "pytesseract"
             else:
                 encoded = BytesIO()
                 image.save(encoded, format="PNG")
                 language = _pipeline_lang_to_sarvam(item.get("language"))
-                text = _worker_sarvam.digitise_or_fallback(
+                outcome = _worker_sarvam.digitise_or_fallback(
                     encoded.getvalue(),
                     f"{item['doc_id']}-{item['page_number']}.png",
                     language,
@@ -259,6 +262,8 @@ def _process_page(item: dict[str, Any]) -> dict[str, Any]:
                         force_lang=pipeline_lang_to_tesseract(item.get("language")),
                     ),
                 )
+                text = outcome.text
+                result["ocr_model"] = outcome.ocr_model
         else:
             from .pytesseract_backend import (
                 extract_text as pt_extract,
@@ -266,6 +271,7 @@ def _process_page(item: dict[str, Any]) -> dict[str, Any]:
             )
             force_lang = pipeline_lang_to_tesseract(item.get("language"))
             text = pt_extract(image, force_lang=force_lang)
+            result["ocr_model"] = "pytesseract"
     except Exception as e:
         result["error"] = f"ocr failed: {e}"
         return result
@@ -297,7 +303,7 @@ def _write_results_with_retry(
     params = [
         {
             "text": r["text"],
-            "model": backend,
+            "model": r.get("ocr_model") or backend,
             "date": today_iso,
             "page_id": r["page_id"],
         }

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -12,7 +12,7 @@ import sqlite3
 import pytest
 
 from janasunani.config import directories
-from janasunani.pipeline.cli import build_parser
+from janasunani.pipeline.cli import build_parser, main
 from janasunani.pipeline.config import PipelineConfig
 from janasunani.pipeline.db import connect, initialize_database
 from janasunani.pipeline.pipeline import STAGE_ORDER, run_pipeline
@@ -120,6 +120,28 @@ def test_sarvam_engine_is_disabled_unless_explicitly_enabled():
 
     enabled = build_parser().parse_args(["run", "--ocr-engine", "sarvam", "--enable-sarvam"])
     assert enabled.enable_sarvam is True
+
+
+def test_cli_rejects_enabled_sarvam_cross_machine_sharding(monkeypatch):
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "janasunani-pipeline",
+            "run",
+            "--ocr-engine",
+            "sarvam",
+            "--enable-sarvam",
+            "--num-workers",
+            "2",
+        ],
+    )
+    monkeypatch.setattr(
+        "janasunani.pipeline.cli.run_pipeline",
+        lambda _config: pytest.fail("pipeline must not start"),
+    )
+
+    with pytest.raises(SystemExit, match="--num-workers 1"):
+        main()
 
 
 def test_cli_rejects_unknown_stage():

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -113,6 +113,15 @@ def test_cli_parses_stage_subset_and_engine():
     assert set(STAGE_ORDER) >= set(args.stages)
 
 
+def test_sarvam_engine_is_disabled_unless_explicitly_enabled():
+    args = build_parser().parse_args(["run", "--ocr-engine", "sarvam"])
+    assert args.ocr_engine == "sarvam"
+    assert args.enable_sarvam is False
+
+    enabled = build_parser().parse_args(["run", "--ocr-engine", "sarvam", "--enable-sarvam"])
+    assert enabled.enable_sarvam is True
+
+
 def test_cli_rejects_unknown_stage():
     with pytest.raises(SystemExit):
         build_parser().parse_args(["run", "--stages", "bogus"])

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -13,7 +13,7 @@ import pytest
 
 from janasunani.config import directories
 from janasunani.pipeline.cli import build_parser, main
-from janasunani.pipeline.config import PipelineConfig
+from janasunani.pipeline.config import PipelineConfig, validate_sarvam_sharding
 from janasunani.pipeline.db import connect, initialize_database
 from janasunani.pipeline.pipeline import STAGE_ORDER, run_pipeline
 
@@ -142,6 +142,19 @@ def test_cli_rejects_enabled_sarvam_cross_machine_sharding(monkeypatch):
 
     with pytest.raises(SystemExit, match="--num-workers 1"):
         main()
+
+
+def test_enabled_sarvam_rejects_cross_machine_sharding_without_ocr_dependencies():
+    with pytest.raises(ValueError, match="num_workers=1"):
+        validate_sarvam_sharding(
+            ocr_engine="sarvam", sarvam_enabled=True, num_workers=2
+        )
+
+
+def test_disabled_sarvam_allows_local_fallback_sharding():
+    validate_sarvam_sharding(
+        ocr_engine="sarvam", sarvam_enabled=False, num_workers=2
+    )
 
 
 def test_cli_rejects_unknown_stage():

--- a/tests/test_sarvam_egress.py
+++ b/tests/test_sarvam_egress.py
@@ -581,22 +581,26 @@ def test_digitise_rejects_invalid_or_ambiguous_zip_results(archive, message):
         SarvamVisionAdapter._primary_markdown(archive)
 
 
-def test_idempotency_key_includes_the_actual_uploaded_bytes():
+def test_idempotency_key_includes_the_actual_uploaded_bytes(tmp_path):
     same_context = _context()
     request = {
         "filename": "page.png",
         "form": {"language": "en-IN", "output_format": "md"},
     }
-    assert SarvamVisionAdapter._idempotency_key(
+    adapter = SarvamVisionAdapter(
+        audit_log=SqliteAuditLog(tmp_path / "audit.sqlite"),
+        route=_verified_test_route(),
+    )
+    assert adapter._idempotency_key(
         same_context, "digitise", b"first", **request
     ) != (
-        SarvamVisionAdapter._idempotency_key(
+        adapter._idempotency_key(
             same_context, "digitise", b"changed", **request
         )
     )
 
 
-def test_idempotency_key_canonicalizes_the_complete_request_form():
+def test_idempotency_key_canonicalizes_the_complete_request_form(tmp_path):
     base_form = {
         "language": "en-IN",
         "output_format": "json",
@@ -610,8 +614,13 @@ def test_idempotency_key_canonicalizes_the_complete_request_form():
         "language": "en-IN",
     }
 
+    adapter = SarvamVisionAdapter(
+        audit_log=SqliteAuditLog(tmp_path / "audit.sqlite"),
+        route=_verified_test_route(),
+    )
+
     def key(form):
-        return SarvamVisionAdapter._idempotency_key(
+        return adapter._idempotency_key(
             _context(),
             "extract",
             b"fixture-png",
@@ -628,6 +637,62 @@ def test_idempotency_key_canonicalizes_the_complete_request_form():
         {**base_form, "future_option": {"beta": False}},
     ):
         assert key(changed) != key(base_form)
+
+
+@pytest.mark.parametrize("route_field", ["provider", "model_id", "endpoint"])
+def test_idempotency_key_includes_route_identity(tmp_path, route_field):
+    route = _verified_test_route()
+    original = SarvamVisionAdapter(
+        audit_log=SqliteAuditLog(tmp_path / "original.sqlite"),
+        route=route,
+    )
+    changed = SarvamVisionAdapter(
+        audit_log=SqliteAuditLog(tmp_path / "changed.sqlite"),
+        route=replace(route, **{route_field: f"changed-{route_field}"}),
+    )
+    request = {
+        "filename": "page.png",
+        "form": {"language": "en-IN", "output_format": "md"},
+    }
+
+    assert original._idempotency_key(
+        _context(), "digitise", b"fixture-png", **request
+    ) != changed._idempotency_key(
+        _context(), "digitise", b"fixture-png", **request
+    )
+
+
+def test_enabled_sarvam_rejects_cross_machine_sharding_before_loading_work(tmp_path):
+    from janasunani.pipeline.config import PipelineConfig
+    from janasunani.pipeline.stages.ocr_extraction.stage import run_ocr_extraction
+
+    config = PipelineConfig(
+        input_dir=tmp_path,
+        db_path=tmp_path / "missing.sqlite",
+        models_dir=tmp_path,
+        ocr_engine="sarvam",
+        sarvam_enabled=True,
+        num_workers=2,
+    )
+
+    with pytest.raises(ValueError, match="num_workers=1"):
+        run_ocr_extraction(config)
+
+
+def test_disabled_sarvam_allows_local_fallback_sharding(tmp_path):
+    from janasunani.pipeline.config import PipelineConfig
+    from janasunani.pipeline.stages.ocr_extraction.stage import run_ocr_extraction
+
+    config = PipelineConfig(
+        input_dir=tmp_path,
+        db_path=tmp_path / "missing.sqlite",
+        models_dir=tmp_path,
+        ocr_engine="sarvam",
+        sarvam_enabled=False,
+        num_workers=2,
+    )
+
+    run_ocr_extraction(config)
 
 
 def test_submission_limiter_enforces_ten_requests_per_rolling_minute(tmp_path):

--- a/tests/test_sarvam_egress.py
+++ b/tests/test_sarvam_egress.py
@@ -31,6 +31,7 @@ class RecordedResponse:
     payload: Any = None
     text: str = ""
     content: bytes = b""
+    headers: dict[str, str] | None = None
 
     def json(self) -> Any:
         return self.payload
@@ -50,6 +51,19 @@ class RecordedTransport:
     def get(self, url: str, **kwargs: Any) -> RecordedResponse:
         self.calls.append(("GET", url, kwargs))
         return self.responses.pop(0)
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.sleeps: list[float] = []
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.sleeps.append(seconds)
+        self.now += seconds
 
 
 def _context() -> SarvamAuditContext:
@@ -272,6 +286,74 @@ def test_partially_completed_job_is_rejected_and_audited_as_fallback(tmp_path, u
     ]
 
 
+@pytest.mark.parametrize("terminal_status", ["failed", "rejected", "partially_completed"])
+def test_terminal_unsuccessful_job_is_not_resumed_on_retry(tmp_path, terminal_status):
+    audit_path = tmp_path / "audit.sqlite"
+    audit_log = SqliteAuditLog(audit_path)
+    first_transport = RecordedTransport(
+        [
+            RecordedResponse(202, {"job_id": "job-failed", "status": "pending"}),
+            RecordedResponse(
+                200,
+                {
+                    "job_id": "job-failed",
+                    "status": terminal_status,
+                    "usage": {
+                        "pages_total": 1,
+                        "pages_succeeded": 0,
+                        "pages_failed": 1,
+                    },
+                },
+            ),
+        ]
+    )
+    first = SarvamVisionAdapter(
+        enabled=True,
+        api_key="recorded-test-key",
+        audit_log=audit_log,
+        route=_verified_test_route(),
+        transport=first_transport,
+        poll_interval_seconds=0,
+        sleep=lambda _seconds: None,
+    )
+    first_outcome = first.digitise_or_fallback(
+        b"fixture-png", "page.png", "en-IN", _context(), lambda: "local OCR"
+    )
+    assert first_outcome.ocr_model == "pytesseract"
+
+    retry_transport = RecordedTransport(
+        [
+            RecordedResponse(202, {"job_id": "job-retry", "status": "pending"}),
+            RecordedResponse(200, {"job_id": "job-retry", "status": "completed"}),
+            RecordedResponse(200, {"download_url": "https://download.example/job-retry"}),
+            RecordedResponse(200, content=_zip_output(**{"result.md": "retry OCR"})),
+        ]
+    )
+    retry = SarvamVisionAdapter(
+        enabled=True,
+        api_key="recorded-test-key",
+        audit_log=audit_log,
+        route=_verified_test_route(),
+        transport=retry_transport,
+        poll_interval_seconds=0,
+        sleep=lambda _seconds: None,
+    )
+
+    retry_outcome = retry.digitise_or_fallback(
+        b"fixture-png", "page.png", "en-IN", _context(), lambda: "local OCR"
+    )
+
+    assert retry_outcome.text == "retry OCR"
+    assert retry_outcome.ocr_model == SARVAM_OCR_MODEL
+    assert [method for method, _, _ in retry_transport.calls] == [
+        "POST",
+        "GET",
+        "GET",
+        "GET",
+    ]
+    assert [row[8] for row in _audit_rows(audit_path)].count("submission") == 2
+
+
 def test_recorded_submission_is_resumed_instead_of_resubmitted_and_rebilled(tmp_path):
     audit_path = tmp_path / "audit.sqlite"
     audit_log = SqliteAuditLog(audit_path)
@@ -317,6 +399,57 @@ def test_recorded_submission_is_resumed_instead_of_resubmitted_and_rebilled(tmp_
     assert resumed.digitise(b"fixture-png", "page.png", "en-IN", _context()) == "resumed markdown"
     assert [method for method, _, _ in resumed_transport.calls] == ["GET", "GET", "GET"]
     assert "resume" in [row[8] for row in _audit_rows(audit_path)]
+
+
+def test_completed_job_is_resumed_without_a_new_submission(tmp_path):
+    audit_path = tmp_path / "audit.sqlite"
+    audit_log = SqliteAuditLog(audit_path)
+    completed_transport = RecordedTransport(
+        [
+            RecordedResponse(202, {"job_id": "job-completed", "status": "pending"}),
+            RecordedResponse(200, {"job_id": "job-completed", "status": "completed"}),
+            RecordedResponse(
+                200, {"download_url": "https://download.example/job-completed"}
+            ),
+            RecordedResponse(200, content=_zip_output(**{"result.md": "first result"})),
+        ]
+    )
+    completed = SarvamVisionAdapter(
+        enabled=True,
+        api_key="recorded-test-key",
+        audit_log=audit_log,
+        route=_verified_test_route(),
+        transport=completed_transport,
+        poll_interval_seconds=0,
+        sleep=lambda _seconds: None,
+    )
+    assert completed.digitise(
+        b"fixture-png", "page.png", "en-IN", _context()
+    ) == "first result"
+
+    resume_transport = RecordedTransport(
+        [
+            RecordedResponse(200, {"job_id": "job-completed", "status": "completed"}),
+            RecordedResponse(
+                200, {"download_url": "https://download.example/job-completed"}
+            ),
+            RecordedResponse(200, content=_zip_output(**{"result.md": "cached result"})),
+        ]
+    )
+    resumed = SarvamVisionAdapter(
+        enabled=True,
+        api_key="recorded-test-key",
+        audit_log=audit_log,
+        route=_verified_test_route(),
+        transport=resume_transport,
+        poll_interval_seconds=0,
+        sleep=lambda _seconds: None,
+    )
+
+    result = resumed.digitise(b"fixture-png", "page.png", "en-IN", _context())
+
+    assert result == "cached result"
+    assert [method for method, _, _ in resume_transport.calls] == ["GET", "GET", "GET"]
 
 
 def test_extract_resume_key_is_stable_across_schema_dict_order(tmp_path):
@@ -495,6 +628,137 @@ def test_idempotency_key_canonicalizes_the_complete_request_form():
         {**base_form, "future_option": {"beta": False}},
     ):
         assert key(changed) != key(base_form)
+
+
+def test_submission_limiter_enforces_ten_requests_per_rolling_minute(tmp_path):
+    clock = FakeClock()
+    responses = []
+    for index in range(11):
+        job_id = f"job-{index}"
+        responses.extend(
+            [
+                RecordedResponse(202, {"job_id": job_id, "status": "pending"}),
+                RecordedResponse(200, {"job_id": job_id, "status": "failed"}),
+            ]
+        )
+    transport = RecordedTransport(responses)
+    adapter = SarvamVisionAdapter(
+        enabled=True,
+        api_key="recorded-test-key",
+        audit_log=SqliteAuditLog(tmp_path / "audit.sqlite"),
+        route=_verified_test_route(),
+        transport=transport,
+        max_poll_attempts=1,
+        poll_interval_seconds=0,
+        sleep=clock.sleep,
+        monotonic=clock.monotonic,
+    )
+
+    for index in range(11):
+        context = SarvamAuditContext(
+            ticket=f"T-{index}",
+            stage="ocr_extraction",
+            document_id=f"doc:{index}",
+        )
+        outcome = adapter.digitise_or_fallback(
+            f"fixture-{index}".encode(),
+            f"page-{index}.png",
+            "en-IN",
+            context,
+            lambda: "local OCR",
+        )
+        assert outcome.ocr_model == "pytesseract"
+
+    assert [method for method, _, _ in transport.calls].count("POST") == 11
+    assert clock.sleeps == [60.0]
+
+
+def test_429_retries_after_provider_delay_and_can_succeed(tmp_path):
+    clock = FakeClock()
+    audit_path = tmp_path / "audit.sqlite"
+    transport = RecordedTransport(
+        [
+            RecordedResponse(429, {"error": "rate limited"}, headers={"Retry-After": "2.5"}),
+            RecordedResponse(202, {"job_id": "job-retried", "status": "pending"}),
+            RecordedResponse(200, {"job_id": "job-retried", "status": "completed"}),
+            RecordedResponse(200, {"download_url": "https://download.example/job-retried"}),
+            RecordedResponse(200, content=_zip_output(**{"result.md": "remote OCR"})),
+        ]
+    )
+    adapter = SarvamVisionAdapter(
+        enabled=True,
+        api_key="recorded-test-key",
+        audit_log=SqliteAuditLog(audit_path),
+        route=_verified_test_route(),
+        transport=transport,
+        poll_interval_seconds=0,
+        sleep=clock.sleep,
+        monotonic=clock.monotonic,
+    )
+
+    outcome = adapter.digitise_or_fallback(
+        b"fixture-png", "page.png", "en-IN", _context(), lambda: "local OCR"
+    )
+
+    assert outcome.text == "remote OCR"
+    assert outcome.ocr_model == SARVAM_OCR_MODEL
+    assert [method for method, _, _ in transport.calls] == [
+        "POST",
+        "POST",
+        "GET",
+        "GET",
+        "GET",
+    ]
+    assert clock.sleeps == [2.5]
+    assert [row[8] for row in _audit_rows(audit_path)] == [
+        "submission_rate_limited",
+        "submission",
+        "poll",
+        "result_lookup",
+        "download",
+    ]
+    assert [row[4] for row in _audit_rows(audit_path)][:2] == [
+        len(b"fixture-png"),
+        len(b"fixture-png"),
+    ]
+
+
+def test_429_exhaustion_falls_back_after_bounded_backoff(tmp_path):
+    clock = FakeClock()
+    audit_path = tmp_path / "audit.sqlite"
+    transport = RecordedTransport(
+        [
+            RecordedResponse(429, {"error": "rate limited"}),
+            RecordedResponse(429, {"error": "rate limited"}),
+            RecordedResponse(429, {"error": "rate limited"}),
+        ]
+    )
+    adapter = SarvamVisionAdapter(
+        enabled=True,
+        api_key="recorded-test-key",
+        audit_log=SqliteAuditLog(audit_path),
+        route=_verified_test_route(),
+        transport=transport,
+        sleep=clock.sleep,
+        monotonic=clock.monotonic,
+        submission_backoff_seconds=6.0,
+    )
+
+    outcome = adapter.digitise_or_fallback(
+        b"fixture-png", "page.png", "en-IN", _context(), lambda: "local OCR"
+    )
+
+    assert outcome.text == "local OCR"
+    assert outcome.ocr_model == "pytesseract"
+    assert [method for method, _, _ in transport.calls] == ["POST", "POST", "POST"]
+    assert clock.sleeps == [6.0, 12.0]
+    assert [row[8] for row in _audit_rows(audit_path)] == [
+        "submission_rate_limited",
+        "submission_rate_limited",
+        "submission_rate_limit_exhausted",
+        "fallback",
+    ]
+    assert len(set(_audit_keys(audit_path))) == 1
 
 
 def test_failed_submission_is_audited_with_only_its_actual_upload_bytes(tmp_path):

--- a/tests/test_sarvam_egress.py
+++ b/tests/test_sarvam_egress.py
@@ -14,6 +14,7 @@ from janasunani.egress.sarvam import (
     AUTHORIZATION_REFERENCE,
     MODEL_ID,
     PROVIDER_REGISTRY,
+    SARVAM_OCR_MODEL,
     SarvamAuditContext,
     SarvamError,
     SarvamVisionAdapter,
@@ -106,9 +107,12 @@ def test_digitise_replays_submit_poll_and_download_with_an_auditable_job(tmp_pat
         sleep=lambda _seconds: None,
     )
 
-    actual = adapter.digitise(b"fixture-png", "page.png", "od-IN", _context())
+    actual = adapter.digitise_or_fallback(
+        b"fixture-png", "page.png", "od-IN", _context(), lambda: "local OCR"
+    )
 
-    assert actual == "# Water complaint\n\nName removed"
+    assert actual.text == "# Water complaint\n\nName removed"
+    assert actual.ocr_model == SARVAM_OCR_MODEL
     assert [method for method, _, _ in transport.calls] == ["POST", "GET", "GET", "GET", "GET"]
     submit = transport.calls[0]
     assert submit[1].endswith("/doc-ai/v1/job/digitise")
@@ -151,7 +155,8 @@ def test_kill_switch_never_constructs_or_calls_the_remote_transport(tmp_path):
         b"fixture-png", "page.png", "en-IN", _context(), lambda: "local pytesseract text"
     )
 
-    assert result == "local pytesseract text"
+    assert result.text == "local pytesseract text"
+    assert result.ocr_model == "pytesseract"
     assert transport.calls == []
     assert [row[8] for row in _audit_rows(tmp_path / "audit.sqlite")] == ["disabled"]
 
@@ -179,10 +184,56 @@ def test_nonterminating_recorded_job_falls_back_after_its_bounded_poll_loop(tmp_
         b"fixture-png", "page.png", "en-IN", _context(), lambda: "local text"
     )
 
-    assert actual == "local text"
+    assert actual.text == "local text"
+    assert actual.ocr_model == "pytesseract"
     assert [row[8] for row in _audit_rows(audit_path)] == [
         "submission",
         "poll",
+        "poll",
+        "fallback",
+    ]
+
+
+@pytest.mark.parametrize(
+    "usage",
+    [
+        {"pages_total": 3, "pages_succeeded": 2, "pages_failed": 1},
+        {"pages_total": 1, "pages_succeeded": 1, "pages_failed": 0},
+    ],
+)
+def test_partially_completed_job_is_rejected_and_audited_as_fallback(tmp_path, usage):
+    audit_path = tmp_path / "audit.sqlite"
+    transport = RecordedTransport(
+        [
+            RecordedResponse(202, {"job_id": "job-partial", "status": "pending"}),
+            RecordedResponse(
+                200,
+                {
+                    "job_id": "job-partial",
+                    "status": "partially_completed",
+                    "usage": usage,
+                },
+            ),
+        ]
+    )
+    adapter = SarvamVisionAdapter(
+        enabled=True,
+        api_key="recorded-test-key",
+        audit_log=SqliteAuditLog(audit_path),
+        transport=transport,
+        poll_interval_seconds=0,
+        sleep=lambda _seconds: None,
+    )
+
+    outcome = adapter.digitise_or_fallback(
+        b"fixture-png", "page.png", "en-IN", _context(), lambda: "local text"
+    )
+
+    assert outcome.text == "local text"
+    assert outcome.ocr_model == "pytesseract"
+    assert [method for method, _, _ in transport.calls] == ["POST", "GET"]
+    assert [row[8] for row in _audit_rows(audit_path)] == [
+        "submission",
         "poll",
         "fallback",
     ]
@@ -206,7 +257,11 @@ def test_recorded_submission_is_resumed_instead_of_resubmitted_and_rebilled(tmp_
         poll_interval_seconds=0,
         sleep=lambda _seconds: None,
     )
-    assert first.digitise_or_fallback(b"fixture-png", "page.png", "en-IN", _context(), lambda: "local") == "local"
+    first_result = first.digitise_or_fallback(
+        b"fixture-png", "page.png", "en-IN", _context(), lambda: "local"
+    )
+    assert first_result.text == "local"
+    assert first_result.ocr_model == "pytesseract"
 
     resumed_transport = RecordedTransport(
         [
@@ -258,9 +313,11 @@ def test_failed_submission_is_audited_with_only_its_actual_upload_bytes(tmp_path
         transport=RecordedTransport([RecordedResponse(503, {"error": "unavailable"})]),
     )
 
-    assert adapter.digitise_or_fallback(
+    outcome = adapter.digitise_or_fallback(
         b"fixture-png", "page.png", "en-IN", _context(), lambda: "local"
-    ) == "local"
+    )
+    assert outcome.text == "local"
+    assert outcome.ocr_model == "pytesseract"
     rows = _audit_rows(audit_path)
     assert [(row[8], row[4]) for row in rows] == [
         ("submission_error", len(b"fixture-png")),
@@ -291,33 +348,174 @@ def test_extract_is_a_distinct_operation_and_requires_one_pinned_schema_source(t
     assert route.authorization_reference == AUTHORIZATION_REFERENCE
 
 
-def test_pipeline_sarvam_switch_uses_the_existing_pytesseract_callback_when_disabled(
-    tmp_path, monkeypatch
+def test_extract_submission_omits_an_unsupported_model_field(tmp_path):
+    transport = RecordedTransport(
+        [
+            RecordedResponse(202, {"job_id": "job-extract", "status": "pending"}),
+            RecordedResponse(200, {"job_id": "job-extract", "status": "completed"}),
+            RecordedResponse(200, {"results": [{"complainant_name": "Example"}]}),
+        ]
+    )
+    adapter = SarvamVisionAdapter(
+        enabled=True,
+        api_key="recorded-test-key",
+        audit_log=SqliteAuditLog(tmp_path / "audit.sqlite"),
+        transport=transport,
+        poll_interval_seconds=0,
+        sleep=lambda _seconds: None,
+    )
+
+    result = adapter.extract(
+        b"fixture-png",
+        "page.png",
+        "en-IN",
+        _context(),
+        schema={"complainant_name": "string"},
+    )
+
+    assert result == {"results": [{"complainant_name": "Example"}]}
+    submission_data = transport.calls[0][2]["data"]
+    assert submission_data == {
+        "language": "en-IN",
+        "output_format": "json",
+        "schema": '{"complainant_name": "string"}',
+    }
+    assert "model" not in submission_data
+
+
+def _process_and_persist_stage_page(
+    *, stage, pytesseract_backend, adapter, db_path, monkeypatch, ticket
 ):
-    # Base CI deliberately excludes the heavy pipeline OCR stack.  Keep this
-    # integration assertion in the adapter module, but skip only this test
-    # there; the pipeline-core job exercises the real pytesseract fallback.
-    pytest.importorskip("pdf2image")
     from PIL import Image
 
-    from janasunani.pipeline.stages.ocr_extraction import stage
-    from janasunani.pipeline.stages.ocr_extraction import pytesseract_backend
+    from janasunani.pipeline.db import initialize_database
+
+    initialize_database(db_path)
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(
+            "INSERT INTO pages "
+            "(doc_id, page_number, full_path, page_id, ticket_number) "
+            "VALUES ('doc-1', 1, 'page.png', 'page-1', ?)",
+            (ticket,),
+        )
 
     monkeypatch.setattr(stage, "render_page", lambda _path, _number: Image.new("RGB", (2, 2)))
-    monkeypatch.setattr(pytesseract_backend, "extract_text", lambda _image, force_lang=None: "local OCR")
-    stage._worker_init("sarvam", sarvam_enabled=False, db_path=tmp_path / "pipeline.sqlite")
+    monkeypatch.setattr(
+        pytesseract_backend,
+        "extract_text",
+        lambda _image, force_lang=None: "local OCR",
+    )
+    monkeypatch.setattr(stage, "_worker_backend", "sarvam")
+    monkeypatch.setattr(stage, "_worker_sarvam", adapter)
 
     result = stage._process_page(
         {
             "page_id": "page-1",
             "doc_id": "doc-1",
             "page_number": 1,
-            "file_path": str(tmp_path / "page.png"),
+            "file_path": str(db_path.parent / "page.png"),
             "language": "Odia",
-            "ticket": "T-1",
+            "ticket": ticket,
         }
+    )
+    with sqlite3.connect(db_path) as connection:
+        assert stage._write_results_with_retry(
+            connection, [result], "2026-08-07", "sarvam"
+        ) == 1
+        persisted = connection.execute(
+            "SELECT extracted_text, ocr_model FROM pages WHERE page_id = 'page-1'"
+        ).fetchone()
+    return result, persisted
+
+
+@pytest.mark.parametrize(
+    ("mode", "ticket", "expected_events"),
+    [
+        ("disabled", "T-1", ["disabled"]),
+        ("missing_ticket", None, []),
+        ("missing_credentials", "T-1", ["fallback"]),
+        ("request_error", "T-1", ["submission_error", "fallback"]),
+        ("timeout", "T-1", ["submission", "poll", "fallback"]),
+    ],
+)
+def test_sarvam_stage_fallback_persists_pytesseract_per_page(
+    tmp_path, monkeypatch, mode, ticket, expected_events
+):
+    # Base CI deliberately excludes the heavy pipeline OCR stack.  Keep this
+    # integration assertion in the adapter module, but skip only this test
+    # there; the pipeline-core job exercises the real pytesseract fallback.
+    pytest.importorskip("pdf2image")
+
+    from janasunani.pipeline.stages.ocr_extraction import stage
+    from janasunani.pipeline.stages.ocr_extraction import pytesseract_backend
+
+    db_path = tmp_path / "pipeline.sqlite"
+    responses = {
+        "request_error": [RecordedResponse(503, {"error": "unavailable"})],
+        "timeout": [
+            RecordedResponse(202, {"job_id": "job-stuck", "status": "pending"}),
+            RecordedResponse(200, {"job_id": "job-stuck", "status": "running"}),
+        ],
+    }.get(mode, [])
+    adapter = SarvamVisionAdapter(
+        enabled=mode != "disabled",
+        api_key="" if mode == "missing_credentials" else "recorded-test-key",
+        audit_log=SqliteAuditLog(db_path),
+        transport=RecordedTransport(responses),
+        poll_interval_seconds=0,
+        max_poll_attempts=1,
+        sleep=lambda _seconds: None,
+    )
+
+    result, persisted = _process_and_persist_stage_page(
+        stage=stage,
+        pytesseract_backend=pytesseract_backend,
+        adapter=adapter,
+        db_path=db_path,
+        monkeypatch=monkeypatch,
+        ticket=ticket,
     )
 
     assert result["text"] == "local OCR"
+    assert result["ocr_model"] == "pytesseract"
     assert result["error"] is None
-    assert [row[8] for row in _audit_rows(tmp_path / "pipeline.sqlite")] == ["disabled"]
+    assert persisted == ("local OCR", "pytesseract")
+    assert [row[8] for row in _audit_rows(db_path)] == expected_events
+
+
+def test_sarvam_stage_success_persists_remote_route_and_model(tmp_path, monkeypatch):
+    pytest.importorskip("pdf2image")
+
+    from janasunani.pipeline.stages.ocr_extraction import stage
+    from janasunani.pipeline.stages.ocr_extraction import pytesseract_backend
+
+    db_path = tmp_path / "pipeline.sqlite"
+    adapter = SarvamVisionAdapter(
+        enabled=True,
+        api_key="recorded-test-key",
+        audit_log=SqliteAuditLog(db_path),
+        transport=RecordedTransport(
+            [
+                RecordedResponse(202, {"job_id": "job-ok", "status": "pending"}),
+                RecordedResponse(200, {"job_id": "job-ok", "status": "completed"}),
+                RecordedResponse(200, {"download_url": "https://download.example/job-ok"}),
+                RecordedResponse(200, content=_zip_output(**{"result.md": "remote OCR"})),
+            ]
+        ),
+        poll_interval_seconds=0,
+        sleep=lambda _seconds: None,
+    )
+
+    result, persisted = _process_and_persist_stage_page(
+        stage=stage,
+        pytesseract_backend=pytesseract_backend,
+        adapter=adapter,
+        db_path=db_path,
+        monkeypatch=monkeypatch,
+        ticket="T-1",
+    )
+
+    assert result["text"] == "remote OCR"
+    assert result["ocr_model"] == SARVAM_OCR_MODEL
+    assert result["error"] is None
+    assert persisted == ("remote OCR", SARVAM_OCR_MODEL)

--- a/tests/test_sarvam_egress.py
+++ b/tests/test_sarvam_egress.py
@@ -1,0 +1,323 @@
+"""Recorded-transport coverage for the sole authorized-external client."""
+
+from __future__ import annotations
+
+import sqlite3
+import zipfile
+from dataclasses import dataclass
+from io import BytesIO
+from typing import Any
+
+import pytest
+
+from janasunani.egress.sarvam import (
+    AUTHORIZATION_REFERENCE,
+    MODEL_ID,
+    PROVIDER_REGISTRY,
+    SarvamAuditContext,
+    SarvamError,
+    SarvamVisionAdapter,
+    SqliteAuditLog,
+)
+
+
+@dataclass
+class RecordedResponse:
+    status_code: int
+    payload: Any = None
+    text: str = ""
+    content: bytes = b""
+
+    def json(self) -> Any:
+        return self.payload
+
+
+class RecordedTransport:
+    """A deliberately inert HTTP transport replaying checked-in shaped data."""
+
+    def __init__(self, responses: list[RecordedResponse]) -> None:
+        self.responses = responses
+        self.calls: list[tuple[str, str, dict[str, Any]]] = []
+
+    def post(self, url: str, **kwargs: Any) -> RecordedResponse:
+        self.calls.append(("POST", url, kwargs))
+        return self.responses.pop(0)
+
+    def get(self, url: str, **kwargs: Any) -> RecordedResponse:
+        self.calls.append(("GET", url, kwargs))
+        return self.responses.pop(0)
+
+
+def _context() -> SarvamAuditContext:
+    return SarvamAuditContext(ticket="T-42", stage="ocr_extraction", document_id="doc:1")
+
+
+def _zip_output(**members: str) -> bytes:
+    output = BytesIO()
+    with zipfile.ZipFile(output, "w") as archive:
+        for name, content in members.items():
+            archive.writestr(name, content)
+    return output.getvalue()
+
+
+def _audit_rows(path):
+    with sqlite3.connect(path) as connection:
+        return connection.execute(
+            """
+            SELECT ticket, stage, provider, model_id, bytes_sent, timestamp,
+                   authorization_reference, operation, event, language, job_id
+            FROM authorized_external_audit ORDER BY id
+            """
+        ).fetchall()
+
+
+def test_digitise_replays_submit_poll_and_download_with_an_auditable_job(tmp_path):
+    audit_path = tmp_path / "pipeline.sqlite"
+    transport = RecordedTransport(
+        [
+            RecordedResponse(202, {"job_id": "job-7", "status": "pending"}),
+            RecordedResponse(200, {"job_id": "job-7", "status": "running"}),
+            RecordedResponse(
+                200,
+                {
+                    "job_id": "job-7",
+                    "status": "completed",
+                    "usage": {"pages_total": 1, "pages_succeeded": 1, "pages_failed": 0},
+                },
+            ),
+            RecordedResponse(200, {"download_url": "https://download.example/job-7"}),
+            RecordedResponse(
+                200,
+                content=_zip_output(
+                    **{
+                        "document.md": "# Water complaint\n\nName removed",
+                        "pages.json": "{}",
+                    }
+                ),
+            ),
+        ]
+    )
+    adapter = SarvamVisionAdapter(
+        enabled=True,
+        api_key="recorded-test-key",
+        audit_log=SqliteAuditLog(audit_path),
+        transport=transport,
+        poll_interval_seconds=0,
+        sleep=lambda _seconds: None,
+    )
+
+    actual = adapter.digitise(b"fixture-png", "page.png", "od-IN", _context())
+
+    assert actual == "# Water complaint\n\nName removed"
+    assert [method for method, _, _ in transport.calls] == ["POST", "GET", "GET", "GET", "GET"]
+    submit = transport.calls[0]
+    assert submit[1].endswith("/doc-ai/v1/job/digitise")
+    assert submit[2]["data"] == {"language": "od-IN", "output_format": "md"}
+    assert "model" not in submit[2]["data"]
+    assert submit[2]["headers"]["Idempotency-Key"] == adapter._idempotency_key(
+        _context(), "digitise", b"fixture-png"
+    )
+
+    rows = _audit_rows(audit_path)
+    assert [row[8] for row in rows] == [
+        "submission",
+        "poll",
+        "poll",
+        "result_lookup",
+        "download",
+    ]
+    assert rows[0][:7] == (
+        "T-42",
+        "ocr_extraction",
+        "sarvam-hosted",
+        MODEL_ID,
+        len(b"fixture-png"),
+        rows[0][5],
+        AUTHORIZATION_REFERENCE,
+    )
+    assert all(row[10] == "job-7" for row in rows)
+    assert [row[4] for row in rows] == [len(b"fixture-png"), 0, 0, 0, 0]
+
+
+def test_kill_switch_never_constructs_or_calls_the_remote_transport(tmp_path):
+    transport = RecordedTransport([])
+    adapter = SarvamVisionAdapter(
+        enabled=False,
+        audit_log=SqliteAuditLog(tmp_path / "audit.sqlite"),
+        transport=transport,
+    )
+
+    result = adapter.digitise_or_fallback(
+        b"fixture-png", "page.png", "en-IN", _context(), lambda: "local pytesseract text"
+    )
+
+    assert result == "local pytesseract text"
+    assert transport.calls == []
+    assert [row[8] for row in _audit_rows(tmp_path / "audit.sqlite")] == ["disabled"]
+
+
+def test_nonterminating_recorded_job_falls_back_after_its_bounded_poll_loop(tmp_path):
+    audit_path = tmp_path / "audit.sqlite"
+    transport = RecordedTransport(
+        [
+            RecordedResponse(202, {"job_id": "job-stuck", "status": "pending"}),
+            RecordedResponse(200, {"job_id": "job-stuck", "status": "running"}),
+            RecordedResponse(200, {"job_id": "job-stuck", "status": "running"}),
+        ]
+    )
+    adapter = SarvamVisionAdapter(
+        enabled=True,
+        api_key="recorded-test-key",
+        audit_log=SqliteAuditLog(audit_path),
+        transport=transport,
+        poll_interval_seconds=0,
+        max_poll_attempts=2,
+        sleep=lambda _seconds: None,
+    )
+
+    actual = adapter.digitise_or_fallback(
+        b"fixture-png", "page.png", "en-IN", _context(), lambda: "local text"
+    )
+
+    assert actual == "local text"
+    assert [row[8] for row in _audit_rows(audit_path)] == [
+        "submission",
+        "poll",
+        "poll",
+        "fallback",
+    ]
+
+
+def test_recorded_submission_is_resumed_instead_of_resubmitted_and_rebilled(tmp_path):
+    audit_path = tmp_path / "audit.sqlite"
+    audit_log = SqliteAuditLog(audit_path)
+    first_transport = RecordedTransport(
+        [
+            RecordedResponse(202, {"job_id": "job-resume", "status": "pending"}),
+            RecordedResponse(200, {"job_id": "job-resume", "status": "running"}),
+        ]
+    )
+    first = SarvamVisionAdapter(
+        enabled=True,
+        api_key="recorded-test-key",
+        audit_log=audit_log,
+        transport=first_transport,
+        max_poll_attempts=1,
+        poll_interval_seconds=0,
+        sleep=lambda _seconds: None,
+    )
+    assert first.digitise_or_fallback(b"fixture-png", "page.png", "en-IN", _context(), lambda: "local") == "local"
+
+    resumed_transport = RecordedTransport(
+        [
+            RecordedResponse(200, {"job_id": "job-resume", "status": "completed"}),
+            RecordedResponse(200, {"download_url": "https://download.example/job-resume"}),
+            RecordedResponse(200, content=_zip_output(**{"result.md": "resumed markdown"})),
+        ]
+    )
+    resumed = SarvamVisionAdapter(
+        enabled=True,
+        api_key="recorded-test-key",
+        audit_log=audit_log,
+        transport=resumed_transport,
+        poll_interval_seconds=0,
+        sleep=lambda _seconds: None,
+    )
+
+    assert resumed.digitise(b"fixture-png", "page.png", "en-IN", _context()) == "resumed markdown"
+    assert [method for method, _, _ in resumed_transport.calls] == ["GET", "GET", "GET"]
+    assert "resume" in [row[8] for row in _audit_rows(audit_path)]
+
+
+@pytest.mark.parametrize(
+    ("archive", "message"),
+    [
+        (_zip_output(**{"pages.json": "{}"}), "exactly one"),
+        (_zip_output(**{"one.md": "one", "two.md": "two"}), "exactly one"),
+        (b"not-a-zip", "valid ZIP"),
+    ],
+)
+def test_digitise_rejects_invalid_or_ambiguous_zip_results(archive, message):
+    with pytest.raises(SarvamError, match=message):
+        SarvamVisionAdapter._primary_markdown(archive)
+
+
+def test_idempotency_key_includes_the_actual_uploaded_bytes():
+    same_context = _context()
+    assert SarvamVisionAdapter._idempotency_key(same_context, "digitise", b"first") != (
+        SarvamVisionAdapter._idempotency_key(same_context, "digitise", b"changed")
+    )
+
+
+def test_failed_submission_is_audited_with_only_its_actual_upload_bytes(tmp_path):
+    audit_path = tmp_path / "audit.sqlite"
+    adapter = SarvamVisionAdapter(
+        enabled=True,
+        api_key="recorded-test-key",
+        audit_log=SqliteAuditLog(audit_path),
+        transport=RecordedTransport([RecordedResponse(503, {"error": "unavailable"})]),
+    )
+
+    assert adapter.digitise_or_fallback(
+        b"fixture-png", "page.png", "en-IN", _context(), lambda: "local"
+    ) == "local"
+    rows = _audit_rows(audit_path)
+    assert [(row[8], row[4]) for row in rows] == [
+        ("submission_error", len(b"fixture-png")),
+        ("fallback", 0),
+    ]
+
+
+def test_prefers_documented_api_key_environment_variable(monkeypatch, tmp_path):
+    monkeypatch.setenv("SARVAM_API_KEY", "preferred")
+    monkeypatch.setenv("SARVAM_API_SUBSCRIPTION_KEY", "legacy")
+    adapter = SarvamVisionAdapter(enabled=False, audit_log=SqliteAuditLog(tmp_path / "audit.sqlite"))
+    assert adapter.api_key == "preferred"
+
+
+def test_extract_is_a_distinct_operation_and_requires_one_pinned_schema_source(tmp_path):
+    adapter = SarvamVisionAdapter(enabled=False, audit_log=SqliteAuditLog(tmp_path / "audit.sqlite"))
+
+    with pytest.raises(ValueError, match="exactly one"):
+        adapter.extract(b"page", "page.png", "en-IN", _context())
+    with pytest.raises(ValueError, match="exactly one"):
+        adapter.extract(
+            b"page", "page.png", "en-IN", _context(), schema={}, config_id="config-1"
+        )
+
+    route = PROVIDER_REGISTRY["sarvam-vision"]
+    assert route.trust_tier == "authorized-external"
+    assert route.fallback == "pytesseract"
+    assert route.authorization_reference == AUTHORIZATION_REFERENCE
+
+
+def test_pipeline_sarvam_switch_uses_the_existing_pytesseract_callback_when_disabled(
+    tmp_path, monkeypatch
+):
+    # Base CI deliberately excludes the heavy pipeline OCR stack.  Keep this
+    # integration assertion in the adapter module, but skip only this test
+    # there; the pipeline-core job exercises the real pytesseract fallback.
+    pytest.importorskip("pdf2image")
+    from PIL import Image
+
+    from janasunani.pipeline.stages.ocr_extraction import stage
+    from janasunani.pipeline.stages.ocr_extraction import pytesseract_backend
+
+    monkeypatch.setattr(stage, "render_page", lambda _path, _number: Image.new("RGB", (2, 2)))
+    monkeypatch.setattr(pytesseract_backend, "extract_text", lambda _image, force_lang=None: "local OCR")
+    stage._worker_init("sarvam", sarvam_enabled=False, db_path=tmp_path / "pipeline.sqlite")
+
+    result = stage._process_page(
+        {
+            "page_id": "page-1",
+            "doc_id": "doc-1",
+            "page_number": 1,
+            "file_path": str(tmp_path / "page.png"),
+            "language": "Odia",
+            "ticket": "T-1",
+        }
+    )
+
+    assert result["text"] == "local OCR"
+    assert result["error"] is None
+    assert [row[8] for row in _audit_rows(tmp_path / "pipeline.sqlite")] == ["disabled"]

--- a/tests/test_sarvam_egress.py
+++ b/tests/test_sarvam_egress.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import json
 import sqlite3
 import zipfile
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from io import BytesIO
 from typing import Any
 
@@ -12,11 +13,13 @@ import pytest
 
 from janasunani.egress.sarvam import (
     AUTHORIZATION_REFERENCE,
+    GovernanceControl,
     MODEL_ID,
     PROVIDER_REGISTRY,
     SARVAM_OCR_MODEL,
     SarvamAuditContext,
     SarvamError,
+    SarvamPollTimeout,
     SarvamVisionAdapter,
     SqliteAuditLog,
 )
@@ -53,6 +56,17 @@ def _context() -> SarvamAuditContext:
     return SarvamAuditContext(ticket="T-42", stage="ocr_extraction", document_id="doc:1")
 
 
+def _verified_test_route():
+    """Recorded transports use explicit synthetic governance evidence."""
+    control = GovernanceControl(statement="verified recorded-test fixture", verified=True)
+    return replace(
+        PROVIDER_REGISTRY["sarvam-vision"],
+        retention_terms=control,
+        encryption_in_transit=control,
+        encryption_at_rest=control,
+    )
+
+
 def _zip_output(**members: str) -> bytes:
     output = BytesIO()
     with zipfile.ZipFile(output, "w") as archive:
@@ -70,6 +84,16 @@ def _audit_rows(path):
             FROM authorized_external_audit ORDER BY id
             """
         ).fetchall()
+
+
+def _audit_keys(path):
+    with sqlite3.connect(path) as connection:
+        return [
+            row[0]
+            for row in connection.execute(
+                "SELECT idempotency_key FROM authorized_external_audit ORDER BY id"
+            )
+        ]
 
 
 def test_digitise_replays_submit_poll_and_download_with_an_auditable_job(tmp_path):
@@ -102,6 +126,7 @@ def test_digitise_replays_submit_poll_and_download_with_an_auditable_job(tmp_pat
         enabled=True,
         api_key="recorded-test-key",
         audit_log=SqliteAuditLog(audit_path),
+        route=_verified_test_route(),
         transport=transport,
         poll_interval_seconds=0,
         sleep=lambda _seconds: None,
@@ -119,7 +144,11 @@ def test_digitise_replays_submit_poll_and_download_with_an_auditable_job(tmp_pat
     assert submit[2]["data"] == {"language": "od-IN", "output_format": "md"}
     assert "model" not in submit[2]["data"]
     assert submit[2]["headers"]["Idempotency-Key"] == adapter._idempotency_key(
-        _context(), "digitise", b"fixture-png"
+        _context(),
+        "digitise",
+        b"fixture-png",
+        filename="page.png",
+        form={"language": "od-IN", "output_format": "md"},
     )
 
     rows = _audit_rows(audit_path)
@@ -141,6 +170,7 @@ def test_digitise_replays_submit_poll_and_download_with_an_auditable_job(tmp_pat
     )
     assert all(row[10] == "job-7" for row in rows)
     assert [row[4] for row in rows] == [len(b"fixture-png"), 0, 0, 0, 0]
+    assert set(_audit_keys(audit_path)) == {submit[2]["headers"]["Idempotency-Key"]}
 
 
 def test_kill_switch_never_constructs_or_calls_the_remote_transport(tmp_path):
@@ -174,6 +204,7 @@ def test_nonterminating_recorded_job_falls_back_after_its_bounded_poll_loop(tmp_
         enabled=True,
         api_key="recorded-test-key",
         audit_log=SqliteAuditLog(audit_path),
+        route=_verified_test_route(),
         transport=transport,
         poll_interval_seconds=0,
         max_poll_attempts=2,
@@ -192,6 +223,7 @@ def test_nonterminating_recorded_job_falls_back_after_its_bounded_poll_loop(tmp_
         "poll",
         "fallback",
     ]
+    assert len(set(_audit_keys(audit_path))) == 1
 
 
 @pytest.mark.parametrize(
@@ -220,6 +252,7 @@ def test_partially_completed_job_is_rejected_and_audited_as_fallback(tmp_path, u
         enabled=True,
         api_key="recorded-test-key",
         audit_log=SqliteAuditLog(audit_path),
+        route=_verified_test_route(),
         transport=transport,
         poll_interval_seconds=0,
         sleep=lambda _seconds: None,
@@ -252,6 +285,7 @@ def test_recorded_submission_is_resumed_instead_of_resubmitted_and_rebilled(tmp_
         enabled=True,
         api_key="recorded-test-key",
         audit_log=audit_log,
+        route=_verified_test_route(),
         transport=first_transport,
         max_poll_attempts=1,
         poll_interval_seconds=0,
@@ -274,6 +308,7 @@ def test_recorded_submission_is_resumed_instead_of_resubmitted_and_rebilled(tmp_
         enabled=True,
         api_key="recorded-test-key",
         audit_log=audit_log,
+        route=_verified_test_route(),
         transport=resumed_transport,
         poll_interval_seconds=0,
         sleep=lambda _seconds: None,
@@ -282,6 +317,122 @@ def test_recorded_submission_is_resumed_instead_of_resubmitted_and_rebilled(tmp_
     assert resumed.digitise(b"fixture-png", "page.png", "en-IN", _context()) == "resumed markdown"
     assert [method for method, _, _ in resumed_transport.calls] == ["GET", "GET", "GET"]
     assert "resume" in [row[8] for row in _audit_rows(audit_path)]
+
+
+def test_extract_resume_key_is_stable_across_schema_dict_order(tmp_path):
+    audit_path = tmp_path / "audit.sqlite"
+    audit_log = SqliteAuditLog(audit_path)
+    first_transport = RecordedTransport(
+        [
+            RecordedResponse(202, {"job_id": "job-schema", "status": "pending"}),
+            RecordedResponse(200, {"job_id": "job-schema", "status": "running"}),
+        ]
+    )
+    first = SarvamVisionAdapter(
+        enabled=True,
+        api_key="recorded-test-key",
+        audit_log=audit_log,
+        route=_verified_test_route(),
+        transport=first_transport,
+        max_poll_attempts=1,
+        poll_interval_seconds=0,
+        sleep=lambda _seconds: None,
+    )
+    with pytest.raises(SarvamPollTimeout):
+        first.extract(
+            b"fixture-png",
+            "page.png",
+            "en-IN",
+            _context(),
+            schema={"z_field": {"type": "string"}, "a_field": {"type": "number"}},
+        )
+
+    resumed_transport = RecordedTransport(
+        [
+            RecordedResponse(200, {"job_id": "job-schema", "status": "completed"}),
+            RecordedResponse(200, {"results": [{"a_field": 1, "z_field": "ok"}]}),
+        ]
+    )
+    resumed = SarvamVisionAdapter(
+        enabled=True,
+        api_key="recorded-test-key",
+        audit_log=audit_log,
+        route=_verified_test_route(),
+        transport=resumed_transport,
+        poll_interval_seconds=0,
+        sleep=lambda _seconds: None,
+    )
+
+    result = resumed.extract(
+        b"fixture-png",
+        "page.png",
+        "en-IN",
+        _context(),
+        schema={"a_field": {"type": "number"}, "z_field": {"type": "string"}},
+    )
+
+    assert result == {"results": [{"a_field": 1, "z_field": "ok"}]}
+    assert [method for method, _, _ in resumed_transport.calls] == ["GET", "GET"]
+    assert "resume" in [row[8] for row in _audit_rows(audit_path)]
+
+
+@pytest.mark.parametrize("changed_parameter", ["language", "schema", "config_id"])
+def test_changed_result_defining_parameter_does_not_resume_recorded_job(
+    tmp_path, changed_parameter
+):
+    audit_path = tmp_path / "audit.sqlite"
+    audit_log = SqliteAuditLog(audit_path)
+
+    def call(adapter, changed):
+        if changed_parameter == "language":
+            return adapter.digitise(
+                b"fixture-png",
+                "page.png",
+                "od-IN" if changed else "en-IN",
+                _context(),
+            )
+        if changed_parameter == "schema":
+            return adapter.extract(
+                b"fixture-png",
+                "page.png",
+                "en-IN",
+                _context(),
+                schema={"field": "number" if changed else "string"},
+            )
+        return adapter.extract(
+            b"fixture-png",
+            "page.png",
+            "en-IN",
+            _context(),
+            config_id="config-new" if changed else "config-old",
+        )
+
+    transports = []
+    for changed, job_id in ((False, "job-old"), (True, "job-new")):
+        transport = RecordedTransport(
+            [
+                RecordedResponse(202, {"job_id": job_id, "status": "pending"}),
+                RecordedResponse(200, {"job_id": job_id, "status": "running"}),
+            ]
+        )
+        transports.append(transport)
+        adapter = SarvamVisionAdapter(
+            enabled=True,
+            api_key="recorded-test-key",
+            audit_log=audit_log,
+            route=_verified_test_route(),
+            transport=transport,
+            max_poll_attempts=1,
+            poll_interval_seconds=0,
+            sleep=lambda _seconds: None,
+        )
+        with pytest.raises(SarvamPollTimeout):
+            call(adapter, changed)
+
+    assert [method for method, _, _ in transports[1].calls] == ["POST", "GET"]
+    first_key = transports[0].calls[0][2]["headers"]["Idempotency-Key"]
+    changed_key = transports[1].calls[0][2]["headers"]["Idempotency-Key"]
+    assert changed_key != first_key
 
 
 @pytest.mark.parametrize(
@@ -299,9 +450,51 @@ def test_digitise_rejects_invalid_or_ambiguous_zip_results(archive, message):
 
 def test_idempotency_key_includes_the_actual_uploaded_bytes():
     same_context = _context()
-    assert SarvamVisionAdapter._idempotency_key(same_context, "digitise", b"first") != (
-        SarvamVisionAdapter._idempotency_key(same_context, "digitise", b"changed")
+    request = {
+        "filename": "page.png",
+        "form": {"language": "en-IN", "output_format": "md"},
+    }
+    assert SarvamVisionAdapter._idempotency_key(
+        same_context, "digitise", b"first", **request
+    ) != (
+        SarvamVisionAdapter._idempotency_key(
+            same_context, "digitise", b"changed", **request
+        )
     )
+
+
+def test_idempotency_key_canonicalizes_the_complete_request_form():
+    base_form = {
+        "language": "en-IN",
+        "output_format": "json",
+        "schema": {"b": {"type": "string"}, "a": {"type": "number"}},
+        "future_option": {"beta": True, "modes": ["layout", "tables"]},
+    }
+    reordered_form = {
+        "future_option": {"modes": ["layout", "tables"], "beta": True},
+        "schema": {"a": {"type": "number"}, "b": {"type": "string"}},
+        "output_format": "json",
+        "language": "en-IN",
+    }
+
+    def key(form):
+        return SarvamVisionAdapter._idempotency_key(
+            _context(),
+            "extract",
+            b"fixture-png",
+            filename="page.png",
+            form=form,
+        )
+
+    assert key(base_form) == key(reordered_form)
+    for changed in (
+        {**base_form, "language": "od-IN"},
+        {**base_form, "output_format": "csv"},
+        {**base_form, "schema": {"a": {"type": "string"}}},
+        {**base_form, "config_id": "config-2"},
+        {**base_form, "future_option": {"beta": False}},
+    ):
+        assert key(changed) != key(base_form)
 
 
 def test_failed_submission_is_audited_with_only_its_actual_upload_bytes(tmp_path):
@@ -310,6 +503,7 @@ def test_failed_submission_is_audited_with_only_its_actual_upload_bytes(tmp_path
         enabled=True,
         api_key="recorded-test-key",
         audit_log=SqliteAuditLog(audit_path),
+        route=_verified_test_route(),
         transport=RecordedTransport([RecordedResponse(503, {"error": "unavailable"})]),
     )
 
@@ -344,8 +538,46 @@ def test_extract_is_a_distinct_operation_and_requires_one_pinned_schema_source(t
 
     route = PROVIDER_REGISTRY["sarvam-vision"]
     assert route.trust_tier == "authorized-external"
+    assert route.data_class == "raw grievance document bytes, including citizen PII"
+    assert route.endpoint == "https://api.sarvam.ai"
     assert route.fallback == "pytesseract"
     assert route.authorization_reference == AUTHORIZATION_REFERENCE
+    assert route.retention_terms.statement
+    assert route.encryption_in_transit.statement
+    assert route.encryption_at_rest.statement
+    assert route.audit_policy
+    assert route.declared_controls_complete is True
+    assert route.unverified_controls == (
+        "retention_terms",
+        "encryption_in_transit",
+        "encryption_at_rest",
+    )
+    assert route.live_use_ready is False
+
+
+def test_unverified_provider_controls_gate_enabled_route_without_remote_call(tmp_path):
+    audit_path = tmp_path / "audit.sqlite"
+    transport = RecordedTransport([])
+    adapter = SarvamVisionAdapter(
+        enabled=True,
+        api_key="recorded-test-key",
+        audit_log=SqliteAuditLog(audit_path),
+        transport=transport,
+    )
+
+    outcome = adapter.digitise_or_fallback(
+        b"fixture-png", "page.png", "en-IN", _context(), lambda: "local OCR"
+    )
+
+    assert outcome.text == "local OCR"
+    assert outcome.ocr_model == "pytesseract"
+    assert transport.calls == []
+    with sqlite3.connect(audit_path) as connection:
+        event, metadata = connection.execute(
+            "SELECT event, response_metadata FROM authorized_external_audit"
+        ).fetchone()
+    assert event == "fallback"
+    assert json.loads(metadata)["reason"] == "SarvamGovernanceError"
 
 
 def test_extract_submission_omits_an_unsupported_model_field(tmp_path):
@@ -360,6 +592,7 @@ def test_extract_submission_omits_an_unsupported_model_field(tmp_path):
         enabled=True,
         api_key="recorded-test-key",
         audit_log=SqliteAuditLog(tmp_path / "audit.sqlite"),
+        route=_verified_test_route(),
         transport=transport,
         poll_interval_seconds=0,
         sleep=lambda _seconds: None,
@@ -378,7 +611,7 @@ def test_extract_submission_omits_an_unsupported_model_field(tmp_path):
     assert submission_data == {
         "language": "en-IN",
         "output_format": "json",
-        "schema": '{"complainant_name": "string"}',
+        "schema": '{"complainant_name":"string"}',
     }
     assert "model" not in submission_data
 
@@ -461,6 +694,7 @@ def test_sarvam_stage_fallback_persists_pytesseract_per_page(
         enabled=mode != "disabled",
         api_key="" if mode == "missing_credentials" else "recorded-test-key",
         audit_log=SqliteAuditLog(db_path),
+        route=_verified_test_route(),
         transport=RecordedTransport(responses),
         poll_interval_seconds=0,
         max_poll_attempts=1,
@@ -494,6 +728,7 @@ def test_sarvam_stage_success_persists_remote_route_and_model(tmp_path, monkeypa
         enabled=True,
         api_key="recorded-test-key",
         audit_log=SqliteAuditLog(db_path),
+        route=_verified_test_route(),
         transport=RecordedTransport(
             [
                 RecordedResponse(202, {"job_id": "job-ok", "status": "pending"}),

--- a/tests/test_sarvam_egress.py
+++ b/tests/test_sarvam_egress.py
@@ -662,39 +662,6 @@ def test_idempotency_key_includes_route_identity(tmp_path, route_field):
     )
 
 
-def test_enabled_sarvam_rejects_cross_machine_sharding_before_loading_work(tmp_path):
-    from janasunani.pipeline.config import PipelineConfig
-    from janasunani.pipeline.stages.ocr_extraction.stage import run_ocr_extraction
-
-    config = PipelineConfig(
-        input_dir=tmp_path,
-        db_path=tmp_path / "missing.sqlite",
-        models_dir=tmp_path,
-        ocr_engine="sarvam",
-        sarvam_enabled=True,
-        num_workers=2,
-    )
-
-    with pytest.raises(ValueError, match="num_workers=1"):
-        run_ocr_extraction(config)
-
-
-def test_disabled_sarvam_allows_local_fallback_sharding(tmp_path):
-    from janasunani.pipeline.config import PipelineConfig
-    from janasunani.pipeline.stages.ocr_extraction.stage import run_ocr_extraction
-
-    config = PipelineConfig(
-        input_dir=tmp_path,
-        db_path=tmp_path / "missing.sqlite",
-        models_dir=tmp_path,
-        ocr_engine="sarvam",
-        sarvam_enabled=False,
-        num_workers=2,
-    )
-
-    run_ocr_extraction(config)
-
-
 def test_submission_limiter_enforces_ten_requests_per_rolling_minute(tmp_path):
     clock = FakeClock()
     responses = []


### PR DESCRIPTION
## Summary

Implements the bounded Sarvam Vision adapter slice for #83:

- one disabled-by-default authorized-external adapter with pytesseract fallback
- async job submit/poll/result handling with request-level audit records
- deterministic content-aware resume key and ZIP Markdown result validation
- recorded-response coverage only; no live Sarvam calls or credentials

## Validation

- Full suite run in bounded batches under `serving` + `pipeline-core`: all modules passed (including 48 deployment tests); existing skips/warnings only
- `ruff check .`
- `git diff --check origin/main...HEAD`

## Scope

Does not add the #84 scorecard or make Sarvam live by default.