### PR TITLE
docs: record where a new module goes, and enforce the egress boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,32 @@ Then [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the system overview.
 - Console scripts (`janasunani-*`) are listed in `pyproject.toml`; the root
   `main.py` is a legacy stub, not the entrypoint.
 
+### Where a new module goes
+[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) has the full package table and is
+the place to look first. Keep it current: a new package that is not in that
+table sends the next person to the wrong place.
+
+The distinctions that have actually caused drift, in the order they bite:
+
+- **Gate or report.** Does the code fail a run when the number is bad? A gate
+  lives with the thing it gates (`pipeline/pii_eval.py`). A harness that
+  measures and prints goes in `evaluation/`.
+- **Batch or single-item.** The same model called over a corpus belongs in
+  `pipeline/`; called once for a live request, in `inference/`.
+- **Lake or OLTP.** Read-only analysis over Parquet goes in `analytics/`.
+  Anything writing to the OLTP database is `pipeline/` or `db/`.
+- **Leaving DPIC control.** Any call carrying citizen data to a third party
+  goes in `egress/` and nowhere else. This one is enforced by CI, not
+  convention.
+
+Prefer an existing package. A new top-level package is a real decision: say so
+in the PR body, and add it to the ARCHITECTURE table in the same PR.
+
+When two branches in one sprint could both plausibly add the same module,
+check what is already on the other branch before choosing. Three of the Sprint
+3 collisions (duplicate branches, an empty PR, two packages disagreeing about
+where scorecards live) were parallel work that never looked sideways.
+
 ## Commands
 - Install/sync: `uv sync` (add `--extra …` as needed).
 - Lint: `uv run ruff check .`

--- a/tests/test_egress_boundary.py
+++ b/tests/test_egress_boundary.py
@@ -1,0 +1,93 @@
+"""Only `janasunani/egress/` may talk to a third party (#83, ROADMAP §5.5).
+
+The egress rule is the strongest safety claim in the repo: exactly one module
+is permitted to send citizen data outside DPIC-controlled systems, so that the
+audit log, the kill switch and the governance gate cannot be bypassed by a
+second HTTP client appearing somewhere else.
+
+It was previously asserted in a PR body as a "CI guard" that did not exist.
+This is the guard. It is deliberately structural, not a grep for a provider
+name: adding a new HTTP client anywhere in the package fails here and forces
+whoever added it to either move it under `egress/` or justify the exception by
+editing the allowlist below in the same diff.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+PACKAGE = Path(__file__).resolve().parent.parent / "janasunani"
+
+HTTP_MODULES = {"httpx", "requests", "aiohttp", "urllib3", "http.client"}
+
+# Modules permitted to construct an HTTP client, and why.
+#
+# egress/sarvam.py  - the sole authorized-external client. Carries citizen
+#                     document bytes to a third party, behind the governance
+#                     gate and the per-call audit log.
+# ingestion/*       - DPIC-controlled endpoints only: the Janasunani source
+#                     API and S3. Not a third party, so not egress.
+ALLOWED = {
+    "egress/sarvam.py",
+    "ingestion/client.py",
+    "ingestion/document_ingestion.py",
+}
+
+
+def _http_importers() -> set[str]:
+    found: set[str] = set()
+    for path in PACKAGE.rglob("*.py"):
+        if "__pycache__" in path.parts:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            names: list[str] = []
+            if isinstance(node, ast.Import):
+                names = [alias.name for alias in node.names]
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                names = [node.module]
+            for name in names:
+                root = name.split(".")[0]
+                if root in HTTP_MODULES or name in HTTP_MODULES:
+                    found.add(path.relative_to(PACKAGE).as_posix())
+    return found
+
+
+def test_only_allowlisted_modules_construct_http_clients():
+    """A new HTTP client anywhere else is a new way out of the building."""
+    unexpected = _http_importers() - ALLOWED
+    assert unexpected == set(), (
+        "these modules import an HTTP client but are not on the egress "
+        f"allowlist: {sorted(unexpected)}. Move the call under "
+        "janasunani/egress/, or add it to ALLOWED with a comment saying which "
+        "DPIC-controlled endpoint it talks to."
+    )
+
+
+def test_allowlist_has_no_stale_entries():
+    """A stale allowlist quietly widens the boundary it is meant to hold."""
+    importers = _http_importers()
+    stale = {name for name in ALLOWED if not (PACKAGE / name).exists()}
+    assert stale == set(), f"allowlisted modules no longer exist: {sorted(stale)}"
+
+    unused = ALLOWED - importers
+    assert unused == set(), (
+        f"allowlisted modules no longer import an HTTP client: {sorted(unused)}. "
+        "Remove them so the allowlist keeps meaning what it says."
+    )
+
+
+def test_the_provider_endpoint_is_only_named_in_egress():
+    """The base URL is the thing a stray client would need. Keep it in one place."""
+    offenders = []
+    for path in PACKAGE.rglob("*.py"):
+        if "__pycache__" in path.parts:
+            continue
+        if path.relative_to(PACKAGE).parts[0] == "egress":
+            continue
+        if "api.sarvam.ai" in path.read_text(encoding="utf-8"):
+            offenders.append(path.relative_to(PACKAGE).as_posix())
+    assert offenders == [], (
+        f"the Sarvam endpoint is referenced outside egress/: {offenders}"
+    )


### PR DESCRIPTION
## Why

Sprint 3 produced four collisions with one cause: parallel branches that never looked sideways.

- #165/#166 and #163/#167 were duplicate branches (each a strict superset of the other).
- #168 was an empty PR.
- #164 and #167 were each clean against `main` but conflicted with **each other**, so GitHub showed both mergeable until the first one landed.
- Two packages disagreed about where a scorecard lives (#189).

The code was fine every time. The seams between branches were not.

## The note

`AGENTS.md` already owns "how it is laid out", so the placement rules go there. Each distinction is one that has **actually** caused drift, not a taxonomy invented for the occasion:

- **Gate or report** — does it fail a run when the number is bad? Gates live with what they gate; harnesses go in `evaluation/`.
- **Batch or single-item** — `pipeline/` vs `inference/`.
- **Lake or OLTP** — read-only Parquet analysis is `analytics/`.
- **Leaving DPIC control** — `egress/`, and nowhere else.

Plus: prefer an existing package, and a new top-level package must be added to the ARCHITECTURE table in the same PR.

## A claim that wasn't true

Writing this up turned up that #168's body said:

> Only `janasunani/egress/sarvam.py` may make an `authorized-external` call (CI guard).

**There was no such guard.** No test, no workflow step. That is worse than an unwritten rule, because it invites trust in enforcement that isn't there — and this is the strongest safety claim in the repo, the one that keeps the audit log, kill switch and governance gate from being bypassed by a second HTTP client.

So rather than soften the note, this makes the claim true.

## The guard

`tests/test_egress_boundary.py` walks the package AST for HTTP client imports and holds them to an allowlist:

| Module | Why allowed |
|---|---|
| `egress/sarvam.py` | the sole authorized-external client, behind the gate and audit log |
| `ingestion/client.py`, `ingestion/document_ingestion.py` | Janasunani source API and S3 — DPIC-controlled, so not egress |

Three tests: unexpected importers fail; a **stale** allowlist entry fails (so it can't quietly widen); and the provider endpoint may not appear outside `egress/`.

Structural rather than a grep for a provider name, so a *new* provider is caught too.

**Verified to actually fail**, not pass vacuously — adding `import httpx` to `janasunani/serving/`:

```
E   assert {'serving/_tmp_violation.py'} == set()
FAILED tests/test_egress_boundary.py::test_only_allowlisted_modules_construct_http_clients
```

## Checks

- `ruff check .` — clean
- `pytest` — **1027 passed, 7 skipped**