### PR TITLE
refactor(egress): centralize Sarvam API key in Settings

### DIFF
--- a/janasunani/config.py
+++ b/janasunani/config.py
@@ -132,6 +132,15 @@ class Settings(BaseSettings):
     # rather than silently hash citizen contact fields unsalted.
     DEDUP_SALT: Optional[str] = os.getenv("DEDUP_SALT")
 
+    # Sarvam Vision (authorized-external) — single source for the hosted API
+    # key. Primary: SARVAM_API_KEY; SARVAM_API_SUBSCRIPTION_KEY kept as the
+    # legacy alias. Rotating the key is how a compromised credential is
+    # revoked, so it lives outside version control via env/.env, not in code.
+    SARVAM_API_KEY: Optional[str] = os.getenv("SARVAM_API_KEY")
+    SARVAM_API_SUBSCRIPTION_KEY: Optional[str] = os.getenv(
+        "SARVAM_API_SUBSCRIPTION_KEY"
+    )
+
     model_config = SettingsConfigDict(env_file=ROOT_DIR / ".env", extra="ignore")
 
     @field_validator("DEBUG", mode="before")

--- a/janasunani/egress/sarvam.py
+++ b/janasunani/egress/sarvam.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
 import sqlite3
 import time
 import zipfile
@@ -23,6 +22,8 @@ from datetime import UTC, datetime
 from io import BytesIO
 from pathlib import Path
 from typing import Any, Callable, Protocol, TypeVar
+
+from janasunani.config import Settings
 
 API_BASE_URL = "https://api.sarvam.ai"
 PROVIDER_ID = "sarvam-hosted"
@@ -456,9 +457,14 @@ class SarvamVisionAdapter:
         if submission_backoff_seconds < 0:
             raise ValueError("submission_backoff_seconds must be non-negative")
         self.enabled = enabled
-        self.api_key = api_key if api_key is not None else (
-            os.getenv("SARVAM_API_KEY") or os.getenv("SARVAM_API_SUBSCRIPTION_KEY")
-        )
+        # Centralized via janasunani/config.Settings: single source for the
+        # hosted key (env var or .env). Fresh Settings() so monkeypatched env
+        # in tests is visible; singleton `settings` is frozen at import time.
+        if api_key is not None:
+            self.api_key = api_key
+        else:
+            live = Settings()
+            self.api_key = live.SARVAM_API_KEY or live.SARVAM_API_SUBSCRIPTION_KEY
         self.audit_log = audit_log
         self.route = route or PROVIDER_REGISTRY["sarvam-vision"]
         self.transport = transport

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,3 +11,9 @@ def test_debug_truthy_env_is_true(monkeypatch):
     monkeypatch.setenv("DEBUG", "debug")
 
     assert Settings().DEBUG is True
+
+
+def test_sarvam_api_key_from_env(monkeypatch):
+    monkeypatch.setenv("SARVAM_API_KEY", "test-key")
+
+    assert Settings().SARVAM_API_KEY == "test-key"

--- a/tests/test_sarvam_egress.py
+++ b/tests/test_sarvam_egress.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import pytest
 
+from janasunani.config import Settings
 from janasunani.egress.sarvam import (
     AUTHORIZATION_REFERENCE,
     GovernanceControl,
@@ -873,6 +874,38 @@ def test_prefers_documented_api_key_environment_variable(monkeypatch, tmp_path):
     monkeypatch.setenv("SARVAM_API_SUBSCRIPTION_KEY", "legacy")
     adapter = SarvamVisionAdapter(enabled=False, audit_log=SqliteAuditLog(tmp_path / "audit.sqlite"))
     assert adapter.api_key == "preferred"
+
+
+def test_adapter_reads_sarvam_key_from_dotenv_only(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env"
+    env_file.write_text("SARVAM_API_KEY=dotenv-only-key\n")
+    monkeypatch.delenv("SARVAM_API_KEY", raising=False)
+    monkeypatch.delenv("SARVAM_API_SUBSCRIPTION_KEY", raising=False)
+    monkeypatch.setattr(
+        "janasunani.egress.sarvam.Settings",
+        lambda: Settings(_env_file=env_file),
+    )
+    adapter = SarvamVisionAdapter(
+        enabled=False,
+        audit_log=SqliteAuditLog(tmp_path / "audit.sqlite"),
+    )
+    assert adapter.api_key == "dotenv-only-key"
+
+
+def test_falls_back_to_legacy_subscription_key(monkeypatch, tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("SARVAM_API_SUBSCRIPTION_KEY=legacy-only\n")
+    monkeypatch.delenv("SARVAM_API_KEY", raising=False)
+    monkeypatch.delenv("SARVAM_API_SUBSCRIPTION_KEY", raising=False)
+    monkeypatch.setattr(
+        "janasunani.egress.sarvam.Settings",
+        lambda: Settings(_env_file=env_file),
+    )
+    adapter = SarvamVisionAdapter(
+        enabled=False,
+        audit_log=SqliteAuditLog(tmp_path / "audit.sqlite"),
+    )
+    assert adapter.api_key == "legacy-only"
 
 
 def test_extract_is_a_distinct_operation_and_requires_one_pinned_schema_source(tmp_path):


### PR DESCRIPTION
## Summary
- Add `SARVAM_API_KEY` and legacy `SARVAM_API_SUBSCRIPTION_KEY` to `Settings` as the single source for the hosted Sarvam credential.
- Update `SarvamVisionAdapter` to resolve the API key via `Settings()` instead of direct `os.getenv` calls, preserving explicit `api_key` injection for tests.

## Test plan
- [x] `uv run ruff check janasunani/config.py janasunani/egress/sarvam.py`
- [x] `uv run --extra serving --extra pipeline-core pytest tests/test_sarvam_egress.py -q` (41 passed)