### PR TITLE
feat(egress): record accepted risk separately from verified controls

### DIFF
--- a/janasunani/egress/sarvam.py
+++ b/janasunani/egress/sarvam.py
@@ -63,6 +63,28 @@ class GovernanceControl:
 
 
 @dataclass(frozen=True)
+class RiskAcceptance:
+    """A named authority knowingly accepting unverified provider controls.
+
+    This is deliberately not the same thing as verification, and setting one
+    must never flip a control to ``verified``. Verification is a claim about
+    what the provider does with the data once it has it; acceptance is a claim
+    about who decided we may send it anyway, and on what basis. Recording an
+    acceptance as a verification would put a false statement about a third
+    party into the registry, and the registry is the artifact a reviewer reads.
+
+    ``unverified_controls`` therefore keeps reporting every unverified control
+    even when an acceptance is present, and the audit log records which of the
+    two bases permitted each call.
+    """
+
+    authority: str
+    basis: str
+    scope: str
+    accepted_on: str
+
+
+@dataclass(frozen=True)
 class ProviderRoute:
     """The registered, reviewable declaration for a provider route."""
 
@@ -78,6 +100,7 @@ class ProviderRoute:
     encryption_at_rest: GovernanceControl
     audit_policy: str
     fallback: str
+    accepted_risk: RiskAcceptance | None = None
 
     @property
     def unverified_controls(self) -> tuple[str, ...]:
@@ -106,8 +129,30 @@ class ProviderRoute:
 
     @property
     def live_use_ready(self) -> bool:
-        """Whether every provider-held-data control has verified repo evidence."""
+        """Whether every provider-held-data control has verified repo evidence.
+
+        Unchanged by an accepted risk, on purpose. This property answers "is
+        the provider's handling of our data verified", and an acceptance does
+        not make it so. Callers deciding whether a call may proceed want
+        :attr:`egress_permitted`.
+        """
         return self.declared_controls_complete and not self.unverified_controls
+
+    @property
+    def egress_permitted(self) -> bool:
+        """Whether a live call may proceed, by verification or by acceptance."""
+        if not self.declared_controls_complete:
+            return False
+        return not self.unverified_controls or self.accepted_risk is not None
+
+    @property
+    def egress_basis(self) -> str:
+        """Which of the two bases permits egress, for the audit record."""
+        if self.live_use_ready:
+            return "verified_controls"
+        if self.egress_permitted:
+            return "accepted_risk"
+        return "blocked"
 
 
 PROVIDER_REGISTRY = {
@@ -137,6 +182,28 @@ PROVIDER_REGISTRY = {
             "operation, event, language, request key, job id, and safe response metadata."
         ),
         fallback="pytesseract",
+        # The three controls above stay `verified=False` because they are still
+        # not verified: Sarvam publishes no retention or residency commitment,
+        # and their documentation says these vary by plan and must be settled
+        # with an account representative. What exists is authorization, not
+        # verification, and the two are recorded separately on purpose.
+        accepted_risk=RiskAcceptance(
+            authority=(
+                "Additional Chief Secretary, Electronics & IT Department, "
+                "Government of Odisha"
+            ),
+            basis=(
+                "Sign-off that citizen PII may be remitted to Sarvam. No state "
+                "statute currently governs this transfer, and the residual risk "
+                "was judged acceptable on that basis. Provider retention and "
+                "encryption terms remain unverified."
+            ),
+            scope=(
+                "Sarvam Vision document digitisation and extraction for the "
+                "grievance corpus."
+            ),
+            accepted_on="2026-08-07",
+        ),
     )
 }
 
@@ -535,7 +602,7 @@ class SarvamVisionAdapter:
     ) -> _Result:
         if not self.enabled:
             raise SarvamDisabled("Sarvam hosted egress is disabled")
-        if not self.route.live_use_ready:
+        if not self.route.egress_permitted:
             controls = ", ".join(self.route.unverified_controls)
             raise SarvamGovernanceError(
                 f"Sarvam hosted egress is gated by unverified controls: {controls}"
@@ -1001,6 +1068,23 @@ class SarvamVisionAdapter:
         )
         return hashlib.sha256(source.encode("utf-8")).hexdigest()
 
+    def _authorization_reference(self) -> str:
+        """The route's authorization, naming the accepted risk when that is the basis.
+
+        A reader of the audit table should not have to go to the source to find
+        out whether a call went out on verified controls or on someone's
+        signature accepting unverified ones.
+        """
+        reference = self.route.authorization_reference
+        accepted = self.route.accepted_risk
+        if self.route.egress_basis == "accepted_risk" and accepted is not None:
+            return (
+                f"{reference} | risk accepted by {accepted.authority}"
+                f" on {accepted.accepted_on}: {accepted.basis}"
+                f" (unverified: {', '.join(self.route.unverified_controls)})"
+            )
+        return reference
+
     def _audit(
         self,
         context: SarvamAuditContext,
@@ -1021,7 +1105,7 @@ class SarvamVisionAdapter:
                 model_id=self.route.model_id,
                 bytes_sent=bytes_sent,
                 timestamp=datetime.now(UTC).isoformat(),
-                authorization_reference=self.route.authorization_reference,
+                authorization_reference=self._authorization_reference(),
                 operation=operation,
                 event=event,
                 language=language,

--- a/tests/test_sarvam_egress.py
+++ b/tests/test_sarvam_egress.py
@@ -905,6 +905,12 @@ def test_extract_is_a_distinct_operation_and_requires_one_pinned_schema_source(t
 
 
 def test_unverified_provider_controls_gate_enabled_route_without_remote_call(tmp_path):
+    """Unverified controls and no accepted risk must still block every call.
+
+    This is the invariant the accepted-risk field must not weaken: an
+    acceptance is an explicit, named decision, and its absence has to keep
+    failing closed.
+    """
     audit_path = tmp_path / "audit.sqlite"
     transport = RecordedTransport([])
     adapter = SarvamVisionAdapter(
@@ -912,6 +918,7 @@ def test_unverified_provider_controls_gate_enabled_route_without_remote_call(tmp
         api_key="recorded-test-key",
         audit_log=SqliteAuditLog(audit_path),
         transport=transport,
+        route=replace(PROVIDER_REGISTRY["sarvam-vision"], accepted_risk=None),
     )
 
     outcome = adapter.digitise_or_fallback(
@@ -927,6 +934,86 @@ def test_unverified_provider_controls_gate_enabled_route_without_remote_call(tmp
         ).fetchone()
     assert event == "fallback"
     assert json.loads(metadata)["reason"] == "SarvamGovernanceError"
+
+
+def test_accepted_risk_permits_egress_without_claiming_verification():
+    """An acceptance unblocks the call and never rewrites the control state.
+
+    The registry is what a reviewer reads. Recording someone's signature as
+    though it were evidence about Sarvam's retention would be a false
+    statement about a third party, so `verified` and `unverified_controls`
+    must be unmoved by it.
+    """
+    route = PROVIDER_REGISTRY["sarvam-vision"]
+
+    assert route.accepted_risk is not None
+    assert route.egress_permitted is True
+    assert route.egress_basis == "accepted_risk"
+
+    # Still not verified, and still reported as such.
+    assert route.live_use_ready is False
+    assert route.unverified_controls == (
+        "retention_terms",
+        "encryption_in_transit",
+        "encryption_at_rest",
+    )
+    assert route.retention_terms.verified is False
+
+
+def test_accepted_risk_is_named_in_the_audit_authorization(tmp_path):
+    """The audit row must say a call went out on acceptance, not verification."""
+    audit_path = tmp_path / "audit.sqlite"
+    transport = RecordedTransport(
+        [
+            RecordedResponse(202, {"job_id": "job-accepted", "status": "pending"}),
+            RecordedResponse(200, {"job_id": "job-accepted", "status": "completed"}),
+            RecordedResponse(
+                200, {"download_url": "https://example.invalid/out.zip"}
+            ),
+            RecordedResponse(200, _zip_output(**{"page-1.md": "recognised text"})),
+        ]
+    )
+    adapter = SarvamVisionAdapter(
+        enabled=True,
+        api_key="recorded-test-key",
+        audit_log=SqliteAuditLog(audit_path),
+        transport=transport,
+        poll_interval_seconds=0,
+    )
+
+    adapter.digitise_or_fallback(
+        b"fixture-png", "page.png", "en-IN", _context(), lambda: "local OCR"
+    )
+
+    with sqlite3.connect(audit_path) as connection:
+        references = [
+            row[0]
+            for row in connection.execute(
+                "SELECT authorization_reference FROM authorized_external_audit"
+            )
+        ]
+    assert references
+    for reference in references:
+        assert "risk accepted by" in reference
+        assert "Additional Chief Secretary" in reference
+        # A reader must be able to see which controls were unverified.
+        assert "retention_terms" in reference
+
+
+def test_verified_route_audit_does_not_mention_accepted_risk(tmp_path):
+    """When controls are genuinely verified, the acceptance wording is absent."""
+    audit_path = tmp_path / "audit.sqlite"
+    transport = RecordedTransport([])
+    adapter = SarvamVisionAdapter(
+        enabled=True,
+        api_key="recorded-test-key",
+        audit_log=SqliteAuditLog(audit_path),
+        transport=transport,
+        route=_verified_test_route(),
+    )
+
+    assert adapter.route.egress_basis == "verified_controls"
+    assert adapter._authorization_reference() == adapter.route.authorization_reference
 
 
 def test_extract_submission_omits_an_unsupported_model_field(tmp_path):


### PR DESCRIPTION
Unblocks the #127 paired Sarvam sample without writing a false claim into the registry.

## The distinction

The route was gated on three `verified=False` provider-held-data controls. The department's position is that the **Additional Chief Secretary, Electronics & IT, Government of Odisha** has signed off on citizen PII being remitted to Sarvam, and that with no state statute governing the transfer the residual risk is acceptable.

That is **authorization**, not **verification**. They answer different questions:

- *May we send this?* — yes, on the ACS sign-off.
- *What does Sarvam do with it once they have it?* — still unknown. Sarvam publishes no retention or residency commitment; their docs say these vary by plan and must be settled with an account representative.

So this PR does **not** flip the controls to `verified=True`. That would put a false statement about a third party into the registry, and the registry is the artifact a reviewer reads.

## What changed

`RiskAcceptance` records authority, basis, scope and date on the route.

| Property | Before | After |
|---|---|---|
| `live_use_ready` | False | **False** (unchanged meaning) |
| `unverified_controls` | 3 controls | **same 3 controls** |
| `retention_terms.verified` | False | **False** |
| `egress_permitted` | — | **True** |
| `egress_basis` | — | `accepted_risk` |

The adapter now gates on `egress_permitted`. `live_use_ready` keeps its original meaning, so anything asking "are the controls verified" still gets the honest answer.

## Audit

The per-call `authorization_reference` names the accepting authority and lists the controls still unverified:

```
GoO-Sarvam MoU; ACS Vishal Dev (IT) sign-off | risk accepted by Additional Chief
Secretary, Electronics & IT Department, Government of Odisha on 2026-08-07: …
(unverified: retention_terms, encryption_in_transit, encryption_at_rest)
```

A reader of the audit table alone can tell that a call went out on a signature rather than on evidence. On a genuinely verified route the wording is absent.

## Fail-closed invariant preserved

`test_unverified_provider_controls_gate_enabled_route_without_remote_call` previously relied on the default route being gated. It now explicitly strips `accepted_risk`, so the guarantee it protects — unverified controls **and no acceptance** make no remote call — is still tested rather than quietly lost.

Three tests added: acceptance does not rewrite control state, the audit names it, and a verified route does not mention it.

## Checks

- `ruff check .` — clean
- `pytest` — **1024 passed, 7 skipped** (41 in `test_sarvam_egress.py`)

Once merged, the live sample still needs a specific path of scanned pages; `data/` is off-limits without explicit per-path permission.