### PR TITLE
docs: adopt the packaged DPIC agent standards

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.opencode/skills

--- a/.dpic/standards/agent-conventions.md
+++ b/.dpic/standards/agent-conventions.md
@@ -1,0 +1,123 @@
+# DPIC Agent Conventions
+
+Canonical source: `dpic/standards/agent-conventions.md` in `dpic-org`.
+
+**This file is synced — do not edit it in a project repo.** Local edits are
+reported by `dpic-sync-standards --check` and overwritten on the next sync.
+Propose changes against `dpic-org`.
+
+Project-specific instructions belong in the repo's own `AGENTS.md`, which
+should reference this file rather than restate it.
+
+## Attribution
+
+**Never mark commits as co-authored by an AI agent, or pull requests as
+authored by one.** No `Co-Authored-By: Claude ...` trailer, no
+`🤖 Generated with Claude Code` footer. This applies to every commit and every
+PR body without exception.
+
+## Commits
+
+- **Conventional Commits** subjects, optionally scoped: `fix:`, `feat:`,
+  `refactor:`, `build:`, `docs:`, `chore:`, `test:` — e.g. `docs(isi): ...`.
+- One commit per logical unit. A unit may span files; a file may hold several
+  units. Do not lump unrelated changes together.
+- Issue trailers: `Closes #NN` when the commit fully resolves the issue,
+  `Refs #NN` when it only advances it.
+- **Not every commit needs an issue, and that is fine.** Chores, tooling,
+  formatting and tests often have none. Never invent or stretch a match to
+  attach one.
+- **Confirm issue links before applying them.** Propose the subject and the
+  intended `Closes`/`Refs` for each unit and wait for approval. If a link is
+  declined or ambiguous, commit without a reference rather than guessing.
+- **Never commit a state that is broken in isolation.** If a follow-up fixes a
+  defect in an unpushed commit, squash them. A commit that fails to build, or
+  that carries a known bug, is a `git bisect` landmine.
+- Write the *why* in the body, not just the what. Reproduction commands,
+  measured evidence, and rejected alternatives belong in the commit message —
+  that is where they survive.
+
+## Branches and pull requests
+
+- Branch names mirror the commit type: `fix/…`, `refactor/…`, `build/…`,
+  `docs/…`, kebab-case, descriptive.
+- Never commit directly to the default branch. Confirm what it is — it is not
+  `main` in every DPIC repo.
+- **Prefer several small PRs over one large branch.** Each must pass its checks
+  independently — verify that by testing the branch on its own, not only via an
+  integration branch.
+- One PR per issue, unless two issues touch the same file and would conflict
+  with each other. Combining is allowed when the PR body explains why they
+  cannot land separately.
+- PR bodies carry the `Closes #NN` / `Refs #NN` lines so GitHub auto-closes on
+  merge.
+- Use the top-level `.worktrees/` directory for git worktrees, and make sure
+  the repo's `.gitignore` contains `.worktrees/`. Without the ignore rule,
+  every worktree an agent creates shows up as an untracked directory in the
+  main checkout's `git status`.
+
+## Working with subagents
+
+- **Do not spawn subagents unless asked.** A task being large or multi-part is
+  not a request to parallelise it.
+- When asked, analyse **file disjointness before** launching anything. Two
+  agents editing one file waste the whole wave. Map each task to the files it
+  will touch, and give every agent an explicit "do not touch" list naming the
+  files other agents own.
+- **Serialize anything that rewrites every file** — a formatter sweep, a mass
+  rename. Nothing else may be in flight during it.
+- Tell each agent its base branch and have it verify, then state the current
+  test baseline so it can tell what it broke.
+- **Verify agent claims independently — do not take reports at face value.**
+  Re-run the check yourself. For a new regression test, confirm it actually
+  fails when the bug is reintroduced.
+- When an agent stops at a scope boundary and reports a problem instead of
+  guessing past it, that is correct behaviour. Verify the finding, then decide.
+
+## Handling review findings
+
+Review comments — human or automated — are claims to verify, not instructions
+to execute. Automated reviewers do fabricate findings, including ones that cite
+a specific commit, file or command that does not exist.
+
+- **Reproduce before acting.** Re-run the check yourself with a named command.
+  A finding that cites a concrete artifact — a SHA, a path, a line — is cheap
+  to settle. One that asserts a property ("this can race", "nothing covers X")
+  is not, and needs a stated method before you accept it.
+- **A citation is not evidence.** A fabricated finding can quote a command it
+  claims to have run, in the same style as a valid one. Only re-running
+  separates them.
+- **Put the reproduction in the reply**, whether you accept or reject. Paste
+  the command and its output, so the decision is auditable rather than
+  something a reader takes on trust.
+- **The remedy is a separate claim from the finding.** A reviewer can be right
+  that something is broken and wrong about how to fix it, and the suggested fix
+  can be worse than the defect. Verify the fix on its own terms, and let CI see
+  it before you believe it.
+- **Ignore the severity label when deciding what to check.** It is produced by
+  the same process as the claim, so it carries no independent information.
+- **Validity ≠ severity ≠ reachability.** Triage on all three before acting,
+  and set a high bar for revisions on later review rounds.
+- Rejecting a finding is a normal outcome. Say so plainly, with the evidence,
+  and move on.
+
+## Judgement
+
+- **Verify against real data, not just by reading code.** Run the query, check
+  the row counts, reproduce the failure. Claims about behaviour need evidence.
+- Prefer fixing a root cause over suppressing a symptom — a deprecated import
+  gets updated, not filtered out.
+- Distinguish a defect from a design gap. Where several defects share one
+  missing abstraction, say so and fix the abstraction; patching them
+  individually rebuilds the same tangle with new bugs.
+- Report faithfully. If tests fail, show the output. If a step was skipped, say
+  so.
+
+## Reproducibility
+
+- Generated outputs must not depend on untracked prompts, private chat history,
+  or local-only instructions.
+- Any file that affects a generated output must be committed and listed as a
+  `dvc.yaml` dependency for the stage that consumes it — this file included,
+  once synced.
+- Never hardcode brand colors; import from `dpic.branding.colors`.

--- a/.gitignore
+++ b/.gitignore
@@ -246,6 +246,12 @@ mlruns/
 # (shared .claude/settings.json stays tracked)
 .claude/settings.local.json
 .claude/worktrees/
+.muse/worktrees/
+
+# Git worktrees: the DPIC agent conventions prescribe the top-level
+# .worktrees/ directory. Without this rule every worktree an agent creates
+# shows up as an untracked directory in the main checkout's git status.
+.worktrees/
 
 # Generated Word docs (management/technical briefs rendered from docs/*.md)
 docs/*.docx

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,18 @@
 # Agent Notes
 
+`CLAUDE.md` is a symlink to this file. Edit `AGENTS.md`.
+
+[.dpic/standards/agent-conventions.md](.dpic/standards/agent-conventions.md) is
+authoritative for commits, branches, pull requests, subagents, and handling
+review findings. It is synced from `dpic-org` by `dpic-sync-standards` — do not
+edit it here; propose changes upstream and re-sync.
+[CONTRIBUTING.md](CONTRIBUTING.md) is authoritative for required checks, the
+data and PII policy, gold-metric gates, pull request size, and the review
+protocol — self-review the diff, request a Codex review with `@codex review`,
+then verify each finding before acting on it. Neither file is restated here —
+read them. This file covers what they do not: where the project stands, how it
+is laid out, and which commands run it.
+
 **Start here: [docs/ROADMAP.md](docs/ROADMAP.md)** — current state, phase
 status, and sequencing (the source of truth, incl. the project snapshot for a
 fresh reviewer; keep it in sync as you land work).
@@ -35,10 +48,10 @@ Then [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the system overview.
 - Lint: `uv run ruff check .`
 - Tests: `uv run --extra serving --extra pipeline-core pytest`
   — every change ships with real-code-path tests, green before "done".
-- PII gate: `uv run --extra pii pytest tests/test_pii_extra_contract.py tests/test_pii_redaction.py tests/test_redact_grievance.py tests/test_rederive_pii_draft.py tests/test_bootstrap_pii_gold.py`
-  — runs every Presidio-gated redaction, evaluation, and bootstrap test.
   **Never run pytest against the production Postgres** (fixtures drop
   tables); see `tests/README.md`.
+- The full pre-PR check list, the Presidio-gated PII suite, and the gold-metric
+  gates are in [CONTRIBUTING.md](CONTRIBUTING.md).
 - Component run commands: root `README.md` §"Running the components".
 
 ## Dependencies And Data

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-Read AGENTS.MD
+AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,135 @@
+# Contributing
+
+Org-wide conventions for commits, branches, pull requests, subagents, and
+handling review findings live in
+[.dpic/standards/agent-conventions.md](.dpic/standards/agent-conventions.md).
+That file is synced from `dpic-org` by `dpic-sync-standards` and is not edited
+here. This file covers what it does not: the checks this repo requires, its
+data and PII policy, and its gold-metric gates.
+
+Changes should be reviewable and reproducible. A pull request should normally
+change one pipeline stage, one serving endpoint, or one bounded slice of the
+demo. Split refactors, generated outputs, and notebook changes from production
+pipeline changes.
+
+## Required checks
+
+Before opening a pull request:
+
+```bash
+uv lock --check
+uv sync --locked --all-groups --extra serving
+uv run ruff check .
+uv run --extra serving --extra pipeline-core pytest
+uv run dvc dag
+uv run dpic-sync-standards --check
+find notebooks -name '*.ipynb' -print0 | xargs -0 -r uv run nbstripout --verify
+```
+
+`dpic-sync-standards --check` reports drift in the synced `.dpic/standards/`
+and `.opencode/skills/` trees. If it fails, either the files were hand-edited
+here, which is not allowed, or `dpic` has moved upstream. To take an upstream
+change:
+
+```bash
+uv lock --upgrade-package dpic && uv sync && uv run dpic-sync-standards
+```
+
+CI runs Lint, Pipeline, and Data Check on every pull request. It does not run
+the heavy ML extras, and it never executes a data stage.
+
+Every feature ships with pytest tests that exercise the real code path. Green
+before "done", not after review.
+
+## PII and redaction
+
+Changes that touch redaction, PII detection, or evaluation also need the
+Presidio-gated suite, which runs in its own environment:
+
+```bash
+uv run --extra pii pytest \
+  tests/test_pii_extra_contract.py \
+  tests/test_pii_redaction.py \
+  tests/test_redact_grievance.py \
+  tests/test_rederive_pii_draft.py \
+  tests/test_bootstrap_pii_gold.py
+```
+
+The heavy ML extras conflict pairwise (see `[tool.uv].conflicts`), so `pii`
+work is run separately from `pipeline-core`, not in one combined environment.
+
+## Data access
+
+- Everything under `data/` is real citizen grievances and PII. The access
+  restriction is in [AGENTS.md](AGENTS.md) and applies to every contributor,
+  human or agent.
+- No data or generated output belongs in a code review. The Data Check
+  workflow rejects tracked files under `data/` and `outputs/`; the only
+  exceptions are `.gitkeep`, `.dvc` pointers, and provenance sidecars, which
+  carry metadata only.
+- Never point pytest at the production Postgres. Fixtures drop tables. See
+  `tests/README.md`.
+
+## Gold metrics
+
+DVC-tracked data does not leave the local machine, so the gold gates cannot run
+in Actions. Run them locally and paste the observed numbers into the pull
+request.
+
+```bash
+uv run --extra pii janasunani-evaluate-pii --gold <gold.jsonl>   # coverage >= 0.8056
+uv run python scripts/verify_pii_gold.py
+```
+
+Any change that can affect detection, redaction, categorization, or a published
+metric must be run against the gold artifacts before merge. The comparison must
+pass, or the pull request must state the observed movement, the gold artifact
+version, and why the movement is correct. Never relax a gate to reproduce a
+number.
+
+## Reproducibility
+
+A file that affects a generated output has to be committed and listed as a
+`dvc.yaml` dependency of the stage that consumes it. No stage output is
+currently agent-generated, so the synced standards file is not yet a stage
+dependency; add it when one becomes so.
+
+Stage dependencies are listed file by file rather than by package directory
+(see the note in `dvc.yaml`). Adding a stage to a command means adding its
+files to `deps`.
+
+## Pull request size
+
+Prefer a sequence of small pull requests whose tests pass independently.
+Changes above roughly 500 non-generated lines, or touching several phases at
+once, should be split unless the pull request explains why the pieces cannot
+land separately.
+
+## Review
+
+Every pull request gets a real review before merge, including one opened by an
+agent. Reviewing means reading the diff against the code it changes, not
+restating the description.
+
+1. **Self-review the diff first.** Read `git diff` against the base branch end
+   to end. Check the failure modes the change introduces, not just the happy
+   path, and confirm the tests would fail without the fix.
+2. **Request a Codex review** by commenting `@codex review` on the pull
+   request. Do this for anything touching the pipeline, serving, deploy, PII,
+   or data paths, and re-request after pushing a material change. Small
+   docs-only or config-only branches do not need one.
+3. **Handle the findings under the protocol** in
+   [.dpic/standards/agent-conventions.md](.dpic/standards/agent-conventions.md).
+   Findings are claims to verify, not instructions to execute. Reproduce before
+   acting, put the command and its output in the reply whether you accept or
+   reject, and treat the suggested remedy as a separate claim from the finding.
+   Automated reviewers do fabricate findings that cite real-looking commits and
+   paths, so a citation is not evidence.
+4. **File what is valid but not blocking as a tech-debt issue** rather than
+   fixing it in the branch. The delivery date in
+   [docs/DELIVERY.md](docs/DELIVERY.md) decides what blocks. Say in the reply
+   which issue the finding became.
+
+Do not merge with review comments left unanswered. Every finding ends in one of
+three states: fixed in the branch, filed as an issue, or rejected in a reply
+that shows the evidence.

--- a/Makefile
+++ b/Makefile
@@ -534,6 +534,7 @@ help:
 	@echo ""
 	@echo "  make setup           First-time setup on a new machine"
 	@echo "  make install-hooks   Enable repository Git hooks"
+	@echo "  make standards       Re-sync DPIC agent conventions and skills"
 	@echo "  make pull            Get latest code, deps, and approved DVC data"
 	@echo "  make ingest          Copy all original source files from Box"
 	@echo "  make publish-raw     Copy all local raw files to Box"
@@ -560,6 +561,14 @@ setup:
 	perl -pi -e 's/\r$$//' scripts/setup.sh
 	BOX_REMOTE=$(call sh_quote,$(BOX_REMOTE_RAW)) bash scripts/setup.sh
 	$(MAKE) install-hooks
+	$(MAKE) standards
+
+# Refresh the org-owned trees the `dpic` package vendors into this repo:
+# .dpic/standards (agent conventions) and .opencode/skills (dpic-deck).
+# Both are consumed verbatim -- never hand-edit them here, propose the change
+# in dpic-org and re-run this. `--check` reports drift without writing.
+standards:
+	uv run dpic-sync-standards
 
 install-hooks:
 	git config core.hooksPath .githooks

--- a/uv.lock
+++ b/uv.lock
@@ -1199,7 +1199,7 @@ wheels = [
 [[package]]
 name = "dpic"
 version = "0.1.0"
-source = { git = "ssh://git@github.com/Data-Policy-and-Innovation-Centre/dpic-org.git?rev=main#6c16b3ecd7df263874327fb41da0c7ece881eef1" }
+source = { git = "ssh://git@github.com/Data-Policy-and-Innovation-Centre/dpic-org.git?rev=main#b7790bbe87c661517247efffc17d7fe7fbc39dfb" }
 dependencies = [
     { name = "matplotlib" },
     { name = "python-docx" },


### PR DESCRIPTION
## Why

The repo had no contribution guide, and `AGENTS.md` carried the gate commands
inline with nothing stating the commit, PR, subagent or review-finding
conventions. The org already packages those conventions in `dpic-org`, but the
`dpic` pin here resolved to `6c16b3e`, which predates that work, so
`dpic-sync-standards` did not exist in the venv and they could not be consumed
at all.

`sams` mirrors the same conventions inline by hand because it is pinned to
Python 3.10 and `dpic` requires >=3.13. This repo is on 3.13, so it takes the
real sync and never has to merge upstream wording manually.

## What

Two commits.

**`build(deps)`** — bump `dpic` to `dpic-org` main (`b7790bb`) and sync. Lands
`.dpic/standards/agent-conventions.md`; `.opencode/skills/dpic-deck` was already
identical, so no diff there. The synced tree is consumed verbatim, never
hand-edited: `dpic-sync-standards --check` reports drift, and changes are
proposed upstream.

**`docs`** — one authoritative home per topic:

- `CONTRIBUTING.md` (new): pre-PR checks, the Presidio-gated PII suite, the gold
  gates, DVC dependency rules, PR size, and the review protocol.
- `.dpic/standards/agent-conventions.md` (synced): everything org-wide.
- `AGENTS.md`: what neither covers, plus pointers to both. Dropped the
  duplicated gate commands.

The review protocol is spelled out because agents open PRs here: self-review the
diff, request a Codex review with `@codex review` on anything touching
pipeline/serving/deploy/PII/data, verify each finding before acting on it per
the synced standard, and file valid-but-not-blocking findings as tech-debt
issues rather than fixing them in the branch. No finding may be open at merge:
fixed, filed, or rejected with evidence in the reply. `@codex review` is the
trigger the connector actually listens for, confirmed from the comment history
on #29 rather than assumed.

Wiring:

- `CLAUDE.md` becomes a symlink to `AGENTS.md`, replacing a 14-byte
  `Read AGENTS.MD` stub that had drifted from the file it pointed at.
- `.claude/skills -> ../.opencode/skills`, so the synced `dpic-deck` skill loads
  from the repo. It was only reaching Claude Code through a stale copy in
  `~/.claude/skills`, which no clone would have.
- `make standards` re-syncs; `make setup` calls it.
- `.gitignore`: `.worktrees/`, which the conventions prescribe and require an
  ignore rule for, plus `.muse/worktrees/` which was showing up untracked.

Both symlinks are stored as mode `120000`, so they survive a clone.

## Verification

```
uv lock --check                     -> ok
uv run ruff check .                 -> All checks passed!
uv run dpic-sync-standards --check  -> DPIC skills and standards are in sync.
make standards                      -> re-syncs both trees, no diff
diff .dpic/standards/agent-conventions.md \
     ../dpic-org/dpic/standards/agent-conventions.md   -> identical
python -c "from dpic.documents import build_brief; from dpic.branding import colors"
                                    -> ok
```

`scripts/md_to_docx.py` holds the only `dpic` import in-tree, so the version
bump has no other reachable surface. No source files change; the gold gates and
the PII suite are not affected by this branch.
