### PR TITLE
feat(triage): add advisory result contract and banner

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -34,9 +34,10 @@ Two backends implement the same contract:
   store). First boot is slow (model warm-up); `/health` must report
   `{"processor":"pipeline"}`.
 - **Mock** — `uv run --extra serving janasunani-api`. Canned/regex responses,
-  useful for fast UI iteration without models loaded. Results from this API
-  come back with `routing.method: "mock"` and the UI marks them with a
-  "mock result" badge.
+useful for fast UI iteration without models loaded. Results from this API
+come back with `routing.method: "mock"` and the UI marks them with a
+  "mock result" badge. Its triage states are deterministic illustrations, not
+  findings about real grievances.
 
 Whichever backend is running, note that `routing.method` frequently comes
 back `"fallback"` (low confidence) rather than `"rules"` — the real
@@ -45,11 +46,19 @@ category→department crosswalk is still being built out (see
 grievance cell rather than failing. This is expected; the UI renders it with
 an explanatory note, not as an error.
 
+The result screen's triage banner is advisory only. Possible resubmissions link
+to the existing history search, campaigns use a distinct collective-grievance
+treatment with the related-filing count, and low-signal scoring shows both the
+reason and an abstention when the scorer declines. Nothing in the banner
+blocks or rejects a submission. Learned routes show their aggregate support
+and destination concentration beside the existing confidence and escalation
+chain.
+
 ## Structure
 
 - `app/` — routes: `/` (submit a grievance) and `/history` (browse/search).
 - `components/` — `SubmitForm`, `ResultView` (the five-step result cards),
-  `HistoryView`, and `ui.tsx` (Card/Field/Badge primitives).
+  `TriageBanner`, `HistoryView`, and `ui.tsx` (Card/Field/Badge primitives).
 - `lib/api.ts` — the fetch client (`submitGrievance`, `fetchHistory`).
 - `lib/types.ts` — TypeScript mirror of `janasunani/serving/schemas.py`. Do
   not rename these fields without a matching backend contract change.

--- a/frontend/app/history/page.tsx
+++ b/frontend/app/history/page.tsx
@@ -1,6 +1,13 @@
 import { HistoryView } from "@/components/HistoryView";
 
-export default function HistoryPageRoute() {
+export default async function HistoryPageRoute({
+  searchParams,
+}: {
+  searchParams: Promise<{ q?: string | string[] }>;
+}) {
+  const q = (await searchParams).q;
+  const initialQuery = Array.isArray(q) ? (q[0] ?? "") : (q ?? "");
+
   return (
     <div className="flex flex-col gap-6">
       <div className="flex flex-col gap-1">
@@ -10,7 +17,7 @@ export default function HistoryPageRoute() {
           district, or category.
         </p>
       </div>
-      <HistoryView />
+      <HistoryView initialQuery={initialQuery} />
     </div>
   );
 }

--- a/frontend/components/HistoryView.tsx
+++ b/frontend/components/HistoryView.tsx
@@ -13,13 +13,17 @@ function fmtDate(iso: string | null): string {
   return Number.isNaN(d.getTime()) ? iso : d.toLocaleDateString();
 }
 
-export function HistoryView() {
+export function HistoryView({ initialQuery = "" }: { initialQuery?: string }) {
   // Applied filters (drive the query); form fields are separate so typing
   // doesn't fire a request per keystroke.
-  const [q, setQ] = useState("");
+  const [q, setQ] = useState(initialQuery);
   const [district, setDistrict] = useState("");
   const [category, setCategory] = useState("");
-  const [applied, setApplied] = useState({ q: "", district: "", category: "" });
+  const [applied, setApplied] = useState({
+    q: initialQuery,
+    district: "",
+    category: "",
+  });
   const [offset, setOffset] = useState(0);
 
   const [page, setPage] = useState<HistoryPage | null>(null);

--- a/frontend/components/ResultView.tsx
+++ b/frontend/components/ResultView.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import type { GrievanceResult, PIIEntity } from "@/lib/types";
+import { TriageBanner } from "./TriageBanner";
 import { Badge, Card, Field } from "./ui";
 
 /** Render extracted text with detected PII spans highlighted in place.
@@ -75,6 +76,8 @@ export function ResultView({ result }: { result: GrievanceResult }) {
           a toy regex, not the production PII analyzer.
         </p>
       )}
+
+      <TriageBanner triage={result.triage} />
 
       {/* 1. Extraction */}
       <Card
@@ -157,6 +160,16 @@ export function ResultView({ result }: { result: GrievanceResult }) {
             No specific rule matched this category/district — routed to the
             generic public grievance cell as a safety net. Confidence is low
             by design.
+          </p>
+        )}
+        {routing.method === "learned" && routing.empirical_evidence && (
+          <p className="mb-3 rounded-sm border border-hair bg-panel px-3 py-2 text-xs leading-relaxed text-text-secondary">
+            This destination describes historical dispatch, not which office
+            resolves cases best. It is based on{" "}
+            {routing.empirical_evidence.support} comparable historical
+            routings;{" "}
+            {(routing.empirical_evidence.concentration * 100).toFixed(0)}% went
+            to this destination.
           </p>
         )}
         <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2">

--- a/frontend/components/TriageBanner.tsx
+++ b/frontend/components/TriageBanner.tsx
@@ -7,10 +7,7 @@ import { Badge } from "./ui";
  * action: a triage signal must never change whether a grievance is received.
  */
 export function TriageBanner({ triage }: { triage: TriageResult }) {
-  const { duplicate, spam } = triage;
-  const hasSpamReview = spam.decision !== "not_scored";
-
-  if (!duplicate && !hasSpamReview) return null;
+  const { duplicate, duplicate_review, spam } = triage;
 
   return (
     <section
@@ -29,6 +26,48 @@ export function TriageBanner({ triage }: { triage: TriageResult }) {
       </p>
 
       <div className="flex flex-col gap-2">
+        {duplicate_review.decision === "not_indexed" && (
+          <article className="rounded-sm border border-hair bg-surface px-3 py-2">
+            <Badge tone="neutral">duplicate check not indexed</Badge>
+            <p className="mt-1 text-sm text-text-body">
+              {duplicate_review.reason}
+            </p>
+            <p className="mt-1 text-xs text-text-secondary">
+              This is not a finding that there are no related filings.
+            </p>
+          </article>
+        )}
+
+        {duplicate_review.decision === "unavailable" && (
+          <article className="rounded-sm border border-hair bg-surface px-3 py-2">
+            <Badge tone="neutral">duplicate check unavailable</Badge>
+            <p className="mt-1 text-sm text-text-body">
+              {duplicate_review.reason}
+            </p>
+          </article>
+        )}
+
+        {duplicate_review.decision === "abstained" && (
+          <article className="rounded-sm border border-hair bg-surface px-3 py-2">
+            <Badge tone="neutral">duplicate check abstained</Badge>
+            <p className="mt-1 text-sm text-text-body">
+              {duplicate_review.reason}
+            </p>
+            <p className="mt-1 text-xs text-text-secondary">
+              No duplicate finding was made.
+            </p>
+          </article>
+        )}
+
+        {duplicate_review.decision === "no_match" && (
+          <article className="rounded-sm border border-hair bg-surface px-3 py-2">
+            <Badge tone="neutral">duplicate check complete</Badge>
+            <p className="mt-1 text-sm text-text-body">
+              No verified related filing was found in the checked index.
+            </p>
+          </article>
+        )}
+
         {duplicate?.duplicate_kind === "resubmission" &&
           duplicate.duplicate_ticket_no && (
             <article className="rounded-sm border border-hair bg-surface px-3 py-2">
@@ -80,6 +119,19 @@ export function TriageBanner({ triage }: { triage: TriageResult }) {
             <p className="mt-1 text-sm text-text-body">{spam.spam_reason}</p>
             <p className="mt-1 text-xs text-text-secondary">
               No low-signal flag was assigned.
+            </p>
+          </article>
+        )}
+
+        {spam.decision === "not_scored" && (
+          <article className="rounded-sm border border-hair bg-surface px-3 py-2">
+            <Badge tone="neutral">low-signal review unavailable</Badge>
+            <p className="mt-1 text-sm text-text-body">
+              Low-signal scoring has not run for this submission.
+            </p>
+            <p className="mt-1 text-xs text-text-secondary">
+              This is neither a low-signal flag nor a finding that the
+              grievance is actionable.
             </p>
           </article>
         )}

--- a/frontend/components/TriageBanner.tsx
+++ b/frontend/components/TriageBanner.tsx
@@ -1,0 +1,89 @@
+import Link from "next/link";
+import type { TriageResult } from "@/lib/types";
+import { Badge } from "./ui";
+
+/**
+ * Review context only. These states deliberately have no dismiss/accept/reject
+ * action: a triage signal must never change whether a grievance is received.
+ */
+export function TriageBanner({ triage }: { triage: TriageResult }) {
+  const { duplicate, spam } = triage;
+  const hasSpamReview = spam.decision !== "not_scored";
+
+  if (!duplicate && !hasSpamReview) return null;
+
+  return (
+    <section
+      aria-label="Advisory triage signals"
+      className="rounded-md border border-hair bg-card p-4"
+    >
+      <div className="mb-3 flex flex-wrap items-baseline justify-between gap-2">
+        <h2 className="text-sm font-bold text-text-dark">
+          Advisory triage signals
+        </h2>
+        <Badge tone="neutral">review only</Badge>
+      </div>
+      <p className="mb-3 text-xs leading-relaxed text-text-secondary">
+        These signals assist officer review. They do not block, reject, or
+        remove this grievance.
+      </p>
+
+      <div className="flex flex-col gap-2">
+        {duplicate?.duplicate_kind === "resubmission" &&
+          duplicate.duplicate_ticket_no && (
+            <article className="rounded-sm border border-hair bg-surface px-3 py-2">
+              <Badge tone="neutral">possible duplicate</Badge>
+              <p className="mt-1 text-sm text-text-body">
+                Possible duplicate of ticket{" "}
+                <Link
+                  href={`/history?q=${encodeURIComponent(duplicate.duplicate_ticket_no)}`}
+                  className="font-mono font-semibold text-maroon underline underline-offset-2"
+                >
+                  {duplicate.duplicate_ticket_no}
+                </Link>
+                . Review both filings before taking any action.
+              </p>
+            </article>
+          )}
+
+        {duplicate?.duplicate_kind === "campaign" &&
+          duplicate.related_filings && (
+          <article className="rounded-sm border border-positive bg-positive/10 px-3 py-2">
+            <Badge tone="positive">collective grievance</Badge>
+            <h3 className="mt-1 text-sm font-semibold text-text-dark">
+              Part of a campaign
+            </h3>
+            <p className="mt-1 text-sm text-text-body">
+              {duplicate.related_filings} related filings were found. This is
+              a collective grievance, not spam; each filing remains visible
+              for review.
+            </p>
+          </article>
+        )}
+
+        {spam.decision === "flagged" && (
+          <article className="rounded-sm border border-negative bg-negative/10 px-3 py-2">
+            <Badge tone="negative">low-signal review</Badge>
+            <h3 className="mt-1 text-sm font-semibold text-text-dark">
+              Flagged low-signal, review
+            </h3>
+            <p className="mt-1 text-sm text-text-body">{spam.spam_reason}</p>
+            <p className="mt-1 text-xs text-text-secondary">
+              This flag does not reject the grievance.
+            </p>
+          </article>
+        )}
+
+        {spam.decision === "abstained" && (
+          <article className="rounded-sm border border-hair bg-surface px-3 py-2">
+            <Badge tone="neutral">low-signal review abstained</Badge>
+            <p className="mt-1 text-sm text-text-body">{spam.spam_reason}</p>
+            <p className="mt-1 text-xs text-text-secondary">
+              No low-signal flag was assigned.
+            </p>
+          </article>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -52,6 +52,16 @@ export interface DuplicateSignal {
   related_filings?: number | null;
 }
 
+export interface DuplicateReview {
+  decision:
+    | "matched"
+    | "no_match"
+    | "abstained"
+    | "not_indexed"
+    | "unavailable";
+  reason?: string | null;
+}
+
 export interface SpamReview {
   decision: "flagged" | "abstained" | "not_scored";
   spam_reason?: string | null;
@@ -60,6 +70,7 @@ export interface SpamReview {
 
 export interface TriageResult {
   duplicate?: DuplicateSignal | null;
+  duplicate_review: DuplicateReview;
   spam: SpamReview;
 }
 

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -32,6 +32,35 @@ export interface RoutingResult {
   escalation_authority?: string | null;
   confidence: number; // 0..1
   method: "rules" | "learned" | "fallback" | "mock";
+  empirical_evidence?: EmpiricalRoutingEvidence | null;
+}
+
+export interface EmpiricalRoutingEvidence {
+  support: number;
+  concentration: number; // 0..1: historic destination share
+  width:
+    | "category+subcategory+district"
+    | "category+subcategory"
+    | "category+district"
+    | "category";
+}
+
+export interface DuplicateSignal {
+  duplicate_kind: "resubmission" | "campaign";
+  duplicate_group_id: string;
+  duplicate_ticket_no?: string | null;
+  related_filings?: number | null;
+}
+
+export interface SpamReview {
+  decision: "flagged" | "abstained" | "not_scored";
+  spam_reason?: string | null;
+  spam_score?: number | null;
+}
+
+export interface TriageResult {
+  duplicate?: DuplicateSignal | null;
+  spam: SpamReview;
 }
 
 export interface GrievanceResult {
@@ -44,6 +73,7 @@ export interface GrievanceResult {
   classification: ClassificationResult;
   summary: string;
   routing: RoutingResult;
+  triage: TriageResult;
 }
 
 export interface HistoryItem {

--- a/janasunani/inference/service.py
+++ b/janasunani/inference/service.py
@@ -8,6 +8,7 @@ component exactly once.
 
 from __future__ import annotations
 
+import logging
 import os
 import shutil
 from datetime import UTC, datetime
@@ -24,8 +25,15 @@ from janasunani.serving.schemas import (
     PIIEntity,
     RedactionResult,
     RoutingResult,
-    TriageResult,
 )
+from janasunani.serving.triage import (
+    TriageProvider,
+    TriageUnavailableError,
+    UnwiredTriageProvider,
+    unavailable_triage,
+)
+
+logger = logging.getLogger(__name__)
 
 # Derived from the canonical label->class map (class 1 = grievance-bearing)
 # instead of a parallel hardcoded literal, so the two can't drift apart.
@@ -79,6 +87,7 @@ class PipelineGrievanceProcessor:
         router: _Router,
         is_english_compatible: Callable[[str], bool],
         detect_language: Callable[[str], str],
+        triage_provider: TriageProvider | None = None,
         now: Callable[[], datetime] | None = None,
     ) -> None:
         self._ocr = ocr
@@ -89,6 +98,7 @@ class PipelineGrievanceProcessor:
         self._router = router
         self._is_english_compatible = is_english_compatible
         self._detect_language = detect_language
+        self._triage_provider = triage_provider or UnwiredTriageProvider()
         self._now = now or (lambda: datetime.now(UTC))
 
     def process(
@@ -174,6 +184,21 @@ class PipelineGrievanceProcessor:
             redacted_text=redacted_text,
             entities=pii_entities,
         )
+        submitted_on = self._now()
+        try:
+            # The provider is intentionally called after redaction, never on
+            # raw OCR or typed citizen text.  Its result is advisory only.
+            triage = self._triage_provider.assess(
+                redacted_text=redaction.redacted_text,
+                district=district,
+                submitted_on=submitted_on,
+            )
+        except TriageUnavailableError:
+            # A triage outage cannot reject or delay a grievance.  Do not
+            # surface the provider exception: it may contain infrastructure
+            # details and is not an officer-facing explanation.
+            logger.warning("advisory triage unavailable; accepting grievance without it")
+            triage = unavailable_triage()
 
         classifier_text = (
             redacted_text if extraction.source == "text" else model_text_source
@@ -196,7 +221,7 @@ class PipelineGrievanceProcessor:
             id=grievance_id,
             ticket_no=ticket_no,
             status="Submitted",
-            submitted_on=self._now(),
+            submitted_on=submitted_on,
             extraction=extraction,
             redaction=redaction,
             classification=ClassificationResult(
@@ -205,10 +230,7 @@ class PipelineGrievanceProcessor:
             ),
             summary=summary,
             routing=routing,
-            # Phase 14 scoring is not wired into the live processor yet. The
-            # explicit state prevents the frontend from mistaking no result for
-            # a negative low-signal decision.
-            triage=TriageResult(),
+            triage=triage,
         )
 
 

--- a/janasunani/inference/service.py
+++ b/janasunani/inference/service.py
@@ -24,6 +24,7 @@ from janasunani.serving.schemas import (
     PIIEntity,
     RedactionResult,
     RoutingResult,
+    TriageResult,
 )
 
 # Derived from the canonical label->class map (class 1 = grievance-bearing)
@@ -204,6 +205,10 @@ class PipelineGrievanceProcessor:
             ),
             summary=summary,
             routing=routing,
+            # Phase 14 scoring is not wired into the live processor yet. The
+            # explicit state prevents the frontend from mistaking no result for
+            # a negative low-signal decision.
+            triage=TriageResult(),
         )
 
 

--- a/janasunani/routing/rules.py
+++ b/janasunani/routing/rules.py
@@ -30,7 +30,7 @@ from janasunani.routing.mappings import (
     _GENERIC_OFFICE_NAME,
     load_mapping_tables,
 )
-from janasunani.serving.schemas import RoutingResult
+from janasunani.serving.schemas import EmpiricalRoutingEvidence, RoutingResult
 
 
 @dataclass(frozen=True)
@@ -324,6 +324,11 @@ class _LazyDefaultRouter:
                     # "learned" rather than "rules": this came from what the
                     # record shows, not from a hand-written table.
                     method="learned",
+                    empirical_evidence=EmpiricalRoutingEvidence(
+                        support=hit.support,
+                        concentration=hit.share,
+                        width=hit.width,
+                    ),
                 )
         return self._get().route(
             category=category,

--- a/janasunani/serving/README.md
+++ b/janasunani/serving/README.md
@@ -44,10 +44,13 @@ There is still no auth/redaction on `/history`, so the real-history opt-in
 **`schemas.py` is the contract.** Field names mirror what already exists —
 pipeline artifact DB (`extracted_text`/`redacted_text`/`ocr_model`),
 `PIISpan` (entity/start/end over the *extracted* text), lake columns for
-history rows — so wire-up is plumbing, not renaming. Changing a field is an
-API break; the frontend is built against exactly these shapes, and
-`tests/test_serving_api.py` pins them (those tests must pass unchanged after
-wire-up).
+history rows, and Phase 14's advisory triage states. `RoutingResult` carries
+support and concentration when `method="learned"`; other routing methods
+cannot claim empirical evidence. `TriageResult` keeps resubmissions, campaigns,
+and low-signal review separate, including an explicit scorer abstention. None
+of these fields rejects a grievance. Changing a field is an API break; the
+frontend is built against exactly these shapes, and `tests/test_serving_api.py`
+plus `tests/test_serving_triage_contract.py` pin them.
 
 ## Mock and live modes
 
@@ -62,6 +65,12 @@ unusable documents (unsupported/corrupt, blank OCR, quality rejection,
 truncation, or no grievance-bearing pages). Unexpected model/runtime failures
 remain server errors. DeepSeek and MLflow runtime resolution are not part of
 this in-process live command.
+
+The mock emits deterministic illustrative resubmission, campaign, flagged, or
+abstained triage states so the frontend can be developed without a backfill.
+Until the live Phase 14 scorer is wired, the live processor returns
+`spam.decision="not_scored"` rather than presenting missing output as a
+negative result.
 
 Only synthetic demo submissions are allowed until the PII gold evaluation gate
 passes. The mock must never serve real citizen submissions.

--- a/janasunani/serving/README.md
+++ b/janasunani/serving/README.md
@@ -47,8 +47,10 @@ pipeline artifact DB (`extracted_text`/`redacted_text`/`ocr_model`),
 history rows, and Phase 14's advisory triage states. `RoutingResult` carries
 support and concentration when `method="learned"`; other routing methods
 cannot claim empirical evidence. `TriageResult` keeps resubmissions, campaigns,
-and low-signal review separate, including an explicit scorer abstention. None
-of these fields rejects a grievance. Changing a field is an API break; the
+and low-signal review separate, including an explicit scorer abstention. Its
+`duplicate_review` distinguishes unindexed, unavailable, and abstained
+lookups from a verified no-match, so absent evidence is never presented as a
+negative finding. None of these fields rejects a grievance. Changing a field is an API break; the
 frontend is built against exactly these shapes, and `tests/test_serving_api.py`
 plus `tests/test_serving_triage_contract.py` pin them.
 
@@ -68,9 +70,12 @@ this in-process live command.
 
 The mock emits deterministic illustrative resubmission, campaign, flagged, or
 abstained triage states so the frontend can be developed without a backfill.
-Until the live Phase 14 scorer is wired, the live processor returns
-`spam.decision="not_scored"` rather than presenting missing output as a
-negative result.
+The live processor calls its advisory triage seam only after PII redaction.
+Until the Phase 14 matcher is wired, it returns
+`duplicate_review.decision="not_indexed"` and `spam.decision="not_scored"`
+rather than presenting missing output as a negative result. If an eventual
+provider is unavailable, the submission proceeds with the explicit
+`duplicate_review.decision="unavailable"` state.
 
 Only synthetic demo submissions are allowed until the PII gold evaluation gate
 passes. The mock must never serve real citizen submissions.

--- a/janasunani/serving/processor.py
+++ b/janasunani/serving/processor.py
@@ -20,6 +20,7 @@ from typing import Optional, Protocol
 
 from janasunani.serving.schemas import (
     ClassificationResult,
+    DuplicateReview,
     DuplicateSignal,
     ExtractionResult,
     GrievanceResult,
@@ -159,7 +160,8 @@ def _mock_triage(text: str) -> TriageResult:
                 duplicate_kind="resubmission",
                 duplicate_group_id=group_id,
                 duplicate_ticket_no="CMO202400042",
-            )
+            ),
+            duplicate_review=DuplicateReview(decision="matched"),
         )
     if bucket == 1:
         return TriageResult(
@@ -167,7 +169,8 @@ def _mock_triage(text: str) -> TriageResult:
                 duplicate_kind="campaign",
                 duplicate_group_id=group_id,
                 related_filings=18,
-            )
+            ),
+            duplicate_review=DuplicateReview(decision="matched"),
         )
     if bucket == 2:
         return TriageResult(

--- a/janasunani/serving/processor.py
+++ b/janasunani/serving/processor.py
@@ -20,11 +20,14 @@ from typing import Optional, Protocol
 
 from janasunani.serving.schemas import (
     ClassificationResult,
+    DuplicateSignal,
     ExtractionResult,
     GrievanceResult,
     PIIEntity,
     RedactionResult,
     RoutingResult,
+    SpamReview,
+    TriageResult,
 )
 
 
@@ -112,6 +115,7 @@ class MockGrievanceProcessor:
                 confidence=0.42,
                 method="mock",
             ),
+            triage=_mock_triage(extraction.extracted_text),
         )
 
 
@@ -143,3 +147,39 @@ def _mock_summary(redacted_text: str, max_chars: int = 180) -> str:
     if len(flat) <= max_chars:
         return flat
     return flat[: max_chars - 1].rsplit(" ", 1)[0] + "…"
+
+
+def _mock_triage(text: str) -> TriageResult:
+    """Deterministic illustrative triage states for frontend contract work only."""
+    bucket = hashlib.sha256(text.encode()).digest()[1] % 4
+    group_id = hashlib.sha256(text.encode()).hexdigest()[:10]
+    if bucket == 0:
+        return TriageResult(
+            duplicate=DuplicateSignal(
+                duplicate_kind="resubmission",
+                duplicate_group_id=group_id,
+                duplicate_ticket_no="CMO202400042",
+            )
+        )
+    if bucket == 1:
+        return TriageResult(
+            duplicate=DuplicateSignal(
+                duplicate_kind="campaign",
+                duplicate_group_id=group_id,
+                related_filings=18,
+            )
+        )
+    if bucket == 2:
+        return TriageResult(
+            spam=SpamReview(
+                decision="flagged",
+                spam_reason="Very little grievance detail was detected.",
+                spam_score=0.81,
+            )
+        )
+    return TriageResult(
+        spam=SpamReview(
+            decision="abstained",
+            spam_reason="The available signals were insufficient for a low-signal flag.",
+        )
+    )

--- a/janasunani/serving/schemas.py
+++ b/janasunani/serving/schemas.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Literal, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class PIIEntity(BaseModel):
@@ -56,6 +56,23 @@ class ClassificationResult(BaseModel):
     language: str  # ISO-ish code the categorizer gate produced ("en", "or")
 
 
+class EmpiricalRoutingEvidence(BaseModel):
+    """Aggregate evidence behind an empirically observed destination.
+
+    The crosswalk describes where comparable cases were historically sent. It
+    does not assert that those destinations produced the best outcome.
+    """
+
+    support: int = Field(ge=1)
+    concentration: float = Field(ge=0.0, le=1.0)
+    width: Literal[
+        "category+subcategory+district",
+        "category+subcategory",
+        "category+district",
+        "category",
+    ]
+
+
 class RoutingResult(BaseModel):
     dept: str
     office: str
@@ -63,6 +80,66 @@ class RoutingResult(BaseModel):
     escalation_authority: Optional[str] = None
     confidence: float = Field(ge=0.0, le=1.0)
     method: Literal["rules", "learned", "fallback", "mock"]
+    empirical_evidence: Optional[EmpiricalRoutingEvidence] = None
+
+    @model_validator(mode="after")
+    def _empirical_evidence_matches_method(self) -> "RoutingResult":
+        if self.method == "learned" and self.empirical_evidence is None:
+            raise ValueError("learned routing requires empirical_evidence")
+        if self.method != "learned" and self.empirical_evidence is not None:
+            raise ValueError("only learned routing may carry empirical_evidence")
+        return self
+
+
+class DuplicateSignal(BaseModel):
+    """A possible resubmission or a collective campaign, never a disposition."""
+
+    duplicate_kind: Literal["resubmission", "campaign"]
+    duplicate_group_id: str = Field(min_length=1)
+    duplicate_ticket_no: Optional[str] = None
+    related_filings: Optional[int] = Field(default=None, ge=2)
+
+    @model_validator(mode="after")
+    def _kind_has_the_right_context(self) -> "DuplicateSignal":
+        if self.duplicate_kind == "resubmission":
+            if not self.duplicate_ticket_no:
+                raise ValueError("resubmission requires duplicate_ticket_no")
+            if self.related_filings is not None:
+                raise ValueError("resubmission must not carry related_filings")
+        elif self.duplicate_ticket_no is not None:
+            raise ValueError("campaign must not carry duplicate_ticket_no")
+        elif self.related_filings is None:
+            raise ValueError("campaign requires related_filings")
+        return self
+
+
+class SpamReview(BaseModel):
+    """Officer-review state for the optional low-signal scorer.
+
+    ``abstained`` is intentionally observable: absence of a flag is not
+    evidence that a scorer ran and found the filing actionable.
+    """
+
+    decision: Literal["flagged", "abstained", "not_scored"]
+    spam_reason: Optional[str] = None
+    spam_score: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+
+    @model_validator(mode="after")
+    def _decision_has_an_explanation(self) -> "SpamReview":
+        if self.decision in {"flagged", "abstained"} and not self.spam_reason:
+            raise ValueError(f"{self.decision} spam review requires a reason")
+        if self.decision == "not_scored" and (
+            self.spam_reason is not None or self.spam_score is not None
+        ):
+            raise ValueError("not_scored spam review must not imply a result")
+        return self
+
+
+class TriageResult(BaseModel):
+    """Advisory signals only; none changes whether a grievance is accepted."""
+
+    duplicate: Optional[DuplicateSignal] = None
+    spam: SpamReview = Field(default_factory=lambda: SpamReview(decision="not_scored"))
 
 
 class GrievanceResult(BaseModel):
@@ -77,6 +154,7 @@ class GrievanceResult(BaseModel):
     classification: ClassificationResult
     summary: str
     routing: RoutingResult
+    triage: TriageResult = Field(default_factory=TriageResult)
 
 
 class HistoryItem(BaseModel):

--- a/janasunani/serving/schemas.py
+++ b/janasunani/serving/schemas.py
@@ -113,6 +113,29 @@ class DuplicateSignal(BaseModel):
         return self
 
 
+class DuplicateReview(BaseModel):
+    """Availability and outcome of the duplicate/campaign lookup.
+
+    An absent ``DuplicateSignal`` alone is ambiguous: it could mean a verified
+    no-match, a short submission the matcher declined to compare, or an index
+    that is unavailable.  Keep those states visible so neither an officer nor
+    the frontend turns missing evidence into a negative finding.
+    """
+
+    decision: Literal[
+        "matched", "no_match", "abstained", "not_indexed", "unavailable"
+    ]
+    reason: Optional[str] = None
+
+    @model_validator(mode="after")
+    def _unavailable_states_explain_themselves(self) -> "DuplicateReview":
+        if self.decision in {"abstained", "not_indexed", "unavailable"} and not self.reason:
+            raise ValueError(f"{self.decision} duplicate review requires a reason")
+        if self.decision in {"matched", "no_match"} and self.reason is not None:
+            raise ValueError(f"{self.decision} duplicate review must not imply uncertainty")
+        return self
+
+
 class SpamReview(BaseModel):
     """Officer-review state for the optional low-signal scorer.
 
@@ -139,7 +162,43 @@ class TriageResult(BaseModel):
     """Advisory signals only; none changes whether a grievance is accepted."""
 
     duplicate: Optional[DuplicateSignal] = None
+    duplicate_review: DuplicateReview = Field(
+        default_factory=lambda: DuplicateReview(
+            decision="not_indexed",
+            reason=(
+                "Duplicate matching has not been run for this submission because "
+                "the live submission path is not connected to a completed index."
+            ),
+        )
+    )
     spam: SpamReview = Field(default_factory=lambda: SpamReview(decision="not_scored"))
+
+    @model_validator(mode="before")
+    @classmethod
+    def _derive_duplicate_review_for_persisted_contracts(cls, value):
+        """Read pre-#163 result JSON without mistaking a prior signal for absent.
+
+        Older persisted results carried ``duplicate`` directly, before the
+        lookup state existed.  A legacy signal is still a match; legacy
+        ``null`` stays explicitly not-indexed through the default above.
+        """
+        if not isinstance(value, dict) or "duplicate_review" in value:
+            return value
+        if value.get("duplicate") is None:
+            return value
+        derived = dict(value)
+        derived["duplicate_review"] = {"decision": "matched"}
+        return derived
+
+    @model_validator(mode="after")
+    def _duplicate_signal_matches_review_state(self) -> "TriageResult":
+        has_signal = self.duplicate is not None
+        is_match = self.duplicate_review.decision == "matched"
+        if has_signal != is_match:
+            raise ValueError(
+                "duplicate signal must be present exactly when duplicate review is matched"
+            )
+        return self
 
 
 class GrievanceResult(BaseModel):

--- a/janasunani/serving/triage.py
+++ b/janasunani/serving/triage.py
@@ -1,0 +1,60 @@
+"""Safe seam for advisory live triage.
+
+The historical duplicate index is slice-scoped and does not yet provide a
+matcher for a newly submitted grievance.  This module makes that absence
+explicit while reserving a narrow future integration point: providers receive
+only redacted text, never the raw grievance or direct identity fields.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional, Protocol
+
+from janasunani.serving.schemas import DuplicateReview, SpamReview, TriageResult
+
+
+class TriageUnavailableError(RuntimeError):
+    """An advisory provider could not be used without blocking submission."""
+
+
+class TriageProvider(Protocol):
+    """Assess one submission after PII redaction and before classification."""
+
+    def assess(
+        self,
+        *,
+        redacted_text: str,
+        district: Optional[str],
+        submitted_on: datetime,
+    ) -> TriageResult: ...
+
+
+def unavailable_triage() -> TriageResult:
+    """Return the safe non-blocking state after a provider availability error."""
+    return TriageResult(
+        duplicate_review=DuplicateReview(
+            decision="unavailable",
+            reason=(
+                "Duplicate matching is temporarily unavailable. This is not a "
+                "finding that no related filing exists."
+            ),
+        ),
+        spam=SpamReview(decision="not_scored"),
+    )
+
+
+class UnwiredTriageProvider:
+    """Current production default until a live duplicate/spam matcher exists."""
+
+    def assess(
+        self,
+        *,
+        redacted_text: str,
+        district: Optional[str],
+        submitted_on: datetime,
+    ) -> TriageResult:
+        # Parameters are deliberately accepted but not inspected: this is not
+        # a heuristic fallback, and must never fabricate a live triage signal.
+        del redacted_text, district, submitted_on
+        return TriageResult()

--- a/tests/test_e2e_synthetic.py
+++ b/tests/test_e2e_synthetic.py
@@ -63,6 +63,7 @@ from janasunani.serving.schemas import (
     ExtractionResult,
     GrievanceResult,
     RedactionResult,
+    TriageResult,
 )
 from janasunani.serving.store import DatabaseResultStore
 
@@ -224,6 +225,7 @@ class _CanaryProcessor:
             classification=ClassificationResult(category="Energy", language="en"),
             summary="Canary submission.",
             routing=self._router.route(category="Energy", district=district),
+            triage=TriageResult(),
         )
 
 

--- a/tests/test_inference_service.py
+++ b/tests/test_inference_service.py
@@ -14,6 +14,8 @@ from janasunani.inference.service import (
     _PageTypeModelError,
 )
 from janasunani.routing.rules import RuleRouter
+from janasunani.serving.schemas import DuplicateReview, SpamReview, TriageResult
+from janasunani.serving.triage import TriageUnavailableError
 
 
 @dataclass
@@ -69,6 +71,7 @@ def _processor(
     summarizer=None,
     english=True,
     language="en",
+    triage_provider=None,
 ):
     return PipelineGrievanceProcessor(
         ocr=ocr
@@ -80,6 +83,7 @@ def _processor(
         router=RuleRouter(),
         is_english_compatible=lambda _text: english,
         detect_language=lambda _text: language,
+        triage_provider=triage_provider,
         now=lambda: datetime(2026, 7, 10, 8, 0, tzinfo=UTC),
     )
 
@@ -117,6 +121,59 @@ def test_typed_text_maps_pii_and_feeds_only_redacted_text_to_models():
     assert result.classification.category == "Water Supply"
     assert result.routing.method == "rules"
     assert result.routing.dept == "Rural Water Supply & Sanitation"
+
+
+def test_live_triage_provider_receives_only_redacted_text():
+    class RecordingTriageProvider:
+        def __init__(self):
+            self.calls = []
+
+        def assess(self, **values):
+            self.calls.append(values)
+            return TriageResult(
+                duplicate_review=DuplicateReview(
+                    decision="abstained",
+                    reason="The redacted submission is too short to compare.",
+                ),
+                spam=SpamReview(decision="not_scored"),
+            )
+
+    provider = RecordingTriageProvider()
+    result = _process(_processor(triage_provider=provider))
+
+    assert provider.calls == [
+        {
+            "redacted_text": "[NAME] reports that the village pump is broken. Call [PHONE].",
+            "district": "Cuttack",
+            "submitted_on": datetime(2026, 7, 10, 8, 0, tzinfo=UTC),
+        }
+    ]
+    assert "Ramesh" not in provider.calls[0]["redacted_text"]
+    assert "9876543210" not in provider.calls[0]["redacted_text"]
+    assert result.triage.duplicate_review.decision == "abstained"
+
+
+def test_default_live_triage_is_explicitly_not_indexed():
+    result = _process(_processor())
+
+    assert result.triage.duplicate is None
+    assert result.triage.duplicate_review.decision == "not_indexed"
+    assert result.triage.duplicate_review.reason
+    assert result.triage.spam.decision == "not_scored"
+
+
+def test_triage_provider_outage_is_nonblocking_and_explicit():
+    class FailingTriageProvider:
+        def assess(self, **_values):
+            raise TriageUnavailableError("database password must not reach the user")
+
+    result = _process(_processor(triage_provider=FailingTriageProvider()))
+
+    assert result.status == "Submitted"
+    assert result.triage.duplicate is None
+    assert result.triage.duplicate_review.decision == "unavailable"
+    assert "password" not in (result.triage.duplicate_review.reason or "")
+    assert result.triage.spam.decision == "not_scored"
 
 
 def test_pdf_preserves_all_ocr_but_gates_models_to_class_one_pages():

--- a/tests/test_routing_crosswalk.py
+++ b/tests/test_routing_crosswalk.py
@@ -437,6 +437,11 @@ class TestWiredIntoTheDefaultRouter:
         assert result.method == "learned"
         assert result.dept == "PHED"
         assert 0.0 < result.confidence <= MAX_CONFIDENCE
+        assert result.empirical_evidence.model_dump() == {
+            "support": 4000,
+            "concentration": 0.9,
+            "width": "category+subcategory+district",
+        }
 
     def test_no_crosswalk_falls_through_to_the_existing_router(self, monkeypatch):
         import janasunani.routing.crosswalk as cw

--- a/tests/test_serving_api.py
+++ b/tests/test_serving_api.py
@@ -66,6 +66,13 @@ def test_submit_text_returns_full_result_shape(client):
     assert body["routing"]["method"] == "mock"
     assert "Cuttack" in body["routing"]["office"]
     assert 0.0 <= body["routing"]["confidence"] <= 1.0
+    assert body["triage"]["duplicate_review"]["decision"] in {
+        "matched",
+        "no_match",
+        "abstained",
+        "not_indexed",
+        "unavailable",
+    }
     assert body["triage"]["spam"]["decision"] in {
         "flagged",
         "abstained",

--- a/tests/test_serving_api.py
+++ b/tests/test_serving_api.py
@@ -51,6 +51,7 @@ def test_submit_text_returns_full_result_shape(client):
         "classification",
         "summary",
         "routing",
+        "triage",
     }
     assert body["extraction"]["source"] == "text"
     assert body["extraction"]["extracted_text"] == _TEXT
@@ -65,6 +66,11 @@ def test_submit_text_returns_full_result_shape(client):
     assert body["routing"]["method"] == "mock"
     assert "Cuttack" in body["routing"]["office"]
     assert 0.0 <= body["routing"]["confidence"] <= 1.0
+    assert body["triage"]["spam"]["decision"] in {
+        "flagged",
+        "abstained",
+        "not_scored",
+    }
 
 
 def test_submit_file_reports_document_source(client):

--- a/tests/test_serving_persistence.py
+++ b/tests/test_serving_persistence.py
@@ -20,6 +20,7 @@ from janasunani.serving.schemas import (  # noqa: E402
     GrievanceResult,
     RedactionResult,
     RoutingResult,
+    TriageResult,
 )
 from janasunani.serving.store import DatabaseResultStore  # noqa: E402
 
@@ -46,6 +47,7 @@ def _sample_result(grievance_id: str = "aware-1") -> GrievanceResult:
         classification=ClassificationResult(category="Roads", language="en"),
         summary="road is bad",
         routing=RoutingResult(dept="PWD", office="PWD Cuttack", confidence=0.5, method="mock"),
+        triage=TriageResult(),
     )
 
 

--- a/tests/test_serving_triage_contract.py
+++ b/tests/test_serving_triage_contract.py
@@ -1,0 +1,136 @@
+"""Typed, advisory-only serving contract for issues #73 and #109."""
+
+import pytest
+from pydantic import ValidationError
+
+from janasunani.serving.schemas import (
+    ClassificationResult,
+    DuplicateSignal,
+    EmpiricalRoutingEvidence,
+    ExtractionResult,
+    GrievanceResult,
+    RedactionResult,
+    RoutingResult,
+    SpamReview,
+    TriageResult,
+)
+from janasunani.serving.processor import _mock_triage
+
+
+def test_resubmission_and_campaign_context_cannot_be_conflated():
+    resubmission = DuplicateSignal(
+        duplicate_kind="resubmission",
+        duplicate_group_id="g-resubmission",
+        duplicate_ticket_no="CMO202400042",
+    )
+    campaign = DuplicateSignal(
+        duplicate_kind="campaign",
+        duplicate_group_id="g-campaign",
+        related_filings=18,
+    )
+
+    assert resubmission.duplicate_ticket_no == "CMO202400042"
+    assert resubmission.related_filings is None
+    assert campaign.duplicate_ticket_no is None
+    assert campaign.related_filings == 18
+
+    with pytest.raises(ValidationError, match="campaign requires related_filings"):
+        DuplicateSignal(duplicate_kind="campaign", duplicate_group_id="g")
+    with pytest.raises(ValidationError, match="campaign must not carry"):
+        DuplicateSignal(
+            duplicate_kind="campaign",
+            duplicate_group_id="g",
+            duplicate_ticket_no="CMO1",
+            related_filings=2,
+        )
+
+
+def test_spam_abstention_is_visible_and_explained():
+    review = SpamReview(
+        decision="abstained",
+        spam_reason="Insufficient evidence for a reliable low-signal flag.",
+    )
+    assert review.decision == "abstained"
+    assert review.spam_reason
+
+    with pytest.raises(ValidationError, match="abstained spam review requires a reason"):
+        SpamReview(decision="abstained")
+    with pytest.raises(ValidationError, match="not_scored spam review must not imply"):
+        SpamReview(decision="not_scored", spam_score=0.0)
+
+
+def test_unwired_live_triage_is_explicitly_not_scored():
+    triage = TriageResult()
+    assert triage.model_dump() == {
+        "duplicate": None,
+        "spam": {
+            "decision": "not_scored",
+            "spam_reason": None,
+            "spam_score": None,
+        },
+    }
+
+
+def test_older_persisted_result_gets_the_explicit_not_scored_default():
+    result = GrievanceResult(
+        id="old-result",
+        ticket_no="JSOLD",
+        status="Submitted",
+        submitted_on="2026-08-07T12:00:00Z",
+        extraction=ExtractionResult(source="text", extracted_text="Synthetic text"),
+        redaction=RedactionResult(redacted_text="Synthetic text", entities=[]),
+        classification=ClassificationResult(category="Roads", language="en"),
+        summary="Synthetic text",
+        routing=RoutingResult(
+            dept="Works",
+            office="Works Department",
+            confidence=0.8,
+            method="rules",
+        ),
+    )
+    assert result.triage.spam.decision == "not_scored"
+
+
+def test_mock_contract_exercises_every_advisory_state():
+    states: set[str] = set()
+    for i in range(100):
+        triage = _mock_triage(f"synthetic grievance {i}")
+        if triage.duplicate is not None:
+            states.add(triage.duplicate.duplicate_kind)
+        else:
+            states.add(triage.spam.decision)
+
+    assert states == {"resubmission", "campaign", "flagged", "abstained"}
+
+
+def test_learned_routing_requires_aggregate_evidence():
+    evidence = EmpiricalRoutingEvidence(
+        support=4000,
+        concentration=0.9,
+        width="category+subcategory+district",
+    )
+    route = RoutingResult(
+        dept="PHED",
+        office="PHED Sambalpur Division",
+        escalation_authority="District Magistrate, Sambalpur",
+        confidence=0.9,
+        method="learned",
+        empirical_evidence=evidence,
+    )
+    assert route.empirical_evidence == evidence
+
+    with pytest.raises(ValidationError, match="learned routing requires"):
+        RoutingResult(
+            dept="PHED",
+            office="PHED Sambalpur Division",
+            confidence=0.9,
+            method="learned",
+        )
+    with pytest.raises(ValidationError, match="only learned routing"):
+        RoutingResult(
+            dept="PHED",
+            office="PHED Sambalpur Division",
+            confidence=0.8,
+            method="rules",
+            empirical_evidence=evidence,
+        )

--- a/tests/test_serving_triage_contract.py
+++ b/tests/test_serving_triage_contract.py
@@ -5,6 +5,7 @@ from pydantic import ValidationError
 
 from janasunani.serving.schemas import (
     ClassificationResult,
+    DuplicateReview,
     DuplicateSignal,
     EmpiricalRoutingEvidence,
     ExtractionResult,
@@ -45,6 +46,48 @@ def test_resubmission_and_campaign_context_cannot_be_conflated():
         )
 
 
+def test_duplicate_review_keeps_absence_distinct_from_a_no_match():
+    not_indexed = DuplicateReview(
+        decision="not_indexed",
+        reason="The live submission is outside every completed index slice.",
+    )
+    abstained = DuplicateReview(
+        decision="abstained",
+        reason="The redacted text is too short to compare safely.",
+    )
+    unavailable = DuplicateReview(
+        decision="unavailable",
+        reason="The duplicate provider could not be reached.",
+    )
+
+    assert not_indexed.decision == "not_indexed"
+    assert abstained.decision == "abstained"
+    assert unavailable.decision == "unavailable"
+
+    with pytest.raises(ValidationError, match="not_indexed duplicate review requires"):
+        DuplicateReview(decision="not_indexed")
+    with pytest.raises(ValidationError, match="no_match duplicate review must not"):
+        DuplicateReview(decision="no_match", reason="not needed")
+
+
+def test_duplicate_signal_requires_a_matched_review_state():
+    signal = DuplicateSignal(
+        duplicate_kind="resubmission",
+        duplicate_group_id="g-resubmission",
+        duplicate_ticket_no="CMO202400042",
+    )
+    legacy_shape = TriageResult(duplicate=signal)
+    assert legacy_shape.duplicate_review.decision == "matched"
+
+    with pytest.raises(ValidationError, match="duplicate signal must be present"):
+        TriageResult(
+            duplicate=signal,
+            duplicate_review=DuplicateReview(decision="no_match"),
+        )
+    with pytest.raises(ValidationError, match="duplicate signal must be present"):
+        TriageResult(duplicate_review=DuplicateReview(decision="matched"))
+
+
 def test_spam_abstention_is_visible_and_explained():
     review = SpamReview(
         decision="abstained",
@@ -63,6 +106,13 @@ def test_unwired_live_triage_is_explicitly_not_scored():
     triage = TriageResult()
     assert triage.model_dump() == {
         "duplicate": None,
+        "duplicate_review": {
+            "decision": "not_indexed",
+            "reason": (
+                "Duplicate matching has not been run for this submission because "
+                "the live submission path is not connected to a completed index."
+            ),
+        },
         "spam": {
             "decision": "not_scored",
             "spam_reason": None,
@@ -89,6 +139,23 @@ def test_older_persisted_result_gets_the_explicit_not_scored_default():
         ),
     )
     assert result.triage.spam.decision == "not_scored"
+    assert result.triage.duplicate_review.decision == "not_indexed"
+
+
+def test_legacy_persisted_duplicate_signal_gets_the_matched_review_state():
+    triage = TriageResult.model_validate(
+        {
+            "duplicate": {
+                "duplicate_kind": "campaign",
+                "duplicate_group_id": "g-campaign",
+                "related_filings": 18,
+            },
+            "spam": {"decision": "not_scored"},
+        }
+    )
+
+    assert triage.duplicate is not None
+    assert triage.duplicate_review.decision == "matched"
 
 
 def test_mock_contract_exercises_every_advisory_state():


### PR DESCRIPTION
## Summary

- add typed, advisory-only duplicate, campaign, spam-review, and empirical-routing evidence contracts
- render distinct non-blocking treatments on the result screen, including scorer abstention and campaign-as-collective-grievance language
- link possible resubmissions into history search
- expose support and concentration for learned routing
- provide deterministic mock states while live duplicate/spam scoring remains unwired

## Scope boundary

This is the contract-first UI/API slice of #73 and #109. It intentionally does not close either issue: learned routing is real, but live duplicate/campaign lookup and spam scoring are not yet connected to the serving processor.

## Validation

- `uv run --extra serving --extra pipeline-core pytest` — 930 passed, 14 skipped
- `npm run lint`
- `npm run build`
- `git diff --check origin/main...HEAD`

Closes #73
