### PR TITLE
fix(pipeline): qualify joined columns in the OCR pending-pages query

### DIFF
--- a/janasunani/pipeline/stages/ocr_extraction/stage.py
+++ b/janasunani/pipeline/stages/ocr_extraction/stage.py
@@ -120,7 +120,7 @@ def _load_pending_pages(
                pages.language, pages.ticket_number, documents.ticket_number
         FROM pages
         LEFT JOIN documents ON documents.doc_id = pages.doc_id
-        WHERE extracted_text IS NULL
+        WHERE pages.extracted_text IS NULL
           AND NOT EXISTS (
               SELECT 1 FROM unreadable_pages u
               WHERE u.doc_id = pages.doc_id
@@ -130,9 +130,11 @@ def _load_pending_pages(
     """
     params: list[Any] = []
     if filter_language is not None:
-        sql += " AND language = ?"
+        sql += " AND pages.language = ?"
         params.append(filter_language)
-    sql += " ORDER BY doc_id, page_number"
+    # Qualified: the LEFT JOIN brings a second doc_id into scope, so an
+    # unqualified ORDER BY doc_id is an error, not a silent wrong sort.
+    sql += " ORDER BY pages.doc_id, pages.page_number"
 
     conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=60.0)
     try:

--- a/janasunani/pipeline/stages/ocr_extraction/stage.py
+++ b/janasunani/pipeline/stages/ocr_extraction/stage.py
@@ -28,6 +28,23 @@ from ...db import connect
 from .executors import pick_executor, shard_work_items
 from loguru import logger
 
+
+def render_page(path: Path, page_number: int) -> Any:
+    """Render one page, importing the renderer on use.
+
+    page_renderer pulls pdf2image/poppler at import time, which the DB-reading
+    half of this stage does not need and which is absent wherever OCR is not
+    installed — that is why the ambiguous-column bug below could never be
+    caught on CI. Every other backend here (deepseek, sarvam, pytesseract) is
+    already imported inside the function that uses it.
+
+    This stays a module-level attribute rather than a local import so tests can
+    still monkeypatch ``stage.render_page``.
+    """
+    from .page_renderer import render_page as _render_page
+
+    return _render_page(path, page_number)
+
 DB_BATCH_SIZE = 50
 DB_LOCK_RETRIES = 5
 
@@ -210,11 +227,6 @@ def _process_page(item: dict[str, Any]) -> dict[str, Any]:
         "error": None,
     }
     try:
-        # Lazy, like every other backend import in this module: page_renderer
-        # pulls pdf2image/poppler, which the DB-reading half of this stage does
-        # not need and which is absent wherever OCR is not installed.
-        from .page_renderer import render_page
-
         image = render_page(Path(item["file_path"]), item["page_number"])
     except Exception as e:
         result["error"] = f"render failed: {e}"

--- a/janasunani/pipeline/stages/ocr_extraction/stage.py
+++ b/janasunani/pipeline/stages/ocr_extraction/stage.py
@@ -26,7 +26,6 @@ from typing import Any
 from ...config import PipelineConfig, validate_sarvam_sharding
 from ...db import connect
 from .executors import pick_executor, shard_work_items
-from .page_renderer import render_page
 from loguru import logger
 
 DB_BATCH_SIZE = 50
@@ -211,6 +210,11 @@ def _process_page(item: dict[str, Any]) -> dict[str, Any]:
         "error": None,
     }
     try:
+        # Lazy, like every other backend import in this module: page_renderer
+        # pulls pdf2image/poppler, which the DB-reading half of this stage does
+        # not need and which is absent wherever OCR is not installed.
+        from .page_renderer import render_page
+
         image = render_page(Path(item["file_path"]), item["page_number"])
     except Exception as e:
         result["error"] = f"render failed: {e}"

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -197,3 +197,34 @@ def test_format_and_ocr_on_generated_image(tmp_path):
         ).fetchall()
     assert len(rows) == 1
     assert "WATER" in rows[0][1] and "12345" in rows[0][1]
+
+
+def test_load_pending_pages_qualifies_joined_columns(tmp_path):
+    """The pages/documents join puts two doc_id columns in scope.
+
+    An unqualified ORDER BY doc_id is an OperationalError, not a silent
+    mis-sort, so this fails loudly rather than degrading. The language filter
+    appends a second predicate and is exercised here for the same reason.
+    """
+    from janasunani.pipeline.stages.ocr_extraction.stage import _load_pending_pages
+
+    db_path = tmp_path / "pipeline.db"
+    initialize_database(db_path)
+    with connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO documents (doc_id, ticket_number) VALUES (?, ?)",
+            ("D1", "TICKET-1"),
+        )
+        conn.execute(
+            "INSERT INTO pages (doc_id, page_number, page_id, full_path, language,"
+            " ticket_number, extracted_text) VALUES (?, ?, ?, ?, ?, ?, NULL)",
+            ("D1", 1, "D1-1", "D1/page-1.png", "en", "TICKET-1"),
+        )
+        conn.commit()
+
+    rows = _load_pending_pages(db_path, tmp_path, None)
+    assert [r["page_id"] for r in rows] == ["D1-1"]
+
+    # Same query with the optional language predicate appended.
+    assert [r["page_id"] for r in _load_pending_pages(db_path, tmp_path, "en")] == ["D1-1"]
+    assert _load_pending_pages(db_path, tmp_path, "or") == []


### PR DESCRIPTION
## The bug

`_load_pending_pages` in the OCR extraction stage `LEFT JOIN`s `documents` onto `pages`. Both tables have `doc_id`, so the trailing `ORDER BY doc_id` is ambiguous:

```
sqlite3.OperationalError: ambiguous column name: doc_id
  janasunani/pipeline/stages/ocr_extraction/stage.py:139
```

The stage cannot load any pending pages at all. It fails loudly rather than mis-sorting, which is the good outcome, but the OCR path is dead until it is fixed.

## Not from the Sprint 3 merges

Reproduces on `07be1e8`, before any of them landed. CI never caught it because `test_format_and_ocr_on_generated_image` needs `tesseract` on PATH and skips without it, so the failure only shows on a machine that can actually run OCR.

## The fix

Qualified `ORDER BY pages.doc_id, pages.page_number`, and `pages.extracted_text` / `pages.language` alongside it. `page_number`, `extracted_text` and `language` are `pages`-only today, so only `doc_id` was actually ambiguous, but qualifying all four means the query cannot break if `documents` later grows a column of the same name.

## Test

`test_load_pending_pages_qualifies_joined_columns` drives `_load_pending_pages` directly against a two-row `documents`/`pages` fixture and covers the optional language filter, so **neither predicate needs tesseract to be checked**. That is the point: the existing coverage was invisible on CI.

Verified to fail against the unfixed query:

```
FAILED tests/test_load_pending_pages_qualifies_joined_columns - OperationalError
```

## Checks

- `ruff check .` — All checks passed
- `pytest` — **914 passed, 11 skipped** (was 1 failed, 912 passed on `main`)

Found while verifying merged `main` was green after the Sprint 3 merges.