### PR TITLE
feat(triage): add abstention-first low-signal review

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -620,15 +620,24 @@ operation and must not share one similarity function.
   is the step-0 pass in §3.2, and the index is built from `grievance_redacted`. Two
   entry points, one index.
 
-New stage order for documents:
+Future full Phase 14 stage order for documents:
 `format_classifier → ocr_extraction → pii_tagger → spam_duplicate →
 page_type_classifier → summarizer → categorizer`.
 
 Backfill order for history:
 `janasunani-redact-grievance → dedup index build (janasunani-dedup-index, #71) → spam_duplicate scoring`.
-The runner exists and is tested on synthetic fixtures; no real district-year
-slice has been run through it yet, and spam_duplicate scoring is still
+The runner exists and is tested on synthetic fixtures; no complete, accepted
+district-year dedup report exists yet, and `spam_duplicate` scoring is still
 unbuilt.
+
+**Reduced August low-signal contract.** The live serving seam runs only after
+PII redaction and records whether the existing OCR repetition-collapse guard
+fired. It returns a reason-coded abstention in every case: no score, no
+"clean" result, no auto-rejection, and no gate on summarization or
+categorization. A review flag remains disabled until a redacted,
+human-adjudicated validation release reports sample size, flag and abstention
+rates, false positives, and PPV by language and input mode. This is deliberately
+separate from the future seventh stage above.
 
 **Three firsts this stage introduces**, worth flagging:
 
@@ -642,8 +651,10 @@ unbuilt.
   dedup index is a PII store by another name.
 - Deduplication is document-level. The artifact DB is page-level.
 
-**Outputs:** `spam_score`, `spam_reason`, `duplicate_group_id`, `duplicate_kind`
-(`resubmission` | `campaign` | `none`).
+**Future full-stage outputs:** `spam_score`, `spam_reason`,
+`duplicate_group_id`, `duplicate_kind` (`resubmission` | `campaign` | `none`).
+The reduced August serving contract emits only a reason-coded low-signal
+abstention plus a boolean, non-content OCR-quality observation.
 
 **Corpus study.** Run the detector over the chosen slice of the 1.37M history, on
 `grievance_redacted`; report prevalence by district, category, mode, year. What share

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -48,8 +48,9 @@ an explanatory note, not as an error.
 
 The result screen's triage banner is advisory only. Possible resubmissions link
 to the existing history search, campaigns use a distinct collective-grievance
-treatment with the related-filing count, and low-signal scoring shows both the
-reason and an abstention when the scorer declines. Nothing in the banner
+treatment with the related-filing count. Low-signal review currently exposes
+an explicit, reason-coded abstention and non-content OCR-quality evidence; it
+does not emit a score or a "clean" finding. Nothing in the banner
 blocks or rejects a submission. Learned routes show their aggregate support
 and destination concentration beside the existing confidence and escalation
 chain.

--- a/frontend/components/TriageBanner.tsx
+++ b/frontend/components/TriageBanner.tsx
@@ -8,6 +8,21 @@ import { Badge } from "./ui";
  */
 export function TriageBanner({ triage }: { triage: TriageResult }) {
   const { duplicate, duplicate_review, spam } = triage;
+  const lowSignalMessage = {
+    validated_low_signal_evidence:
+      "Validated low-signal evidence requests an officer review.",
+    ocr_repetition_collapse_unvalidated:
+      "The established OCR repetition-collapse guard observed a problem, but it is not an approved low-signal review rule.",
+    live_review_disabled_pending_redacted_adjudication:
+      "Low-signal review is disabled pending redacted human-adjudicated validation.",
+    mock_low_signal_review_unavailable:
+      "The mock demo does not run low-signal review.",
+    advisory_provider_unavailable:
+      "The advisory provider was unavailable, so no low-signal review was assigned.",
+  }[spam.reason_code];
+  const repetitionEvidence = spam.evidence.find(
+    (evidence) => evidence.kind === "repetition_collapse",
+  );
 
   return (
     <section
@@ -100,15 +115,16 @@ export function TriageBanner({ triage }: { triage: TriageResult }) {
           </article>
         )}
 
-        {spam.decision === "flagged" && (
+        {spam.decision === "review" && (
           <article className="rounded-sm border border-negative bg-negative/10 px-3 py-2">
             <Badge tone="negative">low-signal review</Badge>
             <h3 className="mt-1 text-sm font-semibold text-text-dark">
-              Flagged low-signal, review
+              Officer review requested
             </h3>
-            <p className="mt-1 text-sm text-text-body">{spam.spam_reason}</p>
+            <p className="mt-1 text-sm text-text-body">{lowSignalMessage}</p>
             <p className="mt-1 text-xs text-text-secondary">
-              This flag does not reject the grievance.
+              Reason code: <code>{spam.reason_code}</code>. This advisory does
+              not reject the grievance.
             </p>
           </article>
         )}
@@ -116,23 +132,16 @@ export function TriageBanner({ triage }: { triage: TriageResult }) {
         {spam.decision === "abstained" && (
           <article className="rounded-sm border border-hair bg-surface px-3 py-2">
             <Badge tone="neutral">low-signal review abstained</Badge>
-            <p className="mt-1 text-sm text-text-body">{spam.spam_reason}</p>
+            <p className="mt-1 text-sm text-text-body">{lowSignalMessage}</p>
             <p className="mt-1 text-xs text-text-secondary">
-              No low-signal flag was assigned.
+              Reason code: <code>{spam.reason_code}</code>. No low-signal
+              review was assigned.
             </p>
-          </article>
-        )}
-
-        {spam.decision === "not_scored" && (
-          <article className="rounded-sm border border-hair bg-surface px-3 py-2">
-            <Badge tone="neutral">low-signal review unavailable</Badge>
-            <p className="mt-1 text-sm text-text-body">
-              Low-signal scoring has not run for this submission.
-            </p>
-            <p className="mt-1 text-xs text-text-secondary">
-              This is neither a low-signal flag nor a finding that the
-              grievance is actionable.
-            </p>
+            {repetitionEvidence && (
+              <p className="mt-1 text-xs text-text-secondary">
+                OCR repetition-collapse guard: {repetitionEvidence.observed ? "observed" : "not observed"}. No source text is shown here.
+              </p>
+            )}
           </article>
         )}
       </div>

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -62,10 +62,20 @@ export interface DuplicateReview {
   reason?: string | null;
 }
 
+export interface OcrQualityEvidence {
+  kind: "repetition_collapse";
+  observed: boolean;
+}
+
 export interface SpamReview {
-  decision: "flagged" | "abstained" | "not_scored";
-  spam_reason?: string | null;
-  spam_score?: number | null;
+  decision: "review" | "abstained";
+  reason_code:
+    | "validated_low_signal_evidence"
+    | "ocr_repetition_collapse_unvalidated"
+    | "live_review_disabled_pending_redacted_adjudication"
+    | "mock_low_signal_review_unavailable"
+    | "advisory_provider_unavailable";
+  evidence: OcrQualityEvidence[];
 }
 
 export interface TriageResult {

--- a/janasunani/pipeline/README.md
+++ b/janasunani/pipeline/README.md
@@ -51,7 +51,7 @@ subsets/resume).
 
 Stages run in canonical order regardless of the order given to `--stages`.
 
-**Planned (Phase 14):** a seventh stage, `spam_duplicate`, inserted between
+**Future full Phase 14 design:** a seventh stage, `spam_duplicate`, inserted between
 `pii_tagger` and `page_type_classifier`. It reads **redacted** text, stripping or
 down-weighting the typed tokens first (every phone becomes the same `[PHONE]`, so
 leaving them in inflates similarity between unrelated documents), writes
@@ -60,6 +60,12 @@ leaving them in inflates similarity between unrelated documents), writes
 already gates the summarizer. It is the first stage needing corpus-level state (a
 MinHash/LSH index built from the lake), which the per-run artifact DB does not
 provide. See [ROADMAP.md](../../docs/ROADMAP.md) §5.2.
+
+The reduced August implementation deliberately does **not** add that stage or
+gate later stages. The live serving path observes the existing OCR
+repetition-collapse guard only after redaction and abstains from low-signal
+review until a redacted, human-adjudicated validation release authorizes a
+rule. It emits no numeric spam score and never changes submission status.
 
 ## The dependency split (why `--stages` and lazy imports exist)
 

--- a/janasunani/serving/README.md
+++ b/janasunani/serving/README.md
@@ -68,14 +68,16 @@ truncation, or no grievance-bearing pages). Unexpected model/runtime failures
 remain server errors. DeepSeek and MLflow runtime resolution are not part of
 this in-process live command.
 
-The mock emits deterministic illustrative resubmission, campaign, flagged, or
-abstained triage states so the frontend can be developed without a backfill.
+The mock emits deterministic illustrative resubmission and campaign states,
+but always abstains from low-signal review so a fixture cannot look like live
+evidence.
 The live processor calls its advisory triage seam only after PII redaction.
 Until the Phase 14 matcher is wired, it returns
-`duplicate_review.decision="not_indexed"` and `spam.decision="not_scored"`
-rather than presenting missing output as a negative result. If an eventual
-provider is unavailable, the submission proceeds with the explicit
-`duplicate_review.decision="unavailable"` state.
+`duplicate_review.decision="not_indexed"`. Low-signal review records only the
+existing repetition-collapse observation and returns `spam.decision="abstained"`;
+no numeric score or review flag is enabled before redacted human-adjudicated
+validation. If an eventual provider is unavailable, the submission proceeds
+with explicit unavailable/abstained states.
 
 Only synthetic demo submissions are allowed until the PII gold evaluation gate
 passes. The mock must never serve real citizen submissions.

--- a/janasunani/serving/processor.py
+++ b/janasunani/serving/processor.py
@@ -116,7 +116,9 @@ class MockGrievanceProcessor:
                 confidence=0.42,
                 method="mock",
             ),
-            triage=_mock_triage(extraction.extracted_text),
+            # Triage receives only the mock-redacted representation too.  The
+            # mock is never a source of live low-signal evidence.
+            triage=_mock_triage(redaction.redacted_text),
         )
 
 
@@ -154,6 +156,10 @@ def _mock_triage(text: str) -> TriageResult:
     """Deterministic illustrative triage states for frontend contract work only."""
     bucket = hashlib.sha256(text.encode()).digest()[1] % 4
     group_id = hashlib.sha256(text.encode()).hexdigest()[:10]
+    mock_low_signal = SpamReview(
+        decision="abstained",
+        reason_code="mock_low_signal_review_unavailable",
+    )
     if bucket == 0:
         return TriageResult(
             duplicate=DuplicateSignal(
@@ -162,6 +168,7 @@ def _mock_triage(text: str) -> TriageResult:
                 duplicate_ticket_no="CMO202400042",
             ),
             duplicate_review=DuplicateReview(decision="matched"),
+            spam=mock_low_signal,
         )
     if bucket == 1:
         return TriageResult(
@@ -171,18 +178,6 @@ def _mock_triage(text: str) -> TriageResult:
                 related_filings=18,
             ),
             duplicate_review=DuplicateReview(decision="matched"),
+            spam=mock_low_signal,
         )
-    if bucket == 2:
-        return TriageResult(
-            spam=SpamReview(
-                decision="flagged",
-                spam_reason="Very little grievance detail was detected.",
-                spam_score=0.81,
-            )
-        )
-    return TriageResult(
-        spam=SpamReview(
-            decision="abstained",
-            spam_reason="The available signals were insufficient for a low-signal flag.",
-        )
-    )
+    return TriageResult(spam=mock_low_signal)

--- a/janasunani/serving/schemas.py
+++ b/janasunani/serving/schemas.py
@@ -136,25 +136,79 @@ class DuplicateReview(BaseModel):
         return self
 
 
-class SpamReview(BaseModel):
-    """Officer-review state for the optional low-signal scorer.
+class OcrQualityEvidence(BaseModel):
+    """A non-content observation from the established OCR quality guard.
 
-    ``abstained`` is intentionally observable: absence of a flag is not
-    evidence that a scorer ran and found the filing actionable.
+    This deliberately records only whether the existing repetition-collapse
+    guard fired.  It never serializes source text, a feature vector, or a
+    purported probability.
     """
 
-    decision: Literal["flagged", "abstained", "not_scored"]
-    spam_reason: Optional[str] = None
-    spam_score: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    kind: Literal["repetition_collapse"]
+    observed: bool
+
+
+class SpamReview(BaseModel):
+    """Officer-review state for the deliberately narrow low-signal advisory.
+
+    ``review`` is reserved for a future, redacted human-adjudicated validation
+    release.  The current provider always abstains, even if the OCR quality
+    guard observes repetition collapse.  There is intentionally no score:
+    no calibrated or trained spam model has been authorized for this service.
+    """
+
+    decision: Literal["review", "abstained"]
+    reason_code: Literal[
+        "validated_low_signal_evidence",
+        "ocr_repetition_collapse_unvalidated",
+        "live_review_disabled_pending_redacted_adjudication",
+        "mock_low_signal_review_unavailable",
+        "advisory_provider_unavailable",
+    ]
+    evidence: tuple[OcrQualityEvidence, ...] = ()
+
+    @model_validator(mode="before")
+    @classmethod
+    def _replace_legacy_score_contract(cls, value):
+        """Read pre-validation persisted results without retaining their score.
+
+        Prior demo responses could contain a mock ``flagged`` result or a
+        ``not_scored`` status plus a numeric ``spam_score``.  Neither is
+        defensible as a live decision, so old records become an explicit
+        abstention instead of preserving a pseudo-score on the new wire shape.
+        """
+
+        if not isinstance(value, dict):
+            return value
+        legacy_decision = value.get("decision")
+        if legacy_decision not in {"flagged", "not_scored", "abstained"}:
+            return value
+        if legacy_decision == "abstained" and "reason_code" in value:
+            return value
+        normalized = dict(value)
+        normalized.update(
+            decision="abstained",
+            reason_code="live_review_disabled_pending_redacted_adjudication",
+            evidence=(),
+        )
+        normalized.pop("spam_reason", None)
+        normalized.pop("spam_score", None)
+        return normalized
 
     @model_validator(mode="after")
-    def _decision_has_an_explanation(self) -> "SpamReview":
-        if self.decision in {"flagged", "abstained"} and not self.spam_reason:
-            raise ValueError(f"{self.decision} spam review requires a reason")
-        if self.decision == "not_scored" and (
-            self.spam_reason is not None or self.spam_score is not None
+    def _decision_matches_the_reason_code(self) -> "SpamReview":
+        if (
+            self.decision == "review"
+            and self.reason_code != "validated_low_signal_evidence"
         ):
-            raise ValueError("not_scored spam review must not imply a result")
+            raise ValueError("review requires validated_low_signal_evidence")
+        if (
+            self.decision == "abstained"
+            and self.reason_code == "validated_low_signal_evidence"
+        ):
+            raise ValueError("validated_low_signal_evidence requires review")
+        if self.decision == "review" and not self.evidence:
+            raise ValueError("review requires auditable low-signal evidence")
         return self
 
 
@@ -171,7 +225,12 @@ class TriageResult(BaseModel):
             ),
         )
     )
-    spam: SpamReview = Field(default_factory=lambda: SpamReview(decision="not_scored"))
+    spam: SpamReview = Field(
+        default_factory=lambda: SpamReview(
+            decision="abstained",
+            reason_code="live_review_disabled_pending_redacted_adjudication",
+        )
+    )
 
     @model_validator(mode="before")
     @classmethod

--- a/janasunani/serving/triage.py
+++ b/janasunani/serving/triage.py
@@ -11,7 +11,13 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Optional, Protocol
 
-from janasunani.serving.schemas import DuplicateReview, SpamReview, TriageResult
+from janasunani.pipeline.ocr_quality import is_repetition_collapsed
+from janasunani.serving.schemas import (
+    DuplicateReview,
+    OcrQualityEvidence,
+    SpamReview,
+    TriageResult,
+)
 
 
 class TriageUnavailableError(RuntimeError):
@@ -40,12 +46,42 @@ def unavailable_triage() -> TriageResult:
                 "finding that no related filing exists."
             ),
         ),
-        spam=SpamReview(decision="not_scored"),
+        spam=SpamReview(
+            decision="abstained",
+            reason_code="advisory_provider_unavailable",
+        ),
+    )
+
+
+def low_signal_advisory(redacted_text: str) -> SpamReview:
+    """Return the current fail-closed low-signal advisory.
+
+    The sole observation is the existing OCR repetition-collapse guard.  It
+    runs over already-redacted text and is recorded for audit, but it cannot
+    create a review flag until a redacted, human-adjudicated validation release
+    authorizes a rule.  This is not a score, spam model, classifier, or a
+    pipeline gate.
+    """
+
+    collapsed = is_repetition_collapsed(redacted_text)
+    evidence = (
+        OcrQualityEvidence(kind="repetition_collapse", observed=collapsed),
+    )
+    if collapsed:
+        return SpamReview(
+            decision="abstained",
+            reason_code="ocr_repetition_collapse_unvalidated",
+            evidence=evidence,
+        )
+    return SpamReview(
+        decision="abstained",
+        reason_code="live_review_disabled_pending_redacted_adjudication",
+        evidence=evidence,
     )
 
 
 class UnwiredTriageProvider:
-    """Current production default until a live duplicate/spam matcher exists."""
+    """Current production default before a validated low-signal release."""
 
     def assess(
         self,
@@ -54,7 +90,8 @@ class UnwiredTriageProvider:
         district: Optional[str],
         submitted_on: datetime,
     ) -> TriageResult:
-        # Parameters are deliberately accepted but not inspected: this is not
-        # a heuristic fallback, and must never fabricate a live triage signal.
-        del redacted_text, district, submitted_on
-        return TriageResult()
+        # Duplicate matching remains unwired.  The low-signal check uses only
+        # redacted text; district and submission time cannot become proxies
+        # for identity, routing, or filing history.
+        del district, submitted_on
+        return TriageResult(spam=low_signal_advisory(redacted_text))

--- a/tests/test_inference_service.py
+++ b/tests/test_inference_service.py
@@ -135,7 +135,10 @@ def test_live_triage_provider_receives_only_redacted_text():
                     decision="abstained",
                     reason="The redacted submission is too short to compare.",
                 ),
-                spam=SpamReview(decision="not_scored"),
+                spam=SpamReview(
+                    decision="abstained",
+                    reason_code="live_review_disabled_pending_redacted_adjudication",
+                ),
             )
 
     provider = RecordingTriageProvider()
@@ -153,13 +156,18 @@ def test_live_triage_provider_receives_only_redacted_text():
     assert result.triage.duplicate_review.decision == "abstained"
 
 
-def test_default_live_triage_is_explicitly_not_indexed():
+def test_default_live_triage_is_explicitly_abstained_pending_validation():
     result = _process(_processor())
 
     assert result.triage.duplicate is None
     assert result.triage.duplicate_review.decision == "not_indexed"
     assert result.triage.duplicate_review.reason
-    assert result.triage.spam.decision == "not_scored"
+    assert result.triage.spam.decision == "abstained"
+    assert result.triage.spam.reason_code == (
+        "live_review_disabled_pending_redacted_adjudication"
+    )
+    assert result.triage.spam.evidence[0].kind == "repetition_collapse"
+    assert "spam_score" not in result.triage.spam.model_dump()
 
 
 def test_triage_provider_outage_is_nonblocking_and_explicit():
@@ -173,7 +181,8 @@ def test_triage_provider_outage_is_nonblocking_and_explicit():
     assert result.triage.duplicate is None
     assert result.triage.duplicate_review.decision == "unavailable"
     assert "password" not in (result.triage.duplicate_review.reason or "")
-    assert result.triage.spam.decision == "not_scored"
+    assert result.triage.spam.decision == "abstained"
+    assert result.triage.spam.reason_code == "advisory_provider_unavailable"
 
 
 def test_pdf_preserves_all_ocr_but_gates_models_to_class_one_pages():

--- a/tests/test_serving_api.py
+++ b/tests/test_serving_api.py
@@ -73,11 +73,8 @@ def test_submit_text_returns_full_result_shape(client):
         "not_indexed",
         "unavailable",
     }
-    assert body["triage"]["spam"]["decision"] in {
-        "flagged",
-        "abstained",
-        "not_scored",
-    }
+    assert body["triage"]["spam"]["decision"] == "abstained"
+    assert "spam_score" not in body["triage"]["spam"]
 
 
 def test_submit_file_reports_document_source(client):

--- a/tests/test_serving_triage_contract.py
+++ b/tests/test_serving_triage_contract.py
@@ -10,12 +10,14 @@ from janasunani.serving.schemas import (
     EmpiricalRoutingEvidence,
     ExtractionResult,
     GrievanceResult,
+    OcrQualityEvidence,
     RedactionResult,
     RoutingResult,
     SpamReview,
     TriageResult,
 )
 from janasunani.serving.processor import _mock_triage
+from janasunani.serving.triage import low_signal_advisory
 
 
 def test_resubmission_and_campaign_context_cannot_be_conflated():
@@ -88,23 +90,66 @@ def test_duplicate_signal_requires_a_matched_review_state():
         TriageResult(duplicate_review=DuplicateReview(decision="matched"))
 
 
-def test_spam_abstention_is_visible_and_explained():
+def test_low_signal_abstention_is_visible_and_has_a_deterministic_reason_code():
     review = SpamReview(
         decision="abstained",
-        spam_reason="Insufficient evidence for a reliable low-signal flag.",
+        reason_code="live_review_disabled_pending_redacted_adjudication",
     )
     assert review.decision == "abstained"
-    assert review.spam_reason
+    assert review.reason_code
+    assert "spam_score" not in review.model_dump()
 
-    with pytest.raises(ValidationError, match="abstained spam review requires a reason"):
-        SpamReview(decision="abstained")
-    with pytest.raises(ValidationError, match="not_scored spam review must not imply"):
-        SpamReview(decision="not_scored", spam_score=0.0)
+    with pytest.raises(ValidationError, match="validated_low_signal_evidence requires review"):
+        SpamReview(
+            decision="abstained",
+            reason_code="validated_low_signal_evidence",
+        )
+    with pytest.raises(ValidationError, match="review requires auditable"):
+        SpamReview(
+            decision="review",
+            reason_code="validated_low_signal_evidence",
+        )
+
+    legacy = SpamReview.model_validate(
+        {
+            "decision": "flagged",
+            "spam_reason": "Old mock flag",
+            "spam_score": 0.81,
+        }
+    )
+    assert legacy.decision == "abstained"
+    assert legacy.reason_code == "live_review_disabled_pending_redacted_adjudication"
+    assert "spam_score" not in legacy.model_dump()
+
+    reserved_review = SpamReview(
+        decision="review",
+        reason_code="validated_low_signal_evidence",
+        evidence=(OcrQualityEvidence(kind="repetition_collapse", observed=True),),
+    )
+    assert reserved_review.decision == "review"
 
 
-def test_unwired_live_triage_is_explicitly_not_scored():
+def test_low_signal_advisory_records_ocr_quality_evidence_but_still_abstains():
+    collapsed = low_signal_advisory("repeat this phrase " * 30)
+    ordinary = low_signal_advisory(
+        "The village road has been damaged for several months and residents "
+        "request a safe repair before the monsoon makes travel more difficult."
+    )
+
+    assert collapsed.decision == "abstained"
+    assert collapsed.reason_code == "ocr_repetition_collapse_unvalidated"
+    assert collapsed.evidence[0].observed is True
+    assert ordinary.decision == "abstained"
+    assert ordinary.reason_code == (
+        "live_review_disabled_pending_redacted_adjudication"
+    )
+    assert ordinary.evidence[0].observed is False
+    assert "spam_score" not in collapsed.model_dump()
+
+
+def test_unwired_live_triage_is_explicitly_abstained_pending_validation():
     triage = TriageResult()
-    assert triage.model_dump() == {
+    assert triage.model_dump(mode="json") == {
         "duplicate": None,
         "duplicate_review": {
             "decision": "not_indexed",
@@ -114,14 +159,14 @@ def test_unwired_live_triage_is_explicitly_not_scored():
             ),
         },
         "spam": {
-            "decision": "not_scored",
-            "spam_reason": None,
-            "spam_score": None,
+            "decision": "abstained",
+            "reason_code": "live_review_disabled_pending_redacted_adjudication",
+            "evidence": [],
         },
     }
 
 
-def test_older_persisted_result_gets_the_explicit_not_scored_default():
+def test_older_persisted_result_gets_the_explicit_low_signal_abstention_default():
     result = GrievanceResult(
         id="old-result",
         ticket_no="JSOLD",
@@ -138,7 +183,7 @@ def test_older_persisted_result_gets_the_explicit_not_scored_default():
             method="rules",
         ),
     )
-    assert result.triage.spam.decision == "not_scored"
+    assert result.triage.spam.decision == "abstained"
     assert result.triage.duplicate_review.decision == "not_indexed"
 
 
@@ -150,15 +195,17 @@ def test_legacy_persisted_duplicate_signal_gets_the_matched_review_state():
                 "duplicate_group_id": "g-campaign",
                 "related_filings": 18,
             },
-            "spam": {"decision": "not_scored"},
+            "spam": {"decision": "not_scored", "spam_score": 0.81},
         }
     )
 
     assert triage.duplicate is not None
     assert triage.duplicate_review.decision == "matched"
+    assert triage.spam.decision == "abstained"
+    assert "spam_score" not in triage.spam.model_dump()
 
 
-def test_mock_contract_exercises_every_advisory_state():
+def test_mock_contract_never_claims_a_low_signal_review():
     states: set[str] = set()
     for i in range(100):
         triage = _mock_triage(f"synthetic grievance {i}")
@@ -167,7 +214,7 @@ def test_mock_contract_exercises_every_advisory_state():
         else:
             states.add(triage.spam.decision)
 
-    assert states == {"resubmission", "campaign", "flagged", "abstained"}
+    assert states == {"resubmission", "campaign", "abstained"}
 
 
 def test_learned_routing_requires_aggregate_evidence():


### PR DESCRIPTION
## Summary

- replaces mock/numeric spam output with a reason-coded low-signal advisory contract
- observes only the established repetition-collapse guard after PII redaction
- always abstains until a redacted human-adjudicated validation release authorizes a review rule
- emits no score or clean verdict and never blocks submission, routing, summarization, or categorization
- documents the reduced August contract separately from the future full Phase 14 stage

## Validation

- 136 relevant backend tests passed; 1 expected Postgres skip
- Ruff passed
- frontend ESLint passed
- TypeScript and production build passed
-  passed

## Remaining release gate

Before enabling , publish a redacted human-adjudicated validation table with sample size, flag/abstention rates, false positives, and PPV by language and input mode.

Stacked on #163.

Refs #74 #109

Closes #109
