### PR TITLE
fix(pii): redact Indian person names the English NER model misses

### DIFF
--- a/janasunani/pipeline/stages/pii_tagger.py
+++ b/janasunani/pipeline/stages/pii_tagger.py
@@ -249,6 +249,81 @@ _CITATION_BEFORE_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Odia and wider Indian surnames (#183).
+#
+# NAME is the one entity with no pattern recognizer behind it: it comes solely
+# from en_core_web_sm PERSON, which is trained on English-language news and is
+# demonstrably weak here. Measured on the live path, 40 probes over 10 Odia
+# names in 4 sentence framings: 42% missed outright, a further 5% partially
+# redacted (given name left exposed, which still identifies). A Western
+# control name in the identical sentence was caught where the Odia one was
+# not.
+#
+# This is a closed-vocabulary problem far more than a model problem. Odia
+# surnames are a small, public, highly distinctive set, so a gazetteer catches
+# what the model does not without touching citizen data to build it.
+#
+# The span deliberately covers the WHOLE name, walking back over preceding
+# capitalised tokens ("Ramesh Kumar Sahoo", not just "Sahoo"). Redacting the
+# surname alone is the partial-redaction failure above, not a fix for it.
+_INDIAN_SURNAMES = frozenset(
+    {
+        "sahoo", "sahu", "patra", "nayak", "naik", "behera", "rout", "routray",
+        "mohanty", "jena", "das", "dash", "swain", "mishra", "misra", "panda",
+        "pradhan", "barik", "sethi", "majhi", "bhoi", "meher", "parida",
+        "pattnaik", "patnaik", "mahapatra", "acharya", "biswal", "tripathy",
+        "tripathi", "kar", "ghadei", "sabar", "murmu", "hembram", "soren",
+        "tudu", "kisan", "gouda", "gountia", "sagar", "bag", "bal", "behra",
+        "khatua", "lenka", "mallik", "malik", "nanda", "ojha", "padhi",
+        "pani", "rath", "samal", "senapati", "singh", "sinha", "tarai",
+        "thakur", "bhue", "digal", "pradhani", "harijan", "bhatra",
+        "kumar", "prasad", "chandra", "charan", "ranjan",
+    }
+)
+
+# A capitalised token, allowing an internal apostrophe or hyphen.
+_CAP_TOKEN = r"[A-Z][a-z'\-]+"
+
+# Surnames that are also scheme-name words. "Pradhan" is a real Odia surname
+# and the first word of "Pradhan Mantri <scheme>", which appears constantly in
+# a corpus about housing and pensions. Redacting it there removes the scheme
+# the grievance is about and leaves the officer a sentence they cannot act on.
+# Keyed on the token that follows, so the surname still redacts everywhere else.
+_SURNAME_SCHEME_FOLLOWERS = {
+    "pradhan": {"mantri"},
+}
+
+# Name-introducing phrases. The misses concentrate here: the "Applicant:"
+# framing missed 7 of 10 against 2 of 10 for a bare subject position, because
+# a label followed by a colon gives the model no grammatical subject to latch
+# onto. Matching the introducer and redacting only what follows keeps the
+# sentence readable for the officer, the same rule the identifier recognizer
+# follows for "account no.".
+#
+# Deliberately excludes a bare "name" and a bare "from". Both over-redact on
+# real grievance text: "Name of the scheme is Pradhan Mantri Awas Yojana"
+# loses the scheme, and "the road from Sambalpur to Bargarh" loses the place.
+# Neither costs recall, because a person named after either introducer is
+# still caught by the surname trigger.
+_NAME_INTRODUCER_RE = re.compile(
+    r"(?:my\s+name\s+is"
+    r"|name\s+of\s+(?:the\s+)?(?:applicant|complainant|petitioner|deponent)"
+    r"|applicant|complainant|petitioner|deponent"
+    r"|submitted\s+by|filed\s+by|signed\s+by"
+    r"|yours\s+(?:faithfully|sincerely|truly))"
+    r"\s*[:\-]?\s+",
+    re.IGNORECASE,
+)
+
+# Titles that reliably precede a person name.
+_TITLE_WORDS = frozenset(
+    {"shri", "sri", "smt", "smit", "mr", "mrs", "ms", "dr", "prof", "kumari", "km"}
+)
+_NAME_TITLE_RE = re.compile(
+    r"\b(?:" + "|".join(sorted(_TITLE_WORDS)) + r")\.?\s+",
+    re.IGNORECASE,
+)
+
 
 class _IndianIdentifierRecognizer:
     """Bank account and scheme-identifier numbers, anchored on context.
@@ -297,6 +372,119 @@ class _IndianIdentifierRecognizer:
                         )
                     )
                 return results
+
+        return _Impl()
+
+
+def _indian_name_spans(text: str) -> list[tuple[int, int]]:
+    """Return (start, end) spans for Indian person names en_core_web_sm misses.
+
+    Two independent triggers, both of which yield the full name:
+
+    * a capitalised token run ending in a known surname;
+    * a name-introducing phrase or title, followed by a capitalised run.
+
+    Pure text in, offsets out, so it is testable without presidio installed.
+    """
+    spans: list[tuple[int, int]] = []
+    token_re = re.compile(_CAP_TOKEN)
+    tokens = [(m.start(), m.end(), m.group()) for m in token_re.finditer(text)]
+
+    # Trigger 1: a run of capitalised tokens ending in a known surname.
+    for index, (start, end, token) in enumerate(tokens):
+        if token.lower() not in _INDIAN_SURNAMES:
+            continue
+        followers = _SURNAME_SCHEME_FOLLOWERS.get(token.lower())
+        if followers:
+            next_word = re.match(r"\s+([A-Za-z]+)", text[end:])
+            if next_word and next_word.group(1).lower() in followers:
+                continue
+        first = start
+        back = index - 1
+        # Walk back over adjacent capitalised tokens, separated by single
+        # spaces only, so a new sentence cannot be absorbed into the name.
+        while back >= 0 and len(tokens) > back:
+            prev_start, prev_end, prev_token = tokens[back]
+            if text[prev_end:start].strip() or (start - prev_end) > 1:
+                break
+            # Keep the honorific outside the span: "Shri [NAME]" reads, and a
+            # title identifies nobody on its own.
+            if prev_token.lower() in _TITLE_WORDS:
+                break
+            first = prev_start
+            start = prev_start
+            back -= 1
+        spans.append((first, end))
+
+    # Trigger 2: an introducer or title, then up to four capitalised tokens.
+    for pattern in (_NAME_INTRODUCER_RE, _NAME_TITLE_RE):
+        for match in pattern.finditer(text):
+            cursor = match.end()
+            run_start = None
+            run_end = None
+            for _ in range(4):
+                token_match = token_re.match(text, cursor)
+                if token_match is None:
+                    break
+                if run_start is None:
+                    run_start = token_match.start()
+                run_end = token_match.end()
+                cursor = token_match.end()
+                if cursor < len(text) and text[cursor] == " ":
+                    cursor += 1
+                else:
+                    break
+            if run_start is not None and run_end is not None:
+                spans.append((run_start, run_end))
+
+    return _merge_spans(spans)
+
+
+def _merge_spans(spans: list[tuple[int, int]]) -> list[tuple[int, int]]:
+    """Union overlapping or touching spans, so one name yields one result."""
+    if not spans:
+        return []
+    ordered = sorted(spans)
+    merged = [ordered[0]]
+    for start, end in ordered[1:]:
+        last_start, last_end = merged[-1]
+        if start <= last_end:
+            merged[-1] = (last_start, max(last_end, end))
+        else:
+            merged.append((start, end))
+    return merged
+
+
+class _IndianNameRecognizer:
+    """Person names the English NER model misses (#183).
+
+    Same construction trick as _IndianIdentifierRecognizer: subclasses
+    EntityRecognizer at call time so this module imports without presidio.
+    """
+
+    def __new__(cls):
+        from presidio_analyzer import EntityRecognizer, RecognizerResult
+
+        class _Impl(EntityRecognizer):
+            def __init__(self) -> None:
+                super().__init__(
+                    supported_entities=["PERSON"],
+                    name="in_name_recognizer",
+                    supported_language="en",
+                )
+
+            def load(self) -> None:  # pragma: no cover - presidio hook
+                pass
+
+            def analyze(self, text, entities, nlp_artifacts=None):
+                if entities and "PERSON" not in entities:
+                    return []
+                return [
+                    RecognizerResult(
+                        entity_type="PERSON", start=start, end=end, score=0.6
+                    )
+                    for start, end in _indian_name_spans(text)
+                ]
 
         return _Impl()
 
@@ -411,6 +599,10 @@ def _get_engines():
     # redact "account no." along with the number and destroy the sentence for
     # the officer reading it.
     analyzer.registry.add_recognizer(_IndianIdentifierRecognizer())
+    # Indian person names (#183). Additive to en_core_web_sm PERSON: overlapping
+    # spans from the two are merged by the anonymizer, so this only ever widens
+    # coverage. See _indian_name_spans for the measured gap it closes.
+    analyzer.registry.add_recognizer(_IndianNameRecognizer())
     # Landline: STD code (2-4 digits after the leading 0) plus a 6-8 digit
     # subscriber number, e.g. Bhubaneswar "0674 2536789". Presidio's built-in
     # PhoneRecognizer used to be the only thing catching these, at the same

--- a/tests/test_pii_name_spans.py
+++ b/tests/test_pii_name_spans.py
@@ -1,0 +1,113 @@
+"""Indian person-name span detection (#183), without Presidio.
+
+`tests/test_pii_redaction.py` skips whenever the `pii` extra is absent, which
+is the normal state on CI. That is exactly how the gap this recognizer closes
+went unmeasured for so long, so the span logic is pure text-in/offsets-out and
+is tested here with no optional dependency at all.
+"""
+
+from janasunani.pipeline.stages.pii_tagger import _indian_name_spans
+
+NAMES = [
+    "Ramesh Kumar Sahoo",
+    "Sunita Devi Patra",
+    "Bijay Kumar Nayak",
+    "Laxmi Priya Behera",
+    "Manoj Kumar Rout",
+    "Sasmita Mohanty",
+    "Prafulla Chandra Jena",
+    "Ananya Das",
+    "Rabindra Nath Swain",
+    "Jagannath Prasad Mishra",
+]
+
+FRAMINGS = [
+    "{n} reports that the tube well is broken in ward seven.",
+    "My name is {n} and the tube well is broken in ward seven.",
+    "Applicant: {n}. The tube well is broken in ward seven.",
+    "This grievance is filed by {n} of Sambalpur district.",
+    "From {n}, resident of ward seven, regarding the broken tube well.",
+]
+
+
+def _covered(text: str) -> str:
+    return "".join(text[s:e] for s, e in _indian_name_spans(text))
+
+
+def test_every_name_token_is_covered_in_every_framing():
+    """A partial redaction still identifies, so every token must be covered.
+
+    The measured failure before this recognizer was 42% missed outright and a
+    further 5% partial, where the surname was covered and the given name was
+    left in the clear.
+    """
+    leaks = []
+    for framing in FRAMINGS:
+        for name in NAMES:
+            text = framing.format(n=name)
+            covered = _covered(text)
+            missing = [part for part in name.split() if part not in covered]
+            if missing:
+                leaks.append((framing, name, missing))
+    assert leaks == []
+
+
+def test_span_covers_the_whole_name_not_just_the_surname():
+    text = "Ramesh Kumar Sahoo reports that the tube well is broken."
+    spans = _indian_name_spans(text)
+    assert spans, "surname gazetteer should have fired"
+    start, end = spans[0]
+    assert text[start:end] == "Ramesh Kumar Sahoo"
+
+
+def test_scheme_names_are_not_redacted():
+    """Over-redaction destroys the sentence the officer has to act on.
+
+    'Pradhan' is a real Odia surname and the first word of 'Pradhan Mantri
+    <scheme>'. Losing the scheme name loses what the grievance is about.
+    """
+    for text in (
+        "Name of the scheme is Pradhan Mantri Awas Yojana and I have not received it.",
+        "I applied under Pradhan Mantri Gram Sadak Yojana at the Khordha office.",
+    ):
+        assert _indian_name_spans(text) == []
+
+
+def test_pradhan_still_redacts_when_it_is_a_person():
+    text = "Sarojini Pradhan of ward seven reports the tube well is broken."
+    assert _covered(text) == "Sarojini Pradhan"
+
+
+def test_places_and_offices_are_not_names():
+    """'from' and a bare 'name' are deliberately not introducers.
+
+    Both over-redact on real grievance text: the place in 'the road from
+    Sambalpur to Bargarh', and the scheme in 'Name of the scheme is ...'.
+    """
+    for text in (
+        "The road from Sambalpur to Bargarh is broken and needs urgent repair.",
+        "I visited the Block Development Office in Sambalpur district on Tuesday.",
+        "From the Public Grievance Cell, no reply was received for sixty days.",
+        "The Executive Engineer, Rural Water Supply visited Bargarh in March.",
+        "I applied under Biju Swasthya Kalyan Yojana at the Khordha office.",
+    ):
+        assert _indian_name_spans(text) == [], text
+
+
+def test_titles_introduce_a_name():
+    assert _covered("Shri Ramesh Kumar reports the tube well is broken.") == (
+        "Ramesh Kumar"
+    )
+    assert "Sunita" in _covered("Smt. Sunita Devi has not received her pension.")
+
+
+def test_a_name_does_not_swallow_the_next_sentence():
+    """The walk-back stops at anything other than a single space."""
+    text = "Applicant: Ananya Das. Bargarh block has not responded."
+    covered = _covered(text)
+    assert "Ananya Das" in covered
+    assert "Bargarh" not in covered
+
+
+def test_no_spans_on_text_without_names():
+    assert _indian_name_spans("The tube well in ward seven has been broken.") == []


### PR DESCRIPTION
Closes #183

## The gap

NAME was the only entity with no pattern recognizer behind it, resting entirely on `en_core_web_sm` PERSON. Measured on the live path (`processor: pipeline`), 40 probes over 10 Odia names in 4 framings:

| | Before | After |
|---|---|---|
| Fully redacted | 52% | **100%** |
| Partial (given name exposed) | 5% | 0% |
| Missed entirely | 42% | 0% |
| **Any leak** | **48%** | **0%** |

A partial redaction still identifies. A Western control name in the identical sentence was caught where the Odia one was not.

## Two triggers, both yielding the whole name

1. **Surname gazetteer** — a capitalised run ending in a known Odia/Indian surname, walking back over preceding capitalised tokens so `Ramesh Kumar Sahoo` is covered, not just `Sahoo`. Redacting the surname alone *is* the partial-redaction failure, not a fix for it.
2. **Introducer / title** — a name-introducing phrase followed by a capitalised run. This is where misses concentrated: `Applicant:` missed 7 of 10 against 2 of 10 for a bare subject position, because a label plus colon gives the model no grammatical subject.

No citizen data was read to build the gazetteer. Odia surnames are a small, public, highly distinctive set.

## Precision was the real risk

Two over-redactions appeared on realistic text and are fixed:

| Text | Before | After |
|---|---|---|
| `the road from Sambalpur to Bargarh` | `from [NAME] to Bargarh` | untouched |
| `Name of the scheme is Pradhan Mantri Awas Yojana` | `[NAME] Mantri Awas Yojana` | untouched |

A bare `from` and a bare `name` are dropped as introducers. Neither costs recall — a person named after either is still caught by the surname trigger, verified by a fifth framing (`From {name}, resident of ward seven…`) that scores 10/10.

`Pradhan` is guarded only when followed by `Mantri`, and still redacts as a surname everywhere else (`Sarojini Pradhan` → `[NAME]`). Honorifics stay outside the span, so `Shri [NAME]` still reads.

**Nine realistic non-name sentences now yield zero false positives** (places, offices, scheme names, designations).

## Tests where CI can see them

`tests/test_pii_redaction.py` skips whenever the `pii` extra is absent, which is the normal state on CI — that is how this gap stayed invisible. So `_indian_name_spans` is pure text-in/offsets-out and the new `tests/test_pii_name_spans.py` has **no optional dependency**: 8 tests covering recall across all framings, whole-name coverage, scheme-name protection, honorifics, sentence-boundary containment, and false positives.

## Verified end to end

Through the running API, one submission:

```
entities: ['AADHAAR', 'EMAIL', 'NAME', 'PHONE']
"My name is [NAME], mobile [PHONE], email [EMAIL], Aadhaar [AADHAAR]. The tube well …"
```

## Checks

- `ruff check .` — clean
- `pytest` — **1019 passed, 7 skipped**

`docs/PERFORMANCE.md` §2 records the before figures and should be updated to the after once this lands.