### PR TITLE
fix(egress): bill Sarvam status polls against the shared rate limit

### DIFF
--- a/janasunani/egress/sarvam.py
+++ b/janasunani/egress/sarvam.py
@@ -40,6 +40,16 @@ AUTHORIZATION_REFERENCE = "GoO-Sarvam MoU; ACS Vishal Dev (IT) sign-off"
 TERMINAL_STATUSES = frozenset({"completed", "partially_completed", "failed", "rejected"})
 VISION_SUBMISSIONS_PER_MINUTE = 10
 SUBMISSION_WINDOW_SECONDS = 60.0
+
+# Sarvam documents 10 req/min for Document Intelligence, uniform across the
+# Starter, Pro and Business plans -- upgrading does not raise it -- and status
+# polls are billed against that same budget. Their guidance is an explicit
+# five-second poll interval. A one-second default polls a single job at up to
+# 60 req/min, so the first live job would rate-limit itself before any second
+# job could be submitted. Recorded-transport tests pass an explicit smaller
+# value, so this default only governs real calls.
+# https://docs.sarvam.ai/api/getting-started/ratelimits
+DEFAULT_POLL_INTERVAL_SECONDS = 5.0
 MAX_SUBMISSION_ATTEMPTS = 3
 MAX_RETRY_DELAY_SECONDS = 60.0
 
@@ -367,7 +377,7 @@ class SarvamVisionAdapter:
         audit_log: AuditLog,
         route: ProviderRoute | None = None,
         transport: HttpTransport | None = None,
-        poll_interval_seconds: float = 1.0,
+        poll_interval_seconds: float = DEFAULT_POLL_INTERVAL_SECONDS,
         max_poll_attempts: int = 60,
         sleep: Callable[[float], None] = time.sleep,
         monotonic: Callable[[], float] = time.monotonic,
@@ -622,6 +632,7 @@ class SarvamVisionAdapter:
         for attempt in range(self.max_poll_attempts):
             if attempt:
                 self.sleep(self.poll_interval_seconds)
+            self._wait_for_submission_slot()
             status = self._get_json(
                 url=f"{self.route.endpoint}/doc-ai/v1/job/{job_id}/status",
                 headers={"api-subscription-key": self.api_key},
@@ -789,7 +800,12 @@ class SarvamVisionAdapter:
         raise AssertionError("bounded Sarvam submission loop did not return or raise")
 
     def _wait_for_submission_slot(self) -> None:
-        """Enforce the documented ten Vision submissions per rolling minute."""
+        """Enforce the documented ten Document Intelligence calls per minute.
+
+        The budget is shared: a status poll is billed the same as a submission,
+        so both take a slot. Counting submissions alone let a single job's poll
+        loop exhaust the quota and then rate-limit the next submission.
+        """
         now = self.monotonic()
         while self._submission_times and (
             now - self._submission_times[0] >= SUBMISSION_WINDOW_SECONDS

--- a/tests/test_sarvam_egress.py
+++ b/tests/test_sarvam_egress.py
@@ -702,7 +702,60 @@ def test_submission_limiter_enforces_ten_requests_per_rolling_minute(tmp_path):
         assert outcome.ocr_model == "pytesseract"
 
     assert [method for method, _, _ in transport.calls].count("POST") == 11
-    assert clock.sleeps == [60.0]
+
+    # The 10/min budget is shared between submissions and status polls: Sarvam
+    # bills a poll the same as a submission, which is why their guidance is a
+    # five-second poll interval. Each of the 11 jobs here is one POST plus one
+    # poll, so 22 calls cross the rolling window twice.
+    assert [method for method, _, _ in transport.calls].count("GET") == 11
+    assert clock.sleeps == [60.0, 60.0]
+
+
+def test_status_polls_consume_the_shared_rate_limit_budget(tmp_path):
+    """A single job's poll loop must not exhaust the quota unmetered.
+
+    Before this was counted, one job polling at the old one-second default
+    issued up to 60 requests a minute against a ten-per-minute budget, so the
+    first live job would rate-limit itself before a second could be submitted.
+    """
+    clock = FakeClock()
+    responses = [RecordedResponse(202, {"job_id": "job-poll", "status": "pending"})]
+    # Nine polls that stay pending, then a terminal one: 1 POST + 10 GETs, so
+    # the eleventh call is the one that has to wait for the window.
+    responses.extend(
+        RecordedResponse(200, {"job_id": "job-poll", "status": "pending"})
+        for _ in range(9)
+    )
+    responses.append(RecordedResponse(200, {"job_id": "job-poll", "status": "failed"}))
+
+    adapter = SarvamVisionAdapter(
+        enabled=True,
+        api_key="recorded-test-key",
+        audit_log=SqliteAuditLog(tmp_path / "audit.sqlite"),
+        route=_verified_test_route(),
+        transport=RecordedTransport(responses),
+        max_poll_attempts=10,
+        poll_interval_seconds=0,
+        sleep=clock.sleep,
+        monotonic=clock.monotonic,
+    )
+
+    outcome = adapter.digitise_or_fallback(
+        b"fixture-png", "page.png", "en-IN", _context(), lambda: "local OCR"
+    )
+
+    assert outcome.ocr_model == "pytesseract"
+    # 1 submission + 10 polls = 11 metered calls, so the window is hit once
+    # even though only one job was ever submitted. The zero-length sleeps are
+    # the poll interval itself, set to 0 here to isolate the limiter.
+    assert [pause for pause in clock.sleeps if pause] == [60.0]
+
+
+def test_default_poll_interval_matches_the_documented_guidance():
+    """Sarvam documents a five-second poll interval for this rate limit."""
+    from janasunani.egress.sarvam import DEFAULT_POLL_INTERVAL_SECONDS
+
+    assert DEFAULT_POLL_INTERVAL_SECONDS == 5.0
 
 
 def test_429_retries_after_provider_delay_and_can_succeed(tmp_path):


### PR DESCRIPTION
Found while assessing whether the #127 paired sample is actually runnable. Two defects that only appear on a live call.

## What was wrong

Sarvam documents **10 req/min for Document Intelligence, uniform across Starter, Pro and Business** — upgrading does not raise it — and a status poll is billed the same as a submission. Their guidance is an explicit five-second poll interval.

Our adapter:

- metered **submissions only**; the poll loop took no slot;
- defaulted to a **one-second** poll interval.

Together, a single job polling at 1s issues up to **60 requests a minute against a 10/min budget**. The first live job would rate-limit itself before a second could be submitted.

Invisible to the existing suite because recorded-transport tests pass an explicit `poll_interval_seconds`, so the default was never exercised, and no test counted GETs against the limiter.

## Fix

Polls take a slot; default interval is 5s.

## Test changes

`test_submission_limiter_enforces_ten_requests_per_rolling_minute` asserted a single 60s wait for 11 submissions. Under the shared budget those 11 jobs are 22 metered calls and cross the rolling window twice, so it now asserts both waits and the GET count.

Two added:
- `test_status_polls_consume_the_shared_rate_limit_budget` — drives one job's poll loop to the limit and asserts the window is hit with only one submission ever made.
- `test_default_poll_interval_matches_the_documented_guidance` — pins 5.0.

## Checks

- `ruff check .` — clean
- `pytest` — **1021 passed, 7 skipped** (38 in `test_sarvam_egress.py`)

No behaviour change for anything already merged: the governance gate still blocks every live call, so this only matters once that is lifted.

Source: https://docs.sarvam.ai/api/getting-started/ratelimits