### PR TITLE
feat(pii): wire Presidio to gold + corpus scan over slice redacted text

### DIFF
--- a/docs/FINDINGS.md
+++ b/docs/FINDINGS.md
@@ -75,6 +75,31 @@ The sequence is deliberate: reproducible database insights come first. Two addit
 
 **Implication.** This baseline can anchor a routing crosswalk that learns where complaints are sent. Outcome claims require separate evidence about what happened after transfer.
 
+# PII redaction — per-entity scorecard and corpus scan
+
+**Gold.** 89 pages (50 documents, 2026-08-06) with 529 hand-corrected spans. Governance: DVC-tracked `data/external/pii_gold_draft_n50.jsonl` (and `pii_draft_n50.jsonl` re-derived draft), duplicate-span rejection and overlap reporting on the scoring path (#89). 49 EMAIL spans on `nic.in`/`gov.in`/`mil.in` are excluded by policy (#56) — they are published officer contact, not citizen PII — so 480 spans enter the denominator (NAME 404, PHONE 29, EMAIL 40, AADHAAR 7; BANK_ACCOUNT/SCHEME_ID not labelled in this gold).
+
+**Number — per-entity overlap recall via the live Presidio analyzers** (`janasunani-evaluate-pii --gold <gold.jsonl>`; same recognizers production uses, not a parallel harness). Measured 2026-08-08 on the 89-page set (English; Odia/romanized slices are thin/no labelled set — `unknown` bucket, thin-slice guard per DELIVERY fallback):
+
+| Entity | Gold | Overlap recall | Exact recall | Missed-PII rate (1 − overlap) |
+|---|---:|---:|---:|---:|
+| PHONE | 29 | **0.828** | 0.828 | 0.172 |
+| AADHAAR | 7 | **0.857** | 0.857 | 0.143 |
+| EMAIL (non-gov) | 40 | **0.750** | 0.725 | 0.250 |
+| NAME | 404 | **0.777** | 0.507 | 0.223 |
+| OVERALL (typed) | 480 | **0.779** | 0.550 | 0.221 |
+| COVERAGE (untyped, DSI-comparable) | 480 | **0.783** | 0.552 | 0.217 |
+
+49 gov-EMAIL excluded; `excluded_by_policy=49`. DSI reference 80.56% any-overlap / 50.00% exact (English, untyped, 106-sentence val split) is reported alongside, not as a threshold — the two are not like-for-like (#67, DELIVERY Table 2).
+
+**What the headline covers and what it cannot.** The 0.78 overall is set by NAME (404 of 480). DELIVERY's pre-fix figure of 0.44 for names (and 0.496 headline) came from the English NER alone; the current 0.777 reflects the Indian-surname gazetteer + ALL-CAPS softening landed in #92/#183 — 53 of 228 NAME misses were ALL-CAPS — without which DELIVERY's 0.44 figure stands. The gold still has no $n<20$ Odia/romanized slice, so per-language is reported as `unknown` only (low-power guard). Bank-account and scheme-ID recognizers (#139/#120) have no labels in this gold and score nothing either way; their evidence is the corpus scan, not this table.
+
+**Number — corpus scan (shape audit over slice redacted text).** Helpers in `janasunani/evaluation/pii_scorecard.py` (`find_shaped_pii` / `scan_texts` / `scan_corpus_parquet`): grep-shaped PII over redacted text — mobile (three 6-9-led groupings inc. +91/0), Aadhaar (12-digit 2-9-led, 4-4-4), PAN (`[A-Z]{5}\d{4}[A-Z]`), EMAIL (non-government only; `nic.in`/`gov.in`/`mil.in` excluded). Tested in `tests/test_corpus_scan.py` (40 cases: shaped regex + zero-cleartext on fixtures + parquet helper).
+
+*Slice `Sambalpur/2024`*: `grievance_redactions.grievance_redacted` for the demo slice scanned via `scan_corpus_parquet` / `scan_texts` — **0 of 55,544** redacted texts contain a mobile, Aadhaar, PAN or non-government email shape (`texts_with_pii=0`, `by_entity {PHONE:0, AADHAAR:0, PAN:0, EMAIL:0}`; `assert_zero_shaped_pii` passes). The lake-side `data/interim/complaints.parquet:grievance_redacted` (or `pages.parquet:redacted_text`) path is equivalent — both are the same `redact_text` output, read through the same helper with `column=` pluggable.
+
+**Caveat — what each number can and cannot support.** The per-entity table measures the analyzer on 89 real scanned pages — the release-critical missed-PII rate — but is small enough that a few pages move it. The corpus scan is the complementary claim: it holds at 55,544, but only checks the four shaped classes we know how to grep; it cannot see a name or other freetext PII a human would catch. Report both together, per DELIVERY §"We come in lower".
+
 # Capabilities awaiting acceptance evidence
 
 ## Capability — Additional duplicate discovery

--- a/janasunani/evaluation/pii_scorecard.py
+++ b/janasunani/evaluation/pii_scorecard.py
@@ -14,15 +14,23 @@ as thresholds (issue #67).
 Thin slices (< 20 gold spans) are flagged ``low_power`` and the fallback is
 to report English only per DELIVERY.md — the scorecard says so rather than
 publishing a number with no power behind it.
+
+Also provides :func:`find_shaped_pii` / :func:`scan_texts` /
+:func:`scan_corpus_parquet` — grep-shaped PII audit over slice redacted
+text. These are the helpers that power the "55,544 scale" claim: after
+redaction no mobile, Aadhaar, PAN or non-government email shape survives.
+Unlike the gold recall they need no labels, only the recognizer shapes.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import re
 from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Iterable
 
 from janasunani.pipeline.pii_eval import (
     EvaluationReport,
@@ -34,6 +42,10 @@ from janasunani.pipeline.pii_eval import (
 
 LEGACY_EXACT_BASELINE = 0.50
 MIN_GOLD_FOR_REPORTABLE_SLICE = 20  # below this, per-language is low power
+
+# ---------------------------------------------------------------------------
+# Language slicing
+# ---------------------------------------------------------------------------
 
 
 def _normalize_language(raw: object | None) -> str:
@@ -77,33 +89,34 @@ def score_per_language(
     the slice is ``unknown``. Each slice is scored independently via
     ``score_examples`` (so the model's language handling is visible). Thin
     slices are flagged rather than hidden.
+
+    Wires the live Presidio recognizers (``detect_pii_spans``) through
+    :func:`janasunani.pipeline.pii_eval.score_examples` — the same path
+    ``janasunani-evaluate-pii`` uses — so the table reports what production
+    actually redacts. Falls back to empty predictions only when the analyzer
+    cannot be imported (e.g. a轻量 env without the ``pii`` extra), keeps the
+    slicing / thin-slice guards testable without heavy deps.
     """
-    # Load with language sidecar
     raw_langs: dict[str, str] = {}
-    # Re-parse to capture language without duplicating load_gold_jsonl validation
     with gold_path.open() as handle:
         for line in handle:
             if not line.strip():
                 continue
             obj = json.loads(line)
             rec_id = str(obj.get("id") or "")
-            # Will be normalized again in slice; record even if empty
             if "language" in obj:
                 raw_langs[rec_id] = str(obj["language"])
-            # also capture synthetic id fallback used by load_gold_jsonl
-            # (line-N) — not needed if author always sets id
 
     examples = load_gold_jsonl(gold_path)
-    # If ids were auto-generated (line-N), language by original index still works
-    # because raw_langs keys are those ids; missing stays unknown.
-
     slices = _slice_by_language(examples, raw_langs)
     out: dict[str, LanguageSlice] = {}
     for lang, exs in sorted(slices.items()):
-        # Use empty predictions so the harness is runnable without pipeline-core
-        # heavy deps (presidio). The slicing and thin-slice guards are what
-        # this harness owns; the model itself is scored via janasunani-evaluate-pii.
-        rep = score_predictions(exs, {}, baseline_overlap_recall=baseline_overlap)
+        try:
+            from janasunani.pipeline.pii_eval import score_examples
+
+            rep = score_examples(exs, baseline_overlap_recall=baseline_overlap)
+        except Exception:
+            rep = score_predictions(exs, {}, baseline_overlap_recall=baseline_overlap)
         gold_total = rep.overall.gold
         low = gold_total < MIN_GOLD_FOR_REPORTABLE_SLICE
         out[lang] = LanguageSlice(language=lang, report=rep, is_low_power=low)
@@ -142,19 +155,233 @@ def render_scorecard(gold_path: Path) -> str:
     for lang in ["english", "odia", "romanized", "unknown"]:
         if lang in per_lang:
             lines.extend(_format_slice(lang, per_lang[lang]))
-    # any other langs
     for lang, sl in per_lang.items():
         if lang not in {"english", "odia", "romanized", "unknown"}:
             lines.extend(_format_slice(lang, sl))
     return "\n".join(lines)
 
 
+# ---------------------------------------------------------------------------
+# Corpus scan — grep-shaped PII over redacted text
+# ---------------------------------------------------------------------------
+
+# Mobile shapes mirror the three Presidio IN_MOBILE patterns (pii_tagger.py).
+_MOBILE_RES = [
+    re.compile(r"(?<!\d)(?:\+91[\s-]?|0)?[6-9]\d{4}[\s-]?\d{5}(?!\d)"),
+    re.compile(r"(?<!\d)(?:\+91[\s-]?|0)?[6-9]\d{3}[\s-]\d{3}[\s-]\d{3}(?!\d)"),
+    re.compile(r"(?<!\d)(?:\+91[\s-]?|0)?[6-9]\d{2}[\s-]\d{3}[\s-]\d{4}(?!\d)"),
+]
+_AADHAAR_RE = re.compile(r"(?<!\d)[2-9]\d{3}[\s-]?\d{4}[\s-]?\d{4}(?!\d)")
+_PAN_RE = re.compile(r"\b[A-Z]{5}\d{4}[A-Z]\b")
+_EMAIL_FIND_RE = re.compile(r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}")
+
+# Government email suffixes — mirrors pii_tagger._GOVERNMENT_EMAIL_SUFFIXES.
+_GOV_SUFFIXES = ("nic.in", "gov.in", "mil.in")
+
+
+def _is_government_email(address: str) -> bool:
+    try:
+        from janasunani.pipeline.stages.pii_tagger import is_government_email as _gov
+
+        return _gov(address)
+    except Exception:
+        if "@" not in address:
+            return False
+        domain = address.strip().lower().rsplit("@", 1)[-1]
+        if not domain:
+            return False
+        return any(domain == s or domain.endswith(f".{s}") for s in _GOV_SUFFIXES)
+
+
+def find_shaped_pii(text: str) -> dict[str, list[str]]:
+    """Return shaped PII matches in *text* by entity.
+
+    Keys: ``PHONE`` (mobile shapes), ``AADHAAR``, ``PAN``, ``EMAIL``
+    (non-government only). A redacted text must return an empty dict for
+    every key — that is the corpus-scan invariant.
+    """
+    if not text:
+        return {"PHONE": [], "AADHAAR": [], "PAN": [], "EMAIL": []}
+    phones: list[str] = []
+    seen: set[tuple[int, int]] = set()
+    for pat in _MOBILE_RES:
+        for m in pat.finditer(text):
+            span = (m.start(), m.end())
+            if span not in seen:
+                seen.add(span)
+                phones.append(m.group(0).strip())
+    aadhaars = [m.group(0).strip() for m in _AADHAAR_RE.finditer(text)]
+    pans = [m.group(0).strip() for m in _PAN_RE.finditer(text)]
+    emails: list[str] = []
+    for m in _EMAIL_FIND_RE.finditer(text):
+        addr = m.group(0)
+        if not _is_government_email(addr):
+            emails.append(addr)
+    return {"PHONE": phones, "AADHAAR": aadhaars, "PAN": pans, "EMAIL": emails}
+
+
+def contains_shaped_pii(text: str | None) -> bool:
+    """True if *text* still contains any shaped PII (mobile/Aadhaar/PAN/non-gov email)."""
+    if not text:
+        return False
+    found = find_shaped_pii(text)
+    return any(len(v) > 0 for v in found.values())
+
+
+@dataclass(frozen=True)
+class CorpusScanResult:
+    total_texts: int
+    texts_with_pii: int
+    by_entity: dict[str, int]
+    # up to a few examples per entity for diagnostics, never more than total
+    examples: dict[str, list[str]]
+
+    def to_dict(self) -> dict:
+        return {
+            "total_texts": self.total_texts,
+            "texts_with_pii": self.texts_with_pii,
+            "by_entity": dict(self.by_entity),
+            "examples": {k: list(v) for k, v in self.examples.items()},
+            "passed": self.texts_with_pii == 0,
+        }
+
+
+def scan_texts(
+    texts: Iterable[str | None],
+    *,
+    sample_limit: int = 3,
+) -> CorpusScanResult:
+    """Scan an iterable of redacted texts for shaped PII.
+
+    Counts how many texts still carry a shape and how many times each
+    entity shape appears (one text may contain multiple shapes). Collects up
+    to *sample_limit* example strings per entity for diagnostics.
+    """
+    total = 0
+    with_pii = 0
+    by_entity: dict[str, int] = {"PHONE": 0, "AADHAAR": 0, "PAN": 0, "EMAIL": 0}
+    examples: dict[str, list[str]] = {"PHONE": [], "AADHAAR": [], "PAN": [], "EMAIL": []}
+    for text in texts:
+        total += 1
+        if text is None:
+            continue
+        found = find_shaped_pii(text)
+        has_any = any(len(v) > 0 for v in found.values())
+        if has_any:
+            with_pii += 1
+        for ent in by_entity:
+            hits = found.get(ent, [])
+            if hits:
+                by_entity[ent] += len(hits)
+                for h in hits:
+                    if len(examples[ent]) < sample_limit:
+                        examples[ent].append(h)
+    return CorpusScanResult(
+        total_texts=total,
+        texts_with_pii=with_pii,
+        by_entity=by_entity,
+        examples=examples,
+    )
+
+
+def scan_corpus_parquet(
+    parquet_path: Path,
+    *,
+    column: str = "grievance_redacted",
+    sample_limit: int = 3,
+) -> CorpusScanResult:
+    """Scan a Parquet file's redacted-text column for shaped PII.
+
+    ``column`` defaults to ``grievance_redacted`` (the slice redaction of
+    ``complaints.grievance``) but callers may pass ``redacted_text`` for
+    ``pages.parquet`` or any other text column. Reads via ``polars`` when
+    available, falling back to ``pyarrow`` so the helper works in both the
+    ``pii`` and ``pipeline-core`` envs.
+    """
+    # Try polars first (fast, project dependency of many extras)
+    try:
+        import polars as pl  # type: ignore
+
+        df = pl.scan_parquet(parquet_path).select(column).collect()
+        texts = df[column].to_list()
+        return scan_texts(texts, sample_limit=sample_limit)
+    except Exception as exc:  # pragma: no cover — fallback path
+        # pyarrow fallback: no polars, or column missing, surface the error
+        try:
+            import pyarrow.parquet as pq  # type: ignore
+
+            table = pq.read_table(parquet_path, columns=[column])
+            col = table.column(column).to_pylist()
+            return scan_texts(col, sample_limit=sample_limit)
+        except Exception:
+            raise exc
+
+
+def assert_zero_shaped_pii(
+    texts: Iterable[str | None] | CorpusScanResult,
+) -> None:
+    """Assert that no shaped PII survives in *texts*.
+
+    Accepts either an iterable of strings or a precomputed
+    :class:`CorpusScanResult`. Raises :class:`AssertionError` with per-entity
+    counts and examples when the invariant is violated.
+    """
+    result = texts if isinstance(texts, CorpusScanResult) else scan_texts(texts)
+    if result.texts_with_pii != 0:
+        raise AssertionError(
+            f"shaped PII survived redaction: {result.texts_with_pii}/{result.total_texts} texts "
+            f"with hits by_entity={result.by_entity} examples={result.examples}"
+        )
+
+
+def format_corpus_scan(result: CorpusScanResult) -> str:
+    lines = [
+        "# Corpus scan — shaped PII over redacted text",
+        "",
+        f"total_texts={result.total_texts} texts_with_pii={result.texts_with_pii} passed={result.texts_with_pii == 0}",
+        f"by_entity: PHONE={result.by_entity.get('PHONE', 0)} AADHAAR={result.by_entity.get('AADHAAR', 0)} "
+        f"PAN={result.by_entity.get('PAN', 0)} EMAIL(non-gov)={result.by_entity.get('EMAIL', 0)}",
+        "",
+    ]
+    if result.texts_with_pii == 0:
+        lines.append("✓ No mobile, Aadhaar, PAN or non-government email shape survived redaction.")
+    else:
+        lines.append(f"✗ {result.texts_with_pii} text(s) still contain shaped PII:")
+        for ent, exs in result.examples.items():
+            if exs:
+                lines.append(f"  {ent}: {exs[:3]}")
+    lines.append("")
+    lines.append("Shapes: mobile PHONE (6-9 led 10-digit, 3 groupings incl. +91/0), "
+                 "AADHAAR (12-digit 2-9 led, 4-4-4), PAN ([A-Z]{5}\\d{4}[A-Z]), "
+                 "EMAIL (non-gov only; nic.in/gov.in/mil.in excluded by policy #56).")
+    return "\n".join(lines)
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Per-entity, per-language PII scorecard (#67)")
-    parser.add_argument("--gold", type=Path, required=True, help="Gold JSONL (with optional language per record)")
+    parser.add_argument("--gold", type=Path, default=None, help="Gold JSONL (with optional language per record)")
     parser.add_argument("--out", type=Path, default=None, help="Write scorecard markdown to file")
     parser.add_argument("--json", action="store_true", help="Print per-language JSON")
+    parser.add_argument("--corpus", type=Path, default=None, help="Parquet file to scan for shaped PII (e.g. data/interim/complaints.parquet)")
+    parser.add_argument("--corpus-column", type=str, default="grievance_redacted", help="Text column in the corpus parquet (default: grievance_redacted)")
+    parser.add_argument("--corpus-sample-limit", type=int, default=3, help="Max examples per entity in corpus scan output")
     args = parser.parse_args(argv)
+
+    # Corpus scan mode
+    if args.corpus is not None:
+        if args.json:
+            result = scan_corpus_parquet(args.corpus, column=args.corpus_column, sample_limit=args.corpus_sample_limit)
+            print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
+            return 0 if result.texts_with_pii == 0 else 1
+        result = scan_corpus_parquet(args.corpus, column=args.corpus_column, sample_limit=args.corpus_sample_limit)
+        text = format_corpus_scan(result)
+        if args.out:
+            args.out.write_text(text)
+        print(text)
+        return 0 if result.texts_with_pii == 0 else 1
+
+    if args.gold is None:
+        parser.error("--gold is required unless --corpus is given")
     if args.json:
         per_lang = score_per_language(args.gold)
         out = {lang: sl.report.to_dict() | {"is_low_power": sl.is_low_power} for lang, sl in per_lang.items()}

--- a/tests/test_corpus_scan.py
+++ b/tests/test_corpus_scan.py
@@ -1,0 +1,239 @@
+"""Corpus scan — grep-shaped PII over redacted text.
+
+The invariant: after redaction no mobile, Aadhaar, PAN or non-government
+email shape survives in the slice redacted text. This tests the
+helper that powers the "55,544 scale" claim, not the gold recall.
+
+Runs without the ``pii`` extra (regex helpers are stdlib-only). One
+test exercises the parquet helper via a tiny fixture.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from janasunani.evaluation.pii_scorecard import (
+    assert_zero_shaped_pii,
+    contains_shaped_pii,
+    find_shaped_pii,
+    scan_corpus_parquet,
+    scan_texts,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shaped-PII regex unit — each entity class
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "call 9876543210 now",
+        "mobile +91 98765 43210 please",
+        "Reach me at 09876543210 for updates",
+        "Contact on 98765 43210 anytime",
+        "Contact on 98765-43210 anytime",
+        "My number is 9876 543 210, please call",  # 4-3-3
+        "My number is 987 654 3210, please call",  # 3-3-4
+    ],
+)
+def test_mobile_shapes_detected(text: str):
+    found = find_shaped_pii(text)
+    assert found["PHONE"], f"expected PHONE in {text!r} got {found}"
+    assert not found["AADHAAR"]
+    assert not found["PAN"]
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Aadhaar 2345 6789 0123 attached",
+        "aadhaar 234567890123 mismatch",
+        "UID 3456-7890-1234",
+    ],
+)
+def test_aadhaar_shapes_detected(text: str):
+    found = find_shaped_pii(text)
+    assert found["AADHAAR"], f"expected AADHAAR in {text!r} got {found}"
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "PAN ABCDE1234F attached",
+        "my pan is FGHIJ5678K",
+    ],
+)
+def test_pan_shapes_detected(text: str):
+    found = find_shaped_pii(text)
+    assert found["PAN"], f"expected PAN in {text!r} got {found}"
+
+
+@pytest.mark.parametrize(
+    "address",
+    [
+        "citizen@gmail.com",
+        "citizen@yahoo.co.in",
+        "user@hotmail.com",
+        "ramesh.k@example.com",
+        "citizen@example.in",
+    ],
+)
+def test_non_government_emails_flagged(address: str):
+    found = find_shaped_pii(f"contact {address} for help")
+    assert found["EMAIL"] == [address]
+
+
+@pytest.mark.parametrize(
+    "address",
+    [
+        "officer@nic.in",
+        "bdo.khordha@nic.in",
+        "officer@rb.nic.in",
+        "officer@odisha.gov.in",
+        "officer@pmo.gov.in",
+        "OFFICER@NIC.IN",
+        "officer@mil.in",
+        "officer@station.mil.in",
+    ],
+)
+def test_government_emails_not_flagged(address: str):
+    found = find_shaped_pii(f"contact {address} for help")
+    assert found["EMAIL"] == [], f"gov {address!r} must not be flagged, got {found}"
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "The hearing was held on 06.05.2025 at the block office.",
+        "Order dated 06-05-2025 was not implemented.",
+        "Application dated 12/03/2024 was rejected.",
+        "water supply in ward 7 has been broken for 3 weeks",
+        "Grievance about water supply. Name [NAME] Phone [PHONE] please help",
+        "",
+        "[PHONE] [AADHAAR] [PAN] [EMAIL]",
+        "ratan tata",  # no shape
+    ],
+)
+def test_clean_text_has_no_shaped_pii(text: str):
+    assert find_shaped_pii(text) == {"PHONE": [], "AADHAAR": [], "PAN": [], "EMAIL": []}
+    assert not contains_shaped_pii(text)
+
+
+def test_contains_shaped_pii_handles_none():
+    assert not contains_shaped_pii(None)
+    assert not contains_shaped_pii("")
+
+
+def test_mixed_content_reports_all_entities():
+    text = "call 9876543210, aadhaar 2345 6789 0123, PAN ABCDE1234F, email x@gmail.com"
+    found = find_shaped_pii(text)
+    assert found["PHONE"] == ["9876543210"]
+    assert found["AADHAAR"] == ["2345 6789 0123"]
+    assert found["PAN"] == ["ABCDE1234F"]
+    assert found["EMAIL"] == ["x@gmail.com"]
+
+
+# ---------------------------------------------------------------------------
+# scan_texts — aggregation over many redacted texts
+# ---------------------------------------------------------------------------
+
+
+def test_scan_texts_zero_on_clean_fixtures():
+    clean = [
+        "Water supply broken since June. Please help. [NAME] [PHONE] redacted",
+        "Pension not received for three months. Contact [EMAIL] done",
+        "Street light not working in ward 7. No PII here.",
+        None,
+        "",
+        "Grievance about water supply. Name [NAME] Phone [PHONE] Aadhaar [AADHAAR]",
+    ]
+    result = scan_texts(clean)
+    assert result.total_texts == 6
+    assert result.texts_with_pii == 0
+    assert result.by_entity == {"PHONE": 0, "AADHAAR": 0, "PAN": 0, "EMAIL": 0}
+    assert result.to_dict()["passed"] is True
+    # assert helper must not raise
+    assert_zero_shaped_pii(clean)
+
+
+def test_scan_texts_counts_leaky_fixtures():
+    texts = [
+        "call me on 9876543210 about water",  # PHONE
+        "aadhaar 2345 6789 0123 mismatch",  # AADHAAR
+        "PAN ABCDE1234F attached",  # PAN
+        "email citizen@gmail.com here",  # EMAIL non-gov
+        "contact officer@nic.in for status",  # gov — clean
+        "no pii here",
+    ]
+    result = scan_texts(texts)
+    assert result.total_texts == 6
+    assert result.texts_with_pii == 4
+    assert result.by_entity["PHONE"] == 1
+    assert result.by_entity["AADHAAR"] == 1
+    assert result.by_entity["PAN"] == 1
+    assert result.by_entity["EMAIL"] == 1
+    assert not result.to_dict()["passed"]
+    with pytest.raises(AssertionError, match="shaped PII survived"):
+        assert_zero_shaped_pii(texts)
+    # also via result object
+    with pytest.raises(AssertionError):
+        assert_zero_shaped_pii(result)
+
+
+def test_scan_texts_samples_are_bounded():
+    texts = [f"leak {9876543200 + i}" for i in range(10)]
+    result = scan_texts(texts, sample_limit=2)
+    assert len(result.examples["PHONE"]) == 2
+
+
+def test_assert_zero_passes_on_empty():
+    assert_zero_shaped_pii([])
+    assert_zero_shaped_pii([None, "", "[NAME] no digits"])
+
+
+# ---------------------------------------------------------------------------
+# Parquet helper — tiny fixture (polars or pyarrow)
+# ---------------------------------------------------------------------------
+
+
+def test_scan_corpus_parquet_zero_and_leaky(tmp_path):
+    try:
+        import polars as pl
+    except ImportError:
+        pytest.skip("polars not installed")
+
+    # clean parquet
+    clean_path = tmp_path / "clean.parquet"
+    pl.DataFrame(
+        {
+            "grievance_redacted": [
+                "Water supply broken. [NAME] [PHONE]",
+                "Pension pending. [EMAIL] done",
+                "No PII at all",
+            ]
+        }
+    ).write_parquet(clean_path)
+    clean = scan_corpus_parquet(clean_path, column="grievance_redacted")
+    assert clean.texts_with_pii == 0
+    assert clean.total_texts == 3
+    assert_zero_shaped_pii(clean)
+
+    # leaky parquet
+    leaky_path = tmp_path / "leaky.parquet"
+    pl.DataFrame(
+        {
+            "grievance_redacted": [
+                "call 9876543210 now",
+                "clean line",
+                "aadhaar 2345 6789 0123 here",
+            ]
+        }
+    ).write_parquet(leaky_path)
+    leaky = scan_corpus_parquet(leaky_path, column="grievance_redacted")
+    assert leaky.texts_with_pii == 2
+    assert leaky.by_entity["PHONE"] == 1
+    assert leaky.by_entity["AADHAAR"] == 1
+    with pytest.raises(AssertionError):
+        assert_zero_shaped_pii(leaky)


### PR DESCRIPTION
Unit 1 — PII scorecard + corpus scan.

- evaluation/pii_scorecard.py wired to live Presidio via pii_eval.score_examples (same path as janasunani-evaluate-pii --gold) with fallback to empty when analyzer unavailable; reports per-entity/per-language (PHONE 0.83 / AADHAAR 0.86 / EMAIL 0.75 / NAME 0.78, coverage 0.78) with thin-slice guard.
- Corpus scan: helpers find_shaped_pii / scan_texts / scan_corpus_parquet / assert_zero_shaped_pii / format_corpus_scan / --corpus CLI; scanned Sambalpur/2024 grievance_redacted (55_544) via scan_texts — 0 shaped hits.
- Tests: new tests/test_corpus_scan.py (40 cases, parquet helper). FINDINGS.md: new PII redaction section.

Verification: `uv run --extra pii pytest` green, ruff 0.

Refs #15
