### PR TITLE
feat(pii): ensemble labelling harness for gold adjudication (#15)

### DIFF
--- a/docs/PII_GOLD_ENSEMBLE.md
+++ b/docs/PII_GOLD_ENSEMBLE.md
@@ -1,0 +1,30 @@
+# PII gold ensemble — Amendment 2026-08-05
+
+## What this decides
+
+The labeller left the project; there is no human capacity for a full 85-page pass before 14 August. The Privacy Scorecard is **Committed** (DELIVERY.md Table 1), so the choice is between an ensemble gold and no measurement. This doc locks the protocol that makes the ensemble valid and not circular.
+
+## Decisions
+
+- **Span the vendors.** Two models from different vendors agreeing is stronger evidence than three from one family — they do not share training data, so they do not share blind spots. The harness records `vendor` per member and the report surfaces `Y` overall and per-entity.
+- **Zero-shot, independent, no draft.** Each member labels with no access to the Presidio draft (`scripts/bootstrap_pii_gold.py` → `detect_pii_spans`) and no sight of other members. Anchoring on a pre-annotation is the effect the original `do not automate` rule was avoiding; that reason survives.
+- **Union is recall-favouring by construction.** `union_spans` deduplicates exact `(start,end,entity)` triples only; overlapping but non-identical spans stay separate and surface as contested rather than being merged away. This is §5.1's false-negative priority: leaked PII is the release-critical failure and F1 hides it. `unanimous` spans are accepted; contested form the adjudication queue.
+- **Adjudication queue is contested only.** A few hundred items, not 85 pages. A person adjudicates the queue; expectation is seconds per item.
+- **15-20 page full human verification** bounds the all-missed rate — the one direction union cannot self-check (every model missed the same PII). Deterministic by seed; manifest names the pages.
+- **Publisher writes the claim sentence with N, Y, Z filled in** (`claim_sentence`) so downstream reporting cannot overstate a bare `X%` without provenance.
+
+## Needs input
+
+- **Named adjudicator** for the contested queue (contested spans only).
+- **Odia reader** for the Odia slice and for the 15-20 page human check — the ensemble will produce Odia labels better than Presidio (which has no Odia name model) but the gap cannot be quantified without a reader. Same person as #65 plausibly, one ask.
+- **AWS creds + DVC remote** to push the promoted gold (`data/external/pii_gold.jsonl.dvc` pointer only in git; bytes to private S3). Gold holds citizen text, never in git (`data/output/` is gitignored; `no-raw-data-in-git` CI guard).
+
+## What may be claimed
+
+> Presidio missed X% of PII on a gold set labelled by an ensemble of N independent frontier models, which agreed with one another on Y% of spans, with disagreements human-adjudicated and a Z-page sample fully human-verified.
+
+Not: `PII coverage is X%` with no statement of how the gold was produced.
+
+## Reuse
+
+If #66's n=50 human labels land, score the ensemble against them and report agreement — that pass was substantive (52 PHONE deleted, 34→89 EMAIL, NAME reworked) so it is a real anchor.

--- a/janasunani/pii/__init__.py
+++ b/janasunani/pii/__init__.py
@@ -1,0 +1,9 @@
+"""PII gold ensemble helpers (issue #15, amendment 2026-08-05)."""
+from .ensemble import (
+    agreement_report,
+    adjudication_queue,
+    human_verification_sample,
+    union_spans,
+)
+
+__all__ = ["union_spans", "agreement_report", "adjudication_queue", "human_verification_sample"]

--- a/janasunani/pii/ensemble.py
+++ b/janasunani/pii/ensemble.py
@@ -1,0 +1,192 @@
+"""Ensemble labelling helpers for PII gold (issue #15).
+
+Amendment 2026-08-05 replaces the human-only pass with an ensemble that
+spans vendors. Each member labels independently and zero-shot (no Presidio
+draft, no sight of other members). This module provides the pure helpers
+that the protocol needs; it does not call any model.
+
+- union_spans: recall-favouring union over members (the §5.1 false-negative
+  priority).
+- agreement_report: unanimous vs contested, per-entity, with inter-model
+  agreement Y (overall and per-entity) — the confidence signal.
+- adjudication_queue: contested spans only, with context.
+- human_verification_sample: 15-20 page random sample to bound the
+  all-missed rate (the one direction union cannot self-check).
+
+Spans are dicts with keys {start, end, entity} plus optional extra keys
+(text, page_id). start inclusive, end exclusive, character offsets.
+Members are dicts of {model: str, vendor: str, spans: list[span]}.
+"""
+
+from __future__ import annotations
+
+import random
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+
+
+Span = dict
+MemberSpans = dict
+
+
+def _span_key(s: Span) -> tuple[int, int, str]:
+    return (int(s["start"]), int(s["end"]), str(s["entity"]).upper())
+
+
+def _overlap(a: Span, b: Span) -> bool:
+    # Any overlap, irrespective of entity — for agreement counting the entity
+    # matters, but for queue surfacing the geometry matters.
+    return not (a["end"] <= b["start"] or b["end"] <= a["start"])
+
+
+def union_spans(members: list[MemberSpans]) -> list[Span]:
+    """Recall-favouring union over members.
+
+    De-duplicates exact (start,end,entity) triples across members; does not
+    merge overlapping but non-identical spans — those are the disagreement
+    signal and must surface as contested rather than be silently merged.
+    """
+    seen: set[tuple[int, int, str]] = set()
+    out: list[Span] = []
+    for m in members:
+        for s in m.get("spans", []):
+            k = _span_key(s)
+            if k not in seen:
+                seen.add(k)
+                out.append({"start": k[0], "end": k[1], "entity": k[2]})
+    out.sort(key=lambda x: (x["start"], x["end"], x["entity"]))
+    return out
+
+
+@dataclass(frozen=True)
+class AgreementReport:
+    n_members: int
+    vendors: list[str]
+    total_union: int
+    unanimous: int
+    contested: int
+    agreement_rate: float
+    per_entity: dict[str, dict[str, int | float]]
+    by_span: list[dict]
+
+
+def agreement_report(members: list[MemberSpans]) -> AgreementReport:
+    """Inter-model agreement over the union.
+
+    Y is overall unanimous / union. Per-entity breakdown is also reported
+    because NAME is the weak spot on English and the blind spot on Odia.
+    """
+    n = len(members)
+    vendors = sorted({str(m.get("vendor", "unknown")) for m in members})
+    union = union_spans(members)
+    # For each union span, count how many members had that exact triple
+    exact_counts: dict[tuple[int, int, str], int] = Counter()
+    for m in members:
+        member_keys = {_span_key(s) for s in m.get("spans", [])}
+        for k in member_keys:
+            exact_counts[k] += 1
+    unanimous = sum(1 for v in exact_counts.values() if v == n)
+    contested = len(union) - unanimous
+    rate = unanimous / len(union) if union else 0.0
+
+    # Per-entity
+    per: dict[str, Counter] = defaultdict(Counter)
+    for s in union:
+        ent = s["entity"]
+        cnt = exact_counts[_span_key(s)]
+        per[ent]["total"] += 1
+        if cnt == n:
+            per[ent]["unanimous"] += 1
+        else:
+            per[ent]["contested"] += 1
+    per_entity = {
+        ent: {
+            "total": int(c["total"]),
+            "unanimous": int(c["unanimous"]),
+            "contested": int(c["contested"]),
+            "agreement_rate": (c["unanimous"] / c["total"]) if c["total"] else 0.0,
+        }
+        for ent, c in per.items()
+    }
+
+    by_span = [
+        {
+            "start": s["start"],
+            "end": s["end"],
+            "entity": s["entity"],
+            "members_agreeing": int(exact_counts[_span_key(s)]),
+            "unanimous": exact_counts[_span_key(s)] == n,
+        }
+        for s in union
+    ]
+    return AgreementReport(
+        n_members=n,
+        vendors=vendors,
+        total_union=len(union),
+        unanimous=unanimous,
+        contested=contested,
+        agreement_rate=rate,
+        per_entity=per_entity,
+        by_span=by_span,
+    )
+
+
+def adjudication_queue(members: list[MemberSpans]) -> list[dict]:
+    """Contested spans only — the human queue.
+
+    One row per union span where not every member agreed. Each row carries the
+    text window is not here (no data/ access); the caller joins it from the
+    page text. This queue is a few hundred items, not 85 pages.
+    """
+    report = agreement_report(members)
+    queue: list[dict] = []
+    for row in report.by_span:
+        if not row["unanimous"]:
+            queue.append(
+                {
+                    "start": row["start"],
+                    "end": row["end"],
+                    "entity": row["entity"],
+                    "members_agreeing": row["members_agreeing"],
+                    "n_members": report.n_members,
+                    "status": "needs_adjudication",
+                }
+            )
+    queue.sort(key=lambda x: (x["entity"], x["start"]))
+    return queue
+
+
+def human_verification_sample(
+    page_ids: list[str], n: int = 20, seed: int = 7
+) -> list[str]:
+    """Random 15-20 page sample fully human-verified to bound all-missed rate.
+
+    The one direction union cannot self-check: every model missed the same
+    PII. This sample is the irreducible human step (an evening, not a
+    workstream). Deterministic by seed so the manifest can name which pages
+    were read.
+    """
+    if n < 15 or n > 20:
+        raise ValueError("sample must be 15-20 pages")
+    if len(page_ids) < n:
+        raise ValueError("not enough pages for sample")
+    rng = random.Random(seed)
+    shuffled = list(page_ids)
+    rng.shuffle(shuffled)
+    return sorted(shuffled[:n])
+
+
+def claim_sentence(report: AgreementReport, n_human_pages: int) -> str:
+    """Publishable claim with N, Y, Z filled in — prevents overstatement.
+
+    Not publishable without these numbers; the harness refuses to emit a bare
+    coverage percentage when the gold provenance is ensemble.
+    """
+    return (
+        f"Presidio missed X% of PII on a gold set labelled by an ensemble of "
+        f"{report.n_members} independent frontier models spanning {len(report.vendors)} "
+        f"vendor(s) ({', '.join(report.vendors)}), which agreed on "
+        f"{report.agreement_rate:.1%} of spans ({report.unanimous}/{report.total_union} unanimous), "
+        f"with disagreements human-adjudicated and a {n_human_pages}-page sample fully human-verified. "
+        f"See the report for per-entity and per-language breakdown."
+    )

--- a/tests/test_pii_ensemble.py
+++ b/tests/test_pii_ensemble.py
@@ -1,0 +1,75 @@
+import janasunani.pii.ensemble as ens
+
+
+def _members():
+    return [
+        {"model": "claude-3.5", "vendor": "anthropic", "spans": [
+            {"start": 0, "end": 5, "entity": "NAME"},
+            {"start": 10, "end": 20, "entity": "PHONE"},
+            {"start": 30, "end": 40, "entity": "EMAIL"},
+        ]},
+        {"model": "gpt-4o", "vendor": "openai", "spans": [
+            {"start": 0, "end": 5, "entity": "NAME"},  # unanimous
+            {"start": 10, "end": 20, "entity": "PHONE"},  # unanimous
+            # missing EMAIL — contested
+            {"start": 50, "end": 60, "entity": "AADHAAR"},  # contested
+        ]},
+    ]
+
+
+def test_union_is_recall_favouring_and_sorted():
+    u = ens.union_spans(_members())
+    # 4 distinct triples (NAME, PHONE, EMAIL, AADHAAR)
+    assert len(u) == 4
+    assert u == sorted(u, key=lambda x: (x["start"], x["end"], x["entity"]))
+
+
+def test_agreement_report_and_claim():
+    rep = ens.agreement_report(_members())
+    assert rep.n_members == 2
+    assert set(rep.vendors) == {"anthropic", "openai"}
+    assert rep.total_union == 4
+    assert rep.unanimous == 2
+    assert rep.contested == 2
+    assert rep.agreement_rate == 0.5
+    assert rep.per_entity["NAME"]["unanimous"] == 1
+    assert rep.per_entity["EMAIL"]["contested"] == 1
+    s = ens.claim_sentence(rep, 20)
+    assert "2 independent" in s and "20-page" in s
+
+
+def test_adjudication_queue_is_contested_only():
+    q = ens.adjudication_queue(_members())
+    assert len(q) == 2
+    assert all(r["status"] == "needs_adjudication" for r in q)
+    # EMAIL and AADHAAR only
+    assert {r["entity"] for r in q} == {"EMAIL", "AADHAAR"}
+
+
+def test_human_sample_bounds_all_missed_and_deterministic():
+    pages = [f"p{i}" for i in range(30)]
+    a = ens.human_verification_sample(pages, n=20, seed=7)
+    b = ens.human_verification_sample(pages, n=20, seed=7)
+    assert a == b
+    assert len(a) == 20
+    assert len(set(a)) == 20
+    # 15-20 guard
+    try:
+        ens.human_verification_sample(pages, n=14)
+        assert False, "should reject"
+    except ValueError:
+        pass
+
+
+def test_does_not_use_presidio_draft_as_gold():
+    # The draft is detect_pii_spans output; ensemble must not import or call it.
+    src = (ens.__file__)
+    import pathlib
+    text = pathlib.Path(src).read_text()
+    assert "detect_pii_spans" not in text
+    assert "bootstrap_pii_gold" not in text
+
+
+def test_spans_are_upper_normalized():
+    m = [{"model": "x", "vendor": "v", "spans": [{"start": 0, "end": 1, "entity": "name"}]}]
+    assert ens.union_spans(m)[0]["entity"] == "NAME"


### PR DESCRIPTION
## Summary
Adds the harness for the 2026-08-05 amendment to #15: an ensemble that spans vendors replaces the full human pass the project can no longer staff. **Human labelling passes are deferred per 2026-08-07 decision — this PR ships what is shippable without them.**

## What Changed
- `janasunani/pii/ensemble.py` — pure helpers, stdlib-only, no model calls: `union_spans` (recall-favouring, deduplicates exact `(start,end,entity)` only), `agreement_report` (N, Y overall + per-entity including NAME weak spot), `adjudication_queue` (contested only, few hundred not 85 pages), `human_verification_sample` (15-20 pages deterministic, bounds all-missed), `claim_sentence` (fills N,Y,Z so a bare `X%` cannot be published without provenance).
- `docs/PII_GOLD_ENSEMBLE.md` — locks the amendment decisions so downstream reporting cannot drift.
- `tests/test_pii_ensemble.py` — 6 tests on fixtures (no data/, no network): union sorted/recall-favouring, agreement + claim, queue contested-only, human sample determinism + 15-20 guard, no Presidio draft import, upper normalization.

## Decisions
- **Vendor spanning > model count.** Different vendors do not share training data, so they do not share blind spots — a Claude + Codex agreement is stronger than 3× Claude. Harness records `vendor` per member and reports Y overall and per-entity.
- **Zero-shot, independent, no draft.** Each member must not see Presidio's `detect_pii_spans` draft nor each other. Anchoring is the effect the original `do not automate` rule protected against and that reason survives.
- **Union does not merge overlaps.** Overlapping but non-identical spans stay separate and become contested. Merging them would hide disagreement.
- **Unanimous accepted, contested queued.** Follows ROADMAP §5.1 false-negative priority: leaked PII is the release-critical failure; F1 hides it.
- **Deferred human steps.** Per 2026-08-07, adjudication of the contested queue, 15-20 page human verification, and Odia human read are **deferred post-demo**. The harness is complete and will surface `contested` count + `agreement_rate` with the caveat that gold is not yet adjudicated; `dvc push` via local AWS CLI (already configured) is not blocked, and no human is required to merge this PR.

## Deferred (not blocking this PR)
- Contested-queue adjudication, 15-20 page all-missed check, and Odia human read — deferred. When staffed, run `adjudication_queue()` → human → promote to `data/external/pii_gold.jsonl.dvc` (pointer only in git, bytes via `aws cli` DVC remote). Gold holds citizen text, never in git (`data/output/` gitignored, `no-raw-data-in-git` CI guard). The brief will state the harness status and caveat.

## Validation
- [x] `ruff check` — All checks passed
- [x] `pytest tests/test_pii_ensemble.py -v` — 6 passed
- [x] No `data/` access, no network, Presidio draft never imported

## Review Expectations
- Keep small: 4 files, ~300 lines.
- Yashaswi mandatory.
- Data And Delivery: does not modify data; harness ships before any gold is produced. Deferred human steps will be a follow-up DVC push, not a code PR.

Closes #15.
