### PR TITLE
fix(dedup): pin source snapshot provenance

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -149,8 +149,13 @@ Three storage layers, deliberately distinct (detail in
   demo's history browse read this, never OLTP.
 - **Pipeline artifact DB.** A per-run SQLite database, the document pipeline's
   resumable working state. Reaches OLTP only through the exporter.
-- **Dedup index** *(Phase 14)*. Corpus-level MinHash/LSH state built from the
-  lake. The first thing a pipeline run needs beyond its own artifact DB.
+- **Dedup index** *(Phase 14)*. Corpus-level MinHash/LSH state currently built
+  directly from OLTP `complaints` + `grievance_redactions`, preserving the
+  short redaction → index chain. Each persisted group carries that source plus
+  a deterministic input-snapshot digest; a lake-based duplicate analytic must
+  assert the digest before joining, so materialization skew fails loudly rather
+  than becoming a mixed-snapshot count (#137). The first thing a pipeline run
+  needs beyond its own artifact DB.
 
 Live flow: raw input → extract → redact → triage → classify → summarize → route →
 persist to OLTP → view.
@@ -622,9 +627,11 @@ unbuilt.
 
 **Three firsts this stage introduces**, worth flagging:
 
-- The **first stage with a corpus-level dependency**. It needs a dedup index built
-  from the lake, not just the per-run artifact DB. That affects resumability and
-  the Phase 19 batch/live recipe convergence.
+- The **first stage with a corpus-level dependency**. It currently builds its
+  dedup index directly from the OLTP redaction tables, not just the per-run
+  artifact DB; each group records a deterministic source snapshot so a
+  lake-based analytic must prove it is joining the same materialization (#137).
+  That affects resumability and the Phase 19 batch/live recipe convergence.
 - Dedup keys derived from `petitioner_mobile` / `petitioner_email` must be
   **salted hashes**, held outside the redacted text path. A raw mobile number in a
   dedup index is a PII store by another name.

--- a/janasunani/db/alembic/versions/f3a91c0d54e7_dedup_group_source_snapshot.py
+++ b/janasunani/db/alembic/versions/f3a91c0d54e7_dedup_group_source_snapshot.py
@@ -1,0 +1,43 @@
+"""add source snapshot provenance to dedup groups
+
+Issue #137 keeps the historical dedup backfill on the OLTP redaction path but
+requires every persisted group assignment to say which source snapshot it
+describes. dedup_signatures.source_record_digest is computed when a row is
+indexed; a group snapshot aggregates those stored values, rather than current
+OLTP values, so stale signatures cannot be relabelled as fresh. The nullable
+columns are deliberate: an existing production index cannot be truthfully
+backfilled by a schema migration alone. Re-run the dedup-index command to
+populate them; downstream duplicate analytics must reject legacy NULL
+provenance.
+
+Revision ID: f3a91c0d54e7
+Revises: e59fb4410dd6
+Create Date: 2026-08-07
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "f3a91c0d54e7"
+down_revision: Union[str, None] = "e59fb4410dd6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "dedup_signatures", sa.Column("source_record_digest", sa.String(), nullable=True)
+    )
+    op.add_column("dedup_groups", sa.Column("source_name", sa.String(), nullable=True))
+    op.add_column(
+        "dedup_groups", sa.Column("source_snapshot_id", sa.String(), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("dedup_groups", "source_snapshot_id")
+    op.drop_column("dedup_groups", "source_name")
+    op.drop_column("dedup_signatures", "source_record_digest")

--- a/janasunani/db/models.py
+++ b/janasunani/db/models.py
@@ -425,6 +425,13 @@ class DedupSignature(Base):
     identity_key_mobile = Column(String, nullable=True, index=True)
     identity_key_email = Column(String, nullable=True, index=True)
 
+    # #137. Digest of the exact OLTP record that produced this signature.
+    # Group provenance aggregates these stored values instead of re-reading
+    # current source rows, which would silently relabel a stale signature as
+    # fresh after a redaction/source update. Existing rows stay NULL until the
+    # runner rebuilds them; groups fail closed while any are missing.
+    source_record_digest = Column(String, nullable=True)
+
     index_version = Column(String, nullable=True)
     indexed_at = Column(DateTime, nullable=False, server_default=func.now())
 
@@ -461,6 +468,15 @@ class DedupGroup(Base):
 
     duplicate_group_id = Column(String, nullable=False, index=True)
     group_size = Column(Integer, nullable=False)
+
+    # #137. The current runner reads the redacted historical slice directly
+    # from OLTP.  These two fields tell a downstream analytics consumer exactly
+    # which source and deterministic source manifest produced the grouping, so
+    # it can reject a mismatched Parquet materialization instead of combining
+    # different snapshots.  Existing pre-migration rows remain NULL in the DB
+    # until rebuilt and are intentionally not valid for such an assertion.
+    source_name = Column(String, nullable=True)
+    source_snapshot_id = Column(String, nullable=True)
 
     index_version = Column(String, nullable=True)
     grouped_at = Column(DateTime, nullable=False, server_default=func.now())

--- a/janasunani/pipeline/dedup.py
+++ b/janasunani/pipeline/dedup.py
@@ -82,10 +82,12 @@ Six things that shape every function below:
 from __future__ import annotations
 
 import hashlib
+import json
 import random
 import re
 import unicodedata
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
+from datetime import date, datetime
 
 # Typed PII placeholder tokens look like "[PHONE]", "[NAME]", "[AADHAAR]"
 # (see janasunani/pipeline/stages/pii_tagger.py:ENTITY_TOKENS) — a bracketed
@@ -139,6 +141,147 @@ _MERSENNE_PRIME = (1 << 61) - 1
 # runs, not unpredictable). Changing this value changes every signature
 # ever produced; don't.
 _PERMUTATION_SEED = 0x4A53_6465_6475_70  # "JSdedup" packed into hex, arbitrary
+
+# The historical backfill currently reads its inputs directly from the OLTP
+# tables below, not from a materialized Parquet lake.  Keep the source name and
+# the canonical record format here, in the stdlib-only module, so a downstream
+# analytics job can calculate exactly the same identifier from either source.
+# A group row stores this source name plus the digest returned by
+# `source_snapshot_id()`.  That makes a lake/OLTP mismatch an explicit error,
+# not a slightly wrong duplicate-adjusted count (#137).
+DEDUP_SOURCE_NAME = "oltp:complaints+grievance_redactions"
+_SOURCE_SNAPSHOT_FORMAT = "janasunani-dedup-source-v1"
+
+
+class DedupSourceSnapshotMismatch(ValueError):
+    """Raised when duplicate groups do not describe the asserted source slice."""
+
+
+def _snapshot_value(value: object) -> str | int | None:
+    """Canonical JSON value for one source-snapshot field.
+
+    SQLite returns ``datetime`` values while a Parquet/DuckDB consumer can
+    return ``date``/``datetime`` values with a different concrete type.  ISO
+    text makes the provenance digest source-independent; all other fields are
+    intentionally kept as their actual scalar values so e.g. ``None`` does
+    not collapse into an empty string.
+    """
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    if value is None or isinstance(value, (str, int)):
+        return value
+    raise TypeError(f"unsupported dedup source snapshot value: {type(value)!r}")
+
+
+def _canonical_source_record(record: Mapping[str, object]) -> tuple[str, bytes]:
+    """Return the ticket and canonical bytes of one dedup index input."""
+    fields = (
+        "ticket_no",
+        "district",
+        "created_year",
+        "created_on",
+        "petitioner_mobile",
+        "petitioner_email",
+        "grievance_redacted",
+    )
+    try:
+        payload = {field: _snapshot_value(record[field]) for field in fields}
+    except KeyError as exc:
+        raise ValueError(f"dedup source snapshot record is missing {exc.args[0]!r}") from exc
+    ticket_no = payload["ticket_no"]
+    if not isinstance(ticket_no, str) or not ticket_no:
+        raise ValueError("dedup source snapshot requires a non-blank ticket_no")
+    return (
+        ticket_no,
+        json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8"),
+    )
+
+
+def source_record_digest(record: Mapping[str, object]) -> str:
+    """Stable digest of the exact source values used for one signature row.
+
+    This is persisted beside a DedupSignature at indexing time. A later
+    grouping run must describe the rows that were actually indexed, rather
+    than re-read current OLTP values and accidentally relabel stale signatures
+    as current (#137).
+    """
+    _, payload = _canonical_source_record(record)
+    return _source_record_digest_from_payload(payload)
+
+
+def _source_record_digest_from_payload(payload: bytes) -> str:
+    return f"sha256:{hashlib.sha256(payload).hexdigest()}"
+
+
+def source_snapshot_id_from_record_digests(
+    record_digests: Iterable[tuple[str, str]],
+) -> str:
+    """Stable slice manifest from (ticket_no, source_record_digest) pairs."""
+    canonical = sorted(record_digests, key=lambda item: item[0])
+    digest = hashlib.sha256()
+    digest.update(f"{_SOURCE_SNAPSHOT_FORMAT}\n".encode("ascii"))
+    previous_ticket: str | None = None
+    for ticket_no, record_digest in canonical:
+        if not isinstance(ticket_no, str) or not ticket_no:
+            raise ValueError("dedup source snapshot requires a non-blank ticket_no")
+        if ticket_no == previous_ticket:
+            raise ValueError(f"dedup source snapshot has duplicate ticket_no {ticket_no!r}")
+        if not isinstance(record_digest, str) or not record_digest.startswith("sha256:"):
+            raise ValueError(f"invalid source record digest for {ticket_no!r}")
+        digest.update(ticket_no.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(record_digest.encode("ascii"))
+        digest.update(b"\n")
+        previous_ticket = ticket_no
+    return f"sha256:{digest.hexdigest()}"
+
+
+def source_snapshot_id(records: Iterable[Mapping[str, object]]) -> str:
+    """Stable manifest of the exact historical inputs used for a dedup slice.
+
+    Each record must carry these OLTP/lake columns: ``ticket_no``, ``district``,
+    ``created_year``, ``created_on``, ``petitioner_mobile``,
+    ``petitioner_email``, and ``grievance_redacted``.  They are every source
+    value that changes the runner's membership, blocking, text signature, or
+    identity candidates.  The digest contains no reversible text or identity
+    value, but remains ``dpic-infra`` provenance because it is derived from
+    citizen data.
+
+    Records are sorted by ticket and a duplicate ticket is rejected.  Therefore
+    the result is stable across SQL/Parquet row order and cannot quietly treat
+    an accidental duplicated join as the same snapshot.
+    """
+    record_digests = []
+    for record in records:
+        ticket_no, payload = _canonical_source_record(record)
+        record_digests.append((ticket_no, _source_record_digest_from_payload(payload)))
+    return source_snapshot_id_from_record_digests(record_digests)
+
+
+def assert_group_source_snapshot(
+    group_rows: Iterable[Mapping[str, object]], source_records: Iterable[Mapping[str, object]]
+) -> str:
+    """Assert that persisted groups and a prospective analytics source agree.
+
+    ``source_records`` is normally the district-year join of lake
+    ``complaints`` and ``grievance_redactions``.  A #72-style consumer calls
+    this before duplicate-adjusted aggregation; a changed or incomplete lake,
+    legacy rows without provenance, and a mix of group runs all raise instead
+    of being combined silently.  The verified digest is returned for callers
+    that need to record it in their own output provenance.
+    """
+    expected = source_snapshot_id(source_records)
+    observed: set[tuple[object, object]] = set()
+    for row in group_rows:
+        observed.add((row.get("source_name"), row.get("source_snapshot_id")))
+
+    required = {(DEDUP_SOURCE_NAME, expected)}
+    if observed != required:
+        raise DedupSourceSnapshotMismatch(
+            "dedup group provenance does not match the asserted source snapshot: "
+            f"expected {required!r}, observed {observed!r}"
+        )
+    return expected
 
 
 def strip_placeholders(text: str) -> str:

--- a/janasunani/pipeline/dedup.py
+++ b/janasunani/pipeline/dedup.py
@@ -189,7 +189,7 @@ def _canonical_source_record(record: Mapping[str, object]) -> tuple[str, bytes]:
     except KeyError as exc:
         raise ValueError(f"dedup source snapshot record is missing {exc.args[0]!r}") from exc
     ticket_no = payload["ticket_no"]
-    if not isinstance(ticket_no, str) or not ticket_no:
+    if not isinstance(ticket_no, str) or not ticket_no.strip():
         raise ValueError("dedup source snapshot requires a non-blank ticket_no")
     return (
         ticket_no,
@@ -266,20 +266,51 @@ def assert_group_source_snapshot(
     ``source_records`` is normally the district-year join of lake
     ``complaints`` and ``grievance_redactions``.  A #72-style consumer calls
     this before duplicate-adjusted aggregation; a changed or incomplete lake,
-    legacy rows without provenance, and a mix of group runs all raise instead
-    of being combined silently.  The verified digest is returned for callers
-    that need to record it in their own output provenance.
+    a missing/extra/duplicate group ticket, legacy rows without provenance,
+    and a mix of group runs all raise instead of being combined silently. The
+    verified digest is returned for callers that need to record it in their
+    own output provenance.
     """
+    source_records = list(source_records)
     expected = source_snapshot_id(source_records)
+    source_tickets = {record["ticket_no"] for record in source_records}
+
     observed: set[tuple[object, object]] = set()
+    group_tickets: set[str] = set()
+    duplicate_group_tickets = 0
+    blank_group_tickets = 0
     for row in group_rows:
+        ticket_no = row.get("ticket_no")
+        if not isinstance(ticket_no, str) or not ticket_no.strip():
+            blank_group_tickets += 1
+        elif ticket_no in group_tickets:
+            duplicate_group_tickets += 1
+        else:
+            group_tickets.add(ticket_no)
         observed.add((row.get("source_name"), row.get("source_snapshot_id")))
+
+    if blank_group_tickets:
+        raise DedupSourceSnapshotMismatch(
+            "dedup group provenance has invalid ticket rows: "
+            f"blank_or_non_string={blank_group_tickets}"
+        )
+    if duplicate_group_tickets:
+        raise DedupSourceSnapshotMismatch(
+            "dedup group provenance has duplicate ticket rows: "
+            f"duplicates={duplicate_group_tickets}"
+        )
 
     required = {(DEDUP_SOURCE_NAME, expected)}
     if observed != required:
         raise DedupSourceSnapshotMismatch(
             "dedup group provenance does not match the asserted source snapshot: "
-            f"expected {required!r}, observed {observed!r}"
+            f"expected_labels={len(required)}, observed_labels={len(observed)}"
+        )
+    if group_tickets != source_tickets:
+        raise DedupSourceSnapshotMismatch(
+            "dedup group ticket population does not match the asserted source snapshot: "
+            f"missing_group_rows={len(source_tickets - group_tickets)}, "
+            f"extra_group_rows={len(group_tickets - source_tickets)}"
         )
     return expected
 

--- a/janasunani/pipeline/dedup_index.py
+++ b/janasunani/pipeline/dedup_index.py
@@ -593,6 +593,7 @@ async def _index_signatures(
     version = _index_version(window_days, threshold, salt)
     epoch = date(year, 1, 1)
     processed = 0
+    refreshed_tickets: set[str] = set()
 
     async with engine.begin() as conn:
         total, already = await _count_signature_slice(conn, district, year)
@@ -651,6 +652,7 @@ async def _index_signatures(
             await conn.execute(
                 _dialect_upsert(DedupSignature, conn.dialect.name, rows, "ticket_no")
             )
+        refreshed_tickets.update(row[0] for row in source_mismatches)
         processed += len(rows)
 
     while True:
@@ -665,6 +667,19 @@ async def _index_signatures(
             )
             if not batch:
                 break
+
+            batch_ticket_nos = [row[0] for row in batch]
+            existing_in_batch = set(
+                (
+                    await conn.execute(
+                        select(DedupSignature.ticket_no).where(
+                            DedupSignature.ticket_no.in_(batch_ticket_nos)
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
 
             # Naive UTC — every timestamp column in this schema is TIMESTAMP
             # WITHOUT TIME ZONE and asyncpg refuses a tz-aware value there,
@@ -683,14 +698,24 @@ async def _index_signatures(
                 _dialect_upsert(DedupSignature, conn.dialect.name, rows, "ticket_no")
             )
 
+        refreshed_tickets.update(existing_in_batch)
         processed += len(batch)
+        unchanged_existing = already - len(refreshed_tickets)
         logger.info(
-            "indexed {} of {} ({} this batch)", processed + already, total, len(batch)
+            "indexed {} of {} ({} this batch)",
+            unchanged_existing + processed,
+            total,
+            len(batch),
         )
 
+    unchanged_existing = already - len(refreshed_tickets)
     return {
         "total": total,
-        "already_indexed": already,
+        # Existing rows overwritten during this run belong in processed, not
+        # here. This keeps the reconciliation contract auditable:
+        # unchanged existing + inserted/refreshed <= total, including a
+        # one-row source refresh inside an otherwise complete slice.
+        "already_indexed": unchanged_existing,
         "processed": processed,
         "stale_at_start": stale,
         "source_mismatches_at_start": len(source_mismatches),

--- a/janasunani/pipeline/dedup_index.py
+++ b/janasunani/pipeline/dedup_index.py
@@ -48,6 +48,16 @@ created_on, petitioner_mobile/email); it never selects `complaints.grievance`.
    incremental update would drift (a late resubmission can change a group id
    that already exists).
 
+   **Source provenance is persisted with every group row (#137).** The
+   current runner deliberately keeps the short redaction → index chain and
+   reads `complaints` + `grievance_redactions` directly from OLTP.  Before it
+   writes groups, it fingerprints the exact source records represented by the
+   signature slice.  The resulting `source_name` and `source_snapshot_id` are
+   deterministic and can be recomputed against a materialized lake by a
+   duplicate-adjusted analytics consumer.  That consumer must assert the
+   match before aggregation; a stale/incomplete lake or a mixture of group
+   runs is an error, not a number to publish.
+
    **Above `REPRESENTATIVE_COMPARISON_CAP` members, a bucket trades recall
    for time (#158).** A campaign-heavy district-year produces buckets in the
    thousands of members — 6,797 was the largest measured on Sambalpur 2024,
@@ -147,6 +157,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 from janasunani.config import settings
 from janasunani.db.models import Complaint, DedupGroup, DedupSignature, GrievanceRedaction
 from janasunani.pipeline.dedup import (
+    DEDUP_SOURCE_NAME,
     DEFAULT_NUM_BANDS,
     DEFAULT_NUM_HASHES,
     DEFAULT_SHINGLE_SIZE,
@@ -154,6 +165,8 @@ from janasunani.pipeline.dedup import (
     jaccard_similarity,
     lsh_bands,
     minhash_signature,
+    source_record_digest,
+    source_snapshot_id_from_record_digests,
     shingles,
 )
 
@@ -363,7 +376,11 @@ async def _load_pending_signature_batch(
     must stay a NOT EXISTS against the output table, not an offset.
     """
     done = select(DedupSignature.ticket_no).where(
-        DedupSignature.ticket_no == GrievanceRedaction.ticket_no
+        DedupSignature.ticket_no == GrievanceRedaction.ticket_no,
+        # Existing rows from before #137 cannot truthfully be stamped with a
+        # current source manifest. Rebuild their signatures automatically;
+        # grouping fails closed if a missing digest survives for any reason.
+        DedupSignature.source_record_digest.isnot(None),
     )
     if version is not None:
         # A row stamped with different parameters counts as pending (#136).
@@ -376,6 +393,7 @@ async def _load_pending_signature_batch(
             GrievanceRedaction.ticket_no,
             GrievanceRedaction.grievance_redacted,
             Complaint.district,
+            Complaint.created_year,
             Complaint.created_on,
             Complaint.petitioner_mobile,
             Complaint.petitioner_email,
@@ -392,6 +410,174 @@ async def _load_pending_signature_batch(
     )
     result = await conn.execute(stmt)
     return result.all()
+
+
+def _source_record(
+    ticket_no: str,
+    redacted_text: str | None,
+    district: str,
+    created_year: int,
+    created_on: datetime | None,
+    mobile: str | None,
+    email: str | None,
+) -> dict[str, object]:
+    """The exact source fields captured by a signature provenance digest."""
+    return {
+        "ticket_no": ticket_no,
+        "district": district,
+        "created_year": created_year,
+        "created_on": created_on,
+        "petitioner_mobile": mobile,
+        "petitioner_email": email,
+        "grievance_redacted": redacted_text,
+    }
+
+
+def _signature_rows_for_source_batch(
+    batch,
+    *,
+    salt: str,
+    epoch: date,
+    window_days: int,
+    version: str,
+    now: datetime,
+) -> list[dict[str, object]]:
+    """Build persisted signature rows from the exact source batch supplied."""
+    rows = []
+    for (
+        ticket_no,
+        redacted_text,
+        row_district,
+        row_year,
+        created_on,
+        mobile,
+        email,
+    ) in batch:
+        text = redacted_text or ""
+        shingle_set = shingles(text)
+        signature = minhash_signature(shingle_set, num_hashes=DEFAULT_NUM_HASHES)
+        script = _script_of(text)
+        window_index = _window_index(created_on, epoch, window_days)
+        source = _source_record(
+            ticket_no, redacted_text, row_district, row_year, created_on, mobile, email
+        )
+        rows.append(
+            {
+                "ticket_no": ticket_no,
+                "district": row_district,
+                "created_year": row_year,
+                "script": script,
+                "window_index": window_index,
+                "block_key": _block_key(row_district, script, window_index),
+                "num_shingles": len(shingle_set),
+                "signature": list(signature) if signature is not None else None,
+                # A separate path from text above: computed from the complaints
+                # columns directly, never from redacted_text (dedup.py module
+                # docstring point 3).
+                "identity_key_mobile": identity_key(mobile, salt) if mobile else None,
+                "identity_key_email": identity_key(email, salt) if email else None,
+                "source_record_digest": source_record_digest(source),
+                "index_version": version,
+                "indexed_at": now,
+            }
+        )
+    return rows
+
+
+async def _source_digest_mismatches(conn, district: str, year: int):
+    """Current source records whose existing signature digest is no longer true.
+
+    This is deliberately a source read before grouping. Candidate generation
+    relies on persisted signatures while exact Jaccard verification reads the
+    current redacted text, so allowing these two inputs to differ would create
+    an unprovable mixed run. Missing legacy digests are handled separately as
+    pending signature rows; non-NULL disagreement requires --refresh-stale.
+    """
+    stmt = (
+        select(
+            DedupSignature.ticket_no,
+            DedupSignature.source_record_digest,
+            Complaint.district,
+            Complaint.created_year,
+            Complaint.created_on,
+            Complaint.petitioner_mobile,
+            Complaint.petitioner_email,
+            GrievanceRedaction.grievance_redacted,
+        )
+        .select_from(DedupSignature)
+        .outerjoin(Complaint, Complaint.ticket_no == DedupSignature.ticket_no)
+        .outerjoin(GrievanceRedaction, GrievanceRedaction.ticket_no == DedupSignature.ticket_no)
+        .where(
+            DedupSignature.district == district,
+            DedupSignature.created_year == year,
+        )
+        .order_by(DedupSignature.ticket_no)
+    )
+    result = await conn.execute(stmt)
+    mismatches = []
+    missing_source = []
+    for (
+        ticket_no,
+        stored_digest,
+        row_district,
+        row_year,
+        created_on,
+        mobile,
+        email,
+        redacted_text,
+    ) in result:
+        if row_district is None or row_year is None or redacted_text is None:
+            missing_source.append(ticket_no)
+            continue
+        current = source_record_digest(
+            _source_record(
+                ticket_no, redacted_text, row_district, row_year, created_on, mobile, email
+            )
+        )
+        if stored_digest is not None and stored_digest != current:
+            mismatches.append(
+                (ticket_no, redacted_text, row_district, row_year, created_on, mobile, email)
+            )
+    return mismatches, missing_source
+
+
+def _source_digest_mismatch_error(count: int) -> ValueError:
+    return ValueError(
+        f"{count} signature(s) no longer match their current OLTP source input. "
+        "Refusing to group old candidates with current redacted text; rerun "
+        "with --refresh-stale to rebuild them."
+    )
+
+
+def _missing_source_error(tickets: list[str]) -> ValueError:
+    return ValueError(
+        f"{len(tickets)} signature(s) no longer have a current complaint/redaction "
+        "source row. Refusing to group orphan signatures; reconcile the slice "
+        "before rebuilding it."
+    )
+
+
+def _source_membership_changed_error(count: int) -> ValueError:
+    return ValueError(
+        f"{count} signature(s) moved outside this district-year source slice. "
+        "Refusing to rewrite an old slice under --refresh-stale; reconcile both "
+        "affected slices explicitly before rebuilding."
+    )
+
+
+def _raise_if_source_is_not_current(
+    source_mismatches, missing_source: list[str], district: str, year: int
+) -> None:
+    """Fail grouping before a stored signature and current text can diverge."""
+    if missing_source:
+        raise _missing_source_error(missing_source)
+    moved_sources = [
+        row for row in source_mismatches if row[2] != district or row[3] != year
+    ]
+    if moved_sources:
+        raise _source_membership_changed_error(len(moved_sources))
+    if source_mismatches:
+        raise _source_digest_mismatch_error(len(source_mismatches))
 
 
 async def _index_signatures(
@@ -411,6 +597,9 @@ async def _index_signatures(
     async with engine.begin() as conn:
         total, already = await _count_signature_slice(conn, district, year)
         stale = await _count_stale_signatures(conn, district, year, version)
+        source_mismatches, missing_source = await _source_digest_mismatches(
+            conn, district, year
+        )
     logger.info(
         "slice {}/{}: {} redacted complaints, {} already indexed",
         district,
@@ -429,6 +618,40 @@ async def _index_signatures(
             "rotation this is not optional -- the old identity hashes stay "
             "stored and linkage breaks across the boundary (#136).",
         )
+    if missing_source:
+        raise _missing_source_error(missing_source)
+    moved_sources = [
+        row for row in source_mismatches if row[2] != district or row[3] != year
+    ]
+    if moved_sources:
+        raise _source_membership_changed_error(len(moved_sources))
+    if source_mismatches and not refresh_stale:
+        raise _source_digest_mismatch_error(len(source_mismatches))
+    if source_mismatches:
+        if limit is not None:
+            raise ValueError(
+                "--limit cannot be combined with --refresh-stale when source "
+                "inputs changed; remove --limit to rebuild every mismatch."
+            )
+        logger.warning(
+            "{} signature(s) no longer match current OLTP source input; "
+            "rebuilding them because --refresh-stale was supplied.",
+            len(source_mismatches),
+        )
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        rows = _signature_rows_for_source_batch(
+            source_mismatches,
+            salt=salt,
+            epoch=epoch,
+            window_days=window_days,
+            version=version,
+            now=now,
+        )
+        async with engine.begin() as conn:
+            await conn.execute(
+                _dialect_upsert(DedupSignature, conn.dialect.name, rows, "ticket_no")
+            )
+        processed += len(rows)
 
     while True:
         remaining = None if limit is None else limit - processed
@@ -448,32 +671,14 @@ async def _index_signatures(
             # while SQLite silently accepts one. Same normalisation as
             # redact_grievance.py / db/crud.py.
             now = datetime.now(timezone.utc).replace(tzinfo=None)
-            rows = []
-            for ticket_no, redacted_text, row_district, created_on, mobile, email in batch:
-                text = redacted_text or ""
-                shingle_set = shingles(text)
-                signature = minhash_signature(shingle_set, num_hashes=DEFAULT_NUM_HASHES)
-                script = _script_of(text)
-                window_index = _window_index(created_on, epoch, window_days)
-                rows.append(
-                    {
-                        "ticket_no": ticket_no,
-                        "district": row_district,
-                        "created_year": year,
-                        "script": script,
-                        "window_index": window_index,
-                        "block_key": _block_key(row_district, script, window_index),
-                        "num_shingles": len(shingle_set),
-                        "signature": list(signature) if signature is not None else None,
-                        # A separate path from `text` above: computed from
-                        # the complaints columns directly, never from
-                        # redacted_text (dedup.py module docstring point 3).
-                        "identity_key_mobile": identity_key(mobile, salt) if mobile else None,
-                        "identity_key_email": identity_key(email, salt) if email else None,
-                        "index_version": version,
-                        "indexed_at": now,
-                    }
-                )
+            rows = _signature_rows_for_source_batch(
+                batch,
+                salt=salt,
+                epoch=epoch,
+                window_days=window_days,
+                version=version,
+                now=now,
+            )
             await conn.execute(
                 _dialect_upsert(DedupSignature, conn.dialect.name, rows, "ticket_no")
             )
@@ -488,6 +693,7 @@ async def _index_signatures(
         "already_indexed": already,
         "processed": processed,
         "stale_at_start": stale,
+        "source_mismatches_at_start": len(source_mismatches),
     }
 
 
@@ -507,6 +713,39 @@ async def _load_slice_signatures(conn, district: str, year: int):
     )
     result = await conn.execute(stmt)
     return result.all()
+
+
+async def _source_snapshot_for_signature_slice(conn, district: str, year: int) -> str:
+    """Manifest the exact indexed inputs represented by this group run.
+
+    This intentionally reads the digest stored at signature time, never the
+    current redaction row. If OLTP changes without re-indexing, persisted
+    groups continue to identify their older actual input, and a prospective
+    lake join fails the public assertion rather than being stamped as current.
+    A partial signature run likewise has a manifest only for its actual subset
+    and cannot validate a full lake slice.
+    """
+    stmt = (
+        select(
+            DedupSignature.ticket_no,
+            DedupSignature.source_record_digest,
+        )
+        .where(
+            DedupSignature.district == district,
+            DedupSignature.created_year == year,
+        )
+        .order_by(DedupSignature.ticket_no)
+    )
+    result = await conn.execute(stmt)
+    row_digests = result.all()
+    missing = [ticket_no for ticket_no, digest in row_digests if digest is None]
+    if missing:
+        raise ValueError(
+            "dedup groups cannot be stamped with source provenance while "
+            f"{len(missing)} signature(s) lack source_record_digest; rerun "
+            "janasunani-dedup-index so #137 can rebuild them"
+        )
+    return source_snapshot_id_from_record_digests(row_digests)
 
 
 async def _load_redacted_text(conn, ticket_nos: list[str]) -> dict[str, str]:
@@ -750,6 +989,13 @@ async def _group_duplicates(
 ) -> dict[str, int]:
     async with engine.begin() as conn:
         rows = await _load_slice_signatures(conn, district, year)
+        source_mismatches, missing_source = await _source_digest_mismatches(
+            conn, district, year
+        )
+        _raise_if_source_is_not_current(
+            source_mismatches, missing_source, district, year
+        )
+        snapshot_id = await _source_snapshot_for_signature_slice(conn, district, year)
 
     if not rows:
         return {
@@ -864,6 +1110,8 @@ async def _group_duplicates(
             "block_key": block_key_by_ticket[ticket_no],
             "duplicate_group_id": group_id,
             "group_size": group_sizes[group_id],
+            "source_name": DEDUP_SOURCE_NAME,
+            "source_snapshot_id": snapshot_id,
             "index_version": version,
             "grouped_at": now,
         }
@@ -871,6 +1119,16 @@ async def _group_duplicates(
     ]
 
     async with engine.begin() as conn:
+        # A source update can race the initial check while candidate text is
+        # being fetched and verified. Check again immediately before persisting
+        # a certified group assignment; this narrows the READ COMMITTED race
+        # window, though it is not a substitute for a transaction-wide lock.
+        source_mismatches, missing_source = await _source_digest_mismatches(
+            conn, district, year
+        )
+        _raise_if_source_is_not_current(
+            source_mismatches, missing_source, district, year
+        )
         for i in range(0, len(group_rows), BATCH_SIZE):
             chunk = group_rows[i : i + BATCH_SIZE]
             await conn.execute(
@@ -1012,10 +1270,12 @@ def main() -> None:
         action="store_true",
         help=(
             "Also rebuild signatures produced under different parameters "
-            "(salt, window, threshold, or dedup.py's own constants). Off by "
-            "default: a backfill over derived citizen data should not change "
-            "scope because an unrelated value moved. Required after a salt "
-            "rotation, or the old identity hashes stay stored."
+            "(salt, window, threshold, or dedup.py's own constants), or whose "
+            "current OLTP source record no longer matches its stored digest. "
+            "Off by default: a backfill over derived citizen data should not "
+            "change scope because an unrelated value moved. Required after a "
+            "salt rotation or redaction/source update; otherwise grouping fails "
+            "closed rather than mixing old candidates with current text."
         ),
     )
     args = parser.parse_args()

--- a/tests/test_dedup_index.py
+++ b/tests/test_dedup_index.py
@@ -26,7 +26,15 @@ from janasunani.db.models import (
     DedupSignature,
     GrievanceRedaction,
 )
-from janasunani.pipeline.dedup import identity_key, minhash_signature, shingles
+from janasunani.pipeline.dedup import (
+    DEDUP_SOURCE_NAME,
+    DedupSourceSnapshotMismatch,
+    assert_group_source_snapshot,
+    identity_key,
+    minhash_signature,
+    shingles,
+    source_snapshot_id,
+)
 from janasunani.pipeline.dedup_index import (
     DEFAULT_NUM_HASHES,
     _script_of,
@@ -215,6 +223,183 @@ class TestNaiveUTCTimestamps:
         row = _group_rows(sync_url)["T1"]
         assert row.grouped_at is not None
         assert row.grouped_at.tzinfo is None
+
+
+class TestGroupSourceSnapshotProvenance:
+    """#137. Groups stay in OLTP for the short redaction -> index chain, but
+    #72-style lake analytics must be able to prove their source slice matches
+    before treating a group id as a denominator."""
+
+    @staticmethod
+    def _source_records():
+        return [
+            {
+                "ticket_no": ticket_no,
+                "district": district,
+                "created_year": year,
+                "created_on": created_on,
+                "petitioner_mobile": mobile,
+                "petitioner_email": None,
+                "grievance_redacted": redacted,
+            }
+            for ticket_no, district, year, created_on, mobile, redacted in _SMALL_ROWS
+            if district == "Khordha" and year == 2024 and redacted is not None
+        ]
+
+    def test_groups_record_the_recomputable_oltp_source_snapshot(self, oltp):
+        async_url, sync_url = oltp
+        build_dedup_index("Khordha", 2024, oltp_url=async_url, salt=_SALT)
+
+        source_records = self._source_records()
+        expected = source_snapshot_id(source_records)
+        groups = _group_rows(sync_url)
+        assert {row.source_name for row in groups.values()} == {DEDUP_SOURCE_NAME}
+        assert {row.source_snapshot_id for row in groups.values()} == {expected}
+
+        # This is the direct downstream guard: source-row ordering is irrelevant,
+        # while a different/incomplete lake source would fail before aggregation.
+        assert (
+            assert_group_source_snapshot(
+                [
+                    {
+                        "source_name": row.source_name,
+                        "source_snapshot_id": row.source_snapshot_id,
+                    }
+                    for row in groups.values()
+                ],
+                reversed(source_records),
+            )
+            == expected
+        )
+
+    def test_changed_oltp_source_fails_until_refresh_then_recertifies(self, oltp):
+        async_url, sync_url = oltp
+        build_dedup_index("Khordha", 2024, oltp_url=async_url, salt=_SALT)
+        before = _group_rows(sync_url)["T1"].source_snapshot_id
+
+        engine = create_engine(sync_url)
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "UPDATE grievance_redactions SET grievance_redacted = :text "
+                    "WHERE ticket_no = 'T1'"
+                ),
+                {"text": "water supply now broken for eight months"},
+            )
+        engine.dispose()
+
+        # Candidate generation would use the old signature while Jaccard
+        # verification would read the new redacted text. Do not write a newly
+        # certified group from those mixed inputs.
+        with pytest.raises(ValueError, match="old candidates with current redacted text"):
+            build_dedup_index("Khordha", 2024, oltp_url=async_url, salt=_SALT)
+        groups = _group_rows(sync_url)
+        assert groups["T1"].source_snapshot_id == before
+        changed_source = self._source_records()
+        changed_source[0]["grievance_redacted"] = "water supply now broken for eight months"
+        with pytest.raises(DedupSourceSnapshotMismatch, match="does not match"):
+            assert_group_source_snapshot(
+                [
+                    {
+                        "source_name": row.source_name,
+                        "source_snapshot_id": row.source_snapshot_id,
+                    }
+                    for row in groups.values()
+                ],
+                changed_source,
+            )
+
+        refreshed = build_dedup_index(
+            "Khordha",
+            2024,
+            oltp_url=async_url,
+            salt=_SALT,
+            refresh_stale=True,
+        )
+        groups = _group_rows(sync_url)
+        assert refreshed["source_mismatches_at_start"] == 1
+        assert groups["T1"].source_snapshot_id != before
+        assert (
+            assert_group_source_snapshot(
+                [
+                    {
+                        "source_name": row.source_name,
+                        "source_snapshot_id": row.source_snapshot_id,
+                    }
+                    for row in groups.values()
+                ],
+                changed_source,
+            )
+            == groups["T1"].source_snapshot_id
+        )
+
+    def test_legacy_signature_without_a_source_digest_is_rebuilt(self, oltp):
+        async_url, sync_url = oltp
+        build_dedup_index("Khordha", 2024, oltp_url=async_url, salt=_SALT)
+        engine = create_engine(sync_url)
+        with engine.begin() as conn:
+            conn.execute(text("UPDATE dedup_signatures SET source_record_digest = NULL"))
+        engine.dispose()
+
+        counts = build_dedup_index("Khordha", 2024, oltp_url=async_url, salt=_SALT)
+        assert counts["processed"] == counts["total"]
+        assert all(row.source_record_digest for row in _signature_rows(sync_url).values())
+
+    def test_source_membership_change_fails_closed_even_with_refresh(self, oltp):
+        async_url, sync_url = oltp
+        build_dedup_index("Khordha", 2024, oltp_url=async_url, salt=_SALT)
+        before = _group_rows(sync_url)["T1"].source_snapshot_id
+        engine = create_engine(sync_url)
+        with engine.begin() as conn:
+            conn.execute(
+                text("UPDATE complaints SET created_year = 2023 WHERE ticket_no = 'T1'")
+            )
+        engine.dispose()
+
+        with pytest.raises(ValueError, match="moved outside this district-year"):
+            build_dedup_index(
+                "Khordha",
+                2024,
+                oltp_url=async_url,
+                salt=_SALT,
+                refresh_stale=True,
+            )
+        assert _group_rows(sync_url)["T1"].source_snapshot_id == before
+
+    def test_missing_current_source_row_fails_closed(self, oltp):
+        async_url, sync_url = oltp
+        build_dedup_index("Khordha", 2024, oltp_url=async_url, salt=_SALT)
+        engine = create_engine(sync_url)
+        with engine.begin() as conn:
+            conn.execute(text("DELETE FROM grievance_redactions WHERE ticket_no = 'T1'"))
+        engine.dispose()
+
+        with pytest.raises(ValueError, match="no longer have a current complaint/redaction"):
+            build_dedup_index("Khordha", 2024, oltp_url=async_url, salt=_SALT)
+
+    def test_source_refresh_rejects_limit_instead_of_exceeding_it(self, oltp):
+        async_url, sync_url = oltp
+        build_dedup_index("Khordha", 2024, oltp_url=async_url, salt=_SALT)
+        engine = create_engine(sync_url)
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "UPDATE grievance_redactions SET grievance_redacted = :text "
+                    "WHERE ticket_no = 'T1'"
+                ),
+                {"text": "water supply now broken for eight months"},
+            )
+        engine.dispose()
+
+        with pytest.raises(ValueError, match="--limit cannot be combined"):
+            build_dedup_index(
+                "Khordha",
+                2024,
+                oltp_url=async_url,
+                salt=_SALT,
+                refresh_stale=True,
+                limit=1,
+            )
 
 
 class TestSaltRequirement:

--- a/tests/test_dedup_index.py
+++ b/tests/test_dedup_index.py
@@ -367,6 +367,10 @@ class TestGroupSourceSnapshotProvenance:
         )
         groups = _group_rows(sync_url)
         assert refreshed["source_mismatches_at_start"] == 1
+        assert refreshed["total"] == 3
+        assert refreshed["already_indexed"] == 2
+        assert refreshed["processed"] == 1
+        assert refreshed["already_indexed"] + refreshed["processed"] == 3
         assert groups["T1"].source_snapshot_id != before
         assert (
             assert_group_source_snapshot(
@@ -1108,6 +1112,8 @@ class TestRefreshStaleSignatures:
             "Sambalpur", 2024, oltp_url=async_url, salt="s", refresh_stale=True
         )
         assert counts["processed"] == first["processed"]
+        assert counts["already_indexed"] == 0
+        assert counts["processed"] + counts["already_indexed"] == counts["total"]
 
         engine = create_engine(sync_url)
         with engine.begin() as conn:
@@ -1252,3 +1258,48 @@ class TestCLIReporting:
         final = next(message for message in messages if message.startswith("done:"))
         assert "comparison_pairs=0" in final
         assert "large_buckets=0" in final
+
+    def test_main_reports_one_refresh_as_three_of_three_not_four(self, oltp, monkeypatch):
+        from loguru import logger as loguru_logger
+
+        import janasunani.pipeline.dedup_index as di
+
+        async_url, sync_url = oltp
+        build_dedup_index("Khordha", 2024, oltp_url=async_url, salt=_SALT)
+        engine = create_engine(sync_url)
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "UPDATE grievance_redactions SET grievance_redacted = :text "
+                    "WHERE ticket_no = 'T1'"
+                ),
+                {"text": "water supply now broken for eight months"},
+            )
+        engine.dispose()
+
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "janasunani-dedup-index",
+                "--district",
+                "Khordha",
+                "--year",
+                "2024",
+                "--oltp-url",
+                async_url,
+                "--salt",
+                _SALT,
+                "--refresh-stale",
+            ],
+        )
+        messages = []
+        sink = loguru_logger.add(
+            lambda message: messages.append(str(message)), level="INFO", format="{message}"
+        )
+        try:
+            di.main()
+        finally:
+            loguru_logger.remove(sink)
+
+        final = next(message for message in messages if message.startswith("done:"))
+        assert final.startswith("done: 1 processed this run, 3 of 3 indexed")

--- a/tests/test_dedup_index.py
+++ b/tests/test_dedup_index.py
@@ -246,7 +246,18 @@ class TestGroupSourceSnapshotProvenance:
             if district == "Khordha" and year == 2024 and redacted is not None
         ]
 
-    def test_groups_record_the_recomputable_oltp_source_snapshot(self, oltp):
+    @staticmethod
+    def _group_provenance_rows(groups):
+        return [
+            {
+                "ticket_no": row.ticket_no,
+                "source_name": row.source_name,
+                "source_snapshot_id": row.source_snapshot_id,
+            }
+            for row in groups.values()
+        ]
+
+    def test_reordered_complete_group_set_validates(self, oltp):
         async_url, sync_url = oltp
         build_dedup_index("Khordha", 2024, oltp_url=async_url, salt=_SALT)
 
@@ -260,17 +271,61 @@ class TestGroupSourceSnapshotProvenance:
         # while a different/incomplete lake source would fail before aggregation.
         assert (
             assert_group_source_snapshot(
-                [
-                    {
-                        "source_name": row.source_name,
-                        "source_snapshot_id": row.source_snapshot_id,
-                    }
-                    for row in groups.values()
-                ],
+                reversed(self._group_provenance_rows(groups)),
                 reversed(source_records),
             )
             == expected
         )
+
+    def test_missing_group_row_fails_with_counts_only(self, oltp):
+        async_url, sync_url = oltp
+        build_dedup_index("Khordha", 2024, oltp_url=async_url, salt=_SALT)
+        group_rows = self._group_provenance_rows(_group_rows(sync_url))
+
+        with pytest.raises(
+            DedupSourceSnapshotMismatch,
+            match="missing_group_rows=1, extra_group_rows=0",
+        ):
+            assert_group_source_snapshot(group_rows[:-1], self._source_records())
+
+    def test_extra_group_row_fails_with_counts_only(self, oltp):
+        async_url, sync_url = oltp
+        build_dedup_index("Khordha", 2024, oltp_url=async_url, salt=_SALT)
+        group_rows = self._group_provenance_rows(_group_rows(sync_url))
+        group_rows.append(
+            {
+                "ticket_no": "synthetic-extra-ticket",
+                "source_name": group_rows[0]["source_name"],
+                "source_snapshot_id": group_rows[0]["source_snapshot_id"],
+            }
+        )
+
+        with pytest.raises(
+            DedupSourceSnapshotMismatch,
+            match="missing_group_rows=0, extra_group_rows=1",
+        ):
+            assert_group_source_snapshot(group_rows, self._source_records())
+
+    def test_duplicate_group_row_fails_with_count_only(self, oltp):
+        async_url, sync_url = oltp
+        build_dedup_index("Khordha", 2024, oltp_url=async_url, salt=_SALT)
+        group_rows = self._group_provenance_rows(_group_rows(sync_url))
+        group_rows.append(dict(group_rows[0]))
+
+        with pytest.raises(DedupSourceSnapshotMismatch, match="duplicates=1"):
+            assert_group_source_snapshot(group_rows, self._source_records())
+
+    def test_blank_group_ticket_fails_with_count_only(self, oltp):
+        async_url, sync_url = oltp
+        build_dedup_index("Khordha", 2024, oltp_url=async_url, salt=_SALT)
+        group_rows = self._group_provenance_rows(_group_rows(sync_url))
+        group_rows[0]["ticket_no"] = " "
+
+        with pytest.raises(
+            DedupSourceSnapshotMismatch,
+            match="blank_or_non_string=1",
+        ):
+            assert_group_source_snapshot(group_rows, self._source_records())
 
     def test_changed_oltp_source_fails_until_refresh_then_recertifies(self, oltp):
         async_url, sync_url = oltp
@@ -299,13 +354,7 @@ class TestGroupSourceSnapshotProvenance:
         changed_source[0]["grievance_redacted"] = "water supply now broken for eight months"
         with pytest.raises(DedupSourceSnapshotMismatch, match="does not match"):
             assert_group_source_snapshot(
-                [
-                    {
-                        "source_name": row.source_name,
-                        "source_snapshot_id": row.source_snapshot_id,
-                    }
-                    for row in groups.values()
-                ],
+                self._group_provenance_rows(groups),
                 changed_source,
             )
 
@@ -321,13 +370,7 @@ class TestGroupSourceSnapshotProvenance:
         assert groups["T1"].source_snapshot_id != before
         assert (
             assert_group_source_snapshot(
-                [
-                    {
-                        "source_name": row.source_name,
-                        "source_snapshot_id": row.source_snapshot_id,
-                    }
-                    for row in groups.values()
-                ],
+                self._group_provenance_rows(groups),
                 changed_source,
             )
             == groups["T1"].source_snapshot_id


### PR DESCRIPTION
## Summary

Keeps the current dedup build on OLTP while making its source snapshot explicit and auditable for downstream lake analytics.

- persists a canonical per-signature source-record digest and group-level snapshot manifest;
- fails closed when source rows changed, moved, disappeared, or otherwise diverge from stored signatures;
- requires explicit `--refresh-stale` to rebuild changed source inputs;
- provides a reusable assertion so duplicate-adjusted analytics reject mixed/stale lake snapshots;
- adds the nullable migration and updates ROADMAP to the settled OLTP + pinned-snapshot architecture.

## Validation

- focused dedup suite: 129 passed
- full `uv run --extra serving --extra pipeline-core pytest`: passed
- migration upgrade/downgrade/upgrade round trip on fresh SQLite: passed
- Ruff and `git diff --check`: passed

Fixes #137.