### PR TITLE
feat(routing): wire empirical crosswalk with learned→rules→fallback ladder

### DIFF
--- a/janasunani/routing/reference/routing_crosswalk.json
+++ b/janasunani/routing/reference/routing_crosswalk.json
@@ -7,6 +7,7 @@
     },
     "agriculture & farming||": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.5703,
       "support": 4242
     },
@@ -17,6 +18,7 @@
     },
     "cmrf||": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.6712,
       "support": 2276
     },
@@ -27,6 +29,7 @@
     },
     "culture||": {
       "dept": "Odia Language Literature & Culture",
+      "office": "Collector",
       "share": 0.6207,
       "support": 396
     },
@@ -37,6 +40,7 @@
     },
     "education||": {
       "dept": "Higher Education",
+      "office": "Departments",
       "share": 0.5712,
       "support": 8285
     },
@@ -57,11 +61,13 @@
     },
     "financial assistance||": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.3542,
       "support": 7020
     },
     "general||": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.2163,
       "support": 30647
     },
@@ -72,6 +78,7 @@
     },
     "housing||": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8677,
       "support": 264366
     },
@@ -82,31 +89,37 @@
     },
     "infrastructure||": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5709,
       "support": 46204
     },
     "irrigation||": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.6087,
       "support": 2148
     },
     "land matters||": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8229,
       "support": 41336
     },
     "legal||": {
       "dept": "School & Mass Education",
+      "office": "Departments",
       "share": 0.2676,
       "support": 152
     },
     "miscellaneous||": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.2076,
       "support": 19135
     },
     "pension/retirement benefits||": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.1939,
       "support": 1722
     },
@@ -122,16 +135,19 @@
     },
     "school & college||": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.5113,
       "support": 3469
     },
     "service matters||": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2284,
       "support": 10717
     },
     "social welfare||": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6207,
       "support": 133524
     },
@@ -142,11 +158,13 @@
     },
     "tourism||": {
       "dept": "Tourism",
+      "office": "Collector",
       "share": 0.6689,
       "support": 497
     },
     "traffic||": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.5796,
       "support": 182
     },
@@ -171,7 +189,5449 @@
       "support": 433
     }
   },
-  "by_category_district": {},
+  "by_category_district": {
+    "accident||angul": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.6667,
+      "support": 4
+    },
+    "accident||balangir": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.6,
+      "support": 3
+    },
+    "accident||baleswar": {
+      "dept": "Revenue & Disaster Management",
+      "share": 0.5,
+      "support": 5
+    },
+    "accident||bargarh": {
+      "dept": "Commerce & Transport",
+      "office": "Collector",
+      "share": 0.375,
+      "support": 3
+    },
+    "accident||bhadrak": {
+      "dept": "Revenue & Disaster Management",
+      "share": 0.8182,
+      "support": 9
+    },
+    "accident||cuttack": {
+      "dept": "Revenue & Disaster Management",
+      "share": 0.5385,
+      "support": 7
+    },
+    "accident||dhenkanal": {
+      "dept": "Revenue & Disaster Management",
+      "share": 0.8571,
+      "support": 6
+    },
+    "accident||ganjam": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.4516,
+      "support": 14
+    },
+    "accident||jagatsinghapur": {
+      "dept": "Revenue & Disaster Management",
+      "share": 0.8571,
+      "support": 6
+    },
+    "accident||jajpur": {
+      "dept": "Revenue & Disaster Management",
+      "share": 0.7143,
+      "support": 5
+    },
+    "accident||kandhamal": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.75,
+      "support": 3
+    },
+    "accident||kendrapara": {
+      "dept": "Revenue & Disaster Management",
+      "share": 0.8,
+      "support": 4
+    },
+    "accident||kendujhar": {
+      "dept": "Home department",
+      "office": "Superintendent of Police",
+      "share": 0.5556,
+      "support": 5
+    },
+    "accident||khordha": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.5,
+      "support": 5
+    },
+    "accident||koraput": {
+      "dept": "Revenue & Disaster Management",
+      "share": 0.75,
+      "support": 3
+    },
+    "accident||mayurbhanj": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.75,
+      "support": 9
+    },
+    "accident||nayagarh": {
+      "dept": "General Administration & Public Grievance",
+      "office": "Collector",
+      "share": 0.6842,
+      "support": 13
+    },
+    "accident||nuapada": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.75,
+      "support": 3
+    },
+    "accident||sundargarh": {
+      "dept": "Revenue & Disaster Management",
+      "share": 0.6667,
+      "support": 4
+    },
+    "agriculture & farming||angul": {
+      "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
+      "share": 0.608,
+      "support": 107
+    },
+    "agriculture & farming||balangir": {
+      "dept": "Agriculture & Farmers' Empowerment",
+      "share": 0.6471,
+      "support": 154
+    },
+    "agriculture & farming||baleswar": {
+      "dept": "Agriculture & Farmers' Empowerment",
+      "share": 0.5159,
+      "support": 211
+    },
+    "agriculture & farming||bargarh": {
+      "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
+      "share": 0.5485,
+      "support": 328
+    },
+    "agriculture & farming||bhadrak": {
+      "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
+      "share": 0.6437,
+      "support": 224
+    },
+    "agriculture & farming||boudh": {
+      "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
+      "share": 0.6593,
+      "support": 120
+    },
+    "agriculture & farming||cuttack": {
+      "dept": "Agriculture & Farmers' Empowerment",
+      "share": 0.5234,
+      "support": 168
+    },
+    "agriculture & farming||deogarh": {
+      "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
+      "share": 0.6636,
+      "support": 71
+    },
+    "agriculture & farming||dhenkanal": {
+      "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
+      "share": 0.6383,
+      "support": 180
+    },
+    "agriculture & farming||gajapati": {
+      "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
+      "share": 0.3021,
+      "support": 58
+    },
+    "agriculture & farming||ganjam": {
+      "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
+      "share": 0.5808,
+      "support": 356
+    },
+    "agriculture & farming||jagatsinghapur": {
+      "dept": "Agriculture & Farmers' Empowerment",
+      "share": 0.4649,
+      "support": 106
+    },
+    "agriculture & farming||jajpur": {
+      "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
+      "share": 0.6184,
+      "support": 175
+    },
+    "agriculture & farming||jharsuguda": {
+      "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
+      "share": 0.5152,
+      "support": 51
+    },
+    "agriculture & farming||kalahandi": {
+      "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
+      "share": 0.6077,
+      "support": 330
+    },
+    "agriculture & farming||kandhamal": {
+      "dept": "Agriculture & Farmers' Empowerment",
+      "share": 0.7059,
+      "support": 36
+    },
+    "agriculture & farming||kendrapara": {
+      "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
+      "share": 0.7913,
+      "support": 311
+    },
+    "agriculture & farming||kendujhar": {
+      "dept": "Agriculture & Farmers' Empowerment",
+      "share": 0.4643,
+      "support": 91
+    },
+    "agriculture & farming||khordha": {
+      "dept": "Agriculture & Farmers' Empowerment",
+      "share": 0.3649,
+      "support": 108
+    },
+    "agriculture & farming||koraput": {
+      "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
+      "share": 0.5143,
+      "support": 54
+    },
+    "agriculture & farming||malkangiri": {
+      "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
+      "share": 0.7568,
+      "support": 56
+    },
+    "agriculture & farming||mayurbhanj": {
+      "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
+      "share": 0.681,
+      "support": 111
+    },
+    "agriculture & farming||nabarangpur": {
+      "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
+      "share": 0.4906,
+      "support": 52
+    },
+    "agriculture & farming||nayagarh": {
+      "dept": "Agriculture & Farmers' Empowerment",
+      "share": 0.5518,
+      "support": 197
+    },
+    "agriculture & farming||nuapada": {
+      "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
+      "share": 0.5251,
+      "support": 115
+    },
+    "agriculture & farming||puri": {
+      "dept": "Agriculture & Farmers' Empowerment",
+      "share": 0.5137,
+      "support": 94
+    },
+    "agriculture & farming||rayagada": {
+      "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
+      "share": 0.3696,
+      "support": 51
+    },
+    "agriculture & farming||sambalpur": {
+      "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
+      "share": 0.692,
+      "support": 155
+    },
+    "agriculture & farming||subarnapur": {
+      "dept": "Agriculture & Farmers' Empowerment",
+      "share": 0.5532,
+      "support": 52
+    },
+    "agriculture & farming||sundargarh": {
+      "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
+      "share": 0.5512,
+      "support": 113
+    },
+    "bsky||angul": {
+      "dept": "Health & Family Welfare",
+      "share": 0.8,
+      "support": 8
+    },
+    "bsky||balangir": {
+      "dept": "Health & Family Welfare",
+      "share": 0.9643,
+      "support": 27
+    },
+    "bsky||baleswar": {
+      "dept": "Health & Family Welfare",
+      "share": 0.8889,
+      "support": 24
+    },
+    "bsky||bargarh": {
+      "dept": "Health & Family Welfare",
+      "share": 0.8571,
+      "support": 12
+    },
+    "bsky||bhadrak": {
+      "dept": "Health & Family Welfare",
+      "share": 0.8333,
+      "support": 15
+    },
+    "bsky||boudh": {
+      "dept": "Health & Family Welfare",
+      "share": 1.0,
+      "support": 3
+    },
+    "bsky||cuttack": {
+      "dept": "Health & Family Welfare",
+      "share": 0.7391,
+      "support": 34
+    },
+    "bsky||deogarh": {
+      "dept": "Health & Family Welfare",
+      "office": "Collector",
+      "share": 0.7143,
+      "support": 5
+    },
+    "bsky||dhenkanal": {
+      "dept": "Health & Family Welfare",
+      "share": 0.88,
+      "support": 22
+    },
+    "bsky||gajapati": {
+      "dept": "Health & Family Welfare",
+      "share": 0.5714,
+      "support": 4
+    },
+    "bsky||ganjam": {
+      "dept": "Health & Family Welfare",
+      "share": 0.7273,
+      "support": 48
+    },
+    "bsky||jagatsinghapur": {
+      "dept": "Health & Family Welfare",
+      "share": 0.9286,
+      "support": 26
+    },
+    "bsky||jajpur": {
+      "dept": "Health & Family Welfare",
+      "share": 0.95,
+      "support": 19
+    },
+    "bsky||jharsuguda": {
+      "dept": "Health & Family Welfare",
+      "share": 0.75,
+      "support": 3
+    },
+    "bsky||kalahandi": {
+      "dept": "Health & Family Welfare",
+      "share": 1.0,
+      "support": 22
+    },
+    "bsky||kandhamal": {
+      "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
+      "share": 1.0,
+      "support": 4
+    },
+    "bsky||kendrapara": {
+      "dept": "Health & Family Welfare",
+      "share": 0.9167,
+      "support": 22
+    },
+    "bsky||kendujhar": {
+      "dept": "Health & Family Welfare",
+      "share": 1.0,
+      "support": 7
+    },
+    "bsky||khordha": {
+      "dept": "Health & Family Welfare",
+      "share": 0.8533,
+      "support": 64
+    },
+    "bsky||koraput": {
+      "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
+      "share": 1.0,
+      "support": 6
+    },
+    "bsky||malkangiri": {
+      "dept": "Health & Family Welfare",
+      "share": 1.0,
+      "support": 3
+    },
+    "bsky||mayurbhanj": {
+      "dept": "Health & Family Welfare",
+      "share": 0.9167,
+      "support": 11
+    },
+    "bsky||nabarangpur": {
+      "dept": "Health & Family Welfare",
+      "share": 0.7778,
+      "support": 7
+    },
+    "bsky||nayagarh": {
+      "dept": "Health & Family Welfare",
+      "share": 0.6765,
+      "support": 23
+    },
+    "bsky||puri": {
+      "dept": "Health & Family Welfare",
+      "share": 0.9,
+      "support": 45
+    },
+    "bsky||rayagada": {
+      "dept": "Health & Family Welfare",
+      "share": 1.0,
+      "support": 5
+    },
+    "bsky||sambalpur": {
+      "dept": "Finance",
+      "office": "Superintendent of Police",
+      "share": 0.4167,
+      "support": 15
+    },
+    "bsky||subarnapur": {
+      "dept": "Health & Family Welfare",
+      "office": "Departments",
+      "share": 0.9,
+      "support": 9
+    },
+    "bsky||sundargarh": {
+      "dept": "Health & Family Welfare",
+      "share": 0.6,
+      "support": 15
+    },
+    "cmrf||angul": {
+      "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
+      "share": 0.9123,
+      "support": 52
+    },
+    "cmrf||balangir": {
+      "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
+      "share": 0.3556,
+      "support": 32
+    },
+    "cmrf||baleswar": {
+      "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
+      "share": 0.9294,
+      "support": 79
+    },
+    "cmrf||bargarh": {
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
+      "share": 0.5426,
+      "support": 51
+    },
+    "cmrf||bhadrak": {
+      "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
+      "share": 0.871,
+      "support": 54
+    },
+    "cmrf||boudh": {
+      "dept": "General Administration & Public Grievance",
+      "office": "Office of Chief Minister",
+      "share": 0.3529,
+      "support": 18
+    },
+    "cmrf||cuttack": {
+      "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
+      "share": 0.7927,
+      "support": 130
+    },
+    "cmrf||deogarh": {
+      "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
+      "share": 0.5455,
+      "support": 6
+    },
+    "cmrf||dhenkanal": {
+      "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
+      "share": 0.3333,
+      "support": 47
+    },
+    "cmrf||gajapati": {
+      "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
+      "share": 0.7368,
+      "support": 14
+    },
+    "cmrf||ganjam": {
+      "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
+      "share": 0.8835,
+      "support": 235
+    },
+    "cmrf||jagatsinghapur": {
+      "dept": "Health & Family Welfare",
+      "office": "Collector",
+      "share": 0.8512,
+      "support": 103
+    },
+    "cmrf||jajpur": {
+      "dept": "Health & Family Welfare",
+      "office": "Collector",
+      "share": 0.5807,
+      "support": 403
+    },
+    "cmrf||jharsuguda": {
+      "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
+      "share": 0.9333,
+      "support": 28
+    },
+    "cmrf||kalahandi": {
+      "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
+      "share": 0.5714,
+      "support": 32
+    },
+    "cmrf||kandhamal": {
+      "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
+      "share": 0.7742,
+      "support": 24
+    },
+    "cmrf||kendrapara": {
+      "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
+      "share": 0.8795,
+      "support": 73
+    },
+    "cmrf||kendujhar": {
+      "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
+      "share": 0.8182,
+      "support": 54
+    },
+    "cmrf||khordha": {
+      "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
+      "share": 0.9264,
+      "support": 365
+    },
+    "cmrf||koraput": {
+      "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
+      "share": 0.4583,
+      "support": 11
+    },
+    "cmrf||mayurbhanj": {
+      "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
+      "share": 0.8182,
+      "support": 27
+    },
+    "cmrf||nabarangpur": {
+      "dept": "Health & Family Welfare",
+      "share": 1.0,
+      "support": 3
+    },
+    "cmrf||nayagarh": {
+      "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
+      "share": 0.6699,
+      "support": 140
+    },
+    "cmrf||nuapada": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.6875,
+      "support": 22
+    },
+    "cmrf||puri": {
+      "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
+      "share": 0.8725,
+      "support": 219
+    },
+    "cmrf||rayagada": {
+      "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
+      "share": 1.0,
+      "support": 6
+    },
+    "cmrf||sambalpur": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.3704,
+      "support": 30
+    },
+    "cmrf||subarnapur": {
+      "dept": "General Administration & Public Grievance",
+      "office": "Office of Chief Minister",
+      "share": 0.384,
+      "support": 48
+    },
+    "cmrf||sundargarh": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.3853,
+      "support": 42
+    },
+    "covid-19||angul": {
+      "dept": "Health & Family Welfare",
+      "share": 0.8519,
+      "support": 23
+    },
+    "covid-19||balangir": {
+      "dept": "Health & Family Welfare",
+      "share": 0.8095,
+      "support": 17
+    },
+    "covid-19||baleswar": {
+      "dept": "Health & Family Welfare",
+      "share": 0.6071,
+      "support": 17
+    },
+    "covid-19||bargarh": {
+      "dept": "Health & Family Welfare",
+      "share": 0.8333,
+      "support": 15
+    },
+    "covid-19||bhadrak": {
+      "dept": "Health & Family Welfare",
+      "share": 0.6,
+      "support": 6
+    },
+    "covid-19||boudh": {
+      "dept": "Health & Family Welfare",
+      "office": "Departments",
+      "share": 0.9231,
+      "support": 12
+    },
+    "covid-19||cuttack": {
+      "dept": "Housing & Urban Development",
+      "share": 0.5,
+      "support": 26
+    },
+    "covid-19||deogarh": {
+      "dept": "Health & Family Welfare",
+      "office": "Collector",
+      "share": 1.0,
+      "support": 5
+    },
+    "covid-19||dhenkanal": {
+      "dept": "Health & Family Welfare",
+      "share": 0.7778,
+      "support": 7
+    },
+    "covid-19||gajapati": {
+      "dept": "School & Mass Education",
+      "office": "Departments",
+      "share": 0.5217,
+      "support": 12
+    },
+    "covid-19||ganjam": {
+      "dept": "Health & Family Welfare",
+      "share": 0.6935,
+      "support": 43
+    },
+    "covid-19||jagatsinghapur": {
+      "dept": "Health & Family Welfare",
+      "share": 0.4545,
+      "support": 5
+    },
+    "covid-19||jajpur": {
+      "dept": "Health & Family Welfare",
+      "share": 0.7895,
+      "support": 15
+    },
+    "covid-19||jharsuguda": {
+      "dept": "Health & Family Welfare",
+      "share": 0.8889,
+      "support": 8
+    },
+    "covid-19||kalahandi": {
+      "dept": "Health & Family Welfare",
+      "share": 0.7,
+      "support": 7
+    },
+    "covid-19||kendrapara": {
+      "dept": "Health & Family Welfare",
+      "share": 0.9474,
+      "support": 18
+    },
+    "covid-19||kendujhar": {
+      "dept": "Health & Family Welfare",
+      "share": 0.7333,
+      "support": 11
+    },
+    "covid-19||khordha": {
+      "dept": "Housing & Urban Development",
+      "share": 0.6532,
+      "support": 145
+    },
+    "covid-19||koraput": {
+      "dept": "Health & Family Welfare",
+      "share": 0.75,
+      "support": 6
+    },
+    "covid-19||mayurbhanj": {
+      "dept": "Health & Family Welfare",
+      "share": 0.8,
+      "support": 20
+    },
+    "covid-19||nabarangpur": {
+      "dept": "Health & Family Welfare",
+      "share": 0.4286,
+      "support": 3
+    },
+    "covid-19||nayagarh": {
+      "dept": "Health & Family Welfare",
+      "share": 0.6667,
+      "support": 4
+    },
+    "covid-19||nuapada": {
+      "dept": "Health & Family Welfare",
+      "office": "Collector",
+      "share": 0.4,
+      "support": 8
+    },
+    "covid-19||puri": {
+      "dept": "Health & Family Welfare",
+      "share": 0.8,
+      "support": 8
+    },
+    "covid-19||rayagada": {
+      "dept": "Health & Family Welfare",
+      "share": 0.6667,
+      "support": 16
+    },
+    "covid-19||sambalpur": {
+      "dept": "Health & Family Welfare",
+      "share": 0.9,
+      "support": 18
+    },
+    "covid-19||subarnapur": {
+      "dept": "Health & Family Welfare",
+      "share": 0.75,
+      "support": 3
+    },
+    "covid-19||sundargarh": {
+      "dept": "Health & Family Welfare",
+      "share": 0.7727,
+      "support": 17
+    },
+    "culture||angul": {
+      "dept": "Odia Language Literature & Culture",
+      "share": 0.6,
+      "support": 9
+    },
+    "culture||balangir": {
+      "dept": "Odia Language Literature & Culture",
+      "office": "Collector",
+      "share": 0.8,
+      "support": 12
+    },
+    "culture||baleswar": {
+      "dept": "Odia Language Literature & Culture",
+      "office": "Collector",
+      "share": 0.4667,
+      "support": 63
+    },
+    "culture||bargarh": {
+      "dept": "Odia Language Literature & Culture",
+      "office": "Collector",
+      "share": 0.9091,
+      "support": 10
+    },
+    "culture||boudh": {
+      "dept": "Odia Language Literature & Culture",
+      "office": "Collector",
+      "share": 0.8571,
+      "support": 6
+    },
+    "culture||cuttack": {
+      "dept": "Odia Language Literature & Culture",
+      "share": 0.8065,
+      "support": 25
+    },
+    "culture||dhenkanal": {
+      "dept": "Odia Language Literature & Culture",
+      "office": "Collector",
+      "share": 0.9167,
+      "support": 22
+    },
+    "culture||ganjam": {
+      "dept": "Odia Language Literature & Culture",
+      "office": "Collector",
+      "share": 0.6739,
+      "support": 62
+    },
+    "culture||jagatsinghapur": {
+      "dept": "Odia Language Literature & Culture",
+      "share": 0.9,
+      "support": 9
+    },
+    "culture||jajpur": {
+      "dept": "Odia Language Literature & Culture",
+      "office": "Office of Chief Minister",
+      "share": 0.6346,
+      "support": 33
+    },
+    "culture||kalahandi": {
+      "dept": "Odia Language Literature & Culture",
+      "office": "Collector",
+      "share": 0.8,
+      "support": 8
+    },
+    "culture||kandhamal": {
+      "dept": "Planning & Convergence",
+      "office": "Collector",
+      "share": 0.8537,
+      "support": 35
+    },
+    "culture||kendrapara": {
+      "dept": "Odia Language Literature & Culture",
+      "office": "Office of Chief Minister",
+      "share": 0.9286,
+      "support": 13
+    },
+    "culture||kendujhar": {
+      "dept": "Odia Language Literature & Culture",
+      "office": "Office of Chief Minister",
+      "share": 1.0,
+      "support": 8
+    },
+    "culture||khordha": {
+      "dept": "Odia Language Literature & Culture",
+      "share": 0.8298,
+      "support": 39
+    },
+    "culture||koraput": {
+      "dept": "Odia Language Literature & Culture",
+      "share": 0.8571,
+      "support": 6
+    },
+    "culture||mayurbhanj": {
+      "dept": "Odia Language Literature & Culture",
+      "office": "Collector",
+      "share": 0.5,
+      "support": 3
+    },
+    "culture||nayagarh": {
+      "dept": "General Administration & Public Grievance",
+      "office": "Collector",
+      "share": 0.5385,
+      "support": 14
+    },
+    "culture||puri": {
+      "dept": "Odia Language Literature & Culture",
+      "share": 0.8095,
+      "support": 17
+    },
+    "culture||sambalpur": {
+      "dept": "Odia Language Literature & Culture",
+      "share": 0.6316,
+      "support": 12
+    },
+    "culture||subarnapur": {
+      "dept": "Odia Language Literature & Culture",
+      "share": 1.0,
+      "support": 4
+    },
+    "culture||sundargarh": {
+      "dept": "Odia Language Literature & Culture",
+      "office": "Collector",
+      "share": 0.7,
+      "support": 21
+    },
+    "disaster management||angul": {
+      "dept": "Revenue & Disaster Management",
+      "share": 0.7692,
+      "support": 10
+    },
+    "disaster management||balangir": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.9667,
+      "support": 29
+    },
+    "disaster management||baleswar": {
+      "dept": "Revenue & Disaster Management",
+      "share": 0.6447,
+      "support": 49
+    },
+    "disaster management||bargarh": {
+      "dept": "Revenue & Disaster Management",
+      "share": 0.8824,
+      "support": 15
+    },
+    "disaster management||bhadrak": {
+      "dept": "Revenue & Disaster Management",
+      "share": 0.9123,
+      "support": 52
+    },
+    "disaster management||boudh": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.9677,
+      "support": 30
+    },
+    "disaster management||cuttack": {
+      "dept": "Revenue & Disaster Management",
+      "share": 0.8837,
+      "support": 38
+    },
+    "disaster management||deogarh": {
+      "dept": "Revenue & Disaster Management",
+      "share": 0.75,
+      "support": 3
+    },
+    "disaster management||dhenkanal": {
+      "dept": "Revenue & Disaster Management",
+      "share": 0.9286,
+      "support": 13
+    },
+    "disaster management||gajapati": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.8125,
+      "support": 13
+    },
+    "disaster management||ganjam": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.8537,
+      "support": 35
+    },
+    "disaster management||jagatsinghapur": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.8873,
+      "support": 63
+    },
+    "disaster management||jajpur": {
+      "dept": "Revenue & Disaster Management",
+      "share": 0.8718,
+      "support": 34
+    },
+    "disaster management||jharsuguda": {
+      "dept": "Revenue & Disaster Management",
+      "share": 0.8571,
+      "support": 6
+    },
+    "disaster management||kalahandi": {
+      "dept": "Revenue & Disaster Management",
+      "share": 1.0,
+      "support": 16
+    },
+    "disaster management||kandhamal": {
+      "dept": "Revenue & Disaster Management",
+      "share": 1.0,
+      "support": 16
+    },
+    "disaster management||kendrapara": {
+      "dept": "Revenue & Disaster Management",
+      "share": 0.9254,
+      "support": 62
+    },
+    "disaster management||kendujhar": {
+      "dept": "Revenue & Disaster Management",
+      "share": 1.0,
+      "support": 31
+    },
+    "disaster management||khordha": {
+      "dept": "Revenue & Disaster Management",
+      "share": 0.9429,
+      "support": 33
+    },
+    "disaster management||koraput": {
+      "dept": "Revenue & Disaster Management",
+      "share": 1.0,
+      "support": 24
+    },
+    "disaster management||malkangiri": {
+      "dept": "Revenue & Disaster Management",
+      "share": 0.9286,
+      "support": 13
+    },
+    "disaster management||mayurbhanj": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.8,
+      "support": 32
+    },
+    "disaster management||nabarangpur": {
+      "dept": "Revenue & Disaster Management",
+      "share": 1.0,
+      "support": 11
+    },
+    "disaster management||nayagarh": {
+      "dept": "Revenue & Disaster Management",
+      "share": 0.6471,
+      "support": 11
+    },
+    "disaster management||nuapada": {
+      "dept": "Revenue & Disaster Management",
+      "share": 0.8095,
+      "support": 17
+    },
+    "disaster management||puri": {
+      "dept": "Revenue & Disaster Management",
+      "share": 0.7778,
+      "support": 56
+    },
+    "disaster management||rayagada": {
+      "dept": "Revenue & Disaster Management",
+      "share": 1.0,
+      "support": 6
+    },
+    "disaster management||sambalpur": {
+      "dept": "Revenue & Disaster Management",
+      "share": 0.9286,
+      "support": 13
+    },
+    "disaster management||subarnapur": {
+      "dept": "Revenue & Disaster Management",
+      "share": 1.0,
+      "support": 5
+    },
+    "disaster management||sundargarh": {
+      "dept": "Revenue & Disaster Management",
+      "share": 0.913,
+      "support": 21
+    },
+    "education||angul": {
+      "dept": "Higher Education",
+      "office": "Departments",
+      "share": 0.6073,
+      "support": 249
+    },
+    "education||balangir": {
+      "dept": "Higher Education",
+      "office": "Departments",
+      "share": 0.4521,
+      "support": 222
+    },
+    "education||baleswar": {
+      "dept": "Higher Education",
+      "office": "Departments",
+      "share": 0.6497,
+      "support": 994
+    },
+    "education||bargarh": {
+      "dept": "Higher Education",
+      "office": "Departments",
+      "share": 0.514,
+      "support": 294
+    },
+    "education||bhadrak": {
+      "dept": "Higher Education",
+      "office": "Departments",
+      "share": 0.5446,
+      "support": 305
+    },
+    "education||boudh": {
+      "dept": "Higher Education",
+      "office": "Departments",
+      "share": 0.4403,
+      "support": 70
+    },
+    "education||cuttack": {
+      "dept": "Higher Education",
+      "office": "Departments",
+      "share": 0.6308,
+      "support": 557
+    },
+    "education||deogarh": {
+      "dept": "Higher Education",
+      "office": "Departments",
+      "share": 0.4247,
+      "support": 31
+    },
+    "education||dhenkanal": {
+      "dept": "Higher Education",
+      "office": "Departments",
+      "share": 0.4672,
+      "support": 228
+    },
+    "education||gajapati": {
+      "dept": "Higher Education",
+      "office": "Departments",
+      "share": 0.4405,
+      "support": 111
+    },
+    "education||ganjam": {
+      "dept": "Higher Education",
+      "office": "Departments",
+      "share": 0.5857,
+      "support": 687
+    },
+    "education||jagatsinghapur": {
+      "dept": "Higher Education",
+      "office": "Departments",
+      "share": 0.64,
+      "support": 208
+    },
+    "education||jajpur": {
+      "dept": "Higher Education",
+      "office": "Departments",
+      "share": 0.5706,
+      "support": 384
+    },
+    "education||jharsuguda": {
+      "dept": "Higher Education",
+      "office": "Departments",
+      "share": 0.4612,
+      "support": 107
+    },
+    "education||kalahandi": {
+      "dept": "School & Mass Education",
+      "office": "Collector",
+      "share": 0.3935,
+      "support": 170
+    },
+    "education||kandhamal": {
+      "dept": "Higher Education",
+      "office": "Departments",
+      "share": 0.5298,
+      "support": 89
+    },
+    "education||kendrapara": {
+      "dept": "Higher Education",
+      "office": "Departments",
+      "share": 0.5817,
+      "support": 292
+    },
+    "education||kendujhar": {
+      "dept": "Higher Education",
+      "office": "Departments",
+      "share": 0.6252,
+      "support": 352
+    },
+    "education||khordha": {
+      "dept": "Higher Education",
+      "office": "Departments",
+      "share": 0.6682,
+      "support": 898
+    },
+    "education||koraput": {
+      "dept": "Higher Education",
+      "office": "Departments",
+      "share": 0.4583,
+      "support": 110
+    },
+    "education||malkangiri": {
+      "dept": "School & Mass Education",
+      "office": "Collector",
+      "share": 0.4179,
+      "support": 28
+    },
+    "education||mayurbhanj": {
+      "dept": "Higher Education",
+      "office": "Departments",
+      "share": 0.522,
+      "support": 296
+    },
+    "education||nabarangpur": {
+      "dept": "Higher Education",
+      "office": "Departments",
+      "share": 0.4444,
+      "support": 64
+    },
+    "education||nayagarh": {
+      "dept": "Higher Education",
+      "office": "Departments",
+      "share": 0.4386,
+      "support": 182
+    },
+    "education||nuapada": {
+      "dept": "School & Mass Education",
+      "office": "Collector",
+      "share": 0.484,
+      "support": 106
+    },
+    "education||puri": {
+      "dept": "Higher Education",
+      "office": "Departments",
+      "share": 0.6894,
+      "support": 384
+    },
+    "education||rayagada": {
+      "dept": "Higher Education",
+      "office": "Departments",
+      "share": 0.5359,
+      "support": 82
+    },
+    "education||sambalpur": {
+      "dept": "Higher Education",
+      "office": "Departments",
+      "share": 0.735,
+      "support": 466
+    },
+    "education||subarnapur": {
+      "dept": "Higher Education",
+      "office": "Departments",
+      "share": 0.5721,
+      "support": 115
+    },
+    "education||sundargarh": {
+      "dept": "Higher Education",
+      "office": "Departments",
+      "share": 0.5606,
+      "support": 208
+    },
+    "energy||angul": {
+      "dept": "Energy",
+      "share": 0.8949,
+      "support": 494
+    },
+    "energy||balangir": {
+      "dept": "Energy",
+      "share": 0.7874,
+      "support": 337
+    },
+    "energy||baleswar": {
+      "dept": "Energy",
+      "office": "Departments",
+      "share": 0.7065,
+      "support": 905
+    },
+    "energy||bargarh": {
+      "dept": "Energy",
+      "share": 0.8062,
+      "support": 416
+    },
+    "energy||bhadrak": {
+      "dept": "Energy",
+      "share": 0.8792,
+      "support": 415
+    },
+    "energy||boudh": {
+      "dept": "Energy",
+      "office": "Collector",
+      "share": 0.9087,
+      "support": 468
+    },
+    "energy||cuttack": {
+      "dept": "Energy",
+      "share": 0.8276,
+      "support": 1032
+    },
+    "energy||deogarh": {
+      "dept": "Energy",
+      "share": 0.8667,
+      "support": 169
+    },
+    "energy||dhenkanal": {
+      "dept": "Energy",
+      "share": 0.9048,
+      "support": 903
+    },
+    "energy||gajapati": {
+      "dept": "Energy",
+      "office": "Collector",
+      "share": 0.7948,
+      "support": 364
+    },
+    "energy||ganjam": {
+      "dept": "Energy",
+      "office": "Departments",
+      "share": 0.8388,
+      "support": 692
+    },
+    "energy||jagatsinghapur": {
+      "dept": "Energy",
+      "share": 0.8217,
+      "support": 470
+    },
+    "energy||jajpur": {
+      "dept": "Energy",
+      "share": 0.8458,
+      "support": 587
+    },
+    "energy||jharsuguda": {
+      "dept": "Energy",
+      "share": 0.6992,
+      "support": 172
+    },
+    "energy||kalahandi": {
+      "dept": "Energy",
+      "office": "Collector",
+      "share": 0.8638,
+      "support": 634
+    },
+    "energy||kandhamal": {
+      "dept": "Energy",
+      "office": "Departments",
+      "share": 0.6067,
+      "support": 455
+    },
+    "energy||kendrapara": {
+      "dept": "Energy",
+      "share": 0.8388,
+      "support": 515
+    },
+    "energy||kendujhar": {
+      "dept": "Energy",
+      "share": 0.8731,
+      "support": 640
+    },
+    "energy||khordha": {
+      "dept": "Energy",
+      "office": "Departments",
+      "share": 0.8295,
+      "support": 1620
+    },
+    "energy||koraput": {
+      "dept": "Energy",
+      "share": 0.7802,
+      "support": 291
+    },
+    "energy||malkangiri": {
+      "dept": "Energy",
+      "share": 0.7285,
+      "support": 110
+    },
+    "energy||mayurbhanj": {
+      "dept": "Energy",
+      "share": 0.6828,
+      "support": 495
+    },
+    "energy||nabarangpur": {
+      "dept": "Energy",
+      "office": "Collector",
+      "share": 0.8278,
+      "support": 250
+    },
+    "energy||nayagarh": {
+      "dept": "Energy",
+      "office": "Departments",
+      "share": 0.7063,
+      "support": 380
+    },
+    "energy||nuapada": {
+      "dept": "Energy",
+      "office": "Collector",
+      "share": 0.8956,
+      "support": 266
+    },
+    "energy||puri": {
+      "dept": "Energy",
+      "office": "Departments",
+      "share": 0.7741,
+      "support": 651
+    },
+    "energy||rayagada": {
+      "dept": "Energy",
+      "share": 0.7904,
+      "support": 215
+    },
+    "energy||sambalpur": {
+      "dept": "Energy",
+      "share": 0.6871,
+      "support": 483
+    },
+    "energy||subarnapur": {
+      "dept": "Energy",
+      "share": 0.8116,
+      "support": 168
+    },
+    "energy||sundargarh": {
+      "dept": "Energy",
+      "share": 0.5648,
+      "support": 427
+    },
+    "environment||angul": {
+      "dept": "Forest, Environment and Climate Change Department",
+      "share": 0.7,
+      "support": 42
+    },
+    "environment||balangir": {
+      "dept": "Forest, Environment and Climate Change Department",
+      "office": "Departments",
+      "share": 0.8438,
+      "support": 27
+    },
+    "environment||baleswar": {
+      "dept": "Forest, Environment and Climate Change Department",
+      "office": "Departments",
+      "share": 0.6923,
+      "support": 27
+    },
+    "environment||bargarh": {
+      "dept": "Forest, Environment and Climate Change Department",
+      "share": 0.4615,
+      "support": 12
+    },
+    "environment||bhadrak": {
+      "dept": "Forest, Environment and Climate Change Department",
+      "office": "Departments",
+      "share": 0.7727,
+      "support": 17
+    },
+    "environment||boudh": {
+      "dept": "Forest, Environment and Climate Change Department",
+      "share": 1.0,
+      "support": 3
+    },
+    "environment||cuttack": {
+      "dept": "Forest, Environment and Climate Change Department",
+      "share": 0.6,
+      "support": 51
+    },
+    "environment||deogarh": {
+      "dept": "Forest, Environment and Climate Change Department",
+      "office": "Collector",
+      "share": 0.8182,
+      "support": 27
+    },
+    "environment||dhenkanal": {
+      "dept": "Forest, Environment and Climate Change Department",
+      "share": 0.5795,
+      "support": 51
+    },
+    "environment||ganjam": {
+      "dept": "Forest, Environment and Climate Change Department",
+      "share": 0.5833,
+      "support": 56
+    },
+    "environment||jagatsinghapur": {
+      "dept": "Forest, Environment and Climate Change Department",
+      "office": "Departments",
+      "share": 0.6136,
+      "support": 54
+    },
+    "environment||jajpur": {
+      "dept": "Forest, Environment and Climate Change Department",
+      "office": "Departments",
+      "share": 0.7107,
+      "support": 113
+    },
+    "environment||jharsuguda": {
+      "dept": "Forest, Environment and Climate Change Department",
+      "share": 0.4697,
+      "support": 31
+    },
+    "environment||kalahandi": {
+      "dept": "Forest, Environment and Climate Change Department",
+      "share": 0.5294,
+      "support": 18
+    },
+    "environment||kandhamal": {
+      "dept": "Forest, Environment and Climate Change Department",
+      "share": 0.7,
+      "support": 7
+    },
+    "environment||kendrapara": {
+      "dept": "Forest, Environment and Climate Change Department",
+      "office": "Departments",
+      "share": 0.7193,
+      "support": 41
+    },
+    "environment||kendujhar": {
+      "dept": "Forest, Environment and Climate Change Department",
+      "office": "Collector",
+      "share": 0.7424,
+      "support": 49
+    },
+    "environment||khordha": {
+      "dept": "Forest, Environment and Climate Change Department",
+      "office": "Departments",
+      "share": 0.5158,
+      "support": 49
+    },
+    "environment||koraput": {
+      "dept": "Forest, Environment and Climate Change Department",
+      "share": 0.5938,
+      "support": 19
+    },
+    "environment||mayurbhanj": {
+      "dept": "Forest, Environment and Climate Change Department",
+      "office": "Collector",
+      "share": 0.5,
+      "support": 9
+    },
+    "environment||nabarangpur": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.4706,
+      "support": 8
+    },
+    "environment||nayagarh": {
+      "dept": "General Administration & Public Grievance",
+      "office": "Collector",
+      "share": 0.4717,
+      "support": 25
+    },
+    "environment||puri": {
+      "dept": "Forest, Environment and Climate Change Department",
+      "share": 0.6889,
+      "support": 31
+    },
+    "environment||rayagada": {
+      "dept": "Forest, Environment and Climate Change Department",
+      "share": 0.8,
+      "support": 12
+    },
+    "environment||sambalpur": {
+      "dept": "Forest, Environment and Climate Change Department",
+      "office": "Collector",
+      "share": 0.5385,
+      "support": 21
+    },
+    "environment||subarnapur": {
+      "dept": "Forest, Environment and Climate Change Department",
+      "share": 1.0,
+      "support": 8
+    },
+    "environment||sundargarh": {
+      "dept": "Forest, Environment and Climate Change Department",
+      "share": 0.6471,
+      "support": 55
+    },
+    "excise||angul": {
+      "dept": "Excise",
+      "share": 0.9273,
+      "support": 51
+    },
+    "excise||balangir": {
+      "dept": "Excise",
+      "office": "Departments",
+      "share": 0.8846,
+      "support": 23
+    },
+    "excise||baleswar": {
+      "dept": "Excise",
+      "office": "Departments",
+      "share": 0.8421,
+      "support": 48
+    },
+    "excise||bargarh": {
+      "dept": "Excise",
+      "share": 0.9123,
+      "support": 52
+    },
+    "excise||bhadrak": {
+      "dept": "Excise",
+      "share": 0.9205,
+      "support": 81
+    },
+    "excise||boudh": {
+      "dept": "Excise",
+      "office": "Collector",
+      "share": 0.9444,
+      "support": 17
+    },
+    "excise||cuttack": {
+      "dept": "Excise",
+      "office": "Departments",
+      "share": 0.9216,
+      "support": 47
+    },
+    "excise||deogarh": {
+      "dept": "Excise",
+      "office": "Collector",
+      "share": 0.8182,
+      "support": 18
+    },
+    "excise||dhenkanal": {
+      "dept": "Excise",
+      "share": 0.8615,
+      "support": 56
+    },
+    "excise||gajapati": {
+      "dept": "Excise",
+      "office": "Collector",
+      "share": 0.9524,
+      "support": 20
+    },
+    "excise||ganjam": {
+      "dept": "Excise",
+      "share": 0.8475,
+      "support": 50
+    },
+    "excise||jagatsinghapur": {
+      "dept": "Excise",
+      "office": "Departments",
+      "share": 0.9722,
+      "support": 35
+    },
+    "excise||jajpur": {
+      "dept": "Excise",
+      "share": 0.958,
+      "support": 114
+    },
+    "excise||jharsuguda": {
+      "dept": "Excise",
+      "office": "Collector",
+      "share": 1.0,
+      "support": 35
+    },
+    "excise||kalahandi": {
+      "dept": "Excise",
+      "office": "Collector",
+      "share": 0.961,
+      "support": 148
+    },
+    "excise||kandhamal": {
+      "dept": "Excise",
+      "office": "Collector",
+      "share": 0.8667,
+      "support": 13
+    },
+    "excise||kendrapara": {
+      "dept": "Excise",
+      "office": "Departments",
+      "share": 0.9118,
+      "support": 31
+    },
+    "excise||kendujhar": {
+      "dept": "Excise",
+      "share": 0.8929,
+      "support": 25
+    },
+    "excise||khordha": {
+      "dept": "Excise",
+      "office": "Departments",
+      "share": 0.9247,
+      "support": 86
+    },
+    "excise||koraput": {
+      "dept": "Excise",
+      "office": "Departments",
+      "share": 0.8788,
+      "support": 29
+    },
+    "excise||malkangiri": {
+      "dept": "Excise",
+      "office": "Departments",
+      "share": 1.0,
+      "support": 8
+    },
+    "excise||mayurbhanj": {
+      "dept": "Excise",
+      "share": 0.8462,
+      "support": 33
+    },
+    "excise||nabarangpur": {
+      "dept": "Excise",
+      "office": "Collector",
+      "share": 0.8667,
+      "support": 26
+    },
+    "excise||nayagarh": {
+      "dept": "Excise",
+      "office": "Departments",
+      "share": 0.7955,
+      "support": 35
+    },
+    "excise||nuapada": {
+      "dept": "Excise",
+      "office": "Collector",
+      "share": 0.9524,
+      "support": 20
+    },
+    "excise||puri": {
+      "dept": "Excise",
+      "office": "Departments",
+      "share": 0.7407,
+      "support": 40
+    },
+    "excise||rayagada": {
+      "dept": "Excise",
+      "office": "Collector",
+      "share": 1.0,
+      "support": 20
+    },
+    "excise||sambalpur": {
+      "dept": "Excise",
+      "share": 0.9,
+      "support": 27
+    },
+    "excise||subarnapur": {
+      "dept": "Excise",
+      "share": 0.8333,
+      "support": 10
+    },
+    "excise||sundargarh": {
+      "dept": "Excise",
+      "office": "Collector",
+      "share": 0.9344,
+      "support": 57
+    },
+    "financial assistance||angul": {
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
+      "share": 0.232,
+      "support": 84
+    },
+    "financial assistance||balangir": {
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
+      "share": 0.6175,
+      "support": 841
+    },
+    "financial assistance||baleswar": {
+      "dept": "General Administration & Public Grievance",
+      "office": "Collector",
+      "share": 0.3033,
+      "support": 212
+    },
+    "financial assistance||bargarh": {
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
+      "share": 0.8445,
+      "support": 2363
+    },
+    "financial assistance||bhadrak": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.3008,
+      "support": 145
+    },
+    "financial assistance||boudh": {
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
+      "share": 0.4239,
+      "support": 234
+    },
+    "financial assistance||cuttack": {
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
+      "share": 0.2187,
+      "support": 166
+    },
+    "financial assistance||deogarh": {
+      "dept": "General Administration & Public Grievance",
+      "office": "Collector",
+      "share": 0.269,
+      "support": 39
+    },
+    "financial assistance||dhenkanal": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.2696,
+      "support": 341
+    },
+    "financial assistance||gajapati": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.25,
+      "support": 77
+    },
+    "financial assistance||ganjam": {
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
+      "share": 0.244,
+      "support": 212
+    },
+    "financial assistance||jagatsinghapur": {
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
+      "share": 0.2817,
+      "support": 120
+    },
+    "financial assistance||jajpur": {
+      "dept": "Health & Family Welfare",
+      "share": 0.1711,
+      "support": 97
+    },
+    "financial assistance||jharsuguda": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.2986,
+      "support": 43
+    },
+    "financial assistance||kalahandi": {
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
+      "share": 0.1937,
+      "support": 142
+    },
+    "financial assistance||kandhamal": {
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
+      "share": 0.3677,
+      "support": 57
+    },
+    "financial assistance||kendrapara": {
+      "dept": "General Administration & Public Grievance",
+      "office": "Office of Chief Minister",
+      "share": 0.1905,
+      "support": 64
+    },
+    "financial assistance||kendujhar": {
+      "dept": "General Administration & Public Grievance",
+      "office": "Collector",
+      "share": 0.2106,
+      "support": 91
+    },
+    "financial assistance||khordha": {
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
+      "share": 0.2789,
+      "support": 302
+    },
+    "financial assistance||koraput": {
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
+      "share": 0.23,
+      "support": 49
+    },
+    "financial assistance||malkangiri": {
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
+      "share": 0.3519,
+      "support": 19
+    },
+    "financial assistance||mayurbhanj": {
+      "dept": "General Administration & Public Grievance",
+      "office": "Collector",
+      "share": 0.4993,
+      "support": 365
+    },
+    "financial assistance||nabarangpur": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.2649,
+      "support": 107
+    },
+    "financial assistance||nayagarh": {
+      "dept": "General Administration & Public Grievance",
+      "office": "Collector",
+      "share": 0.5606,
+      "support": 421
+    },
+    "financial assistance||nuapada": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.253,
+      "support": 106
+    },
+    "financial assistance||puri": {
+      "dept": "General Administration & Public Grievance",
+      "office": "Office of Chief Minister",
+      "share": 0.2097,
+      "support": 147
+    },
+    "financial assistance||rayagada": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.1942,
+      "support": 27
+    },
+    "financial assistance||sambalpur": {
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
+      "share": 0.4034,
+      "support": 211
+    },
+    "financial assistance||subarnapur": {
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
+      "share": 0.5751,
+      "support": 1126
+    },
+    "financial assistance||sundargarh": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.2552,
+      "support": 110
+    },
+    "general||angul": {
+      "dept": "Home department",
+      "office": "Superintendent of Police",
+      "share": 0.2653,
+      "support": 643
+    },
+    "general||balangir": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.3495,
+      "support": 986
+    },
+    "general||baleswar": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.258,
+      "support": 2156
+    },
+    "general||bargarh": {
+      "dept": "School & Mass Education",
+      "office": "Departments",
+      "share": 0.3033,
+      "support": 484
+    },
+    "general||bhadrak": {
+      "dept": "School & Mass Education",
+      "office": "Departments",
+      "share": 0.2973,
+      "support": 619
+    },
+    "general||boudh": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.3529,
+      "support": 1155
+    },
+    "general||cuttack": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.1786,
+      "support": 1252
+    },
+    "general||deogarh": {
+      "dept": "General Administration & Public Grievance",
+      "office": "Collector",
+      "share": 0.2617,
+      "support": 174
+    },
+    "general||dhenkanal": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Chief Secretary",
+      "share": 0.2008,
+      "support": 544
+    },
+    "general||gajapati": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.3215,
+      "support": 553
+    },
+    "general||ganjam": {
+      "dept": "General Administration & Public Grievance",
+      "office": "Collector",
+      "share": 0.1949,
+      "support": 1620
+    },
+    "general||jagatsinghapur": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.3183,
+      "support": 1868
+    },
+    "general||jajpur": {
+      "dept": "Home department",
+      "office": "Superintendent of Police",
+      "share": 0.7279,
+      "support": 7745
+    },
+    "general||jharsuguda": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.2309,
+      "support": 478
+    },
+    "general||kalahandi": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.2326,
+      "support": 642
+    },
+    "general||kandhamal": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Chief Secretary",
+      "share": 0.4804,
+      "support": 1055
+    },
+    "general||kendrapara": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.3102,
+      "support": 3554
+    },
+    "general||kendujhar": {
+      "dept": "Home department",
+      "office": "Superintendent of Police",
+      "share": 0.3708,
+      "support": 1221
+    },
+    "general||khordha": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.1562,
+      "support": 1760
+    },
+    "general||koraput": {
+      "dept": "School & Mass Education",
+      "office": "Departments",
+      "share": 0.2669,
+      "support": 356
+    },
+    "general||malkangiri": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.2737,
+      "support": 159
+    },
+    "general||mayurbhanj": {
+      "dept": "General Administration & Public Grievance",
+      "office": "Collector",
+      "share": 0.5202,
+      "support": 6676
+    },
+    "general||nabarangpur": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.2483,
+      "support": 329
+    },
+    "general||nayagarh": {
+      "dept": "General Administration & Public Grievance",
+      "office": "Collector",
+      "share": 0.5599,
+      "support": 3090
+    },
+    "general||nuapada": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.2707,
+      "support": 488
+    },
+    "general||puri": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.2995,
+      "support": 2692
+    },
+    "general||rayagada": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.3244,
+      "support": 1142
+    },
+    "general||sambalpur": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.5937,
+      "support": 3070
+    },
+    "general||subarnapur": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.3868,
+      "support": 1212
+    },
+    "general||sundargarh": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.2313,
+      "support": 1381
+    },
+    "health care||angul": {
+      "dept": "Health & Family Welfare",
+      "share": 0.9336,
+      "support": 408
+    },
+    "health care||balangir": {
+      "dept": "Health & Family Welfare",
+      "share": 0.9363,
+      "support": 426
+    },
+    "health care||baleswar": {
+      "dept": "Health & Family Welfare",
+      "share": 0.7849,
+      "support": 770
+    },
+    "health care||bargarh": {
+      "dept": "Health & Family Welfare",
+      "share": 0.9122,
+      "support": 405
+    },
+    "health care||bhadrak": {
+      "dept": "Health & Family Welfare",
+      "share": 0.9127,
+      "support": 418
+    },
+    "health care||boudh": {
+      "dept": "Health & Family Welfare",
+      "office": "Collector",
+      "share": 0.9157,
+      "support": 239
+    },
+    "health care||cuttack": {
+      "dept": "Health & Family Welfare",
+      "share": 0.9156,
+      "support": 824
+    },
+    "health care||deogarh": {
+      "dept": "Health & Family Welfare",
+      "office": "Collector",
+      "share": 0.9062,
+      "support": 116
+    },
+    "health care||dhenkanal": {
+      "dept": "Health & Family Welfare",
+      "share": 0.9015,
+      "support": 558
+    },
+    "health care||gajapati": {
+      "dept": "Health & Family Welfare",
+      "office": "Collector",
+      "share": 0.8333,
+      "support": 375
+    },
+    "health care||ganjam": {
+      "dept": "Health & Family Welfare",
+      "share": 0.9134,
+      "support": 759
+    },
+    "health care||jagatsinghapur": {
+      "dept": "Health & Family Welfare",
+      "share": 0.9358,
+      "support": 539
+    },
+    "health care||jajpur": {
+      "dept": "Health & Family Welfare",
+      "share": 0.9115,
+      "support": 814
+    },
+    "health care||jharsuguda": {
+      "dept": "Health & Family Welfare",
+      "share": 0.9057,
+      "support": 144
+    },
+    "health care||kalahandi": {
+      "dept": "Health & Family Welfare",
+      "office": "Collector",
+      "share": 0.9439,
+      "support": 639
+    },
+    "health care||kandhamal": {
+      "dept": "Health & Family Welfare",
+      "share": 0.9595,
+      "support": 308
+    },
+    "health care||kendrapara": {
+      "dept": "Health & Family Welfare",
+      "share": 0.9235,
+      "support": 604
+    },
+    "health care||kendujhar": {
+      "dept": "Health & Family Welfare",
+      "share": 0.9592,
+      "support": 447
+    },
+    "health care||khordha": {
+      "dept": "Health & Family Welfare",
+      "share": 0.89,
+      "support": 882
+    },
+    "health care||koraput": {
+      "dept": "Health & Family Welfare",
+      "share": 0.9391,
+      "support": 324
+    },
+    "health care||malkangiri": {
+      "dept": "Health & Family Welfare",
+      "share": 0.8912,
+      "support": 172
+    },
+    "health care||mayurbhanj": {
+      "dept": "Health & Family Welfare",
+      "share": 0.8881,
+      "support": 373
+    },
+    "health care||nabarangpur": {
+      "dept": "Health & Family Welfare",
+      "share": 0.8859,
+      "support": 326
+    },
+    "health care||nayagarh": {
+      "dept": "Health & Family Welfare",
+      "share": 0.6943,
+      "support": 302
+    },
+    "health care||nuapada": {
+      "dept": "Health & Family Welfare",
+      "office": "Collector",
+      "share": 0.8535,
+      "support": 233
+    },
+    "health care||puri": {
+      "dept": "Health & Family Welfare",
+      "share": 0.8782,
+      "support": 548
+    },
+    "health care||rayagada": {
+      "dept": "Health & Family Welfare",
+      "share": 0.9152,
+      "support": 259
+    },
+    "health care||sambalpur": {
+      "dept": "Health & Family Welfare",
+      "share": 0.8992,
+      "support": 330
+    },
+    "health care||subarnapur": {
+      "dept": "Health & Family Welfare",
+      "share": 0.9249,
+      "support": 160
+    },
+    "health care||sundargarh": {
+      "dept": "Health & Family Welfare",
+      "share": 0.8799,
+      "support": 315
+    },
+    "housing||angul": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.9657,
+      "support": 7274
+    },
+    "housing||balangir": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.9859,
+      "support": 32933
+    },
+    "housing||baleswar": {
+      "dept": "General Administration & Public Grievance",
+      "office": "Collector",
+      "share": 0.555,
+      "support": 10951
+    },
+    "housing||bargarh": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.985,
+      "support": 14722
+    },
+    "housing||bhadrak": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.9761,
+      "support": 14525
+    },
+    "housing||boudh": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.9115,
+      "support": 3710
+    },
+    "housing||cuttack": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
+      "share": 0.9398,
+      "support": 4214
+    },
+    "housing||deogarh": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.9923,
+      "support": 4495
+    },
+    "housing||dhenkanal": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.9122,
+      "support": 17682
+    },
+    "housing||gajapati": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
+      "share": 0.9553,
+      "support": 726
+    },
+    "housing||ganjam": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
+      "share": 0.9402,
+      "support": 7279
+    },
+    "housing||jagatsinghapur": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
+      "share": 0.8743,
+      "support": 1809
+    },
+    "housing||jajpur": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.9798,
+      "support": 18137
+    },
+    "housing||jharsuguda": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.9738,
+      "support": 2561
+    },
+    "housing||kalahandi": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.9884,
+      "support": 25534
+    },
+    "housing||kandhamal": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.9845,
+      "support": 6998
+    },
+    "housing||kendrapara": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.775,
+      "support": 6552
+    },
+    "housing||kendujhar": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
+      "share": 0.9491,
+      "support": 2706
+    },
+    "housing||khordha": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.936,
+      "support": 9528
+    },
+    "housing||koraput": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.887,
+      "support": 3831
+    },
+    "housing||malkangiri": {
+      "dept": "Housing & Urban Development",
+      "office": "Collector",
+      "share": 0.5464,
+      "support": 1408
+    },
+    "housing||mayurbhanj": {
+      "dept": "General Administration & Public Grievance",
+      "office": "Collector",
+      "share": 0.7302,
+      "support": 11681
+    },
+    "housing||nabarangpur": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.975,
+      "support": 8001
+    },
+    "housing||nayagarh": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
+      "share": 0.9132,
+      "support": 2842
+    },
+    "housing||nuapada": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.9817,
+      "support": 7813
+    },
+    "housing||puri": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.9828,
+      "support": 16024
+    },
+    "housing||rayagada": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.9531,
+      "support": 2031
+    },
+    "housing||sambalpur": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.885,
+      "support": 7352
+    },
+    "housing||subarnapur": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.9783,
+      "support": 10510
+    },
+    "housing||sundargarh": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.9893,
+      "support": 15702
+    },
+    "icds||angul": {
+      "dept": "Women & Child Development",
+      "share": 0.7241,
+      "support": 42
+    },
+    "icds||balangir": {
+      "dept": "Women & Child Development",
+      "office": "Departments",
+      "share": 0.7439,
+      "support": 61
+    },
+    "icds||baleswar": {
+      "dept": "Women & Child Development",
+      "office": "Departments",
+      "share": 0.5263,
+      "support": 100
+    },
+    "icds||bargarh": {
+      "dept": "Women & Child Development",
+      "share": 0.7818,
+      "support": 43
+    },
+    "icds||bhadrak": {
+      "dept": "Women & Child Development",
+      "office": "Departments",
+      "share": 0.7957,
+      "support": 74
+    },
+    "icds||boudh": {
+      "dept": "Women & Child Development",
+      "share": 0.6538,
+      "support": 17
+    },
+    "icds||cuttack": {
+      "dept": "Women & Child Development",
+      "share": 0.8318,
+      "support": 89
+    },
+    "icds||deogarh": {
+      "dept": "Women & Child Development",
+      "office": "Departments",
+      "share": 0.42,
+      "support": 21
+    },
+    "icds||dhenkanal": {
+      "dept": "Women & Child Development",
+      "share": 0.7818,
+      "support": 43
+    },
+    "icds||gajapati": {
+      "dept": "Women & Child Development",
+      "office": "Collector",
+      "share": 0.5244,
+      "support": 43
+    },
+    "icds||ganjam": {
+      "dept": "Women & Child Development",
+      "share": 0.7768,
+      "support": 87
+    },
+    "icds||jagatsinghapur": {
+      "dept": "Women & Child Development",
+      "share": 0.6852,
+      "support": 37
+    },
+    "icds||jajpur": {
+      "dept": "Women & Child Development",
+      "share": 0.902,
+      "support": 92
+    },
+    "icds||jharsuguda": {
+      "dept": "Women & Child Development",
+      "office": "Departments",
+      "share": 0.5833,
+      "support": 7
+    },
+    "icds||kalahandi": {
+      "dept": "Women & Child Development",
+      "office": "Collector",
+      "share": 0.8376,
+      "support": 98
+    },
+    "icds||kandhamal": {
+      "dept": "Women & Child Development",
+      "office": "Departments",
+      "share": 0.7253,
+      "support": 66
+    },
+    "icds||kendrapara": {
+      "dept": "Women & Child Development",
+      "share": 0.7222,
+      "support": 52
+    },
+    "icds||kendujhar": {
+      "dept": "Women & Child Development",
+      "share": 0.7103,
+      "support": 76
+    },
+    "icds||khordha": {
+      "dept": "Women & Child Development",
+      "office": "Departments",
+      "share": 0.75,
+      "support": 54
+    },
+    "icds||koraput": {
+      "dept": "Women & Child Development",
+      "share": 0.6782,
+      "support": 59
+    },
+    "icds||malkangiri": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.6,
+      "support": 36
+    },
+    "icds||mayurbhanj": {
+      "dept": "Women & Child Development",
+      "share": 0.8152,
+      "support": 75
+    },
+    "icds||nabarangpur": {
+      "dept": "Women & Child Development",
+      "office": "Collector",
+      "share": 0.7544,
+      "support": 43
+    },
+    "icds||nayagarh": {
+      "dept": "Women & Child Development",
+      "share": 0.3846,
+      "support": 25
+    },
+    "icds||nuapada": {
+      "dept": "Women & Child Development",
+      "office": "Collector",
+      "share": 0.7019,
+      "support": 73
+    },
+    "icds||puri": {
+      "dept": "Women & Child Development",
+      "office": "Departments",
+      "share": 0.6912,
+      "support": 47
+    },
+    "icds||rayagada": {
+      "dept": "Women & Child Development",
+      "share": 0.8082,
+      "support": 59
+    },
+    "icds||sambalpur": {
+      "dept": "Women & Child Development",
+      "office": "Collector",
+      "share": 0.5455,
+      "support": 36
+    },
+    "icds||subarnapur": {
+      "dept": "Women & Child Development",
+      "share": 0.75,
+      "support": 18
+    },
+    "icds||sundargarh": {
+      "dept": "Women & Child Development",
+      "share": 0.7963,
+      "support": 43
+    },
+    "infrastructure||angul": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.5641,
+      "support": 836
+    },
+    "infrastructure||balangir": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.7936,
+      "support": 4530
+    },
+    "infrastructure||baleswar": {
+      "dept": "General Administration & Public Grievance",
+      "office": "Collector",
+      "share": 0.3317,
+      "support": 895
+    },
+    "infrastructure||bargarh": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.7169,
+      "support": 2213
+    },
+    "infrastructure||bhadrak": {
+      "dept": "Planning & Convergence",
+      "office": "Collector",
+      "share": 0.4305,
+      "support": 694
+    },
+    "infrastructure||boudh": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.6694,
+      "support": 642
+    },
+    "infrastructure||cuttack": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.3175,
+      "support": 860
+    },
+    "infrastructure||deogarh": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.7946,
+      "support": 1110
+    },
+    "infrastructure||dhenkanal": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.5909,
+      "support": 1095
+    },
+    "infrastructure||gajapati": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.8,
+      "support": 3345
+    },
+    "infrastructure||ganjam": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.5073,
+      "support": 2210
+    },
+    "infrastructure||jagatsinghapur": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.5768,
+      "support": 1190
+    },
+    "infrastructure||jajpur": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.6915,
+      "support": 1878
+    },
+    "infrastructure||jharsuguda": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.4656,
+      "support": 474
+    },
+    "infrastructure||kalahandi": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.6393,
+      "support": 2990
+    },
+    "infrastructure||kandhamal": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.6384,
+      "support": 1953
+    },
+    "infrastructure||kendrapara": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.3121,
+      "support": 436
+    },
+    "infrastructure||kendujhar": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.5829,
+      "support": 1618
+    },
+    "infrastructure||khordha": {
+      "dept": "Housing & Urban Development",
+      "share": 0.4177,
+      "support": 1361
+    },
+    "infrastructure||koraput": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.465,
+      "support": 1802
+    },
+    "infrastructure||malkangiri": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.6604,
+      "support": 943
+    },
+    "infrastructure||mayurbhanj": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.5754,
+      "support": 1930
+    },
+    "infrastructure||nabarangpur": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.4249,
+      "support": 1129
+    },
+    "infrastructure||nayagarh": {
+      "dept": "General Administration & Public Grievance",
+      "office": "Collector",
+      "share": 0.5088,
+      "support": 662
+    },
+    "infrastructure||nuapada": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.8537,
+      "support": 1500
+    },
+    "infrastructure||puri": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.4951,
+      "support": 956
+    },
+    "infrastructure||rayagada": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.5996,
+      "support": 566
+    },
+    "infrastructure||sambalpur": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.6191,
+      "support": 4200
+    },
+    "infrastructure||subarnapur": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.6605,
+      "support": 603
+    },
+    "infrastructure||sundargarh": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.593,
+      "support": 2687
+    },
+    "irrigation||angul": {
+      "dept": "Water Resources",
+      "office": "Collector",
+      "share": 0.7051,
+      "support": 55
+    },
+    "irrigation||balangir": {
+      "dept": "Water Resources",
+      "office": "Collector",
+      "share": 0.4836,
+      "support": 59
+    },
+    "irrigation||baleswar": {
+      "dept": "General Administration & Public Grievance",
+      "office": "Collector",
+      "share": 0.3835,
+      "support": 51
+    },
+    "irrigation||bargarh": {
+      "dept": "Water Resources",
+      "office": "Collector",
+      "share": 0.9542,
+      "support": 146
+    },
+    "irrigation||bhadrak": {
+      "dept": "Water Resources",
+      "share": 0.7544,
+      "support": 43
+    },
+    "irrigation||boudh": {
+      "dept": "Water Resources",
+      "office": "Collector",
+      "share": 0.5657,
+      "support": 56
+    },
+    "irrigation||cuttack": {
+      "dept": "Water Resources",
+      "share": 0.7273,
+      "support": 72
+    },
+    "irrigation||deogarh": {
+      "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
+      "share": 0.3171,
+      "support": 26
+    },
+    "irrigation||dhenkanal": {
+      "dept": "Water Resources",
+      "office": "Collector",
+      "share": 0.5394,
+      "support": 89
+    },
+    "irrigation||gajapati": {
+      "dept": "Works",
+      "office": "Collector",
+      "share": 0.3034,
+      "support": 44
+    },
+    "irrigation||ganjam": {
+      "dept": "Water Resources",
+      "office": "Collector",
+      "share": 0.4157,
+      "support": 111
+    },
+    "irrigation||jagatsinghapur": {
+      "dept": "Water Resources",
+      "office": "Collector",
+      "share": 0.7033,
+      "support": 64
+    },
+    "irrigation||jajpur": {
+      "dept": "Water Resources",
+      "share": 0.6977,
+      "support": 60
+    },
+    "irrigation||jharsuguda": {
+      "dept": "Water Resources",
+      "office": "Collector",
+      "share": 0.5,
+      "support": 38
+    },
+    "irrigation||kalahandi": {
+      "dept": "Water Resources",
+      "office": "Collector",
+      "share": 0.8398,
+      "support": 367
+    },
+    "irrigation||kandhamal": {
+      "dept": "Water Resources",
+      "office": "Collector",
+      "share": 0.7945,
+      "support": 58
+    },
+    "irrigation||kendrapara": {
+      "dept": "Water Resources",
+      "office": "Departments",
+      "share": 0.8696,
+      "support": 60
+    },
+    "irrigation||kendujhar": {
+      "dept": "Water Resources",
+      "office": "Collector",
+      "share": 0.6466,
+      "support": 75
+    },
+    "irrigation||khordha": {
+      "dept": "Water Resources",
+      "office": "Collector",
+      "share": 0.8559,
+      "support": 95
+    },
+    "irrigation||koraput": {
+      "dept": "Water Resources",
+      "office": "Collector",
+      "share": 0.5169,
+      "support": 46
+    },
+    "irrigation||malkangiri": {
+      "dept": "Water Resources",
+      "office": "Collector",
+      "share": 0.5,
+      "support": 11
+    },
+    "irrigation||mayurbhanj": {
+      "dept": "Water Resources",
+      "office": "Collector",
+      "share": 0.7885,
+      "support": 205
+    },
+    "irrigation||nabarangpur": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.45,
+      "support": 9
+    },
+    "irrigation||nayagarh": {
+      "dept": "General Administration & Public Grievance",
+      "office": "Collector",
+      "share": 0.7447,
+      "support": 70
+    },
+    "irrigation||nuapada": {
+      "dept": "Water Resources",
+      "office": "Collector",
+      "share": 0.6207,
+      "support": 72
+    },
+    "irrigation||puri": {
+      "dept": "Water Resources",
+      "share": 0.6818,
+      "support": 30
+    },
+    "irrigation||rayagada": {
+      "dept": "Water Resources",
+      "share": 0.8636,
+      "support": 38
+    },
+    "irrigation||sambalpur": {
+      "dept": "Water Resources",
+      "office": "Collector",
+      "share": 0.3692,
+      "support": 79
+    },
+    "irrigation||subarnapur": {
+      "dept": "Water Resources",
+      "office": "Collector",
+      "share": 0.8108,
+      "support": 30
+    },
+    "irrigation||sundargarh": {
+      "dept": "Water Resources",
+      "office": "Collector",
+      "share": 0.5077,
+      "support": 66
+    },
+    "land matters||angul": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.8963,
+      "support": 1089
+    },
+    "land matters||balangir": {
+      "dept": "Revenue & Disaster Management",
+      "share": 0.8151,
+      "support": 626
+    },
+    "land matters||baleswar": {
+      "dept": "Revenue & Disaster Management",
+      "share": 0.5167,
+      "support": 1653
+    },
+    "land matters||bargarh": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.9149,
+      "support": 1118
+    },
+    "land matters||bhadrak": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.9039,
+      "support": 1628
+    },
+    "land matters||boudh": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.9588,
+      "support": 931
+    },
+    "land matters||cuttack": {
+      "dept": "Revenue & Disaster Management",
+      "share": 0.8806,
+      "support": 2544
+    },
+    "land matters||deogarh": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.8934,
+      "support": 662
+    },
+    "land matters||dhenkanal": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.8757,
+      "support": 1402
+    },
+    "land matters||gajapati": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.9438,
+      "support": 1494
+    },
+    "land matters||ganjam": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.8779,
+      "support": 3005
+    },
+    "land matters||jagatsinghapur": {
+      "dept": "Revenue & Disaster Management",
+      "share": 0.9072,
+      "support": 1202
+    },
+    "land matters||jajpur": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.9196,
+      "support": 2447
+    },
+    "land matters||jharsuguda": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.9076,
+      "support": 835
+    },
+    "land matters||kalahandi": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.9366,
+      "support": 2939
+    },
+    "land matters||kandhamal": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.8986,
+      "support": 496
+    },
+    "land matters||kendrapara": {
+      "dept": "Revenue & Disaster Management",
+      "share": 0.9309,
+      "support": 1777
+    },
+    "land matters||kendujhar": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.8709,
+      "support": 1079
+    },
+    "land matters||khordha": {
+      "dept": "Revenue & Disaster Management",
+      "share": 0.7175,
+      "support": 3211
+    },
+    "land matters||koraput": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.8973,
+      "support": 629
+    },
+    "land matters||malkangiri": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.8333,
+      "support": 215
+    },
+    "land matters||mayurbhanj": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.5175,
+      "support": 1210
+    },
+    "land matters||nabarangpur": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.8711,
+      "support": 1257
+    },
+    "land matters||nayagarh": {
+      "dept": "General Administration & Public Grievance",
+      "office": "Collector",
+      "share": 0.5003,
+      "support": 715
+    },
+    "land matters||nuapada": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.8184,
+      "support": 1113
+    },
+    "land matters||puri": {
+      "dept": "Revenue & Disaster Management",
+      "share": 0.7905,
+      "support": 1147
+    },
+    "land matters||rayagada": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.8676,
+      "support": 511
+    },
+    "land matters||sambalpur": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.85,
+      "support": 1570
+    },
+    "land matters||subarnapur": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.8859,
+      "support": 559
+    },
+    "land matters||sundargarh": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.9232,
+      "support": 2273
+    },
+    "legal||balangir": {
+      "dept": "Home department",
+      "share": 0.32,
+      "support": 8
+    },
+    "legal||baleswar": {
+      "dept": "Higher Education",
+      "office": "Office of Chief Minister",
+      "share": 0.2895,
+      "support": 11
+    },
+    "legal||bargarh": {
+      "dept": "School & Mass Education",
+      "office": "Departments",
+      "share": 0.5,
+      "support": 4
+    },
+    "legal||bhadrak": {
+      "dept": "School & Mass Education",
+      "office": "Departments",
+      "share": 0.4231,
+      "support": 11
+    },
+    "legal||boudh": {
+      "dept": "Higher Education",
+      "office": "Office of Chief Minister",
+      "share": 0.5,
+      "support": 5
+    },
+    "legal||cuttack": {
+      "dept": "Home department",
+      "share": 0.3077,
+      "support": 16
+    },
+    "legal||dhenkanal": {
+      "dept": "Law",
+      "office": "Collector",
+      "share": 0.2727,
+      "support": 6
+    },
+    "legal||gajapati": {
+      "dept": "School & Mass Education",
+      "office": "Departments",
+      "share": 0.5385,
+      "support": 7
+    },
+    "legal||ganjam": {
+      "dept": "School & Mass Education",
+      "office": "Departments",
+      "share": 0.2245,
+      "support": 11
+    },
+    "legal||jagatsinghapur": {
+      "dept": "Home department",
+      "share": 0.2727,
+      "support": 3
+    },
+    "legal||jajpur": {
+      "dept": "Law",
+      "office": "Office of Chief Minister",
+      "share": 0.3043,
+      "support": 7
+    },
+    "legal||jharsuguda": {
+      "dept": "Fisheries & Animal Resources Development",
+      "office": "Departments",
+      "share": 0.3,
+      "support": 3
+    },
+    "legal||kalahandi": {
+      "dept": "School & Mass Education",
+      "office": "Departments",
+      "share": 0.3333,
+      "support": 9
+    },
+    "legal||kandhamal": {
+      "dept": "School & Mass Education",
+      "share": 0.5,
+      "support": 3
+    },
+    "legal||kendrapara": {
+      "dept": "School & Mass Education",
+      "office": "Departments",
+      "share": 0.2778,
+      "support": 5
+    },
+    "legal||kendujhar": {
+      "dept": "Higher Education",
+      "office": "Office of Chief Minister",
+      "share": 0.25,
+      "support": 7
+    },
+    "legal||khordha": {
+      "dept": "School & Mass Education",
+      "office": "Departments",
+      "share": 0.4146,
+      "support": 17
+    },
+    "legal||koraput": {
+      "dept": "Law",
+      "share": 0.1765,
+      "support": 3
+    },
+    "legal||mayurbhanj": {
+      "dept": "Higher Education",
+      "office": "Office of Chief Minister",
+      "share": 0.3125,
+      "support": 5
+    },
+    "legal||nabarangpur": {
+      "dept": "School & Mass Education",
+      "office": "Departments",
+      "share": 0.6,
+      "support": 3
+    },
+    "legal||nuapada": {
+      "dept": "School & Mass Education",
+      "office": "Departments",
+      "share": 0.5,
+      "support": 3
+    },
+    "legal||puri": {
+      "dept": "School & Mass Education",
+      "office": "Departments",
+      "share": 0.4792,
+      "support": 23
+    },
+    "legal||rayagada": {
+      "dept": "School & Mass Education",
+      "office": "Departments",
+      "share": 0.4286,
+      "support": 3
+    },
+    "legal||sambalpur": {
+      "dept": "Women & Child Development",
+      "office": "Office of Chief Minister",
+      "share": 0.3333,
+      "support": 4
+    },
+    "legal||subarnapur": {
+      "dept": "Law",
+      "share": 0.3333,
+      "support": 3
+    },
+    "legal||sundargarh": {
+      "dept": "Law",
+      "office": "Collector",
+      "share": 0.3333,
+      "support": 6
+    },
+    "miscellaneous||angul": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.1852,
+      "support": 388
+    },
+    "miscellaneous||balangir": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.2535,
+      "support": 764
+    },
+    "miscellaneous||baleswar": {
+      "dept": "Information & Public Relations",
+      "office": "Collector",
+      "share": 0.3955,
+      "support": 4030
+    },
+    "miscellaneous||bargarh": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.2332,
+      "support": 714
+    },
+    "miscellaneous||bhadrak": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.2027,
+      "support": 1350
+    },
+    "miscellaneous||boudh": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.3191,
+      "support": 202
+    },
+    "miscellaneous||cuttack": {
+      "dept": "Home department",
+      "share": 0.1952,
+      "support": 933
+    },
+    "miscellaneous||deogarh": {
+      "dept": "Revenue & Disaster Management",
+      "share": 0.1765,
+      "support": 69
+    },
+    "miscellaneous||dhenkanal": {
+      "dept": "Home department",
+      "share": 0.1638,
+      "support": 386
+    },
+    "miscellaneous||gajapati": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.2334,
+      "support": 221
+    },
+    "miscellaneous||ganjam": {
+      "dept": "Revenue & Disaster Management",
+      "share": 0.1519,
+      "support": 631
+    },
+    "miscellaneous||jagatsinghapur": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.4493,
+      "support": 2757
+    },
+    "miscellaneous||jajpur": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.2562,
+      "support": 1152
+    },
+    "miscellaneous||jharsuguda": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Departments",
+      "share": 0.1748,
+      "support": 86
+    },
+    "miscellaneous||kalahandi": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.2511,
+      "support": 833
+    },
+    "miscellaneous||kandhamal": {
+      "dept": "Electronics & Information Technology",
+      "office": "Departments",
+      "share": 0.2977,
+      "support": 343
+    },
+    "miscellaneous||kendrapara": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Departments",
+      "share": 0.1514,
+      "support": 343
+    },
+    "miscellaneous||kendujhar": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.1542,
+      "support": 366
+    },
+    "miscellaneous||khordha": {
+      "dept": "Home department",
+      "share": 0.2159,
+      "support": 1220
+    },
+    "miscellaneous||koraput": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.1983,
+      "support": 295
+    },
+    "miscellaneous||malkangiri": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.214,
+      "support": 107
+    },
+    "miscellaneous||mayurbhanj": {
+      "dept": "Home department",
+      "office": "Superintendent of Police",
+      "share": 0.2171,
+      "support": 520
+    },
+    "miscellaneous||nabarangpur": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.2958,
+      "support": 347
+    },
+    "miscellaneous||nayagarh": {
+      "dept": "Home department",
+      "office": "Superintendent of Police",
+      "share": 0.3374,
+      "support": 994
+    },
+    "miscellaneous||nuapada": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.2587,
+      "support": 570
+    },
+    "miscellaneous||puri": {
+      "dept": "Home department",
+      "share": 0.1781,
+      "support": 412
+    },
+    "miscellaneous||rayagada": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.1638,
+      "support": 95
+    },
+    "miscellaneous||sambalpur": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.6233,
+      "support": 7107
+    },
+    "miscellaneous||subarnapur": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
+      "share": 0.177,
+      "support": 120
+    },
+    "miscellaneous||sundargarh": {
+      "dept": "Home department",
+      "share": 0.1801,
+      "support": 315
+    },
+    "pension/retirement benefits||angul": {
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
+      "share": 0.2146,
+      "support": 56
+    },
+    "pension/retirement benefits||balangir": {
+      "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
+      "share": 0.1585,
+      "support": 26
+    },
+    "pension/retirement benefits||baleswar": {
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
+      "share": 0.371,
+      "support": 161
+    },
+    "pension/retirement benefits||bargarh": {
+      "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
+      "share": 0.2,
+      "support": 37
+    },
+    "pension/retirement benefits||bhadrak": {
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
+      "share": 0.3038,
+      "support": 96
+    },
+    "pension/retirement benefits||boudh": {
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
+      "share": 0.4012,
+      "support": 65
+    },
+    "pension/retirement benefits||cuttack": {
+      "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
+      "share": 0.14,
+      "support": 83
+    },
+    "pension/retirement benefits||deogarh": {
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
+      "share": 0.1505,
+      "support": 14
+    },
+    "pension/retirement benefits||dhenkanal": {
+      "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
+      "share": 0.1982,
+      "support": 43
+    },
+    "pension/retirement benefits||gajapati": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.2857,
+      "support": 56
+    },
+    "pension/retirement benefits||ganjam": {
+      "dept": "School & Mass Education",
+      "share": 0.2059,
+      "support": 140
+    },
+    "pension/retirement benefits||jagatsinghapur": {
+      "dept": "School & Mass Education",
+      "share": 0.1889,
+      "support": 34
+    },
+    "pension/retirement benefits||jajpur": {
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
+      "share": 0.2597,
+      "support": 94
+    },
+    "pension/retirement benefits||jharsuguda": {
+      "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
+      "share": 0.1646,
+      "support": 13
+    },
+    "pension/retirement benefits||kalahandi": {
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
+      "share": 0.2876,
+      "support": 67
+    },
+    "pension/retirement benefits||kandhamal": {
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
+      "share": 0.2263,
+      "support": 31
+    },
+    "pension/retirement benefits||kendrapara": {
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
+      "share": 0.1905,
+      "support": 32
+    },
+    "pension/retirement benefits||kendujhar": {
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
+      "share": 0.2141,
+      "support": 94
+    },
+    "pension/retirement benefits||khordha": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.4249,
+      "support": 699
+    },
+    "pension/retirement benefits||koraput": {
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
+      "share": 0.203,
+      "support": 41
+    },
+    "pension/retirement benefits||malkangiri": {
+      "dept": "School & Mass Education",
+      "office": "Collector",
+      "share": 0.2951,
+      "support": 18
+    },
+    "pension/retirement benefits||mayurbhanj": {
+      "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
+      "share": 0.2371,
+      "support": 83
+    },
+    "pension/retirement benefits||nabarangpur": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.3438,
+      "support": 77
+    },
+    "pension/retirement benefits||nayagarh": {
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
+      "share": 0.2091,
+      "support": 55
+    },
+    "pension/retirement benefits||nuapada": {
+      "dept": "School & Mass Education",
+      "office": "Collector",
+      "share": 0.226,
+      "support": 33
+    },
+    "pension/retirement benefits||puri": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.1164,
+      "support": 27
+    },
+    "pension/retirement benefits||rayagada": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.3083,
+      "support": 41
+    },
+    "pension/retirement benefits||sambalpur": {
+      "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
+      "share": 0.1744,
+      "support": 60
+    },
+    "pension/retirement benefits||subarnapur": {
+      "dept": "School & Mass Education",
+      "share": 0.2078,
+      "support": 16
+    },
+    "pension/retirement benefits||sundargarh": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.1803,
+      "support": 44
+    },
+    "police case||angul": {
+      "dept": "Home department",
+      "office": "DG & IG Police",
+      "share": 0.9685,
+      "support": 892
+    },
+    "police case||balangir": {
+      "dept": "Home department",
+      "share": 0.938,
+      "support": 772
+    },
+    "police case||baleswar": {
+      "dept": "Home department",
+      "office": "DG & IG Police",
+      "share": 0.7524,
+      "support": 2151
+    },
+    "police case||bargarh": {
+      "dept": "Home department",
+      "share": 0.9725,
+      "support": 812
+    },
+    "police case||bhadrak": {
+      "dept": "Home department",
+      "office": "Superintendent of Police",
+      "share": 0.9917,
+      "support": 11388
+    },
+    "police case||boudh": {
+      "dept": "Home department",
+      "share": 0.9707,
+      "support": 364
+    },
+    "police case||cuttack": {
+      "dept": "Home department",
+      "share": 0.9866,
+      "support": 6396
+    },
+    "police case||deogarh": {
+      "dept": "Home department",
+      "share": 0.7299,
+      "support": 154
+    },
+    "police case||dhenkanal": {
+      "dept": "Home department",
+      "office": "DG & IG Police",
+      "share": 0.9569,
+      "support": 1533
+    },
+    "police case||gajapati": {
+      "dept": "Home department",
+      "share": 0.9626,
+      "support": 463
+    },
+    "police case||ganjam": {
+      "dept": "Home department",
+      "share": 0.9704,
+      "support": 4060
+    },
+    "police case||jagatsinghapur": {
+      "dept": "Home department",
+      "office": "DG & IG Police",
+      "share": 0.9813,
+      "support": 1835
+    },
+    "police case||jajpur": {
+      "dept": "Home department",
+      "share": 0.9405,
+      "support": 2198
+    },
+    "police case||jharsuguda": {
+      "dept": "Home department",
+      "share": 0.9799,
+      "support": 391
+    },
+    "police case||kalahandi": {
+      "dept": "Home department",
+      "share": 0.9569,
+      "support": 754
+    },
+    "police case||kandhamal": {
+      "dept": "Home department",
+      "office": "DG & IG Police",
+      "share": 0.9674,
+      "support": 415
+    },
+    "police case||kendrapara": {
+      "dept": "Home department",
+      "share": 0.989,
+      "support": 2868
+    },
+    "police case||kendujhar": {
+      "dept": "Home department",
+      "share": 0.9639,
+      "support": 1016
+    },
+    "police case||khordha": {
+      "dept": "Home department",
+      "office": "DG & IG Police",
+      "share": 0.9845,
+      "support": 8092
+    },
+    "police case||koraput": {
+      "dept": "Home department",
+      "share": 0.9665,
+      "support": 462
+    },
+    "police case||malkangiri": {
+      "dept": "Home department",
+      "share": 0.9504,
+      "support": 134
+    },
+    "police case||mayurbhanj": {
+      "dept": "Home department",
+      "share": 0.9245,
+      "support": 992
+    },
+    "police case||nabarangpur": {
+      "dept": "Home department",
+      "share": 0.9391,
+      "support": 293
+    },
+    "police case||nayagarh": {
+      "dept": "Home department",
+      "share": 0.8591,
+      "support": 1720
+    },
+    "police case||nuapada": {
+      "dept": "Home department",
+      "share": 0.8412,
+      "support": 249
+    },
+    "police case||puri": {
+      "dept": "Home department",
+      "office": "DG & IG Police",
+      "share": 0.9783,
+      "support": 3338
+    },
+    "police case||rayagada": {
+      "dept": "Home department",
+      "share": 0.9598,
+      "support": 406
+    },
+    "police case||sambalpur": {
+      "dept": "Home department",
+      "share": 0.9734,
+      "support": 1063
+    },
+    "police case||subarnapur": {
+      "dept": "Home department",
+      "office": "DG & IG Police",
+      "share": 0.9357,
+      "support": 233
+    },
+    "police case||sundargarh": {
+      "dept": "Home department",
+      "office": "DG & IG Police",
+      "share": 0.9788,
+      "support": 1107
+    },
+    "public utility||angul": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.5323,
+      "support": 288
+    },
+    "public utility||balangir": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
+      "share": 0.5225,
+      "support": 174
+    },
+    "public utility||baleswar": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
+      "share": 0.3747,
+      "support": 184
+    },
+    "public utility||bargarh": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.4531,
+      "support": 285
+    },
+    "public utility||bhadrak": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.4494,
+      "support": 160
+    },
+    "public utility||boudh": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.5235,
+      "support": 78
+    },
+    "public utility||cuttack": {
+      "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
+      "share": 0.297,
+      "support": 479
+    },
+    "public utility||deogarh": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.8895,
+      "support": 346
+    },
+    "public utility||dhenkanal": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
+      "share": 0.3718,
+      "support": 161
+    },
+    "public utility||gajapati": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.4987,
+      "support": 199
+    },
+    "public utility||ganjam": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.3653,
+      "support": 488
+    },
+    "public utility||jagatsinghapur": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.4663,
+      "support": 152
+    },
+    "public utility||jajpur": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.4118,
+      "support": 287
+    },
+    "public utility||jharsuguda": {
+      "dept": "Housing & Urban Development",
+      "office": "Office of Chief Minister",
+      "share": 0.3275,
+      "support": 56
+    },
+    "public utility||kalahandi": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.3746,
+      "support": 209
+    },
+    "public utility||kandhamal": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.5618,
+      "support": 250
+    },
+    "public utility||kendrapara": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
+      "share": 0.3758,
+      "support": 168
+    },
+    "public utility||kendujhar": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
+      "share": 0.4521,
+      "support": 165
+    },
+    "public utility||khordha": {
+      "dept": "Housing & Urban Development",
+      "office": "Office of Chief Minister",
+      "share": 0.5099,
+      "support": 591
+    },
+    "public utility||koraput": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.4557,
+      "support": 139
+    },
+    "public utility||malkangiri": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.6202,
+      "support": 129
+    },
+    "public utility||mayurbhanj": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.3073,
+      "support": 110
+    },
+    "public utility||nabarangpur": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.4711,
+      "support": 57
+    },
+    "public utility||nayagarh": {
+      "dept": "General Administration & Public Grievance",
+      "office": "Collector",
+      "share": 0.7168,
+      "support": 524
+    },
+    "public utility||nuapada": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.5554,
+      "support": 386
+    },
+    "public utility||puri": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
+      "share": 0.3292,
+      "support": 161
+    },
+    "public utility||rayagada": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.3899,
+      "support": 62
+    },
+    "public utility||sambalpur": {
+      "dept": "Housing & Urban Development",
+      "office": "Office of Chief Minister",
+      "share": 0.5043,
+      "support": 291
+    },
+    "public utility||subarnapur": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.486,
+      "support": 52
+    },
+    "public utility||sundargarh": {
+      "dept": "Housing & Urban Development",
+      "office": "Departments",
+      "share": 0.3619,
+      "support": 148
+    },
+    "school & college||angul": {
+      "dept": "School & Mass Education",
+      "share": 0.4474,
+      "support": 68
+    },
+    "school & college||balangir": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.498,
+      "support": 125
+    },
+    "school & college||baleswar": {
+      "dept": "School & Mass Education",
+      "share": 0.5095,
+      "support": 107
+    },
+    "school & college||bargarh": {
+      "dept": "School & Mass Education",
+      "office": "Collector",
+      "share": 0.5916,
+      "support": 184
+    },
+    "school & college||bhadrak": {
+      "dept": "School & Mass Education",
+      "share": 0.6019,
+      "support": 65
+    },
+    "school & college||boudh": {
+      "dept": "School & Mass Education",
+      "office": "Collector",
+      "share": 0.6535,
+      "support": 66
+    },
+    "school & college||cuttack": {
+      "dept": "School & Mass Education",
+      "share": 0.51,
+      "support": 153
+    },
+    "school & college||deogarh": {
+      "dept": "School & Mass Education",
+      "office": "Collector",
+      "share": 0.6812,
+      "support": 94
+    },
+    "school & college||dhenkanal": {
+      "dept": "School & Mass Education",
+      "share": 0.4527,
+      "support": 67
+    },
+    "school & college||gajapati": {
+      "dept": "School & Mass Education",
+      "office": "Collector",
+      "share": 0.4428,
+      "support": 120
+    },
+    "school & college||ganjam": {
+      "dept": "School & Mass Education",
+      "office": "Collector",
+      "share": 0.5024,
+      "support": 212
+    },
+    "school & college||jagatsinghapur": {
+      "dept": "School & Mass Education",
+      "office": "Collector",
+      "share": 0.7849,
+      "support": 197
+    },
+    "school & college||jajpur": {
+      "dept": "School & Mass Education",
+      "share": 0.5671,
+      "support": 93
+    },
+    "school & college||jharsuguda": {
+      "dept": "School & Mass Education",
+      "share": 0.5,
+      "support": 28
+    },
+    "school & college||kalahandi": {
+      "dept": "School & Mass Education",
+      "office": "Collector",
+      "share": 0.5878,
+      "support": 328
+    },
+    "school & college||kandhamal": {
+      "dept": "School & Mass Education",
+      "share": 0.4635,
+      "support": 89
+    },
+    "school & college||kendrapara": {
+      "dept": "School & Mass Education",
+      "share": 0.4945,
+      "support": 90
+    },
+    "school & college||kendujhar": {
+      "dept": "School & Mass Education",
+      "share": 0.5485,
+      "support": 147
+    },
+    "school & college||khordha": {
+      "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
+      "share": 0.5147,
+      "support": 140
+    },
+    "school & college||koraput": {
+      "dept": "School & Mass Education",
+      "share": 0.4649,
+      "support": 106
+    },
+    "school & college||malkangiri": {
+      "dept": "School & Mass Education",
+      "office": "Collector",
+      "share": 0.6687,
+      "support": 109
+    },
+    "school & college||mayurbhanj": {
+      "dept": "School & Mass Education",
+      "office": "Collector",
+      "share": 0.4557,
+      "support": 262
+    },
+    "school & college||nabarangpur": {
+      "dept": "School & Mass Education",
+      "office": "Collector",
+      "share": 0.4861,
+      "support": 122
+    },
+    "school & college||nayagarh": {
+      "dept": "General Administration & Public Grievance",
+      "office": "Collector",
+      "share": 0.491,
+      "support": 109
+    },
+    "school & college||nuapada": {
+      "dept": "School & Mass Education",
+      "office": "Collector",
+      "share": 0.5514,
+      "support": 102
+    },
+    "school & college||puri": {
+      "dept": "School & Mass Education",
+      "share": 0.5329,
+      "support": 81
+    },
+    "school & college||rayagada": {
+      "dept": "School & Mass Education",
+      "office": "Collector",
+      "share": 0.4872,
+      "support": 76
+    },
+    "school & college||sambalpur": {
+      "dept": "School & Mass Education",
+      "office": "Collector",
+      "share": 0.5234,
+      "support": 112
+    },
+    "school & college||subarnapur": {
+      "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
+      "share": 0.4035,
+      "support": 23
+    },
+    "school & college||sundargarh": {
+      "dept": "School & Mass Education",
+      "office": "Collector",
+      "share": 0.4813,
+      "support": 103
+    },
+    "service matters||angul": {
+      "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
+      "share": 0.1531,
+      "support": 185
+    },
+    "service matters||balangir": {
+      "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
+      "share": 0.3404,
+      "support": 452
+    },
+    "service matters||baleswar": {
+      "dept": "Higher Education",
+      "office": "Office of Chief Minister",
+      "share": 0.3513,
+      "support": 958
+    },
+    "service matters||bargarh": {
+      "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
+      "share": 0.2994,
+      "support": 430
+    },
+    "service matters||bhadrak": {
+      "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
+      "share": 0.3035,
+      "support": 407
+    },
+    "service matters||boudh": {
+      "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
+      "share": 0.3097,
+      "support": 144
+    },
+    "service matters||cuttack": {
+      "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
+      "share": 0.1783,
+      "support": 598
+    },
+    "service matters||deogarh": {
+      "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
+      "share": 0.2088,
+      "support": 81
+    },
+    "service matters||dhenkanal": {
+      "dept": "School & Mass Education",
+      "share": 0.1726,
+      "support": 217
+    },
+    "service matters||gajapati": {
+      "dept": "School & Mass Education",
+      "office": "Collector",
+      "share": 0.2886,
+      "support": 282
+    },
+    "service matters||ganjam": {
+      "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
+      "share": 0.3105,
+      "support": 1143
+    },
+    "service matters||jagatsinghapur": {
+      "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
+      "share": 0.1964,
+      "support": 227
+    },
+    "service matters||jajpur": {
+      "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
+      "share": 0.2786,
+      "support": 465
+    },
+    "service matters||jharsuguda": {
+      "dept": "Higher Education",
+      "office": "Office of Chief Minister",
+      "share": 0.3069,
+      "support": 178
+    },
+    "service matters||kalahandi": {
+      "dept": "School & Mass Education",
+      "office": "Collector",
+      "share": 0.3312,
+      "support": 672
+    },
+    "service matters||kandhamal": {
+      "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
+      "share": 0.2187,
+      "support": 152
+    },
+    "service matters||kendrapara": {
+      "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
+      "share": 0.2175,
+      "support": 300
+    },
+    "service matters||kendujhar": {
+      "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
+      "share": 0.2534,
+      "support": 668
+    },
+    "service matters||khordha": {
+      "dept": "General Administration & Public Grievance",
+      "share": 0.1585,
+      "support": 842
+    },
+    "service matters||koraput": {
+      "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
+      "share": 0.275,
+      "support": 322
+    },
+    "service matters||malkangiri": {
+      "dept": "School & Mass Education",
+      "office": "Collector",
+      "share": 0.3346,
+      "support": 175
+    },
+    "service matters||mayurbhanj": {
+      "dept": "General Administration & Public Grievance",
+      "office": "Collector",
+      "share": 0.2098,
+      "support": 432
+    },
+    "service matters||nabarangpur": {
+      "dept": "School & Mass Education",
+      "office": "Collector",
+      "share": 0.2505,
+      "support": 247
+    },
+    "service matters||nayagarh": {
+      "dept": "General Administration & Public Grievance",
+      "office": "Collector",
+      "share": 0.273,
+      "support": 350
+    },
+    "service matters||nuapada": {
+      "dept": "School & Mass Education",
+      "office": "Collector",
+      "share": 0.2209,
+      "support": 186
+    },
+    "service matters||puri": {
+      "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
+      "share": 0.2545,
+      "support": 528
+    },
+    "service matters||rayagada": {
+      "dept": "School & Mass Education",
+      "share": 0.2525,
+      "support": 248
+    },
+    "service matters||sambalpur": {
+      "dept": "Home department",
+      "office": "Office of Chief Minister",
+      "share": 0.177,
+      "support": 231
+    },
+    "service matters||subarnapur": {
+      "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
+      "share": 0.2158,
+      "support": 123
+    },
+    "service matters||sundargarh": {
+      "dept": "School & Mass Education",
+      "share": 0.1843,
+      "support": 263
+    },
+    "social welfare||angul": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.8171,
+      "support": 7947
+    },
+    "social welfare||balangir": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
+      "share": 0.4261,
+      "support": 2471
+    },
+    "social welfare||baleswar": {
+      "dept": "General Administration & Public Grievance",
+      "office": "Collector",
+      "share": 0.2944,
+      "support": 2314
+    },
+    "social welfare||bargarh": {
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
+      "share": 0.5732,
+      "support": 3307
+    },
+    "social welfare||bhadrak": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.7162,
+      "support": 9428
+    },
+    "social welfare||boudh": {
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "share": 0.3007,
+      "support": 646
+    },
+    "social welfare||cuttack": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.6648,
+      "support": 10464
+    },
+    "social welfare||deogarh": {
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
+      "share": 0.2774,
+      "support": 200
+    },
+    "social welfare||dhenkanal": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
+      "share": 0.4266,
+      "support": 2229
+    },
+    "social welfare||gajapati": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.8323,
+      "support": 3167
+    },
+    "social welfare||ganjam": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.7722,
+      "support": 30389
+    },
+    "social welfare||jagatsinghapur": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.8312,
+      "support": 11570
+    },
+    "social welfare||jajpur": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
+      "share": 0.4516,
+      "support": 2724
+    },
+    "social welfare||jharsuguda": {
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "share": 0.2117,
+      "support": 112
+    },
+    "social welfare||kalahandi": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.753,
+      "support": 11807
+    },
+    "social welfare||kandhamal": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.4242,
+      "support": 554
+    },
+    "social welfare||kendrapara": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
+      "share": 0.2935,
+      "support": 1183
+    },
+    "social welfare||kendujhar": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.8543,
+      "support": 15539
+    },
+    "social welfare||khordha": {
+      "dept": "Food Supplies & Consumer Welfare",
+      "office": "Office of Chief Minister",
+      "share": 0.256,
+      "support": 1140
+    },
+    "social welfare||koraput": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.4827,
+      "support": 1060
+    },
+    "social welfare||malkangiri": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.5718,
+      "support": 661
+    },
+    "social welfare||mayurbhanj": {
+      "dept": "General Administration & Public Grievance",
+      "office": "Collector",
+      "share": 0.2691,
+      "support": 881
+    },
+    "social welfare||nabarangpur": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.329,
+      "support": 404
+    },
+    "social welfare||nayagarh": {
+      "dept": "General Administration & Public Grievance",
+      "office": "Collector",
+      "share": 0.6204,
+      "support": 5051
+    },
+    "social welfare||nuapada": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.6123,
+      "support": 2541
+    },
+    "social welfare||puri": {
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "share": 0.2595,
+      "support": 837
+    },
+    "social welfare||rayagada": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.344,
+      "support": 258
+    },
+    "social welfare||sambalpur": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.8555,
+      "support": 10251
+    },
+    "social welfare||subarnapur": {
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
+      "share": 0.6151,
+      "support": 1638
+    },
+    "social welfare||sundargarh": {
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "share": 0.2481,
+      "support": 352
+    },
+    "sports||angul": {
+      "dept": "Sports & Youth Services",
+      "office": "Departments",
+      "share": 0.7143,
+      "support": 15
+    },
+    "sports||balangir": {
+      "dept": "Sports & Youth Services",
+      "office": "Collector",
+      "share": 0.5781,
+      "support": 37
+    },
+    "sports||baleswar": {
+      "dept": "Sports & Youth Services",
+      "share": 0.7333,
+      "support": 33
+    },
+    "sports||bargarh": {
+      "dept": "Sports & Youth Services",
+      "share": 0.7115,
+      "support": 37
+    },
+    "sports||bhadrak": {
+      "dept": "Sports & Youth Services",
+      "office": "Departments",
+      "share": 0.697,
+      "support": 23
+    },
+    "sports||boudh": {
+      "dept": "Sports & Youth Services",
+      "share": 0.6,
+      "support": 3
+    },
+    "sports||cuttack": {
+      "dept": "Sports & Youth Services",
+      "office": "Departments",
+      "share": 0.9,
+      "support": 36
+    },
+    "sports||deogarh": {
+      "dept": "Sports & Youth Services",
+      "office": "Collector",
+      "share": 0.6667,
+      "support": 4
+    },
+    "sports||dhenkanal": {
+      "dept": "Sports & Youth Services",
+      "share": 0.8857,
+      "support": 31
+    },
+    "sports||gajapati": {
+      "dept": "Sports & Youth Services",
+      "office": "Collector",
+      "share": 0.5385,
+      "support": 7
+    },
+    "sports||ganjam": {
+      "dept": "Sports & Youth Services",
+      "office": "Departments",
+      "share": 0.7391,
+      "support": 34
+    },
+    "sports||jagatsinghapur": {
+      "dept": "Sports & Youth Services",
+      "office": "Departments",
+      "share": 0.9062,
+      "support": 29
+    },
+    "sports||jajpur": {
+      "dept": "Sports & Youth Services",
+      "share": 0.6792,
+      "support": 36
+    },
+    "sports||jharsuguda": {
+      "dept": "Sports & Youth Services",
+      "office": "Departments",
+      "share": 0.8125,
+      "support": 13
+    },
+    "sports||kalahandi": {
+      "dept": "Sports & Youth Services",
+      "office": "Collector",
+      "share": 0.5349,
+      "support": 46
+    },
+    "sports||kandhamal": {
+      "dept": "Sports & Youth Services",
+      "share": 0.7647,
+      "support": 13
+    },
+    "sports||kendrapara": {
+      "dept": "Sports & Youth Services",
+      "office": "Departments",
+      "share": 0.7647,
+      "support": 26
+    },
+    "sports||kendujhar": {
+      "dept": "Sports & Youth Services",
+      "share": 0.6,
+      "support": 24
+    },
+    "sports||khordha": {
+      "dept": "Sports & Youth Services",
+      "office": "Departments",
+      "share": 0.8283,
+      "support": 82
+    },
+    "sports||koraput": {
+      "dept": "Sports & Youth Services",
+      "share": 0.5652,
+      "support": 13
+    },
+    "sports||malkangiri": {
+      "dept": "Sports & Youth Services",
+      "office": "Collector",
+      "share": 0.5,
+      "support": 12
+    },
+    "sports||mayurbhanj": {
+      "dept": "Sports & Youth Services",
+      "office": "Collector",
+      "share": 0.9346,
+      "support": 100
+    },
+    "sports||nabarangpur": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.4412,
+      "support": 15
+    },
+    "sports||nayagarh": {
+      "dept": "Sports & Youth Services",
+      "office": "Departments",
+      "share": 0.72,
+      "support": 18
+    },
+    "sports||nuapada": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.5732,
+      "support": 47
+    },
+    "sports||puri": {
+      "dept": "Sports & Youth Services",
+      "office": "Departments",
+      "share": 0.9318,
+      "support": 41
+    },
+    "sports||rayagada": {
+      "dept": "Sports & Youth Services",
+      "office": "Collector",
+      "share": 0.6774,
+      "support": 21
+    },
+    "sports||sambalpur": {
+      "dept": "Sports & Youth Services",
+      "share": 0.7273,
+      "support": 32
+    },
+    "sports||subarnapur": {
+      "dept": "Sports & Youth Services",
+      "office": "Departments",
+      "share": 0.6176,
+      "support": 21
+    },
+    "sports||sundargarh": {
+      "dept": "Sports & Youth Services",
+      "share": 0.6607,
+      "support": 37
+    },
+    "tourism||angul": {
+      "dept": "Tourism",
+      "office": "Collector",
+      "share": 0.6961,
+      "support": 71
+    },
+    "tourism||balangir": {
+      "dept": "Tourism",
+      "office": "Collector",
+      "share": 0.9052,
+      "support": 105
+    },
+    "tourism||baleswar": {
+      "dept": "Tourism",
+      "office": "Collector",
+      "share": 0.878,
+      "support": 36
+    },
+    "tourism||bargarh": {
+      "dept": "Tourism",
+      "share": 0.4286,
+      "support": 3
+    },
+    "tourism||bhadrak": {
+      "dept": "Tourism",
+      "office": "Collector",
+      "share": 0.7143,
+      "support": 5
+    },
+    "tourism||cuttack": {
+      "dept": "Tourism",
+      "share": 0.6875,
+      "support": 11
+    },
+    "tourism||deogarh": {
+      "dept": "Tourism",
+      "office": "Collector",
+      "share": 0.625,
+      "support": 5
+    },
+    "tourism||dhenkanal": {
+      "dept": "Tourism",
+      "office": "Collector",
+      "share": 0.9375,
+      "support": 15
+    },
+    "tourism||gajapati": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.8333,
+      "support": 45
+    },
+    "tourism||ganjam": {
+      "dept": "Tourism",
+      "share": 0.56,
+      "support": 14
+    },
+    "tourism||jagatsinghapur": {
+      "dept": "Tourism",
+      "share": 0.7273,
+      "support": 8
+    },
+    "tourism||jajpur": {
+      "dept": "Tourism",
+      "share": 0.5,
+      "support": 3
+    },
+    "tourism||jharsuguda": {
+      "dept": "Tourism",
+      "office": "Collector",
+      "share": 0.75,
+      "support": 3
+    },
+    "tourism||kalahandi": {
+      "dept": "Tourism",
+      "office": "Collector",
+      "share": 0.619,
+      "support": 13
+    },
+    "tourism||kandhamal": {
+      "dept": "Tourism",
+      "office": "Collector",
+      "share": 0.9459,
+      "support": 35
+    },
+    "tourism||kendrapara": {
+      "dept": "Tourism",
+      "share": 0.6154,
+      "support": 8
+    },
+    "tourism||kendujhar": {
+      "dept": "Tourism",
+      "office": "Collector",
+      "share": 0.6667,
+      "support": 22
+    },
+    "tourism||khordha": {
+      "dept": "Tourism",
+      "office": "Collector",
+      "share": 0.8214,
+      "support": 46
+    },
+    "tourism||koraput": {
+      "dept": "Tourism",
+      "share": 0.5385,
+      "support": 7
+    },
+    "tourism||mayurbhanj": {
+      "dept": "Tourism",
+      "office": "Collector",
+      "share": 0.9231,
+      "support": 12
+    },
+    "tourism||nabarangpur": {
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
+      "share": 0.8,
+      "support": 8
+    },
+    "tourism||nayagarh": {
+      "dept": "Tourism",
+      "office": "Collector",
+      "share": 0.4839,
+      "support": 15
+    },
+    "tourism||nuapada": {
+      "dept": "Tourism",
+      "office": "Collector",
+      "share": 0.8571,
+      "support": 6
+    },
+    "tourism||puri": {
+      "dept": "Tourism",
+      "share": 0.7368,
+      "support": 28
+    },
+    "tourism||sambalpur": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.3478,
+      "support": 8
+    },
+    "tourism||subarnapur": {
+      "dept": "Tourism",
+      "office": "Office of Chief Minister",
+      "share": 0.6,
+      "support": 3
+    },
+    "tourism||sundargarh": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.6667,
+      "support": 14
+    },
+    "traffic||angul": {
+      "dept": "Home department",
+      "office": "Departments",
+      "share": 0.5385,
+      "support": 7
+    },
+    "traffic||baleswar": {
+      "dept": "General Administration & Public Grievance",
+      "office": "Superintendent of Police",
+      "share": 0.5455,
+      "support": 6
+    },
+    "traffic||bargarh": {
+      "dept": "Home department",
+      "share": 0.7,
+      "support": 7
+    },
+    "traffic||bhadrak": {
+      "dept": "Home department",
+      "share": 0.6,
+      "support": 3
+    },
+    "traffic||cuttack": {
+      "dept": "Home department",
+      "office": "Departments",
+      "share": 0.6154,
+      "support": 24
+    },
+    "traffic||dhenkanal": {
+      "dept": "Home department",
+      "share": 0.75,
+      "support": 3
+    },
+    "traffic||ganjam": {
+      "dept": "Home department",
+      "office": "Superintendent of Police",
+      "share": 0.5882,
+      "support": 10
+    },
+    "traffic||jagatsinghapur": {
+      "dept": "Home department",
+      "share": 0.8333,
+      "support": 5
+    },
+    "traffic||jajpur": {
+      "dept": "Home department",
+      "office": "Departments",
+      "share": 0.625,
+      "support": 10
+    },
+    "traffic||jharsuguda": {
+      "dept": "Commerce & Transport",
+      "office": "Collector",
+      "share": 0.5,
+      "support": 4
+    },
+    "traffic||kalahandi": {
+      "dept": "Commerce & Transport",
+      "office": "Collector",
+      "share": 0.7,
+      "support": 7
+    },
+    "traffic||kendrapara": {
+      "dept": "Home department",
+      "office": "Departments",
+      "share": 0.6154,
+      "support": 8
+    },
+    "traffic||kendujhar": {
+      "dept": "Home department",
+      "share": 0.7143,
+      "support": 5
+    },
+    "traffic||khordha": {
+      "dept": "Home department",
+      "office": "Departments",
+      "share": 0.6885,
+      "support": 42
+    },
+    "traffic||koraput": {
+      "dept": "Home department",
+      "share": 0.4167,
+      "support": 5
+    },
+    "traffic||mayurbhanj": {
+      "dept": "Commerce & Transport",
+      "office": "Departments",
+      "share": 0.3,
+      "support": 3
+    },
+    "traffic||nayagarh": {
+      "dept": "Home department",
+      "office": "Departments",
+      "share": 0.5833,
+      "support": 7
+    },
+    "traffic||puri": {
+      "dept": "Home department",
+      "office": "Departments",
+      "share": 0.5556,
+      "support": 5
+    },
+    "traffic||sambalpur": {
+      "dept": "Home department",
+      "share": 0.5556,
+      "support": 5
+    },
+    "traffic||sundargarh": {
+      "dept": "Home department",
+      "share": 0.6667,
+      "support": 14
+    },
+    "transport||angul": {
+      "dept": "Commerce & Transport",
+      "share": 0.9362,
+      "support": 44
+    },
+    "transport||balangir": {
+      "dept": "Commerce & Transport",
+      "office": "Departments",
+      "share": 0.6786,
+      "support": 19
+    },
+    "transport||baleswar": {
+      "dept": "Commerce & Transport",
+      "office": "Departments",
+      "share": 0.6269,
+      "support": 42
+    },
+    "transport||bargarh": {
+      "dept": "Commerce & Transport",
+      "share": 0.8261,
+      "support": 38
+    },
+    "transport||bhadrak": {
+      "dept": "Commerce & Transport",
+      "share": 0.7692,
+      "support": 30
+    },
+    "transport||boudh": {
+      "dept": "Commerce & Transport",
+      "office": "Collector",
+      "share": 0.6875,
+      "support": 11
+    },
+    "transport||cuttack": {
+      "dept": "Commerce & Transport",
+      "office": "Departments",
+      "share": 0.8586,
+      "support": 85
+    },
+    "transport||deogarh": {
+      "dept": "Commerce & Transport",
+      "office": "Collector",
+      "share": 0.5455,
+      "support": 6
+    },
+    "transport||dhenkanal": {
+      "dept": "Commerce & Transport",
+      "share": 0.8636,
+      "support": 38
+    },
+    "transport||gajapati": {
+      "dept": "Commerce & Transport",
+      "office": "Collector",
+      "share": 0.6849,
+      "support": 50
+    },
+    "transport||ganjam": {
+      "dept": "Commerce & Transport",
+      "share": 0.8455,
+      "support": 93
+    },
+    "transport||jagatsinghapur": {
+      "dept": "Commerce & Transport",
+      "office": "Departments",
+      "share": 0.7667,
+      "support": 23
+    },
+    "transport||jajpur": {
+      "dept": "Commerce & Transport",
+      "office": "Departments",
+      "share": 0.8846,
+      "support": 46
+    },
+    "transport||jharsuguda": {
+      "dept": "Commerce & Transport",
+      "share": 0.878,
+      "support": 36
+    },
+    "transport||kalahandi": {
+      "dept": "Commerce & Transport",
+      "share": 0.7778,
+      "support": 49
+    },
+    "transport||kandhamal": {
+      "dept": "Commerce & Transport",
+      "share": 0.7288,
+      "support": 43
+    },
+    "transport||kendrapara": {
+      "dept": "Commerce & Transport",
+      "office": "Departments",
+      "share": 0.8831,
+      "support": 68
+    },
+    "transport||kendujhar": {
+      "dept": "Commerce & Transport",
+      "share": 0.7632,
+      "support": 58
+    },
+    "transport||khordha": {
+      "dept": "Commerce & Transport",
+      "office": "Departments",
+      "share": 0.7798,
+      "support": 170
+    },
+    "transport||koraput": {
+      "dept": "Commerce & Transport",
+      "share": 0.8333,
+      "support": 60
+    },
+    "transport||malkangiri": {
+      "dept": "Commerce & Transport",
+      "office": "Collector",
+      "share": 0.8235,
+      "support": 28
+    },
+    "transport||mayurbhanj": {
+      "dept": "Commerce & Transport",
+      "share": 0.8511,
+      "support": 40
+    },
+    "transport||nabarangpur": {
+      "dept": "Commerce & Transport",
+      "office": "Collector",
+      "share": 0.8125,
+      "support": 13
+    },
+    "transport||nayagarh": {
+      "dept": "Commerce & Transport",
+      "share": 0.7429,
+      "support": 26
+    },
+    "transport||nuapada": {
+      "dept": "Commerce & Transport",
+      "share": 0.8571,
+      "support": 30
+    },
+    "transport||puri": {
+      "dept": "Commerce & Transport",
+      "office": "Departments",
+      "share": 0.6296,
+      "support": 34
+    },
+    "transport||rayagada": {
+      "dept": "Commerce & Transport",
+      "share": 0.9333,
+      "support": 28
+    },
+    "transport||sambalpur": {
+      "dept": "Commerce & Transport",
+      "office": "Collector",
+      "share": 0.6947,
+      "support": 66
+    },
+    "transport||subarnapur": {
+      "dept": "Commerce & Transport",
+      "office": "Departments",
+      "share": 0.8462,
+      "support": 11
+    },
+    "transport||sundargarh": {
+      "dept": "Commerce & Transport",
+      "share": 0.7541,
+      "support": 46
+    },
+    "waste management||angul": {
+      "dept": "Housing & Urban Development",
+      "share": 0.8378,
+      "support": 31
+    },
+    "waste management||balangir": {
+      "dept": "Housing & Urban Development",
+      "share": 0.6296,
+      "support": 17
+    },
+    "waste management||baleswar": {
+      "dept": "Housing & Urban Development",
+      "share": 0.7667,
+      "support": 23
+    },
+    "waste management||bargarh": {
+      "dept": "Housing & Urban Development",
+      "share": 0.8043,
+      "support": 37
+    },
+    "waste management||bhadrak": {
+      "dept": "Housing & Urban Development",
+      "share": 0.5556,
+      "support": 5
+    },
+    "waste management||boudh": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.75,
+      "support": 3
+    },
+    "waste management||cuttack": {
+      "dept": "Housing & Urban Development",
+      "share": 0.9052,
+      "support": 191
+    },
+    "waste management||dhenkanal": {
+      "dept": "Housing & Urban Development",
+      "share": 0.8889,
+      "support": 16
+    },
+    "waste management||gajapati": {
+      "dept": "Housing & Urban Development",
+      "office": "Collector",
+      "share": 0.6364,
+      "support": 7
+    },
+    "waste management||ganjam": {
+      "dept": "Housing & Urban Development",
+      "share": 0.7391,
+      "support": 51
+    },
+    "waste management||jagatsinghapur": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.5,
+      "support": 5
+    },
+    "waste management||jajpur": {
+      "dept": "Housing & Urban Development",
+      "share": 0.6667,
+      "support": 12
+    },
+    "waste management||jharsuguda": {
+      "dept": "Housing & Urban Development",
+      "share": 0.9375,
+      "support": 15
+    },
+    "waste management||kalahandi": {
+      "dept": "Housing & Urban Development",
+      "share": 0.8571,
+      "support": 18
+    },
+    "waste management||kandhamal": {
+      "dept": "Housing & Urban Development",
+      "share": 0.5,
+      "support": 4
+    },
+    "waste management||kendrapara": {
+      "dept": "Housing & Urban Development",
+      "share": 0.5,
+      "support": 11
+    },
+    "waste management||kendujhar": {
+      "dept": "Housing & Urban Development",
+      "share": 0.9032,
+      "support": 28
+    },
+    "waste management||khordha": {
+      "dept": "Housing & Urban Development",
+      "share": 0.9609,
+      "support": 295
+    },
+    "waste management||koraput": {
+      "dept": "Housing & Urban Development",
+      "share": 0.5556,
+      "support": 15
+    },
+    "waste management||mayurbhanj": {
+      "dept": "Housing & Urban Development",
+      "share": 0.8182,
+      "support": 9
+    },
+    "waste management||nabarangpur": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.5385,
+      "support": 7
+    },
+    "waste management||nayagarh": {
+      "dept": "Housing & Urban Development",
+      "share": 0.8824,
+      "support": 15
+    },
+    "waste management||nuapada": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.6,
+      "support": 3
+    },
+    "waste management||puri": {
+      "dept": "Housing & Urban Development",
+      "share": 0.8391,
+      "support": 73
+    },
+    "waste management||rayagada": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.625,
+      "support": 5
+    },
+    "waste management||sambalpur": {
+      "dept": "Housing & Urban Development",
+      "share": 0.9474,
+      "support": 54
+    },
+    "waste management||subarnapur": {
+      "dept": "Housing & Urban Development",
+      "share": 0.8333,
+      "support": 5
+    },
+    "waste management||sundargarh": {
+      "dept": "Housing & Urban Development",
+      "office": "Departments",
+      "share": 0.8475,
+      "support": 50
+    },
+    "water supply||angul": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.868,
+      "support": 434
+    },
+    "water supply||balangir": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.8613,
+      "support": 627
+    },
+    "water supply||baleswar": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.685,
+      "support": 387
+    },
+    "water supply||bargarh": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.8347,
+      "support": 394
+    },
+    "water supply||bhadrak": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.9275,
+      "support": 256
+    },
+    "water supply||boudh": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.856,
+      "support": 434
+    },
+    "water supply||cuttack": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.7249,
+      "support": 506
+    },
+    "water supply||deogarh": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.8315,
+      "support": 227
+    },
+    "water supply||dhenkanal": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.8561,
+      "support": 482
+    },
+    "water supply||gajapati": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
+      "share": 0.7575,
+      "support": 653
+    },
+    "water supply||ganjam": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.7603,
+      "support": 571
+    },
+    "water supply||jagatsinghapur": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.8929,
+      "support": 450
+    },
+    "water supply||jajpur": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.9237,
+      "support": 702
+    },
+    "water supply||jharsuguda": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.5632,
+      "support": 98
+    },
+    "water supply||kalahandi": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.8444,
+      "support": 635
+    },
+    "water supply||kandhamal": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.9319,
+      "support": 1231
+    },
+    "water supply||kendrapara": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.947,
+      "support": 679
+    },
+    "water supply||kendujhar": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.9133,
+      "support": 780
+    },
+    "water supply||khordha": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.6073,
+      "support": 348
+    },
+    "water supply||koraput": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.9296,
+      "support": 726
+    },
+    "water supply||malkangiri": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.9542,
+      "support": 292
+    },
+    "water supply||mayurbhanj": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.7736,
+      "support": 581
+    },
+    "water supply||nabarangpur": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.8292,
+      "support": 403
+    },
+    "water supply||nayagarh": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.7949,
+      "support": 566
+    },
+    "water supply||nuapada": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.8479,
+      "support": 552
+    },
+    "water supply||puri": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.7083,
+      "support": 561
+    },
+    "water supply||rayagada": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.877,
+      "support": 321
+    },
+    "water supply||sambalpur": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.5524,
+      "support": 390
+    },
+    "water supply||subarnapur": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.9247,
+      "support": 270
+    },
+    "water supply||sundargarh": {
+      "dept": "Panchayati Raj & Drinking Water",
+      "share": 0.7828,
+      "support": 537
+    },
+    "women issues||angul": {
+      "dept": "Home department",
+      "office": "Office of Chief Minister",
+      "share": 0.7895,
+      "support": 15
+    },
+    "women issues||balangir": {
+      "dept": "Home department",
+      "share": 0.6667,
+      "support": 4
+    },
+    "women issues||baleswar": {
+      "dept": "Home department",
+      "share": 0.5217,
+      "support": 24
+    },
+    "women issues||bargarh": {
+      "dept": "Home department",
+      "office": "Office of Chief Minister",
+      "share": 1.0,
+      "support": 7
+    },
+    "women issues||bhadrak": {
+      "dept": "Home department",
+      "office": "Departments",
+      "share": 0.7568,
+      "support": 28
+    },
+    "women issues||cuttack": {
+      "dept": "Home department",
+      "office": "Office of Chief Minister",
+      "share": 0.75,
+      "support": 33
+    },
+    "women issues||dhenkanal": {
+      "dept": "Home department",
+      "share": 0.75,
+      "support": 12
+    },
+    "women issues||gajapati": {
+      "dept": "Home department",
+      "share": 0.4286,
+      "support": 3
+    },
+    "women issues||ganjam": {
+      "dept": "Home department",
+      "office": "Superintendent of Police",
+      "share": 0.7714,
+      "support": 54
+    },
+    "women issues||jagatsinghapur": {
+      "dept": "Home department",
+      "share": 0.9,
+      "support": 9
+    },
+    "women issues||jajpur": {
+      "dept": "Home department",
+      "office": "Collector",
+      "share": 0.7241,
+      "support": 42
+    },
+    "women issues||jharsuguda": {
+      "dept": "Home department",
+      "office": "Departments",
+      "share": 0.5,
+      "support": 3
+    },
+    "women issues||kalahandi": {
+      "dept": "Home department",
+      "office": "Collector",
+      "share": 0.5455,
+      "support": 6
+    },
+    "women issues||kandhamal": {
+      "dept": "Home department",
+      "share": 0.7778,
+      "support": 7
+    },
+    "women issues||kendrapara": {
+      "dept": "Home department",
+      "share": 0.875,
+      "support": 14
+    },
+    "women issues||kendujhar": {
+      "dept": "Home department",
+      "office": "Superintendent of Police",
+      "share": 0.7222,
+      "support": 26
+    },
+    "women issues||khordha": {
+      "dept": "Home department",
+      "office": "Office of Chief Minister",
+      "share": 0.725,
+      "support": 58
+    },
+    "women issues||koraput": {
+      "dept": "Home department",
+      "share": 0.5,
+      "support": 6
+    },
+    "women issues||mayurbhanj": {
+      "dept": "Home department",
+      "share": 0.6875,
+      "support": 11
+    },
+    "women issues||nabarangpur": {
+      "dept": "Home department",
+      "office": "Superintendent of Police",
+      "share": 0.5455,
+      "support": 6
+    },
+    "women issues||nayagarh": {
+      "dept": "Home department",
+      "share": 0.4839,
+      "support": 15
+    },
+    "women issues||nuapada": {
+      "dept": "Women & Child Development",
+      "office": "Office of Chief Minister",
+      "share": 0.4545,
+      "support": 5
+    },
+    "women issues||puri": {
+      "dept": "Home department",
+      "share": 0.6552,
+      "support": 19
+    },
+    "women issues||rayagada": {
+      "dept": "Home department",
+      "share": 0.6667,
+      "support": 4
+    },
+    "women issues||sambalpur": {
+      "dept": "Home department",
+      "office": "Office of Chief Minister",
+      "share": 0.7143,
+      "support": 5
+    },
+    "women issues||sundargarh": {
+      "dept": "Home department",
+      "share": 0.8571,
+      "support": 12
+    }
+  },
   "by_full": {
     "accident|fire accident|baleswar": {
       "dept": "Revenue & Disaster Management",
@@ -195,6 +5655,7 @@
     },
     "accident|fire accident|ganjam": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.5455,
       "support": 6
     },
@@ -210,16 +5671,19 @@
     },
     "accident|fire accident|khordha": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.75,
       "support": 3
     },
     "accident|fire accident|mayurbhanj": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.875,
       "support": 7
     },
     "accident|fire accident|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.7857,
       "support": 11
     },
@@ -230,26 +5694,31 @@
     },
     "accident|others|bargarh": {
       "dept": "Commerce & Transport",
+      "office": "Collector",
       "share": 0.375,
       "support": 3
     },
     "accident|others|ganjam": {
-      "dept": "Revenue & Disaster Management",
+      "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.3571,
       "support": 5
     },
     "accident|others|kendujhar": {
       "dept": "Home department",
+      "office": "Superintendent of Police",
       "share": 0.625,
       "support": 5
     },
     "accident|snake bite|ganjam": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8333,
       "support": 5
     },
     "agriculture & farming|agriculture/farming|angul": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.8163,
       "support": 40
     },
@@ -260,41 +5729,49 @@
     },
     "agriculture & farming|agriculture/farming|baleswar": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.8366,
       "support": 128
     },
     "agriculture & farming|agriculture/farming|bargarh": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.8118,
       "support": 138
     },
     "agriculture & farming|agriculture/farming|bhadrak": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.835,
       "support": 172
     },
     "agriculture & farming|agriculture/farming|boudh": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.8393,
       "support": 47
     },
     "agriculture & farming|agriculture/farming|cuttack": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Departments",
       "share": 0.8421,
       "support": 64
     },
     "agriculture & farming|agriculture/farming|deogarh": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.7895,
       "support": 15
     },
     "agriculture & farming|agriculture/farming|dhenkanal": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.8068,
       "support": 71
     },
     "agriculture & farming|agriculture/farming|gajapati": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.6667,
       "support": 14
     },
@@ -305,21 +5782,25 @@
     },
     "agriculture & farming|agriculture/farming|jagatsinghapur": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Departments",
       "share": 0.6792,
       "support": 36
     },
     "agriculture & farming|agriculture/farming|jajpur": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.7885,
       "support": 41
     },
     "agriculture & farming|agriculture/farming|jharsuguda": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.6522,
       "support": 15
     },
     "agriculture & farming|agriculture/farming|kalahandi": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.8776,
       "support": 129
     },
@@ -330,6 +5811,7 @@
     },
     "agriculture & farming|agriculture/farming|kendrapara": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.9341,
       "support": 156
     },
@@ -340,16 +5822,19 @@
     },
     "agriculture & farming|agriculture/farming|khordha": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Departments",
       "share": 0.4483,
       "support": 39
     },
     "agriculture & farming|agriculture/farming|koraput": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.6562,
       "support": 21
     },
     "agriculture & farming|agriculture/farming|malkangiri": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 1.0,
       "support": 35
     },
@@ -360,6 +5845,7 @@
     },
     "agriculture & farming|agriculture/farming|nabarangpur": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Departments",
       "share": 0.7143,
       "support": 15
     },
@@ -370,6 +5856,7 @@
     },
     "agriculture & farming|agriculture/farming|nuapada": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.7079,
       "support": 63
     },
@@ -380,56 +5867,67 @@
     },
     "agriculture & farming|agriculture/farming|rayagada": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.8182,
       "support": 27
     },
     "agriculture & farming|agriculture/farming|sambalpur": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.9104,
       "support": 61
     },
     "agriculture & farming|agriculture/farming|subarnapur": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Departments",
       "share": 0.8148,
       "support": 22
     },
     "agriculture & farming|agriculture/farming|sundargarh": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.6222,
       "support": 28
     },
     "agriculture & farming|animal husbandry|angul": {
       "dept": "Fisheries & Animal Resources Development",
+      "office": "Office of Chief Minister",
       "share": 0.4333,
       "support": 13
     },
     "agriculture & farming|animal husbandry|balangir": {
       "dept": "Fisheries & Animal Resources Development",
+      "office": "Office of Chief Minister",
       "share": 0.75,
       "support": 6
     },
     "agriculture & farming|animal husbandry|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.3636,
       "support": 8
     },
     "agriculture & farming|animal husbandry|bargarh": {
       "dept": "Fisheries & Animal Resources Development",
+      "office": "Office of Chief Minister",
       "share": 0.7727,
       "support": 17
     },
     "agriculture & farming|animal husbandry|bhadrak": {
       "dept": "Fisheries & Animal Resources Development",
+      "office": "Office of Chief Minister",
       "share": 0.7778,
       "support": 7
     },
     "agriculture & farming|animal husbandry|boudh": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.4167,
       "support": 10
     },
     "agriculture & farming|animal husbandry|cuttack": {
       "dept": "Fisheries & Animal Resources Development",
+      "office": "Office of Chief Minister",
       "share": 0.875,
       "support": 21
     },
@@ -440,11 +5938,13 @@
     },
     "agriculture & farming|animal husbandry|dhenkanal": {
       "dept": "Fisheries & Animal Resources Development",
+      "office": "Office of Chief Minister",
       "share": 0.5,
       "support": 13
     },
     "agriculture & farming|animal husbandry|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5455,
       "support": 6
     },
@@ -455,41 +5955,49 @@
     },
     "agriculture & farming|animal husbandry|jagatsinghapur": {
       "dept": "Fisheries & Animal Resources Development",
+      "office": "Office of Chief Minister",
       "share": 0.625,
       "support": 10
     },
     "agriculture & farming|animal husbandry|jajpur": {
       "dept": "Fisheries & Animal Resources Development",
+      "office": "Office of Chief Minister",
       "share": 0.6154,
       "support": 8
     },
     "agriculture & farming|animal husbandry|jharsuguda": {
       "dept": "Fisheries & Animal Resources Development",
+      "office": "Chief Secretary",
       "share": 0.5,
       "support": 5
     },
     "agriculture & farming|animal husbandry|kalahandi": {
       "dept": "Fisheries & Animal Resources Development",
+      "office": "Collector",
       "share": 0.6,
       "support": 12
     },
     "agriculture & farming|animal husbandry|kandhamal": {
       "dept": "Fisheries & Animal Resources Development",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 6
     },
     "agriculture & farming|animal husbandry|kendrapara": {
       "dept": "Fisheries & Animal Resources Development",
+      "office": "Office of Chief Minister",
       "share": 0.5714,
       "support": 4
     },
     "agriculture & farming|animal husbandry|kendujhar": {
       "dept": "Fisheries & Animal Resources Development",
+      "office": "Office of Chief Minister",
       "share": 0.7143,
       "support": 5
     },
     "agriculture & farming|animal husbandry|khordha": {
       "dept": "Fisheries & Animal Resources Development",
+      "office": "Office of Chief Minister",
       "share": 0.8929,
       "support": 25
     },
@@ -505,21 +6013,25 @@
     },
     "agriculture & farming|animal husbandry|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.5,
       "support": 6
     },
     "agriculture & farming|animal husbandry|nuapada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5333,
       "support": 16
     },
     "agriculture & farming|animal husbandry|puri": {
-      "dept": "Panchayati Raj & Drinking Water",
+      "dept": "Fisheries & Animal Resources Development",
+      "office": "Office of Chief Minister",
       "share": 0.4,
       "support": 4
     },
     "agriculture & farming|animal husbandry|sambalpur": {
       "dept": "Fisheries & Animal Resources Development",
+      "office": "Office of Chief Minister",
       "share": 0.5714,
       "support": 4
     },
@@ -535,11 +6047,13 @@
     },
     "agriculture & farming|crop damage/agricultural damage|baleswar": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Office of Chief Minister",
       "share": 0.8,
       "support": 8
     },
     "agriculture & farming|crop damage/agricultural damage|bargarh": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.6444,
       "support": 29
     },
@@ -555,11 +6069,13 @@
     },
     "agriculture & farming|crop damage/agricultural damage|cuttack": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Office of Chief Minister",
       "share": 0.6552,
       "support": 19
     },
     "agriculture & farming|crop damage/agricultural damage|deogarh": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.6667,
       "support": 10
     },
@@ -570,11 +6086,13 @@
     },
     "agriculture & farming|crop damage/agricultural damage|gajapati": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.55,
       "support": 11
     },
     "agriculture & farming|crop damage/agricultural damage|ganjam": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.927,
       "support": 127
     },
@@ -585,11 +6103,13 @@
     },
     "agriculture & farming|crop damage/agricultural damage|jajpur": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Office of Chief Minister",
       "share": 0.6923,
       "support": 18
     },
     "agriculture & farming|crop damage/agricultural damage|jharsuguda": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.8235,
       "support": 14
     },
@@ -600,6 +6120,7 @@
     },
     "agriculture & farming|crop damage/agricultural damage|kendrapara": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Office of Chief Minister",
       "share": 0.5294,
       "support": 9
     },
@@ -610,6 +6131,7 @@
     },
     "agriculture & farming|crop damage/agricultural damage|khordha": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Office of Chief Minister",
       "share": 0.6,
       "support": 6
     },
@@ -620,21 +6142,25 @@
     },
     "agriculture & farming|crop damage/agricultural damage|nabarangpur": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.5,
       "support": 8
     },
     "agriculture & farming|crop damage/agricultural damage|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.4211,
       "support": 8
     },
     "agriculture & farming|crop damage/agricultural damage|nuapada": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.75,
       "support": 9
     },
     "agriculture & farming|crop damage/agricultural damage|puri": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Office of Chief Minister",
       "share": 0.7222,
       "support": 13
     },
@@ -650,6 +6176,7 @@
     },
     "agriculture & farming|crop damage/agricultural damage|sundargarh": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.697,
       "support": 23
     },
@@ -660,21 +6187,25 @@
     },
     "agriculture & farming|farmers' issues|balangir": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Office of Chief Minister",
       "share": 0.9091,
       "support": 20
     },
     "agriculture & farming|farmers' issues|baleswar": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.321,
       "support": 26
     },
     "agriculture & farming|farmers' issues|bargarh": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.5556,
       "support": 50
     },
     "agriculture & farming|farmers' issues|bhadrak": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Office of Chief Minister",
       "share": 0.4667,
       "support": 14
     },
@@ -685,36 +6216,43 @@
     },
     "agriculture & farming|farmers' issues|cuttack": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Office of Chief Minister",
       "share": 0.725,
       "support": 29
     },
     "agriculture & farming|farmers' issues|deogarh": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.9,
       "support": 18
     },
     "agriculture & farming|farmers' issues|dhenkanal": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.6429,
       "support": 18
     },
     "agriculture & farming|farmers' issues|gajapati": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.5556,
       "support": 10
     },
     "agriculture & farming|farmers' issues|ganjam": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Office of Chief Minister",
       "share": 0.7949,
       "support": 62
     },
     "agriculture & farming|farmers' issues|jagatsinghapur": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Office of Chief Minister",
       "share": 0.7,
       "support": 14
     },
     "agriculture & farming|farmers' issues|jajpur": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Office of Chief Minister",
       "share": 0.8571,
       "support": 24
     },
@@ -725,31 +6263,37 @@
     },
     "agriculture & farming|farmers' issues|kalahandi": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.7121,
       "support": 47
     },
     "agriculture & farming|farmers' issues|kandhamal": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Office of Chief Minister",
       "share": 0.875,
       "support": 7
     },
     "agriculture & farming|farmers' issues|kendrapara": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Office of Chief Minister",
       "share": 0.75,
       "support": 12
     },
     "agriculture & farming|farmers' issues|kendujhar": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Office of Chief Minister",
       "share": 0.8235,
       "support": 14
     },
     "agriculture & farming|farmers' issues|khordha": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Office of Chief Minister",
       "share": 0.6667,
       "support": 18
     },
     "agriculture & farming|farmers' issues|koraput": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.9091,
       "support": 10
     },
@@ -765,6 +6309,7 @@
     },
     "agriculture & farming|farmers' issues|nabarangpur": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.6,
       "support": 3
     },
@@ -775,16 +6320,19 @@
     },
     "agriculture & farming|farmers' issues|nuapada": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.6364,
       "support": 7
     },
     "agriculture & farming|farmers' issues|puri": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Office of Chief Minister",
       "share": 0.5882,
       "support": 10
     },
     "agriculture & farming|farmers' issues|rayagada": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Office of Chief Minister",
       "share": 0.2857,
       "support": 4
     },
@@ -800,26 +6348,31 @@
     },
     "agriculture & farming|farmers' issues|sundargarh": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.7826,
       "support": 18
     },
     "agriculture & farming|financial assistance|angul": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.7879,
       "support": 26
     },
     "agriculture & farming|financial assistance|balangir": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.8571,
       "support": 42
     },
     "agriculture & farming|financial assistance|baleswar": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Office of Chief Minister",
       "share": 0.75,
       "support": 24
     },
     "agriculture & farming|financial assistance|bargarh": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.9012,
       "support": 73
     },
@@ -830,16 +6383,19 @@
     },
     "agriculture & farming|financial assistance|boudh": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 1.0,
       "support": 27
     },
     "agriculture & farming|financial assistance|cuttack": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Office of Chief Minister",
       "share": 0.7838,
       "support": 29
     },
     "agriculture & farming|financial assistance|deogarh": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.6364,
       "support": 7
     },
@@ -850,41 +6406,49 @@
     },
     "agriculture & farming|financial assistance|gajapati": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.7778,
       "support": 7
     },
     "agriculture & farming|financial assistance|ganjam": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.7317,
       "support": 30
     },
     "agriculture & farming|financial assistance|jagatsinghapur": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.7632,
       "support": 29
     },
     "agriculture & farming|financial assistance|jajpur": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.913,
       "support": 42
     },
     "agriculture & farming|financial assistance|jharsuguda": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 1.0,
       "support": 4
     },
     "agriculture & farming|financial assistance|kalahandi": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.8367,
       "support": 41
     },
     "agriculture & farming|financial assistance|kandhamal": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.7778,
       "support": 7
     },
     "agriculture & farming|financial assistance|kendrapara": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.9817,
       "support": 107
     },
@@ -895,11 +6459,13 @@
     },
     "agriculture & farming|financial assistance|khordha": {
       "dept": "Co-operation",
+      "office": "Office of Chief Minister",
       "share": 0.4909,
       "support": 27
     },
     "agriculture & farming|financial assistance|koraput": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.9375,
       "support": 15
     },
@@ -915,56 +6481,67 @@
     },
     "agriculture & farming|financial assistance|nabarangpur": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.7,
       "support": 7
     },
     "agriculture & farming|financial assistance|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.4348,
       "support": 10
     },
     "agriculture & farming|financial assistance|nuapada": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.8333,
       "support": 10
     },
     "agriculture & farming|financial assistance|puri": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.6765,
       "support": 23
     },
     "agriculture & farming|financial assistance|rayagada": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.8571,
       "support": 6
     },
     "agriculture & farming|financial assistance|sambalpur": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.8788,
       "support": 29
     },
     "agriculture & farming|financial assistance|subarnapur": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Office of Chief Minister",
       "share": 0.75,
       "support": 6
     },
     "agriculture & farming|financial assistance|sundargarh": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.7568,
       "support": 28
     },
     "agriculture & farming|fishermen's issues|baleswar": {
       "dept": "Fisheries & Animal Resources Development",
+      "office": "Office of Chief Minister",
       "share": 0.8,
       "support": 8
     },
     "agriculture & farming|fishermen's issues|bhadrak": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.75,
       "support": 3
     },
     "agriculture & farming|fishermen's issues|ganjam": {
       "dept": "Fisheries & Animal Resources Development",
+      "office": "Office of Chief Minister",
       "share": 0.6154,
       "support": 8
     },
@@ -985,16 +6562,19 @@
     },
     "agriculture & farming|irrigation problem|balangir": {
       "dept": "Water Resources",
+      "office": "Office of Chief Minister",
       "share": 0.4412,
       "support": 15
     },
     "agriculture & farming|irrigation problem|baleswar": {
       "dept": "Water Resources",
+      "office": "Office of Chief Minister",
       "share": 0.7692,
       "support": 20
     },
     "agriculture & farming|irrigation problem|bargarh": {
       "dept": "Water Resources",
+      "office": "Office of Chief Minister",
       "share": 0.5778,
       "support": 26
     },
@@ -1010,21 +6590,25 @@
     },
     "agriculture & farming|irrigation problem|cuttack": {
       "dept": "Water Resources",
+      "office": "Office of Chief Minister",
       "share": 0.7273,
       "support": 16
     },
     "agriculture & farming|irrigation problem|deogarh": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.5714,
       "support": 8
     },
     "agriculture & farming|irrigation problem|dhenkanal": {
       "dept": "Water Resources",
+      "office": "Office of Chief Minister",
       "share": 0.7857,
       "support": 11
     },
     "agriculture & farming|irrigation problem|gajapati": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.5814,
       "support": 25
     },
@@ -1040,16 +6624,19 @@
     },
     "agriculture & farming|irrigation problem|jajpur": {
       "dept": "Water Resources",
+      "office": "Office of Chief Minister",
       "share": 0.7619,
       "support": 16
     },
     "agriculture & farming|irrigation problem|jharsuguda": {
       "dept": "Water Resources",
+      "office": "Office of Chief Minister",
       "share": 0.5,
       "support": 4
     },
     "agriculture & farming|irrigation problem|kalahandi": {
       "dept": "Water Resources",
+      "office": "Office of Chief Minister",
       "share": 0.9273,
       "support": 51
     },
@@ -1065,11 +6652,13 @@
     },
     "agriculture & farming|irrigation problem|kendujhar": {
       "dept": "Water Resources",
+      "office": "Office of Chief Minister",
       "share": 0.9375,
       "support": 15
     },
     "agriculture & farming|irrigation problem|khordha": {
       "dept": "Water Resources",
+      "office": "Office of Chief Minister",
       "share": 0.8333,
       "support": 15
     },
@@ -1115,11 +6704,13 @@
     },
     "agriculture & farming|irrigation problem|sambalpur": {
       "dept": "Water Resources",
+      "office": "Office of Chief Minister",
       "share": 0.75,
       "support": 15
     },
     "agriculture & farming|irrigation problem|subarnapur": {
       "dept": "Water Resources",
+      "office": "Office of Chief Minister",
       "share": 0.6,
       "support": 6
     },
@@ -1130,46 +6721,55 @@
     },
     "agriculture & farming|natural calamities/ relief|dhenkanal": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 1.0,
       "support": 3
     },
     "agriculture & farming|natural calamities/ relief|jajpur": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.9545,
       "support": 21
     },
     "agriculture & farming|natural calamities|jajpur": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 1.0,
       "support": 3
     },
     "agriculture & farming|natural calamities|sambalpur": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 1.0,
       "support": 6
     },
     "agriculture & farming|pacs/lampcs/fscs|angul": {
       "dept": "Co-operation",
+      "office": "Collector",
       "share": 0.8571,
       "support": 6
     },
     "agriculture & farming|pacs/lampcs/fscs|balangir": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.5,
       "support": 8
     },
     "agriculture & farming|pacs/lampcs/fscs|baleswar": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.4375,
       "support": 7
     },
     "agriculture & farming|pacs/lampcs/fscs|bargarh": {
       "dept": "Co-operation",
+      "office": "Collector",
       "share": 0.5556,
       "support": 30
     },
     "agriculture & farming|pacs/lampcs/fscs|bhadrak": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.8333,
       "support": 5
     },
@@ -1180,6 +6780,7 @@
     },
     "agriculture & farming|pacs/lampcs/fscs|cuttack": {
       "dept": "Co-operation",
+      "office": "Office of Chief Minister",
       "share": 0.6286,
       "support": 22
     },
@@ -1190,26 +6791,31 @@
     },
     "agriculture & farming|pacs/lampcs/fscs|dhenkanal": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.5,
       "support": 10
     },
     "agriculture & farming|pacs/lampcs/fscs|gajapati": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.4167,
       "support": 5
     },
     "agriculture & farming|pacs/lampcs/fscs|ganjam": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.5763,
       "support": 34
     },
     "agriculture & farming|pacs/lampcs/fscs|jagatsinghapur": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.6667,
       "support": 14
     },
     "agriculture & farming|pacs/lampcs/fscs|jajpur": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.6364,
       "support": 7
     },
@@ -1220,41 +6826,49 @@
     },
     "agriculture & farming|pacs/lampcs/fscs|kalahandi": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.4828,
       "support": 28
     },
     "agriculture & farming|pacs/lampcs/fscs|kendrapara": {
       "dept": "Co-operation",
+      "office": "Office of Chief Minister",
       "share": 0.8333,
       "support": 5
     },
     "agriculture & farming|pacs/lampcs/fscs|kendujhar": {
       "dept": "Co-operation",
+      "office": "Office of Chief Minister",
       "share": 0.44,
       "support": 11
     },
     "agriculture & farming|pacs/lampcs/fscs|khordha": {
       "dept": "Co-operation",
+      "office": "Office of Chief Minister",
       "share": 0.6087,
       "support": 14
     },
     "agriculture & farming|pacs/lampcs/fscs|koraput": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.5,
       "support": 3
     },
     "agriculture & farming|pacs/lampcs/fscs|mayurbhanj": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.4375,
       "support": 7
     },
     "agriculture & farming|pacs/lampcs/fscs|nabarangpur": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.5556,
       "support": 5
     },
     "agriculture & farming|pacs/lampcs/fscs|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.4783,
       "support": 11
     },
@@ -1265,6 +6879,7 @@
     },
     "agriculture & farming|pacs/lampcs/fscs|rayagada": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.7778,
       "support": 14
     },
@@ -1280,16 +6895,19 @@
     },
     "agriculture & farming|sale purchase issue|angul": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Departments",
       "share": 0.8,
       "support": 8
     },
     "agriculture & farming|sale purchase issue|balangir": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Departments",
       "share": 0.7059,
       "support": 12
     },
     "agriculture & farming|sale purchase issue|baleswar": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Departments",
       "share": 0.6098,
       "support": 25
     },
@@ -1305,11 +6923,13 @@
     },
     "agriculture & farming|sale purchase issue|boudh": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Departments",
       "share": 0.8333,
       "support": 10
     },
     "agriculture & farming|sale purchase issue|cuttack": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Departments",
       "share": 0.8205,
       "support": 32
     },
@@ -1320,11 +6940,13 @@
     },
     "agriculture & farming|sale purchase issue|dhenkanal": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Departments",
       "share": 0.625,
       "support": 15
     },
     "agriculture & farming|sale purchase issue|gajapati": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.8889,
       "support": 40
     },
@@ -1335,11 +6957,13 @@
     },
     "agriculture & farming|sale purchase issue|jagatsinghapur": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Departments",
       "share": 0.8438,
       "support": 27
     },
     "agriculture & farming|sale purchase issue|jajpur": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Departments",
       "share": 0.7551,
       "support": 37
     },
@@ -1350,11 +6974,13 @@
     },
     "agriculture & farming|sale purchase issue|kalahandi": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.4353,
       "support": 37
     },
     "agriculture & farming|sale purchase issue|kendrapara": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Departments",
       "share": 0.7143,
       "support": 15
     },
@@ -1365,21 +6991,25 @@
     },
     "agriculture & farming|sale purchase issue|khordha": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.76,
       "support": 19
     },
     "agriculture & farming|sale purchase issue|koraput": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Departments",
       "share": 0.7895,
       "support": 15
     },
     "agriculture & farming|sale purchase issue|malkangiri": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.4615,
       "support": 6
     },
     "agriculture & farming|sale purchase issue|mayurbhanj": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.7059,
       "support": 24
     },
@@ -1390,21 +7020,25 @@
     },
     "agriculture & farming|sale purchase issue|nayagarh": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Departments",
       "share": 0.3611,
       "support": 13
     },
     "agriculture & farming|sale purchase issue|nuapada": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.6579,
       "support": 25
     },
     "agriculture & farming|sale purchase issue|puri": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Departments",
       "share": 0.4762,
       "support": 10
     },
     "agriculture & farming|sale purchase issue|rayagada": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Departments",
       "share": 0.8684,
       "support": 33
     },
@@ -1415,21 +7049,25 @@
     },
     "agriculture & farming|sale purchase issue|subarnapur": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Departments",
       "share": 0.75,
       "support": 15
     },
     "agriculture & farming|sale purchase issue|sundargarh": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Departments",
       "share": 0.5385,
       "support": 7
     },
     "agriculture & farming|seeds &amp;amp; fertilizer|angul": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 5
     },
     "agriculture & farming|seeds &amp;amp; fertilizer|balangir": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Departments",
       "share": 1.0,
       "support": 5
     },
@@ -1475,16 +7113,19 @@
     },
     "agriculture & farming|seeds &amp;amp; fertilizer|khordha": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Office of Chief Minister",
       "share": 0.8333,
       "support": 5
     },
     "agriculture & farming|seeds &amp;amp; fertilizer|mayurbhanj": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Office of Chief Minister",
       "share": 0.6667,
       "support": 4
     },
     "agriculture & farming|seeds &amp;amp; fertilizer|nabarangpur": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 1.0,
       "support": 11
     },
@@ -1495,6 +7136,7 @@
     },
     "agriculture & farming|seeds &amp;amp; fertilizer|nuapada": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.9,
       "support": 9
     },
@@ -1505,6 +7147,7 @@
     },
     "agriculture & farming|soil conservation/watershed management|boudh": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.5556,
       "support": 5
     },
@@ -1515,6 +7158,7 @@
     },
     "agriculture & farming|storage issue|angul": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.6667,
       "support": 4
     },
@@ -1530,6 +7174,7 @@
     },
     "agriculture & farming|storage issue|dhenkanal": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 1.0,
       "support": 9
     },
@@ -1555,6 +7200,7 @@
     },
     "agriculture & farming|storage issue|kalahandi": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.4,
       "support": 6
     },
@@ -1565,6 +7211,7 @@
     },
     "agriculture & farming|storage issue|kendrapara": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Departments",
       "share": 1.0,
       "support": 13
     },
@@ -1585,6 +7232,7 @@
     },
     "agriculture & farming|storage issue|malkangiri": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 1.0,
       "support": 5
     },
@@ -1630,6 +7278,7 @@
     },
     "bsky|gjay/ayushman bharat|deogarh": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.7143,
       "support": 5
     },
@@ -1670,6 +7319,7 @@
     },
     "bsky|gjay/ayushman bharat|kandhamal": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 4
     },
@@ -1690,6 +7340,7 @@
     },
     "bsky|gjay/ayushman bharat|koraput": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 6
     },
@@ -1725,11 +7376,13 @@
     },
     "bsky|gjay/ayushman bharat|sambalpur": {
       "dept": "Finance",
+      "office": "Superintendent of Police",
       "share": 0.4167,
       "support": 15
     },
     "bsky|gjay/ayushman bharat|subarnapur": {
       "dept": "Health & Family Welfare",
+      "office": "Departments",
       "share": 0.9,
       "support": 9
     },
@@ -1740,106 +7393,127 @@
     },
     "cmrf|cmrf|angul": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.9123,
       "support": 52
     },
     "cmrf|cmrf|balangir": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.3556,
       "support": 32
     },
     "cmrf|cmrf|baleswar": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.9294,
       "support": 79
     },
     "cmrf|cmrf|bargarh": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.5426,
       "support": 51
     },
     "cmrf|cmrf|bhadrak": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.871,
       "support": 54
     },
     "cmrf|cmrf|boudh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Office of Chief Minister",
       "share": 0.3529,
       "support": 18
     },
     "cmrf|cmrf|cuttack": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.7927,
       "support": 130
     },
     "cmrf|cmrf|deogarh": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.5455,
       "support": 6
     },
     "cmrf|cmrf|dhenkanal": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.3333,
       "support": 47
     },
     "cmrf|cmrf|gajapati": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.7368,
       "support": 14
     },
     "cmrf|cmrf|ganjam": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.8835,
       "support": 235
     },
     "cmrf|cmrf|jagatsinghapur": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.8512,
       "support": 103
     },
     "cmrf|cmrf|jajpur": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.5807,
       "support": 403
     },
     "cmrf|cmrf|jharsuguda": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.9333,
       "support": 28
     },
     "cmrf|cmrf|kalahandi": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.5714,
       "support": 32
     },
     "cmrf|cmrf|kandhamal": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.7742,
       "support": 24
     },
     "cmrf|cmrf|kendrapara": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.8795,
       "support": 73
     },
     "cmrf|cmrf|kendujhar": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.8182,
       "support": 54
     },
     "cmrf|cmrf|khordha": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.9264,
       "support": 365
     },
     "cmrf|cmrf|koraput": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.4583,
       "support": 11
     },
     "cmrf|cmrf|mayurbhanj": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.8182,
       "support": 27
     },
@@ -1850,36 +7524,43 @@
     },
     "cmrf|cmrf|nayagarh": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.6699,
       "support": 140
     },
     "cmrf|cmrf|nuapada": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.6875,
       "support": 22
     },
     "cmrf|cmrf|puri": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.8725,
       "support": 219
     },
     "cmrf|cmrf|rayagada": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 6
     },
     "cmrf|cmrf|sambalpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.3704,
       "support": 30
     },
     "cmrf|cmrf|subarnapur": {
       "dept": "General Administration & Public Grievance",
+      "office": "Office of Chief Minister",
       "share": 0.384,
       "support": 48
     },
     "cmrf|cmrf|sundargarh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.3853,
       "support": 42
     },
@@ -1970,6 +7651,7 @@
     },
     "covid-19|others|balangir": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.7857,
       "support": 11
     },
@@ -1985,6 +7667,7 @@
     },
     "covid-19|others|boudh": {
       "dept": "Health & Family Welfare",
+      "office": "Departments",
       "share": 0.9091,
       "support": 10
     },
@@ -1995,6 +7678,7 @@
     },
     "covid-19|others|deogarh": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 1.0,
       "support": 4
     },
@@ -2005,6 +7689,7 @@
     },
     "covid-19|others|gajapati": {
       "dept": "School & Mass Education",
+      "office": "Departments",
       "share": 0.5556,
       "support": 10
     },
@@ -2030,11 +7715,13 @@
     },
     "covid-19|others|kendrapara": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.9333,
       "support": 14
     },
     "covid-19|others|kendujhar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6667,
       "support": 4
     },
@@ -2055,6 +7742,7 @@
     },
     "covid-19|others|nuapada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.3889,
       "support": 7
     },
@@ -2090,41 +7778,49 @@
     },
     "culture|artists' issues|angul": {
       "dept": "Odia Language Literature & Culture",
+      "office": "Collector",
       "share": 0.375,
       "support": 3
     },
     "culture|artists' issues|balangir": {
       "dept": "Odia Language Literature & Culture",
+      "office": "Collector",
       "share": 0.8,
       "support": 8
     },
     "culture|artists' issues|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.473,
       "support": 35
     },
     "culture|artists' issues|bargarh": {
       "dept": "Odia Language Literature & Culture",
+      "office": "Collector",
       "share": 1.0,
       "support": 8
     },
     "culture|artists' issues|boudh": {
       "dept": "Odia Language Literature & Culture",
+      "office": "Collector",
       "share": 0.8333,
       "support": 5
     },
     "culture|artists' issues|cuttack": {
       "dept": "Odia Language Literature & Culture",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 14
     },
     "culture|artists' issues|dhenkanal": {
       "dept": "Odia Language Literature & Culture",
+      "office": "Collector",
       "share": 0.9412,
       "support": 16
     },
     "culture|artists' issues|ganjam": {
       "dept": "Odia Language Literature & Culture",
+      "office": "Collector",
       "share": 0.6705,
       "support": 59
     },
@@ -2135,21 +7831,25 @@
     },
     "culture|artists' issues|jajpur": {
       "dept": "Odia Language Literature & Culture",
+      "office": "Office of Chief Minister",
       "share": 0.617,
       "support": 29
     },
     "culture|artists' issues|kalahandi": {
       "dept": "Odia Language Literature & Culture",
+      "office": "Collector",
       "share": 0.6667,
       "support": 4
     },
     "culture|artists' issues|kendrapara": {
       "dept": "Odia Language Literature & Culture",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 9
     },
     "culture|artists' issues|kendujhar": {
       "dept": "Odia Language Literature & Culture",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 4
     },
@@ -2165,21 +7865,25 @@
     },
     "culture|artists' issues|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.6875,
       "support": 11
     },
     "culture|artists' issues|puri": {
       "dept": "Odia Language Literature & Culture",
+      "office": "Office of Chief Minister",
       "share": 0.6667,
       "support": 4
     },
     "culture|artists' issues|sambalpur": {
       "dept": "Odia Language Literature & Culture",
+      "office": "Collector",
       "share": 0.7,
       "support": 7
     },
     "culture|artists' issues|sundargarh": {
       "dept": "Odia Language Literature & Culture",
+      "office": "Collector",
       "share": 0.7,
       "support": 21
     },
@@ -2195,6 +7899,7 @@
     },
     "culture|negligence|baleswar": {
       "dept": "Odia Language Literature & Culture",
+      "office": "Collector",
       "share": 0.9016,
       "support": 55
     },
@@ -2205,6 +7910,7 @@
     },
     "culture|negligence|dhenkanal": {
       "dept": "Odia Language Literature & Culture",
+      "office": "Collector",
       "share": 0.8571,
       "support": 6
     },
@@ -2230,6 +7936,7 @@
     },
     "culture|negligence|kandhamal": {
       "dept": "Planning & Convergence",
+      "office": "Collector",
       "share": 0.8718,
       "support": 34
     },
@@ -2240,6 +7947,7 @@
     },
     "culture|negligence|kendujhar": {
       "dept": "Odia Language Literature & Culture",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 4
     },
@@ -2275,11 +7983,13 @@
     },
     "disaster management|cyclone centres|baleswar": {
       "dept": "Information & Public Relations",
+      "office": "Collector",
       "share": 0.3929,
       "support": 11
     },
     "disaster management|cyclone centres|bhadrak": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8571,
       "support": 6
     },
@@ -2295,11 +8005,13 @@
     },
     "disaster management|cyclone centres|ganjam": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.7368,
       "support": 14
     },
     "disaster management|cyclone centres|jagatsinghapur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9048,
       "support": 19
     },
@@ -2315,6 +8027,7 @@
     },
     "disaster management|cyclone centres|mayurbhanj": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7143,
       "support": 5
     },
@@ -2330,6 +8043,7 @@
     },
     "disaster management|natural calamities/ relief|balangir": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9667,
       "support": 29
     },
@@ -2350,11 +8064,13 @@
     },
     "disaster management|natural calamities/ relief|boudh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9677,
       "support": 30
     },
     "disaster management|natural calamities/ relief|cuttack": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.875,
       "support": 28
     },
@@ -2370,16 +8086,19 @@
     },
     "disaster management|natural calamities/ relief|gajapati": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.7857,
       "support": 11
     },
     "disaster management|natural calamities/ relief|ganjam": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9545,
       "support": 21
     },
     "disaster management|natural calamities/ relief|jagatsinghapur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.88,
       "support": 44
     },
@@ -2415,6 +8134,7 @@
     },
     "disaster management|natural calamities/ relief|khordha": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9677,
       "support": 30
     },
@@ -2430,6 +8150,7 @@
     },
     "disaster management|natural calamities/ relief|mayurbhanj": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9091,
       "support": 30
     },
@@ -2475,171 +8196,205 @@
     },
     "education|higher education|angul": {
       "dept": "Higher Education",
+      "office": "Departments",
       "share": 0.9692,
       "support": 220
     },
     "education|higher education|balangir": {
       "dept": "Higher Education",
+      "office": "Departments",
       "share": 0.9054,
       "support": 201
     },
     "education|higher education|baleswar": {
       "dept": "Higher Education",
+      "office": "Departments",
       "share": 0.9637,
       "support": 928
     },
     "education|higher education|bargarh": {
       "dept": "Higher Education",
+      "office": "Departments",
       "share": 0.8742,
       "support": 264
     },
     "education|higher education|bhadrak": {
       "dept": "Higher Education",
+      "office": "Departments",
       "share": 0.9652,
       "support": 277
     },
     "education|higher education|boudh": {
       "dept": "Higher Education",
+      "office": "Departments",
       "share": 0.9265,
       "support": 63
     },
     "education|higher education|cuttack": {
       "dept": "Higher Education",
+      "office": "Departments",
       "share": 0.9423,
       "support": 506
     },
     "education|higher education|deogarh": {
       "dept": "Higher Education",
+      "office": "Departments",
       "share": 0.963,
       "support": 26
     },
     "education|higher education|dhenkanal": {
       "dept": "Higher Education",
+      "office": "Departments",
       "share": 0.8927,
       "support": 183
     },
     "education|higher education|gajapati": {
       "dept": "Higher Education",
+      "office": "Departments",
       "share": 0.8182,
       "support": 90
     },
     "education|higher education|ganjam": {
       "dept": "Higher Education",
+      "office": "Departments",
       "share": 0.9225,
       "support": 619
     },
     "education|higher education|jagatsinghapur": {
       "dept": "Higher Education",
+      "office": "Departments",
       "share": 0.9652,
       "support": 194
     },
     "education|higher education|jajpur": {
       "dept": "Higher Education",
+      "office": "Departments",
       "share": 0.9615,
       "support": 350
     },
     "education|higher education|jharsuguda": {
       "dept": "Higher Education",
+      "office": "Departments",
       "share": 0.9196,
       "support": 103
     },
     "education|higher education|kalahandi": {
       "dept": "Higher Education",
+      "office": "Departments",
       "share": 0.8786,
       "support": 152
     },
     "education|higher education|kandhamal": {
       "dept": "Higher Education",
+      "office": "Departments",
       "share": 0.9176,
       "support": 78
     },
     "education|higher education|kendrapara": {
       "dept": "Higher Education",
+      "office": "Departments",
       "share": 0.9565,
       "support": 264
     },
     "education|higher education|kendujhar": {
       "dept": "Higher Education",
+      "office": "Departments",
       "share": 0.9129,
       "support": 325
     },
     "education|higher education|khordha": {
       "dept": "Higher Education",
+      "office": "Departments",
       "share": 0.9683,
       "support": 825
     },
     "education|higher education|koraput": {
       "dept": "Higher Education",
+      "office": "Departments",
       "share": 0.875,
       "support": 91
     },
     "education|higher education|malkangiri": {
       "dept": "Higher Education",
+      "office": "Departments",
       "share": 0.7692,
       "support": 20
     },
     "education|higher education|mayurbhanj": {
       "dept": "Higher Education",
+      "office": "Departments",
       "share": 0.9635,
       "support": 264
     },
     "education|higher education|nabarangpur": {
       "dept": "Higher Education",
+      "office": "Departments",
       "share": 0.8676,
       "support": 59
     },
     "education|higher education|nayagarh": {
       "dept": "Higher Education",
+      "office": "Departments",
       "share": 0.883,
       "support": 166
     },
     "education|higher education|nuapada": {
       "dept": "Higher Education",
+      "office": "Departments",
       "share": 0.5922,
       "support": 61
     },
     "education|higher education|puri": {
       "dept": "Higher Education",
+      "office": "Departments",
       "share": 0.9728,
       "support": 358
     },
     "education|higher education|rayagada": {
       "dept": "Higher Education",
+      "office": "Departments",
       "share": 0.8222,
       "support": 74
     },
     "education|higher education|sambalpur": {
       "dept": "Higher Education",
+      "office": "Departments",
       "share": 0.9542,
       "support": 438
     },
     "education|higher education|subarnapur": {
       "dept": "Higher Education",
+      "office": "Departments",
       "share": 0.9412,
       "support": 112
     },
     "education|higher education|sundargarh": {
       "dept": "Higher Education",
+      "office": "Departments",
       "share": 0.9268,
       "support": 190
     },
     "education|higher secondary education|angul": {
       "dept": "Higher Education",
+      "office": "Collector",
       "share": 0.5833,
       "support": 14
     },
     "education|higher secondary education|balangir": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.4444,
       "support": 12
     },
     "education|higher secondary education|baleswar": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.3559,
       "support": 21
     },
     "education|higher secondary education|bargarh": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.6,
       "support": 12
     },
@@ -2650,26 +8405,31 @@
     },
     "education|higher secondary education|boudh": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.7143,
       "support": 5
     },
     "education|higher secondary education|cuttack": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.7826,
       "support": 18
     },
     "education|higher secondary education|dhenkanal": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.52,
       "support": 13
     },
     "education|higher secondary education|gajapati": {
       "dept": "Higher Education",
+      "office": "Collector",
       "share": 0.5862,
       "support": 17
     },
     "education|higher secondary education|ganjam": {
       "dept": "Higher Education",
+      "office": "Collector",
       "share": 0.3696,
       "support": 17
     },
@@ -2680,16 +8440,19 @@
     },
     "education|higher secondary education|jajpur": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.8571,
       "support": 24
     },
     "education|higher secondary education|jharsuguda": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.9545,
       "support": 21
     },
     "education|higher secondary education|kalahandi": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.8182,
       "support": 18
     },
@@ -2700,6 +8463,7 @@
     },
     "education|higher secondary education|kendujhar": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.5789,
       "support": 11
     },
@@ -2710,11 +8474,13 @@
     },
     "education|higher secondary education|koraput": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.8095,
       "support": 17
     },
     "education|higher secondary education|mayurbhanj": {
       "dept": "Higher Education",
+      "office": "Collector",
       "share": 0.5833,
       "support": 7
     },
@@ -2725,11 +8491,13 @@
     },
     "education|higher secondary education|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.4815,
       "support": 13
     },
     "education|higher secondary education|nuapada": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.8,
       "support": 8
     },
@@ -2740,21 +8508,25 @@
     },
     "education|higher secondary education|rayagada": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.5714,
       "support": 4
     },
     "education|higher secondary education|sambalpur": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.4737,
       "support": 9
     },
     "education|higher secondary education|subarnapur": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.5714,
       "support": 4
     },
     "education|higher secondary education|sundargarh": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.3846,
       "support": 5
     },
@@ -2765,6 +8537,7 @@
     },
     "education|primary/secondary education|balangir": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.7045,
       "support": 124
     },
@@ -2775,6 +8548,7 @@
     },
     "education|primary/secondary education|bargarh": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.8642,
       "support": 140
     },
@@ -2785,6 +8559,7 @@
     },
     "education|primary/secondary education|boudh": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.8889,
       "support": 48
     },
@@ -2795,26 +8570,31 @@
     },
     "education|primary/secondary education|deogarh": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.8846,
       "support": 23
     },
     "education|primary/secondary education|dhenkanal": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.8299,
       "support": 122
     },
     "education|primary/secondary education|gajapati": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.7849,
       "support": 73
     },
     "education|primary/secondary education|ganjam": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.8532,
       "support": 186
     },
     "education|primary/secondary education|jagatsinghapur": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.9167,
       "support": 44
     },
@@ -2825,11 +8605,13 @@
     },
     "education|primary/secondary education|jharsuguda": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.8889,
       "support": 56
     },
     "education|primary/secondary education|kalahandi": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.8652,
       "support": 122
     },
@@ -2845,6 +8627,7 @@
     },
     "education|primary/secondary education|kendujhar": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.7692,
       "support": 70
     },
@@ -2855,6 +8638,7 @@
     },
     "education|primary/secondary education|koraput": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.8148,
       "support": 66
     },
@@ -2870,6 +8654,7 @@
     },
     "education|primary/secondary education|nabarangpur": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.8043,
       "support": 37
     },
@@ -2880,6 +8665,7 @@
     },
     "education|primary/secondary education|nuapada": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.7215,
       "support": 57
     },
@@ -2895,11 +8681,13 @@
     },
     "education|primary/secondary education|sambalpur": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.6667,
       "support": 54
     },
     "education|primary/secondary education|subarnapur": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.8085,
       "support": 38
     },
@@ -2910,46 +8698,55 @@
     },
     "education|scholarship/study loan|angul": {
       "dept": "ST & SC Development, Minorities & Backward Classes Welfare",
+      "office": "Departments",
       "share": 0.4468,
       "support": 21
     },
     "education|scholarship/study loan|balangir": {
       "dept": "ST & SC Development, Minorities & Backward Classes Welfare",
+      "office": "Departments",
       "share": 0.4255,
       "support": 20
     },
     "education|scholarship/study loan|baleswar": {
       "dept": "ST & SC Development, Minorities & Backward Classes Welfare",
+      "office": "Departments",
       "share": 0.3472,
       "support": 75
     },
     "education|scholarship/study loan|bargarh": {
       "dept": "ST & SC Development, Minorities & Backward Classes Welfare",
+      "office": "Departments",
       "share": 0.3944,
       "support": 28
     },
     "education|scholarship/study loan|bhadrak": {
       "dept": "ST & SC Development, Minorities & Backward Classes Welfare",
+      "office": "Departments",
       "share": 0.375,
       "support": 69
     },
     "education|scholarship/study loan|boudh": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.32,
       "support": 8
     },
     "education|scholarship/study loan|cuttack": {
       "dept": "ST & SC Development, Minorities & Backward Classes Welfare",
+      "office": "Departments",
       "share": 0.3736,
       "support": 65
     },
     "education|scholarship/study loan|deogarh": {
       "dept": "ST & SC Development, Minorities & Backward Classes Welfare",
+      "office": "Departments",
       "share": 0.5,
       "support": 5
     },
     "education|scholarship/study loan|dhenkanal": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.3077,
       "support": 28
     },
@@ -2960,46 +8757,55 @@
     },
     "education|scholarship/study loan|ganjam": {
       "dept": "ST & SC Development, Minorities & Backward Classes Welfare",
+      "office": "Departments",
       "share": 0.4412,
       "support": 75
     },
     "education|scholarship/study loan|jagatsinghapur": {
       "dept": "ST & SC Development, Minorities & Backward Classes Welfare",
+      "office": "Departments",
       "share": 0.371,
       "support": 23
     },
     "education|scholarship/study loan|jajpur": {
       "dept": "ST & SC Development, Minorities & Backward Classes Welfare",
+      "office": "Departments",
       "share": 0.5605,
       "support": 88
     },
     "education|scholarship/study loan|jharsuguda": {
-      "dept": "School & Mass Education",
+      "dept": "ST & SC Development, Minorities & Backward Classes Welfare",
+      "office": "Departments",
       "share": 0.25,
       "support": 3
     },
     "education|scholarship/study loan|kalahandi": {
       "dept": "ST & SC Development, Minorities & Backward Classes Welfare",
+      "office": "Departments",
       "share": 0.5909,
       "support": 39
     },
     "education|scholarship/study loan|kandhamal": {
       "dept": "ST & SC Development, Minorities & Backward Classes Welfare",
+      "office": "Departments",
       "share": 0.5185,
       "support": 14
     },
     "education|scholarship/study loan|kendrapara": {
       "dept": "ST & SC Development, Minorities & Backward Classes Welfare",
+      "office": "Departments",
       "share": 0.2941,
       "support": 35
     },
     "education|scholarship/study loan|kendujhar": {
       "dept": "ST & SC Development, Minorities & Backward Classes Welfare",
+      "office": "Departments",
       "share": 0.4342,
       "support": 33
     },
     "education|scholarship/study loan|khordha": {
       "dept": "ST & SC Development, Minorities & Backward Classes Welfare",
+      "office": "Departments",
       "share": 0.4615,
       "support": 78
     },
@@ -3009,12 +8815,14 @@
       "support": 8
     },
     "education|scholarship/study loan|malkangiri": {
-      "dept": "School & Mass Education",
+      "dept": "ST & SC Development, Minorities & Backward Classes Welfare",
+      "office": "Departments",
       "share": 0.5,
       "support": 3
     },
     "education|scholarship/study loan|mayurbhanj": {
       "dept": "ST & SC Development, Minorities & Backward Classes Welfare",
+      "office": "Departments",
       "share": 0.4824,
       "support": 41
     },
@@ -3025,36 +8833,43 @@
     },
     "education|scholarship/study loan|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.3913,
       "support": 18
     },
     "education|scholarship/study loan|nuapada": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.3636,
       "support": 8
     },
     "education|scholarship/study loan|puri": {
       "dept": "ST & SC Development, Minorities & Backward Classes Welfare",
+      "office": "Departments",
       "share": 0.5862,
       "support": 51
     },
     "education|scholarship/study loan|rayagada": {
       "dept": "ST & SC Development, Minorities & Backward Classes Welfare",
+      "office": "Departments",
       "share": 0.7059,
       "support": 12
     },
     "education|scholarship/study loan|sambalpur": {
       "dept": "ST & SC Development, Minorities & Backward Classes Welfare",
+      "office": "Departments",
       "share": 0.6765,
       "support": 23
     },
     "education|scholarship/study loan|subarnapur": {
       "dept": "ST & SC Development, Minorities & Backward Classes Welfare",
+      "office": "Departments",
       "share": 0.55,
       "support": 11
     },
     "education|scholarship/study loan|sundargarh": {
       "dept": "ST & SC Development, Minorities & Backward Classes Welfare",
+      "office": "Departments",
       "share": 0.7143,
       "support": 50
     },
@@ -3065,41 +8880,49 @@
     },
     "education|technical education/professional education|balangir": {
       "dept": "Skill Development & Technical Education",
+      "office": "Departments",
       "share": 0.3684,
       "support": 7
     },
     "education|technical education/professional education|baleswar": {
       "dept": "Skill Development & Technical Education",
+      "office": "Departments",
       "share": 0.3953,
       "support": 17
     },
     "education|technical education/professional education|bargarh": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.4118,
       "support": 7
     },
     "education|technical education/professional education|bhadrak": {
       "dept": "Skill Development & Technical Education",
+      "office": "Departments",
       "share": 0.52,
       "support": 13
     },
     "education|technical education/professional education|boudh": {
       "dept": "Skill Development & Technical Education",
+      "office": "Departments",
       "share": 0.6,
       "support": 3
     },
     "education|technical education/professional education|cuttack": {
       "dept": "Skill Development & Technical Education",
+      "office": "Departments",
       "share": 0.5957,
       "support": 28
     },
     "education|technical education/professional education|dhenkanal": {
       "dept": "Skill Development & Technical Education",
+      "office": "Departments",
       "share": 0.6,
       "support": 12
     },
     "education|technical education/professional education|ganjam": {
       "dept": "Skill Development & Technical Education",
+      "office": "Departments",
       "share": 0.5,
       "support": 34
     },
@@ -3110,6 +8933,7 @@
     },
     "education|technical education/professional education|jajpur": {
       "dept": "Skill Development & Technical Education",
+      "office": "Departments",
       "share": 0.5862,
       "support": 17
     },
@@ -3130,6 +8954,7 @@
     },
     "education|technical education/professional education|kendrapara": {
       "dept": "Skill Development & Technical Education",
+      "office": "Departments",
       "share": 0.5172,
       "support": 15
     },
@@ -3155,16 +8980,19 @@
     },
     "education|technical education/professional education|nayagarh": {
       "dept": "Skill Development & Technical Education",
+      "office": "Departments",
       "share": 0.5556,
       "support": 15
     },
     "education|technical education/professional education|nuapada": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.6,
       "support": 3
     },
     "education|technical education/professional education|puri": {
       "dept": "Skill Development & Technical Education",
+      "office": "Departments",
       "share": 0.3636,
       "support": 8
     },
@@ -3190,6 +9018,7 @@
     },
     "energy|faulty meter/ bill|angul": {
       "dept": "Energy",
+      "office": "Collector",
       "share": 1.0,
       "support": 11
     },
@@ -3205,26 +9034,31 @@
     },
     "energy|faulty meter/ bill|bargarh": {
       "dept": "Energy",
+      "office": "Collector",
       "share": 0.9697,
       "support": 32
     },
     "energy|faulty meter/ bill|bhadrak": {
       "dept": "Energy",
+      "office": "Office of Chief Minister",
       "share": 0.9375,
       "support": 15
     },
     "energy|faulty meter/ bill|boudh": {
       "dept": "Energy",
+      "office": "Collector",
       "share": 0.9524,
       "support": 20
     },
     "energy|faulty meter/ bill|cuttack": {
       "dept": "Energy",
+      "office": "Office of Chief Minister",
       "share": 0.9841,
       "support": 62
     },
     "energy|faulty meter/ bill|deogarh": {
       "dept": "Energy",
+      "office": "Collector",
       "share": 0.9643,
       "support": 27
     },
@@ -3235,6 +9069,7 @@
     },
     "energy|faulty meter/ bill|gajapati": {
       "dept": "Energy",
+      "office": "Collector",
       "share": 0.9091,
       "support": 20
     },
@@ -3255,11 +9090,13 @@
     },
     "energy|faulty meter/ bill|jharsuguda": {
       "dept": "Energy",
+      "office": "Collector",
       "share": 0.7778,
       "support": 14
     },
     "energy|faulty meter/ bill|kalahandi": {
       "dept": "Energy",
+      "office": "Collector",
       "share": 0.8679,
       "support": 46
     },
@@ -3280,6 +9117,7 @@
     },
     "energy|faulty meter/ bill|khordha": {
       "dept": "Energy",
+      "office": "Office of Chief Minister",
       "share": 0.962,
       "support": 76
     },
@@ -3290,21 +9128,25 @@
     },
     "energy|faulty meter/ bill|malkangiri": {
       "dept": "Energy",
+      "office": "Collector",
       "share": 0.875,
       "support": 7
     },
     "energy|faulty meter/ bill|mayurbhanj": {
       "dept": "Energy",
+      "office": "Collector",
       "share": 0.6129,
       "support": 38
     },
     "energy|faulty meter/ bill|nabarangpur": {
       "dept": "Energy",
+      "office": "Collector",
       "share": 1.0,
       "support": 9
     },
     "energy|faulty meter/ bill|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.4667,
       "support": 7
     },
@@ -3320,11 +9162,13 @@
     },
     "energy|faulty meter/ bill|rayagada": {
       "dept": "Energy",
+      "office": "Collector",
       "share": 0.7222,
       "support": 13
     },
     "energy|faulty meter/ bill|sambalpur": {
       "dept": "Energy",
+      "office": "Collector",
       "share": 1.0,
       "support": 21
     },
@@ -3385,6 +9229,7 @@
     },
     "energy|infrastructure development|gajapati": {
       "dept": "Energy",
+      "office": "Collector",
       "share": 0.9756,
       "support": 40
     },
@@ -3500,11 +9345,13 @@
     },
     "energy|power cable shifting|baleswar": {
       "dept": "Energy",
+      "office": "Office of Chief Minister",
       "share": 0.4937,
       "support": 39
     },
     "energy|power cable shifting|bargarh": {
       "dept": "Energy",
+      "office": "Collector",
       "share": 0.9286,
       "support": 52
     },
@@ -3515,16 +9362,19 @@
     },
     "energy|power cable shifting|boudh": {
       "dept": "Energy",
+      "office": "Collector",
       "share": 1.0,
       "support": 23
     },
     "energy|power cable shifting|cuttack": {
       "dept": "Energy",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 51
     },
     "energy|power cable shifting|deogarh": {
       "dept": "Energy",
+      "office": "Collector",
       "share": 1.0,
       "support": 8
     },
@@ -3535,6 +9385,7 @@
     },
     "energy|power cable shifting|gajapati": {
       "dept": "Energy",
+      "office": "Collector",
       "share": 0.9268,
       "support": 38
     },
@@ -3545,6 +9396,7 @@
     },
     "energy|power cable shifting|jagatsinghapur": {
       "dept": "Energy",
+      "office": "Collector",
       "share": 0.9737,
       "support": 37
     },
@@ -3555,16 +9407,19 @@
     },
     "energy|power cable shifting|jharsuguda": {
       "dept": "Energy",
+      "office": "Collector",
       "share": 0.7143,
       "support": 15
     },
     "energy|power cable shifting|kalahandi": {
       "dept": "Energy",
+      "office": "Collector",
       "share": 0.9259,
       "support": 50
     },
     "energy|power cable shifting|kandhamal": {
       "dept": "Energy",
+      "office": "Collector",
       "share": 1.0,
       "support": 9
     },
@@ -3580,6 +9435,7 @@
     },
     "energy|power cable shifting|khordha": {
       "dept": "Energy",
+      "office": "Office of Chief Minister",
       "share": 0.9683,
       "support": 61
     },
@@ -3590,6 +9446,7 @@
     },
     "energy|power cable shifting|malkangiri": {
       "dept": "Energy",
+      "office": "Collector",
       "share": 1.0,
       "support": 4
     },
@@ -3600,21 +9457,25 @@
     },
     "energy|power cable shifting|nabarangpur": {
       "dept": "Energy",
+      "office": "Collector",
       "share": 0.875,
       "support": 21
     },
     "energy|power cable shifting|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.7037,
       "support": 19
     },
     "energy|power cable shifting|nuapada": {
       "dept": "Energy",
+      "office": "Collector",
       "share": 0.9375,
       "support": 15
     },
     "energy|power cable shifting|puri": {
       "dept": "Energy",
+      "office": "Office of Chief Minister",
       "share": 0.9615,
       "support": 25
     },
@@ -3630,6 +9491,7 @@
     },
     "energy|power cable shifting|subarnapur": {
       "dept": "Energy",
+      "office": "Collector",
       "share": 1.0,
       "support": 17
     },
@@ -3640,36 +9502,43 @@
     },
     "energy|power supply|angul": {
       "dept": "Energy",
+      "office": "Departments",
       "share": 0.9729,
       "support": 287
     },
     "energy|power supply|balangir": {
       "dept": "Energy",
+      "office": "Departments",
       "share": 0.9208,
       "support": 186
     },
     "energy|power supply|baleswar": {
       "dept": "Energy",
+      "office": "Departments",
       "share": 0.7848,
       "support": 660
     },
     "energy|power supply|bargarh": {
       "dept": "Energy",
+      "office": "Departments",
       "share": 0.9221,
       "support": 213
     },
     "energy|power supply|bhadrak": {
       "dept": "Energy",
+      "office": "Departments",
       "share": 0.9481,
       "support": 274
     },
     "energy|power supply|boudh": {
       "dept": "Energy",
+      "office": "Collector",
       "share": 0.9549,
       "support": 339
     },
     "energy|power supply|cuttack": {
       "dept": "Energy",
+      "office": "Departments",
       "share": 0.9725,
       "support": 636
     },
@@ -3680,46 +9549,55 @@
     },
     "energy|power supply|dhenkanal": {
       "dept": "Energy",
+      "office": "Departments",
       "share": 0.9761,
       "support": 613
     },
     "energy|power supply|gajapati": {
       "dept": "Energy",
+      "office": "Collector",
       "share": 0.8669,
       "support": 254
     },
     "energy|power supply|ganjam": {
       "dept": "Energy",
+      "office": "Departments",
       "share": 0.9402,
       "support": 472
     },
     "energy|power supply|jagatsinghapur": {
       "dept": "Energy",
+      "office": "Departments",
       "share": 0.9395,
       "support": 264
     },
     "energy|power supply|jajpur": {
       "dept": "Energy",
+      "office": "Departments",
       "share": 0.9655,
       "support": 336
     },
     "energy|power supply|jharsuguda": {
       "dept": "Energy",
+      "office": "Departments",
       "share": 0.8222,
       "support": 111
     },
     "energy|power supply|kalahandi": {
       "dept": "Energy",
+      "office": "Collector",
       "share": 0.96,
       "support": 408
     },
     "energy|power supply|kandhamal": {
       "dept": "Energy",
+      "office": "Departments",
       "share": 0.9793,
       "support": 378
     },
     "energy|power supply|kendrapara": {
       "dept": "Energy",
+      "office": "Departments",
       "share": 0.9684,
       "support": 337
     },
@@ -3730,6 +9608,7 @@
     },
     "energy|power supply|khordha": {
       "dept": "Energy",
+      "office": "Departments",
       "share": 0.9843,
       "support": 1250
     },
@@ -3750,21 +9629,25 @@
     },
     "energy|power supply|nabarangpur": {
       "dept": "Energy",
+      "office": "Collector",
       "share": 0.907,
       "support": 156
     },
     "energy|power supply|nayagarh": {
       "dept": "Energy",
+      "office": "Departments",
       "share": 0.7924,
       "support": 271
     },
     "energy|power supply|nuapada": {
       "dept": "Energy",
+      "office": "Collector",
       "share": 0.933,
       "support": 209
     },
     "energy|power supply|puri": {
       "dept": "Energy",
+      "office": "Departments",
       "share": 0.9432,
       "support": 432
     },
@@ -3785,6 +9668,7 @@
     },
     "energy|power supply|sundargarh": {
       "dept": "Energy",
+      "office": "Departments",
       "share": 0.913,
       "support": 294
     },
@@ -3805,6 +9689,7 @@
     },
     "energy|renewable / solar energy|kandhamal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.8889,
       "support": 8
     },
@@ -3815,21 +9700,24 @@
     },
     "energy|renewable / solar energy|koraput": {
       "dept": "Energy",
+      "office": "Collector",
       "share": 0.6,
       "support": 3
     },
     "energy|renewable / solar energy|sambalpur": {
-      "dept": "Panchayati Raj & Drinking Water",
+      "dept": "Energy",
       "share": 0.4286,
       "support": 3
     },
     "energy|renewable / solar energy|subarnapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 1.0,
       "support": 3
     },
     "energy|solar pumps|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 1.0,
       "support": 3
     },
@@ -3845,6 +9733,7 @@
     },
     "energy|street light/led lights|baleswar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.4886,
       "support": 43
     },
@@ -3880,6 +9769,7 @@
     },
     "energy|street light/led lights|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.72,
       "support": 36
     },
@@ -3900,21 +9790,25 @@
     },
     "energy|street light/led lights|jharsuguda": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.381,
       "support": 16
     },
     "energy|street light/led lights|kalahandi": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8333,
       "support": 60
     },
     "energy|street light/led lights|kandhamal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.947,
       "support": 268
     },
     "energy|street light/led lights|kendrapara": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.6667,
       "support": 56
     },
@@ -3935,6 +9829,7 @@
     },
     "energy|street light/led lights|malkangiri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7097,
       "support": 22
     },
@@ -3980,11 +9875,13 @@
     },
     "energy|street light/led lights|sundargarh": {
       "dept": "Housing & Urban Development",
+      "office": "Departments",
       "share": 0.6766,
       "support": 205
     },
     "energy|voltage fluctuations|angul": {
       "dept": "Energy",
+      "office": "Collector",
       "share": 1.0,
       "support": 23
     },
@@ -4000,6 +9897,7 @@
     },
     "energy|voltage fluctuations|boudh": {
       "dept": "Energy",
+      "office": "Collector",
       "share": 1.0,
       "support": 7
     },
@@ -4010,21 +9908,25 @@
     },
     "energy|voltage fluctuations|deogarh": {
       "dept": "Energy",
+      "office": "Collector",
       "share": 1.0,
       "support": 5
     },
     "energy|voltage fluctuations|dhenkanal": {
       "dept": "Energy",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 5
     },
     "energy|voltage fluctuations|gajapati": {
       "dept": "Energy",
+      "office": "Collector",
       "share": 1.0,
       "support": 5
     },
     "energy|voltage fluctuations|ganjam": {
       "dept": "Energy",
+      "office": "Collector",
       "share": 0.875,
       "support": 7
     },
@@ -4035,6 +9937,7 @@
     },
     "energy|voltage fluctuations|jajpur": {
       "dept": "Energy",
+      "office": "Office of Chief Minister",
       "share": 0.8462,
       "support": 11
     },
@@ -4045,16 +9948,19 @@
     },
     "energy|voltage fluctuations|kendrapara": {
       "dept": "Energy",
+      "office": "Office of Chief Minister",
       "share": 0.9444,
       "support": 17
     },
     "energy|voltage fluctuations|kendujhar": {
       "dept": "Energy",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 7
     },
     "energy|voltage fluctuations|khordha": {
       "dept": "Energy",
+      "office": "Office of Chief Minister",
       "share": 0.9429,
       "support": 33
     },
@@ -4080,6 +9986,7 @@
     },
     "energy|voltage fluctuations|sundargarh": {
       "dept": "Energy",
+      "office": "Collector",
       "share": 1.0,
       "support": 4
     },
@@ -4090,11 +9997,13 @@
     },
     "environment|entry of animals|deogarh": {
       "dept": "Forest, Environment and Climate Change Department",
+      "office": "Collector",
       "share": 0.8,
       "support": 8
     },
     "environment|entry of animals|dhenkanal": {
       "dept": "Forest, Environment and Climate Change Department",
+      "office": "Collector",
       "share": 0.8125,
       "support": 13
     },
@@ -4120,6 +10029,7 @@
     },
     "environment|entry of animals|kendujhar": {
       "dept": "Forest, Environment and Climate Change Department",
+      "office": "Collector",
       "share": 0.8824,
       "support": 15
     },
@@ -4135,6 +10045,7 @@
     },
     "environment|entry of animals|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 1.0,
       "support": 3
     },
@@ -4160,21 +10071,25 @@
     },
     "environment|entry of animals|sundargarh": {
       "dept": "Forest, Environment and Climate Change Department",
+      "office": "Collector",
       "share": 0.75,
       "support": 6
     },
     "environment|environment pollution/protection|angul": {
       "dept": "Forest, Environment and Climate Change Department",
+      "office": "Departments",
       "share": 0.7115,
       "support": 37
     },
     "environment|environment pollution/protection|balangir": {
       "dept": "Forest, Environment and Climate Change Department",
+      "office": "Departments",
       "share": 0.8667,
       "support": 26
     },
     "environment|environment pollution/protection|baleswar": {
       "dept": "Forest, Environment and Climate Change Department",
+      "office": "Departments",
       "share": 0.697,
       "support": 23
     },
@@ -4185,6 +10100,7 @@
     },
     "environment|environment pollution/protection|bhadrak": {
       "dept": "Forest, Environment and Climate Change Department",
+      "office": "Departments",
       "share": 0.85,
       "support": 17
     },
@@ -4200,11 +10116,13 @@
     },
     "environment|environment pollution/protection|deogarh": {
       "dept": "Forest, Environment and Climate Change Department",
+      "office": "Collector",
       "share": 0.8636,
       "support": 19
     },
     "environment|environment pollution/protection|dhenkanal": {
       "dept": "Forest, Environment and Climate Change Department",
+      "office": "Departments",
       "share": 0.6667,
       "support": 38
     },
@@ -4215,11 +10133,13 @@
     },
     "environment|environment pollution/protection|jagatsinghapur": {
       "dept": "Forest, Environment and Climate Change Department",
+      "office": "Departments",
       "share": 0.6353,
       "support": 54
     },
     "environment|environment pollution/protection|jajpur": {
       "dept": "Forest, Environment and Climate Change Department",
+      "office": "Departments",
       "share": 0.7852,
       "support": 106
     },
@@ -4230,6 +10150,7 @@
     },
     "environment|environment pollution/protection|kalahandi": {
       "dept": "Forest, Environment and Climate Change Department",
+      "office": "Collector",
       "share": 0.5769,
       "support": 15
     },
@@ -4240,6 +10161,7 @@
     },
     "environment|environment pollution/protection|kendrapara": {
       "dept": "Forest, Environment and Climate Change Department",
+      "office": "Departments",
       "share": 0.7059,
       "support": 36
     },
@@ -4250,6 +10172,7 @@
     },
     "environment|environment pollution/protection|khordha": {
       "dept": "Forest, Environment and Climate Change Department",
+      "office": "Departments",
       "share": 0.5783,
       "support": 48
     },
@@ -4265,6 +10188,7 @@
     },
     "environment|environment pollution/protection|nabarangpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.4667,
       "support": 7
     },
@@ -4285,6 +10209,7 @@
     },
     "environment|environment pollution/protection|sambalpur": {
       "dept": "Forest, Environment and Climate Change Department",
+      "office": "Collector",
       "share": 0.5625,
       "support": 18
     },
@@ -4300,21 +10225,25 @@
     },
     "environment|illegal mining|cuttack": {
       "dept": "Steel & Mines",
+      "office": "Office of Chief Minister",
       "share": 0.6667,
       "support": 6
     },
     "environment|illegal mining|dhenkanal": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.6667,
       "support": 10
     },
     "environment|illegal mining|ganjam": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.6364,
       "support": 7
     },
     "environment|illegal mining|jajpur": {
       "dept": "Steel & Mines",
+      "office": "Office of Chief Minister",
       "share": 0.45,
       "support": 9
     },
@@ -4325,11 +10254,13 @@
     },
     "environment|illegal mining|kendujhar": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.5,
       "support": 5
     },
     "environment|illegal mining|khordha": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.875,
       "support": 7
     },
@@ -4345,11 +10276,13 @@
     },
     "excise|excise matters|balangir": {
       "dept": "Excise",
+      "office": "Departments",
       "share": 0.8846,
       "support": 23
     },
     "excise|excise matters|baleswar": {
       "dept": "Excise",
+      "office": "Departments",
       "share": 0.8421,
       "support": 48
     },
@@ -4365,16 +10298,19 @@
     },
     "excise|excise matters|boudh": {
       "dept": "Excise",
+      "office": "Collector",
       "share": 0.9444,
       "support": 17
     },
     "excise|excise matters|cuttack": {
       "dept": "Excise",
+      "office": "Departments",
       "share": 0.9216,
       "support": 47
     },
     "excise|excise matters|deogarh": {
       "dept": "Excise",
+      "office": "Collector",
       "share": 0.8182,
       "support": 18
     },
@@ -4385,6 +10321,7 @@
     },
     "excise|excise matters|gajapati": {
       "dept": "Excise",
+      "office": "Collector",
       "share": 0.9524,
       "support": 20
     },
@@ -4395,6 +10332,7 @@
     },
     "excise|excise matters|jagatsinghapur": {
       "dept": "Excise",
+      "office": "Departments",
       "share": 0.9722,
       "support": 35
     },
@@ -4405,21 +10343,25 @@
     },
     "excise|excise matters|jharsuguda": {
       "dept": "Excise",
+      "office": "Collector",
       "share": 1.0,
       "support": 35
     },
     "excise|excise matters|kalahandi": {
       "dept": "Excise",
+      "office": "Collector",
       "share": 0.961,
       "support": 148
     },
     "excise|excise matters|kandhamal": {
       "dept": "Excise",
+      "office": "Collector",
       "share": 0.8667,
       "support": 13
     },
     "excise|excise matters|kendrapara": {
       "dept": "Excise",
+      "office": "Departments",
       "share": 0.9118,
       "support": 31
     },
@@ -4430,16 +10372,19 @@
     },
     "excise|excise matters|khordha": {
       "dept": "Excise",
+      "office": "Departments",
       "share": 0.9247,
       "support": 86
     },
     "excise|excise matters|koraput": {
       "dept": "Excise",
+      "office": "Departments",
       "share": 0.8788,
       "support": 29
     },
     "excise|excise matters|malkangiri": {
       "dept": "Excise",
+      "office": "Departments",
       "share": 1.0,
       "support": 8
     },
@@ -4450,26 +10395,31 @@
     },
     "excise|excise matters|nabarangpur": {
       "dept": "Excise",
+      "office": "Collector",
       "share": 0.8667,
       "support": 26
     },
     "excise|excise matters|nayagarh": {
       "dept": "Excise",
+      "office": "Departments",
       "share": 0.7955,
       "support": 35
     },
     "excise|excise matters|nuapada": {
       "dept": "Excise",
+      "office": "Collector",
       "share": 0.9524,
       "support": 20
     },
     "excise|excise matters|puri": {
       "dept": "Excise",
+      "office": "Departments",
       "share": 0.7407,
       "support": 40
     },
     "excise|excise matters|rayagada": {
       "dept": "Excise",
+      "office": "Collector",
       "share": 1.0,
       "support": 20
     },
@@ -4485,21 +10435,25 @@
     },
     "excise|excise matters|sundargarh": {
       "dept": "Excise",
+      "office": "Collector",
       "share": 0.9344,
       "support": 57
     },
     "financial assistance|accidental claims|bhadrak": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.6364,
       "support": 7
     },
     "financial assistance|accidental claims|dhenkanal": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.3333,
       "support": 5
     },
     "financial assistance|accidental claims|gajapati": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.7273,
       "support": 8
     },
@@ -4510,11 +10464,13 @@
     },
     "financial assistance|accidental claims|jajpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.6667,
       "support": 10
     },
     "financial assistance|accidental claims|kendrapara": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8,
       "support": 4
     },
@@ -4525,6 +10481,7 @@
     },
     "financial assistance|accidental claims|mayurbhanj": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.3333,
       "support": 5
     },
@@ -4535,76 +10492,91 @@
     },
     "financial assistance|accidental claims|sundargarh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.4,
       "support": 4
     },
     "financial assistance|aids|balangir": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.6667,
       "support": 6
     },
     "financial assistance|aids|dhenkanal": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 1.0,
       "support": 3
     },
     "financial assistance|cmrf/red cross fund|angul": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.4286,
       "support": 36
     },
     "financial assistance|cmrf/red cross fund|balangir": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.6,
       "support": 120
     },
     "financial assistance|cmrf/red cross fund|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Office of Chief Minister",
       "share": 0.4742,
       "support": 46
     },
     "financial assistance|cmrf/red cross fund|bargarh": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.8245,
       "support": 357
     },
     "financial assistance|cmrf/red cross fund|bhadrak": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.3788,
       "support": 25
     },
     "financial assistance|cmrf/red cross fund|boudh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Office of Chief Minister",
       "share": 0.3246,
       "support": 37
     },
     "financial assistance|cmrf/red cross fund|cuttack": {
       "dept": "General Administration & Public Grievance",
+      "office": "Office of Chief Minister",
       "share": 0.272,
       "support": 34
     },
     "financial assistance|cmrf/red cross fund|deogarh": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.2857,
       "support": 8
     },
     "financial assistance|cmrf/red cross fund|dhenkanal": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.467,
       "support": 85
     },
     "financial assistance|cmrf/red cross fund|gajapati": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.25,
       "support": 3
     },
     "financial assistance|cmrf/red cross fund|ganjam": {
       "dept": "General Administration & Public Grievance",
+      "office": "Office of Chief Minister",
       "share": 0.3231,
       "support": 42
     },
     "financial assistance|cmrf/red cross fund|jagatsinghapur": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.2931,
       "support": 17
     },
@@ -4615,31 +10587,37 @@
     },
     "financial assistance|cmrf/red cross fund|jharsuguda": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.5185,
       "support": 14
     },
     "financial assistance|cmrf/red cross fund|kalahandi": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.4713,
       "support": 41
     },
     "financial assistance|cmrf/red cross fund|kandhamal": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.4737,
       "support": 18
     },
     "financial assistance|cmrf/red cross fund|kendrapara": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.5263,
       "support": 30
     },
     "financial assistance|cmrf/red cross fund|kendujhar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.5673,
       "support": 59
     },
     "financial assistance|cmrf/red cross fund|khordha": {
       "dept": "General Administration & Public Grievance",
+      "office": "Office of Chief Minister",
       "share": 0.3744,
       "support": 82
     },
@@ -4650,106 +10628,127 @@
     },
     "financial assistance|cmrf/red cross fund|mayurbhanj": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.5636,
       "support": 31
     },
     "financial assistance|cmrf/red cross fund|nabarangpur": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.4615,
       "support": 12
     },
     "financial assistance|cmrf/red cross fund|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.6336,
       "support": 83
     },
     "financial assistance|cmrf/red cross fund|nuapada": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.48,
       "support": 12
     },
     "financial assistance|cmrf/red cross fund|puri": {
       "dept": "General Administration & Public Grievance",
+      "office": "Office of Chief Minister",
       "share": 0.4818,
       "support": 53
     },
     "financial assistance|cmrf/red cross fund|rayagada": {
-      "dept": "Health & Family Welfare",
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.3333,
       "support": 4
     },
     "financial assistance|cmrf/red cross fund|sambalpur": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.557,
       "support": 44
     },
     "financial assistance|cmrf/red cross fund|subarnapur": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.4537,
       "support": 196
     },
     "financial assistance|cmrf/red cross fund|sundargarh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.4545,
       "support": 25
     },
     "financial assistance|compensation/refunds|angul": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.3939,
       "support": 13
     },
     "financial assistance|compensation/refunds|balangir": {
       "dept": "Water Resources",
+      "office": "Office of Chief Minister",
       "share": 0.3684,
       "support": 7
     },
     "financial assistance|compensation/refunds|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.359,
       "support": 14
     },
     "financial assistance|compensation/refunds|bargarh": {
       "dept": "Forest, Environment and Climate Change Department",
+      "office": "Collector",
       "share": 0.4615,
       "support": 24
     },
     "financial assistance|compensation/refunds|bhadrak": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.375,
       "support": 9
     },
     "financial assistance|compensation/refunds|boudh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.3,
       "support": 3
     },
     "financial assistance|compensation/refunds|cuttack": {
       "dept": "Co-operation",
+      "office": "Departments",
       "share": 0.3594,
       "support": 23
     },
     "financial assistance|compensation/refunds|deogarh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.4762,
       "support": 20
     },
     "financial assistance|compensation/refunds|dhenkanal": {
       "dept": "Forest, Environment and Climate Change Department",
+      "office": "Office of Chief Minister",
       "share": 0.25,
       "support": 8
     },
     "financial assistance|compensation/refunds|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.1923,
       "support": 5
     },
     "financial assistance|compensation/refunds|ganjam": {
       "dept": "Co-operation",
+      "office": "Departments",
       "share": 0.4471,
       "support": 38
     },
     "financial assistance|compensation/refunds|jagatsinghapur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.6491,
       "support": 37
     },
@@ -4760,41 +10759,49 @@
     },
     "financial assistance|compensation/refunds|kalahandi": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.2319,
       "support": 16
     },
     "financial assistance|compensation/refunds|kendujhar": {
       "dept": "Finance",
+      "office": "Office of Chief Minister",
       "share": 0.125,
       "support": 5
     },
     "financial assistance|compensation/refunds|khordha": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.3,
       "support": 21
     },
     "financial assistance|compensation/refunds|koraput": {
       "dept": "Co-operation",
+      "office": "Departments",
       "share": 0.25,
       "support": 6
     },
     "financial assistance|compensation/refunds|mayurbhanj": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.5493,
       "support": 39
     },
     "financial assistance|compensation/refunds|nabarangpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.2286,
       "support": 8
     },
     "financial assistance|compensation/refunds|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.58,
       "support": 29
     },
     "financial assistance|compensation/refunds|nuapada": {
       "dept": "Water Resources",
+      "office": "Office of Chief Minister",
       "share": 0.3077,
       "support": 12
     },
@@ -4805,6 +10812,7 @@
     },
     "financial assistance|compensation/refunds|sambalpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.2609,
       "support": 6
     },
@@ -4815,6 +10823,7 @@
     },
     "financial assistance|compensation/refunds|sundargarh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.6818,
       "support": 45
     },
@@ -4825,11 +10834,13 @@
     },
     "financial assistance|ex gratia|balangir": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.36,
       "support": 9
     },
     "financial assistance|ex gratia|baleswar": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.5,
       "support": 5
     },
@@ -4840,6 +10851,7 @@
     },
     "financial assistance|ex gratia|bhadrak": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.9231,
       "support": 12
     },
@@ -4860,76 +10872,91 @@
     },
     "financial assistance|ex gratia|gajapati": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.7143,
       "support": 5
     },
     "financial assistance|ex gratia|ganjam": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.3448,
       "support": 10
     },
     "financial assistance|ex gratia|jajpur": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Office of Chief Minister",
       "share": 0.3333,
       "support": 4
     },
     "financial assistance|ex gratia|jharsuguda": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.7647,
       "support": 13
     },
     "financial assistance|ex gratia|kalahandi": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.25,
       "support": 3
     },
     "financial assistance|ex gratia|kandhamal": {
       "dept": "Energy",
+      "office": "Office of Chief Minister",
       "share": 0.75,
       "support": 3
     },
     "financial assistance|ex gratia|kendrapara": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Office of Chief Minister",
       "share": 0.75,
       "support": 6
     },
     "financial assistance|ex gratia|kendujhar": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.35,
       "support": 7
     },
     "financial assistance|ex gratia|khordha": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.36,
       "support": 9
     },
     "financial assistance|ex gratia|koraput": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.4706,
       "support": 8
     },
     "financial assistance|ex gratia|mayurbhanj": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.6061,
       "support": 40
     },
     "financial assistance|ex gratia|nabarangpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.4839,
       "support": 15
     },
     "financial assistance|ex gratia|nayagarh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.4,
       "support": 4
     },
     "financial assistance|ex gratia|puri": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.4375,
       "support": 7
     },
     "financial assistance|ex gratia|subarnapur": {
       "dept": "General Administration & Public Grievance",
+      "office": "Office of Chief Minister",
       "share": 0.5556,
       "support": 5
     },
@@ -4940,156 +10967,187 @@
     },
     "financial assistance|financial assistance/loan|angul": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.2806,
       "support": 55
     },
     "financial assistance|financial assistance/loan|balangir": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.6705,
       "support": 692
     },
     "financial assistance|financial assistance/loan|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.2845,
       "support": 99
     },
     "financial assistance|financial assistance/loan|bargarh": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.8767,
       "support": 1927
     },
     "financial assistance|financial assistance/loan|bhadrak": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.2158,
       "support": 63
     },
     "financial assistance|financial assistance/loan|boudh": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.5095,
       "support": 188
     },
     "financial assistance|financial assistance/loan|cuttack": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.1972,
       "support": 84
     },
     "financial assistance|financial assistance/loan|deogarh": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.322,
       "support": 19
     },
     "financial assistance|financial assistance/loan|dhenkanal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.3459,
       "support": 330
     },
     "financial assistance|financial assistance/loan|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.2928,
       "support": 65
     },
     "financial assistance|financial assistance/loan|ganjam": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.1836,
       "support": 83
     },
     "financial assistance|financial assistance/loan|jagatsinghapur": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.237,
       "support": 50
     },
     "financial assistance|financial assistance/loan|jajpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.2032,
       "support": 64
     },
     "financial assistance|financial assistance/loan|jharsuguda": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.2,
       "support": 15
     },
     "financial assistance|financial assistance/loan|kalahandi": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.2369,
       "support": 113
     },
     "financial assistance|financial assistance/loan|kandhamal": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.3483,
       "support": 31
     },
     "financial assistance|financial assistance/loan|kendrapara": {
       "dept": "General Administration & Public Grievance",
+      "office": "Office of Chief Minister",
       "share": 0.1935,
       "support": 36
     },
     "financial assistance|financial assistance/loan|kendujhar": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.1651,
       "support": 35
     },
     "financial assistance|financial assistance/loan|khordha": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.2123,
       "support": 114
     },
     "financial assistance|financial assistance/loan|koraput": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.307,
       "support": 35
     },
     "financial assistance|financial assistance/loan|malkangiri": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.3864,
       "support": 17
     },
     "financial assistance|financial assistance/loan|mayurbhanj": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.5312,
       "support": 238
     },
     "financial assistance|financial assistance/loan|nabarangpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.2473,
       "support": 70
     },
     "financial assistance|financial assistance/loan|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.5936,
       "support": 279
     },
     "financial assistance|financial assistance/loan|nuapada": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.2372,
       "support": 79
     },
     "financial assistance|financial assistance/loan|puri": {
       "dept": "General Administration & Public Grievance",
+      "office": "Office of Chief Minister",
       "share": 0.1994,
       "support": 70
     },
     "financial assistance|financial assistance/loan|rayagada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.2222,
       "support": 22
     },
     "financial assistance|financial assistance/loan|sambalpur": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.4985,
       "support": 164
     },
     "financial assistance|financial assistance/loan|subarnapur": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.6184,
       "support": 914
     },
     "financial assistance|financial assistance/loan|sundargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.1626,
       "support": 40
     },
     "financial assistance|insurance matters|balangir": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Departments",
       "share": 0.6316,
       "support": 12
     },
@@ -5100,46 +11158,54 @@
     },
     "financial assistance|insurance matters|ganjam": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.5,
       "support": 5
     },
     "financial assistance|insurance matters|jajpur": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.6154,
       "support": 8
     },
     "financial assistance|insurance matters|kalahandi": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.5238,
       "support": 11
     },
     "financial assistance|insurance matters|khordha": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Office of Chief Minister",
       "share": 0.7,
       "support": 7
     },
     "financial assistance|insurance matters|nabarangpur": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Collector",
       "share": 0.7778,
       "support": 7
     },
     "financial assistance|insurance matters|nuapada": {
-      "dept": "Labour & Employees' State Insurance",
+      "dept": "Agriculture & Farmers' Empowerment",
       "share": 0.5,
       "support": 3
     },
     "financial assistance|insurance matters|puri": {
       "dept": "Finance",
+      "office": "Office of Chief Minister",
       "share": 0.5,
       "support": 3
     },
     "financial assistance|insurance matters|sambalpur": {
       "dept": "Health & Family Welfare",
+      "office": "Departments",
       "share": 0.8571,
       "support": 48
     },
     "financial assistance|insurance matters|sundargarh": {
-      "dept": "Home department",
+      "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Office of Chief Minister",
       "share": 0.3125,
       "support": 5
     },
@@ -5155,16 +11221,19 @@
     },
     "financial assistance|natural calamities/ relief|bhadrak": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8056,
       "support": 29
     },
     "financial assistance|natural calamities/ relief|cuttack": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.5294,
       "support": 9
     },
     "financial assistance|natural calamities/ relief|deogarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.8889,
       "support": 8
     },
@@ -5175,6 +11244,7 @@
     },
     "financial assistance|natural calamities/ relief|gajapati": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.4286,
       "support": 6
     },
@@ -5190,16 +11260,19 @@
     },
     "financial assistance|natural calamities/ relief|jajpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8667,
       "support": 13
     },
     "financial assistance|natural calamities/ relief|kalahandi": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8846,
       "support": 23
     },
     "financial assistance|natural calamities/ relief|kendrapara": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.8571,
       "support": 6
     },
@@ -5210,16 +11283,19 @@
     },
     "financial assistance|natural calamities/ relief|mayurbhanj": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.7143,
       "support": 20
     },
     "financial assistance|natural calamities/ relief|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.6154,
       "support": 8
     },
     "financial assistance|natural calamities/ relief|nuapada": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.75,
       "support": 3
     },
@@ -5245,171 +11321,205 @@
     },
     "financial assistance|natural calamities/ relief|sundargarh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.5,
       "support": 3
     },
     "financial assistance|self employment/ skill development|angul": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.4615,
       "support": 12
     },
     "financial assistance|self employment/ skill development|balangir": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.5102,
       "support": 25
     },
     "financial assistance|self employment/ skill development|baleswar": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.614,
       "support": 105
     },
     "financial assistance|self employment/ skill development|bargarh": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.8837,
       "support": 76
     },
     "financial assistance|self employment/ skill development|bhadrak": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.6857,
       "support": 24
     },
     "financial assistance|self employment/ skill development|boudh": {
       "dept": "Micro, Small & Medium Enterprise",
+      "office": "Office of Chief Minister",
       "share": 0.5111,
       "support": 23
     },
     "financial assistance|self employment/ skill development|cuttack": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.4653,
       "support": 47
     },
     "financial assistance|self employment/ skill development|dhenkanal": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.3409,
       "support": 15
     },
     "financial assistance|self employment/ skill development|gajapati": {
       "dept": "Fisheries & Animal Resources Development",
+      "office": "Collector",
       "share": 0.2308,
       "support": 3
     },
     "financial assistance|self employment/ skill development|ganjam": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.6623,
       "support": 100
     },
     "financial assistance|self employment/ skill development|jagatsinghapur": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.7051,
       "support": 55
     },
     "financial assistance|self employment/ skill development|jajpur": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.4364,
       "support": 24
     },
     "financial assistance|self employment/ skill development|jharsuguda": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.375,
       "support": 3
     },
     "financial assistance|self employment/ skill development|kalahandi": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.4667,
       "support": 14
     },
     "financial assistance|self employment/ skill development|kandhamal": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.5333,
       "support": 8
     },
     "financial assistance|self employment/ skill development|kendrapara": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.3929,
       "support": 22
     },
     "financial assistance|self employment/ skill development|kendujhar": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.3902,
       "support": 16
     },
     "financial assistance|self employment/ skill development|khordha": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.6108,
       "support": 124
     },
     "financial assistance|self employment/ skill development|koraput": {
       "dept": "General Administration & Public Grievance",
+      "office": "Office of Chief Minister",
       "share": 0.2593,
       "support": 7
     },
     "financial assistance|self employment/ skill development|mayurbhanj": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.4762,
       "support": 20
     },
     "financial assistance|self employment/ skill development|nabarangpur": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.4,
       "support": 4
     },
     "financial assistance|self employment/ skill development|nayagarh": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.6667,
       "support": 44
     },
     "financial assistance|self employment/ skill development|puri": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.6977,
       "support": 60
     },
     "financial assistance|self employment/ skill development|sambalpur": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.2381,
       "support": 5
     },
     "financial assistance|self employment/ skill development|subarnapur": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.75,
       "support": 15
     },
     "financial assistance|self employment/ skill development|sundargarh": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.2105,
       "support": 4
     },
     "general|associations' issues|angul": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.3333,
       "support": 3
     },
     "general|associations' issues|balangir": {
       "dept": "Finance",
+      "office": "Collector",
       "share": 0.2807,
       "support": 16
     },
     "general|associations' issues|baleswar": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.3125,
       "support": 5
     },
     "general|associations' issues|bhadrak": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.5,
       "support": 3
     },
     "general|associations' issues|boudh": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.8571,
       "support": 6
     },
     "general|associations' issues|cuttack": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.3824,
       "support": 13
     },
     "general|associations' issues|deogarh": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.8,
       "support": 16
     },
@@ -5420,71 +11530,85 @@
     },
     "general|associations' issues|gajapati": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.6,
       "support": 9
     },
     "general|associations' issues|ganjam": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.6346,
       "support": 33
     },
     "general|associations' issues|jagatsinghapur": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.4444,
       "support": 4
     },
     "general|associations' issues|jajpur": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.3,
       "support": 3
     },
     "general|associations' issues|jharsuguda": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.8333,
       "support": 5
     },
     "general|associations' issues|kendrapara": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.875,
       "support": 14
     },
     "general|associations' issues|kendujhar": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.6786,
       "support": 19
     },
     "general|associations' issues|khordha": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.2338,
       "support": 18
     },
     "general|associations' issues|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.6154,
       "support": 8
     },
     "general|associations' issues|nuapada": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.6154,
       "support": 8
     },
     "general|associations' issues|puri": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.7321,
       "support": 41
     },
     "general|associations' issues|rayagada": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.4474,
       "support": 17
     },
     "general|associations' issues|sambalpur": {
       "dept": "Higher Education",
+      "office": "Collector",
       "share": 0.3607,
       "support": 22
     },
     "general|associations' issues|sundargarh": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.7333,
       "support": 11
     },
@@ -5495,16 +11619,19 @@
     },
     "general|bank/atm|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.375,
       "support": 6
     },
     "general|bank/atm|cuttack": {
       "dept": "Finance",
+      "office": "Office of Chief Minister",
       "share": 0.7143,
       "support": 5
     },
     "general|bank/atm|gajapati": {
       "dept": "Finance",
+      "office": "Collector",
       "share": 0.4286,
       "support": 3
     },
@@ -5515,16 +11642,19 @@
     },
     "general|bank/atm|kalahandi": {
       "dept": "Finance",
+      "office": "Collector",
       "share": 0.5556,
       "support": 10
     },
     "general|bank/atm|kendrapara": {
       "dept": "Finance",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 4
     },
     "general|bank/atm|kendujhar": {
       "dept": "Finance",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 5
     },
@@ -5535,6 +11665,7 @@
     },
     "general|bank/atm|mayurbhanj": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.5556,
       "support": 5
     },
@@ -5545,21 +11676,25 @@
     },
     "general|bank/atm|nayagarh": {
       "dept": "Finance",
+      "office": "Departments",
       "share": 0.75,
       "support": 9
     },
     "general|bank/atm|nuapada": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.5,
       "support": 7
     },
     "general|bank/atm|puri": {
       "dept": "Finance",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 10
     },
     "general|certificates|angul": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.5686,
       "support": 29
     },
@@ -5575,11 +11710,13 @@
     },
     "general|certificates|bargarh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.5,
       "support": 43
     },
     "general|certificates|bhadrak": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.4268,
       "support": 70
     },
@@ -5590,46 +11727,55 @@
     },
     "general|certificates|cuttack": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.6579,
       "support": 150
     },
     "general|certificates|deogarh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.6667,
       "support": 4
     },
     "general|certificates|dhenkanal": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.3816,
       "support": 29
     },
     "general|certificates|gajapati": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.6161,
       "support": 69
     },
     "general|certificates|ganjam": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.5466,
       "support": 129
     },
     "general|certificates|jagatsinghapur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.5369,
       "support": 109
     },
     "general|certificates|jajpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.7586,
       "support": 154
     },
     "general|certificates|jharsuguda": {
-      "dept": "Revenue & Disaster Management",
+      "dept": "ST & SC Development, Minorities & Backward Classes Welfare",
+      "office": "Departments",
       "share": 0.3846,
       "support": 5
     },
     "general|certificates|kalahandi": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.3617,
       "support": 51
     },
@@ -5640,11 +11786,13 @@
     },
     "general|certificates|kendrapara": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.6927,
       "support": 124
     },
     "general|certificates|kendujhar": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.4124,
       "support": 40
     },
@@ -5655,21 +11803,25 @@
     },
     "general|certificates|koraput": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.6596,
       "support": 31
     },
     "general|certificates|malkangiri": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.5938,
       "support": 19
     },
     "general|certificates|mayurbhanj": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.439,
       "support": 90
     },
     "general|certificates|nabarangpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.55,
       "support": 44
     },
@@ -5680,6 +11832,7 @@
     },
     "general|certificates|nuapada": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.5976,
       "support": 49
     },
@@ -5690,6 +11843,7 @@
     },
     "general|certificates|rayagada": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.65,
       "support": 26
     },
@@ -5700,26 +11854,31 @@
     },
     "general|certificates|subarnapur": {
       "dept": "Housing & Urban Development",
+      "office": "Collector",
       "share": 0.3939,
       "support": 13
     },
     "general|certificates|sundargarh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.6106,
       "support": 69
     },
     "general|encroachment|angul": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.75,
       "support": 3
     },
     "general|encroachment|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.7297,
       "support": 27
     },
     "general|encroachment|bhadrak": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8571,
       "support": 6
     },
@@ -5730,6 +11889,7 @@
     },
     "general|encroachment|gajapati": {
       "dept": "Housing & Urban Development",
+      "office": "Collector",
       "share": 0.5,
       "support": 4
     },
@@ -5740,6 +11900,7 @@
     },
     "general|encroachment|jagatsinghapur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8,
       "support": 8
     },
@@ -5750,6 +11911,7 @@
     },
     "general|encroachment|kalahandi": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.375,
       "support": 3
     },
@@ -5760,16 +11922,19 @@
     },
     "general|encroachment|khordha": {
       "dept": "Housing & Urban Development",
+      "office": "Departments",
       "share": 0.65,
       "support": 13
     },
     "general|encroachment|mayurbhanj": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.6,
       "support": 6
     },
     "general|encroachment|nuapada": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8,
       "support": 4
     },
@@ -5780,16 +11945,19 @@
     },
     "general|encroachment|sambalpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.6364,
       "support": 7
     },
     "general|encroachment|subarnapur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.875,
       "support": 21
     },
     "general|encroachment|sundargarh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.5625,
       "support": 9
     },
@@ -5800,11 +11968,13 @@
     },
     "general|establishment of new offices|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.7143,
       "support": 5
     },
     "general|establishment of new offices|cuttack": {
       "dept": "Fisheries & Animal Resources Development",
+      "office": "Departments",
       "share": 0.4444,
       "support": 4
     },
@@ -5825,6 +11995,7 @@
     },
     "general|establishment of new offices|nuapada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8333,
       "support": 5
     },
@@ -5885,6 +12056,7 @@
     },
     "general|family problem|jagatsinghapur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.5686,
       "support": 29
     },
@@ -5935,6 +12107,7 @@
     },
     "general|family problem|mayurbhanj": {
       "dept": "Home department",
+      "office": "Superintendent of Police",
       "share": 0.3831,
       "support": 59
     },
@@ -5945,6 +12118,7 @@
     },
     "general|family problem|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.7419,
       "support": 46
     },
@@ -5980,6 +12154,7 @@
     },
     "general|food products|angul": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.8,
       "support": 4
     },
@@ -5995,16 +12170,19 @@
     },
     "general|food products|bargarh": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.8,
       "support": 4
     },
     "general|food products|boudh": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 1.0,
       "support": 4
     },
     "general|food products|cuttack": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.5625,
       "support": 9
     },
@@ -6015,6 +12193,7 @@
     },
     "general|food products|ganjam": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.7857,
       "support": 11
     },
@@ -6025,66 +12204,79 @@
     },
     "general|food products|jharsuguda": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.8276,
       "support": 24
     },
     "general|food products|kalahandi": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.3333,
       "support": 4
     },
     "general|food products|kendrapara": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.9125,
       "support": 73
     },
     "general|food products|khordha": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.7333,
       "support": 22
     },
     "general|food products|koraput": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.8,
       "support": 4
     },
     "general|food products|mayurbhanj": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.5833,
       "support": 7
     },
     "general|food products|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.4667,
       "support": 7
     },
     "general|food products|nuapada": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 1.0,
       "support": 3
     },
     "general|food products|puri": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.8824,
       "support": 30
     },
     "general|food products|sambalpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4444,
       "support": 4
     },
     "general|food products|sundargarh": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.5,
       "support": 3
     },
     "general|illegal activities|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.6438,
       "support": 47
     },
     "general|illegal activities|bhadrak": {
       "dept": "Home department",
+      "office": "DG & IG Police",
       "share": 0.55,
       "support": 11
     },
@@ -6100,6 +12292,7 @@
     },
     "general|illegal activities|ganjam": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.2679,
       "support": 30
     },
@@ -6115,16 +12308,19 @@
     },
     "general|illegal activities|kalahandi": {
       "dept": "Excise",
+      "office": "Collector",
       "share": 0.2571,
       "support": 9
     },
     "general|illegal activities|kandhamal": {
       "dept": "Home department",
+      "office": "Superintendent of Police",
       "share": 0.4,
       "support": 4
     },
     "general|illegal activities|kendrapara": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.4,
       "support": 6
     },
@@ -6140,61 +12336,73 @@
     },
     "general|illegal activities|mayurbhanj": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.6667,
       "support": 14
     },
     "general|illegal activities|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.7568,
       "support": 28
     },
     "general|illegal activities|puri": {
       "dept": "Home department",
+      "office": "DG & IG Police",
       "share": 0.4545,
       "support": 5
     },
     "general|illegal activities|rayagada": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.3125,
       "support": 5
     },
     "general|illegal activities|sambalpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.7027,
       "support": 520
     },
     "general|illegal activities|sundargarh": {
       "dept": "Home department",
+      "office": "Superintendent of Police",
       "share": 0.2778,
       "support": 5
     },
     "general|illegal parking|khordha": {
       "dept": "Housing & Urban Development",
+      "office": "Departments",
       "share": 0.7059,
       "support": 12
     },
     "general|illegal parking|sundargarh": {
       "dept": "Housing & Urban Development",
+      "office": "Departments",
       "share": 0.75,
       "support": 3
     },
     "general|indivudal household latrine|bargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.9,
       "support": 9
     },
     "general|indivudal household latrine|bhadrak": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 4
     },
     "general|indivudal household latrine|cuttack": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.8333,
       "support": 5
     },
     "general|indivudal household latrine|dhenkanal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.625,
       "support": 5
     },
@@ -6225,21 +12433,25 @@
     },
     "general|indivudal household latrine|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.5714,
       "support": 4
     },
     "general|infrastructure related to depts|angul": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 1.0,
       "support": 38
     },
     "general|infrastructure related to depts|khordha": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8,
       "support": 4
     },
     "general|infrastructure related to depts|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 1.0,
       "support": 3
     },
@@ -6250,26 +12462,31 @@
     },
     "general|insurance matters|dhenkanal": {
       "dept": "Finance",
+      "office": "Office of Chief Minister",
       "share": 0.75,
       "support": 3
     },
     "general|insurance matters|ganjam": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Office of Chief Minister",
       "share": 0.5385,
       "support": 7
     },
     "general|insurance matters|kalahandi": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.7778,
       "support": 21
     },
     "general|insurance matters|khordha": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Office of Chief Minister",
       "share": 0.8,
       "support": 4
     },
     "general|insurance matters|nabarangpur": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Collector",
       "share": 0.5714,
       "support": 4
     },
@@ -6280,96 +12497,115 @@
     },
     "general|insurance matters|sundargarh": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 1.0,
       "support": 7
     },
     "general|irrelevant/absurd|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Superintendent of Police",
       "share": 1.0,
       "support": 9
     },
     "general|irrelevant/absurd|khordha": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 0.8571,
       "support": 6
     },
     "general|non-govt service matters|angul": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.6667,
       "support": 6
     },
     "general|non-govt service matters|baleswar": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.7143,
       "support": 5
     },
     "general|non-govt service matters|bargarh": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.6,
       "support": 3
     },
     "general|non-govt service matters|bhadrak": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.8,
       "support": 4
     },
     "general|non-govt service matters|cuttack": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.4545,
       "support": 5
     },
     "general|non-govt service matters|dhenkanal": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.7143,
       "support": 5
     },
     "general|non-govt service matters|ganjam": {
-      "dept": "General Administration & Public Grievance",
+      "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.2143,
       "support": 3
     },
     "general|non-govt service matters|jagatsinghapur": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.7143,
       "support": 5
     },
     "general|non-govt service matters|jajpur": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.5,
       "support": 4
     },
     "general|non-govt service matters|jharsuguda": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.8889,
       "support": 8
     },
     "general|non-govt service matters|kendrapara": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.5,
       "support": 4
     },
     "general|non-govt service matters|khordha": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.7333,
       "support": 22
     },
     "general|non-govt service matters|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.5,
       "support": 5
     },
     "general|non-govt service matters|puri": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.7273,
       "support": 8
     },
     "general|non-govt service matters|rayagada": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.8333,
       "support": 5
     },
     "general|non-govt service matters|sambalpur": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.4545,
       "support": 5
     },
@@ -6390,6 +12626,7 @@
     },
     "general|odia signage/sign board|bargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.3125,
       "support": 5
     },
@@ -6400,6 +12637,7 @@
     },
     "general|odia signage/sign board|boudh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.3636,
       "support": 4
     },
@@ -6410,11 +12648,13 @@
     },
     "general|odia signage/sign board|gajapati": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.4,
       "support": 6
     },
     "general|odia signage/sign board|jagatsinghapur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.4444,
       "support": 4
     },
@@ -6425,6 +12665,7 @@
     },
     "general|odia signage/sign board|kendrapara": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.25,
       "support": 3
     },
@@ -6445,11 +12686,13 @@
     },
     "general|odia signage/sign board|mayurbhanj": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.5333,
       "support": 8
     },
     "general|odia signage/sign board|puri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.24,
       "support": 6
     },
@@ -6460,166 +12703,199 @@
     },
     "general|others|angul": {
       "dept": "Home department",
+      "office": "Superintendent of Police",
       "share": 0.3305,
       "support": 624
     },
     "general|others|balangir": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.3588,
       "support": 865
     },
     "general|others|baleswar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.2775,
       "support": 2029
     },
     "general|others|bargarh": {
       "dept": "School & Mass Education",
+      "office": "Departments",
       "share": 0.3617,
       "support": 467
     },
     "general|others|bhadrak": {
       "dept": "School & Mass Education",
+      "office": "Departments",
       "share": 0.3562,
       "support": 608
     },
     "general|others|boudh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.3572,
       "support": 1126
     },
     "general|others|cuttack": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.1864,
       "support": 1146
     },
     "general|others|deogarh": {
       "dept": "School & Mass Education",
+      "office": "Departments",
       "share": 0.2055,
       "support": 45
     },
     "general|others|dhenkanal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Chief Secretary",
       "share": 0.1927,
       "support": 442
     },
     "general|others|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.3162,
       "support": 405
     },
     "general|others|ganjam": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.2099,
       "support": 1462
     },
     "general|others|jagatsinghapur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.3161,
       "support": 1702
     },
     "general|others|jajpur": {
       "dept": "Home department",
+      "office": "Superintendent of Police",
       "share": 0.7704,
       "support": 7709
     },
     "general|others|jharsuguda": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.2401,
       "support": 448
     },
     "general|others|kalahandi": {
       "dept": "School & Mass Education",
+      "office": "Departments",
       "share": 0.2486,
       "support": 481
     },
     "general|others|kandhamal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Chief Secretary",
       "share": 0.4702,
       "support": 876
     },
     "general|others|kendrapara": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.3215,
       "support": 3494
     },
     "general|others|kendujhar": {
       "dept": "Home department",
+      "office": "Superintendent of Police",
       "share": 0.4292,
       "support": 1186
     },
     "general|others|khordha": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.1676,
       "support": 1678
     },
     "general|others|koraput": {
       "dept": "School & Mass Education",
+      "office": "Departments",
       "share": 0.3704,
       "support": 350
     },
     "general|others|malkangiri": {
       "dept": "School & Mass Education",
+      "office": "Departments",
       "share": 0.3703,
       "support": 117
     },
     "general|others|mayurbhanj": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.5452,
       "support": 6443
     },
     "general|others|nabarangpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.2453,
       "support": 233
     },
     "general|others|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.565,
       "support": 2699
     },
     "general|others|nuapada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.2858,
       "support": 325
     },
     "general|others|puri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.3146,
       "support": 2632
     },
     "general|others|rayagada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.3154,
       "support": 1000
     },
     "general|others|sambalpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Chief Secretary",
       "share": 0.6013,
       "support": 2250
     },
     "general|others|subarnapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.3992,
       "support": 1190
     },
     "general|others|sundargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.2372,
       "support": 1284
     },
     "general|personal claims|angul": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.1121,
       "support": 13
     },
     "general|personal claims|balangir": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.234,
       "support": 11
     },
     "general|personal claims|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.4583,
       "support": 121
     },
@@ -6630,76 +12906,91 @@
     },
     "general|personal claims|bhadrak": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.3182,
       "support": 14
     },
     "general|personal claims|boudh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.25,
       "support": 6
     },
     "general|personal claims|cuttack": {
       "dept": "Co-operation",
+      "office": "Collector",
       "share": 0.2359,
       "support": 46
     },
     "general|personal claims|deogarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.4438,
       "support": 154
     },
     "general|personal claims|dhenkanal": {
       "dept": "Energy",
+      "office": "Departments",
       "share": 0.2857,
       "support": 20
     },
     "general|personal claims|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.2843,
       "support": 29
     },
     "general|personal claims|ganjam": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.2582,
       "support": 87
     },
     "general|personal claims|jagatsinghapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.1698,
       "support": 9
     },
     "general|personal claims|jajpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.2258,
       "support": 28
     },
     "general|personal claims|jharsuguda": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.2742,
       "support": 17
     },
     "general|personal claims|kalahandi": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.3134,
       "support": 42
     },
     "general|personal claims|kandhamal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.403,
       "support": 27
     },
     "general|personal claims|kendrapara": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.2037,
       "support": 22
     },
     "general|personal claims|kendujhar": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.2763,
       "support": 21
     },
     "general|personal claims|khordha": {
       "dept": "Housing & Urban Development",
+      "office": "Office of Chief Minister",
       "share": 0.2832,
       "support": 113
     },
@@ -6710,36 +13001,43 @@
     },
     "general|personal claims|malkangiri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5169,
       "support": 46
     },
     "general|personal claims|mayurbhanj": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.2026,
       "support": 77
     },
     "general|personal claims|nabarangpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.2727,
       "support": 18
     },
     "general|personal claims|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.75,
       "support": 237
     },
     "general|personal claims|nuapada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.3378,
       "support": 75
     },
     "general|personal claims|puri": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.35,
       "support": 56
     },
     "general|personal claims|rayagada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.2637,
       "support": 24
     },
@@ -6750,6 +13048,7 @@
     },
     "general|personal claims|subarnapur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.25,
       "support": 5
     },
@@ -6865,6 +13164,7 @@
     },
     "general|rehabilitation of the distressed|nuapada": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.8702,
       "support": 114
     },
@@ -6875,6 +13175,7 @@
     },
     "general|rehabilitation of the distressed|rayagada": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.3,
       "support": 3
     },
@@ -6895,26 +13196,31 @@
     },
     "general|rti matters|baleswar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.1905,
       "support": 8
     },
     "general|rti matters|bargarh": {
       "dept": "Information & Public Relations",
+      "office": "Departments",
       "share": 0.5,
       "support": 7
     },
     "general|rti matters|bhadrak": {
       "dept": "Health & Family Welfare",
+      "office": "Chief Secretary",
       "share": 0.2632,
       "support": 5
     },
     "general|rti matters|cuttack": {
       "dept": "Home department",
+      "office": "DG & IG Police",
       "share": 0.283,
       "support": 15
     },
     "general|rti matters|dhenkanal": {
       "dept": "Information & Public Relations",
+      "office": "Departments",
       "share": 0.6667,
       "support": 8
     },
@@ -6930,6 +13236,7 @@
     },
     "general|rti matters|kalahandi": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4167,
       "support": 5
     },
@@ -6940,46 +13247,55 @@
     },
     "general|rti matters|kendrapara": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.3,
       "support": 3
     },
     "general|rti matters|khordha": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.2105,
       "support": 4
     },
     "general|rti matters|koraput": {
       "dept": "Information & Public Relations",
+      "office": "Departments",
       "share": 0.6667,
       "support": 6
     },
     "general|rti matters|mayurbhanj": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.3636,
       "support": 4
     },
     "general|rti matters|nabarangpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8889,
       "support": 8
     },
     "general|rti matters|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.5,
       "support": 3
     },
     "general|rti matters|nuapada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4667,
       "support": 7
     },
     "general|rti matters|puri": {
-      "dept": "Fisheries & Animal Resources Development",
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.2727,
       "support": 3
     },
     "general|rti matters|sambalpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.8333,
       "support": 5
     },
@@ -6990,31 +13306,37 @@
     },
     "general|rti matters|sundargarh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.5556,
       "support": 5
     },
     "general|rto matters|angul": {
       "dept": "Commerce & Transport",
+      "office": "Departments",
       "share": 1.0,
       "support": 21
     },
     "general|rto matters|balangir": {
       "dept": "Commerce & Transport",
+      "office": "Departments",
       "share": 1.0,
       "support": 10
     },
     "general|rto matters|baleswar": {
       "dept": "Commerce & Transport",
+      "office": "Departments",
       "share": 0.8929,
       "support": 25
     },
     "general|rto matters|bargarh": {
       "dept": "Commerce & Transport",
+      "office": "Departments",
       "share": 0.8947,
       "support": 17
     },
     "general|rto matters|bhadrak": {
       "dept": "Commerce & Transport",
+      "office": "Departments",
       "share": 1.0,
       "support": 13
     },
@@ -7025,31 +13347,37 @@
     },
     "general|rto matters|cuttack": {
       "dept": "Commerce & Transport",
+      "office": "Departments",
       "share": 0.9688,
       "support": 31
     },
     "general|rto matters|dhenkanal": {
       "dept": "Commerce & Transport",
+      "office": "Departments",
       "share": 0.8571,
       "support": 18
     },
     "general|rto matters|gajapati": {
       "dept": "Commerce & Transport",
+      "office": "Collector",
       "share": 0.8333,
       "support": 5
     },
     "general|rto matters|ganjam": {
       "dept": "Commerce & Transport",
+      "office": "Departments",
       "share": 0.975,
       "support": 39
     },
     "general|rto matters|jagatsinghapur": {
       "dept": "Commerce & Transport",
+      "office": "Departments",
       "share": 1.0,
       "support": 13
     },
     "general|rto matters|jajpur": {
       "dept": "Commerce & Transport",
+      "office": "Departments",
       "share": 0.875,
       "support": 21
     },
@@ -7070,16 +13398,19 @@
     },
     "general|rto matters|kendrapara": {
       "dept": "Commerce & Transport",
+      "office": "Departments",
       "share": 1.0,
       "support": 26
     },
     "general|rto matters|kendujhar": {
       "dept": "Commerce & Transport",
+      "office": "Departments",
       "share": 0.8421,
       "support": 16
     },
     "general|rto matters|khordha": {
       "dept": "Commerce & Transport",
+      "office": "Departments",
       "share": 0.9882,
       "support": 84
     },
@@ -7090,21 +13421,25 @@
     },
     "general|rto matters|mayurbhanj": {
       "dept": "Commerce & Transport",
+      "office": "Departments",
       "share": 0.5714,
       "support": 8
     },
     "general|rto matters|nayagarh": {
       "dept": "Commerce & Transport",
+      "office": "Departments",
       "share": 0.5789,
       "support": 11
     },
     "general|rto matters|nuapada": {
       "dept": "Commerce & Transport",
+      "office": "Collector",
       "share": 0.75,
       "support": 6
     },
     "general|rto matters|puri": {
       "dept": "Commerce & Transport",
+      "office": "Departments",
       "share": 1.0,
       "support": 23
     },
@@ -7115,11 +13450,13 @@
     },
     "general|rto matters|sambalpur": {
       "dept": "Commerce & Transport",
+      "office": "Departments",
       "share": 1.0,
       "support": 7
     },
     "general|rto matters|sundargarh": {
       "dept": "Commerce & Transport",
+      "office": "Collector",
       "share": 0.8644,
       "support": 51
     },
@@ -7160,6 +13497,7 @@
     },
     "general|various demands|deogarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8095,
       "support": 34
     },
@@ -7170,16 +13508,19 @@
     },
     "general|various demands|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8594,
       "support": 110
     },
     "general|various demands|ganjam": {
       "dept": "Rural Development",
+      "office": "Collector",
       "share": 0.3895,
       "support": 148
     },
     "general|various demands|jagatsinghapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6962,
       "support": 55
     },
@@ -7245,6 +13586,7 @@
     },
     "general|various demands|nuapada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5667,
       "support": 68
     },
@@ -7260,6 +13602,7 @@
     },
     "general|various demands|sambalpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7765,
       "support": 271
     },
@@ -7275,21 +13618,25 @@
     },
     "general|web portal issues|angul": {
       "dept": "General Administration & Public Grievance",
+      "office": "Departments",
       "share": 0.5714,
       "support": 4
     },
     "general|web portal issues|cuttack": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.2857,
       "support": 4
     },
     "general|web portal issues|kendrapara": {
       "dept": "Planning & Convergence",
+      "office": "Departments",
       "share": 1.0,
       "support": 3
     },
     "general|web portal issues|kendujhar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Departments",
       "share": 0.4286,
       "support": 3
     },
@@ -7335,16 +13682,19 @@
     },
     "health care|blood requirement/blood donation|jagatsinghapur": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.8966,
       "support": 26
     },
     "health care|blood requirement/blood donation|jajpur": {
       "dept": "Health & Family Welfare",
+      "office": "Departments",
       "share": 1.0,
       "support": 5
     },
     "health care|blood requirement/blood donation|kalahandi": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 1.0,
       "support": 8
     },
@@ -7370,21 +13720,25 @@
     },
     "health care|financial assistance|angul": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.8462,
       "support": 22
     },
     "health care|financial assistance|balangir": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.7143,
       "support": 15
     },
     "health care|financial assistance|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.567,
       "support": 55
     },
     "health care|financial assistance|bargarh": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.881,
       "support": 37
     },
@@ -7395,36 +13749,43 @@
     },
     "health care|financial assistance|boudh": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.6316,
       "support": 12
     },
     "health care|financial assistance|cuttack": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.7907,
       "support": 34
     },
     "health care|financial assistance|deogarh": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.8462,
       "support": 11
     },
     "health care|financial assistance|dhenkanal": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.9259,
       "support": 75
     },
     "health care|financial assistance|gajapati": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.6825,
       "support": 43
     },
     "health care|financial assistance|ganjam": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.8431,
       "support": 43
     },
     "health care|financial assistance|jagatsinghapur": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.7692,
       "support": 20
     },
@@ -7435,21 +13796,25 @@
     },
     "health care|financial assistance|jharsuguda": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.6667,
       "support": 8
     },
     "health care|financial assistance|kalahandi": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.9504,
       "support": 115
     },
     "health care|financial assistance|kandhamal": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.625,
       "support": 5
     },
     "health care|financial assistance|kendrapara": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.8974,
       "support": 35
     },
@@ -7460,66 +13825,79 @@
     },
     "health care|financial assistance|khordha": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.814,
       "support": 35
     },
     "health care|financial assistance|koraput": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.6923,
       "support": 9
     },
     "health care|financial assistance|malkangiri": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.6667,
       "support": 10
     },
     "health care|financial assistance|mayurbhanj": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.5652,
       "support": 13
     },
     "health care|financial assistance|nabarangpur": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 1.0,
       "support": 15
     },
     "health care|financial assistance|nayagarh": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.5,
       "support": 14
     },
     "health care|financial assistance|nuapada": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.75,
       "support": 42
     },
     "health care|financial assistance|puri": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.7586,
       "support": 22
     },
     "health care|financial assistance|rayagada": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.8056,
       "support": 29
     },
     "health care|financial assistance|sambalpur": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.9091,
       "support": 10
     },
     "health care|financial assistance|subarnapur": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.7333,
       "support": 11
     },
     "health care|financial assistance|sundargarh": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.913,
       "support": 21
     },
     "health care|food adulteration|cuttack": {
       "dept": "Health & Family Welfare",
+      "office": "Departments",
       "share": 0.75,
       "support": 3
     },
@@ -7530,11 +13908,13 @@
     },
     "health care|food adulteration|nayagarh": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Departments",
       "share": 0.4286,
       "support": 6
     },
     "health care|food adulteration|puri": {
       "dept": "Health & Family Welfare",
+      "office": "Departments",
       "share": 1.0,
       "support": 6
     },
@@ -7565,6 +13945,7 @@
     },
     "health care|health care facility|boudh": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.964,
       "support": 107
     },
@@ -7575,6 +13956,7 @@
     },
     "health care|health care facility|deogarh": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.9592,
       "support": 47
     },
@@ -7585,6 +13967,7 @@
     },
     "health care|health care facility|gajapati": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.9535,
       "support": 82
     },
@@ -7660,6 +14043,7 @@
     },
     "health care|health care facility|nuapada": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.8871,
       "support": 55
     },
@@ -7705,6 +14089,7 @@
     },
     "health care|healthcare infrastructure|bargarh": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.9143,
       "support": 64
     },
@@ -7725,6 +14110,7 @@
     },
     "health care|healthcare infrastructure|deogarh": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.9375,
       "support": 15
     },
@@ -7735,6 +14121,7 @@
     },
     "health care|healthcare infrastructure|gajapati": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.8621,
       "support": 25
     },
@@ -7750,6 +14137,7 @@
     },
     "health care|healthcare infrastructure|jajpur": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.8395,
       "support": 68
     },
@@ -7760,6 +14148,7 @@
     },
     "health care|healthcare infrastructure|kalahandi": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.9487,
       "support": 74
     },
@@ -7790,11 +14179,13 @@
     },
     "health care|healthcare infrastructure|malkangiri": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.85,
       "support": 17
     },
     "health care|healthcare infrastructure|mayurbhanj": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.9067,
       "support": 68
     },
@@ -7810,6 +14201,7 @@
     },
     "health care|healthcare infrastructure|nuapada": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.8824,
       "support": 15
     },
@@ -7880,6 +14272,7 @@
     },
     "health care|lack of doctors|gajapati": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.9412,
       "support": 16
     },
@@ -7905,6 +14298,7 @@
     },
     "health care|lack of doctors|kalahandi": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.9459,
       "support": 35
     },
@@ -7935,6 +14329,7 @@
     },
     "health care|lack of doctors|malkangiri": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.8333,
       "support": 5
     },
@@ -7980,11 +14375,13 @@
     },
     "health care|lack of doctors|sundargarh": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.9167,
       "support": 22
     },
     "health care|lack of medicines|bargarh": {
       "dept": "Fisheries & Animal Resources Development",
+      "office": "Departments",
       "share": 0.5,
       "support": 3
     },
@@ -8010,6 +14407,7 @@
     },
     "health care|lack of medicines|kalahandi": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 1.0,
       "support": 8
     },
@@ -8085,6 +14483,7 @@
     },
     "health care|ostf/ rbsk|ganjam": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.8,
       "support": 4
     },
@@ -8135,6 +14534,7 @@
     },
     "health care|treatment assistance|gajapati": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.816,
       "support": 204
     },
@@ -8160,6 +14560,7 @@
     },
     "health care|treatment assistance|kalahandi": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.9444,
       "support": 221
     },
@@ -8255,6 +14656,7 @@
     },
     "health care|unhygienic|bhadrak": {
       "dept": "Health & Family Welfare",
+      "office": "Departments",
       "share": 0.8,
       "support": 4
     },
@@ -8280,21 +14682,25 @@
     },
     "health care|unhygienic|jajpur": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.4444,
       "support": 4
     },
     "health care|unhygienic|kalahandi": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.5,
       "support": 4
     },
     "health care|unhygienic|kendrapara": {
       "dept": "Health & Family Welfare",
+      "office": "Departments",
       "share": 1.0,
       "support": 5
     },
     "health care|unhygienic|khordha": {
       "dept": "Health & Family Welfare",
+      "office": "Departments",
       "share": 0.5,
       "support": 13
     },
@@ -8315,21 +14721,25 @@
     },
     "health care|unhygienic|sambalpur": {
       "dept": "Housing & Urban Development",
+      "office": "Collector",
       "share": 0.3846,
       "support": 5
     },
     "health care|unhygienic|sundargarh": {
       "dept": "Health & Family Welfare",
+      "office": "Departments",
       "share": 0.6,
       "support": 15
     },
     "health care|upgradation of phc to chc|angul": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 1.0,
       "support": 3
     },
     "health care|upgradation of phc to chc|balangir": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 1.0,
       "support": 5
     },
@@ -8350,21 +14760,25 @@
     },
     "health care|upgradation of phc to chc|gajapati": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 1.0,
       "support": 3
     },
     "health care|upgradation of phc to chc|ganjam": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 1.0,
       "support": 10
     },
     "health care|upgradation of phc to chc|jajpur": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.92,
       "support": 23
     },
     "health care|upgradation of phc to chc|kalahandi": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.8235,
       "support": 14
     },
@@ -8380,16 +14794,19 @@
     },
     "health care|upgradation of phc to chc|malkangiri": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 1.0,
       "support": 8
     },
     "health care|upgradation of phc to chc|mayurbhanj": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.8889,
       "support": 16
     },
     "health care|upgradation of phc to chc|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 1.0,
       "support": 3
     },
@@ -8400,141 +14817,169 @@
     },
     "housing|financial assistance|balangir": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 1.0,
       "support": 103
     },
     "housing|rural housing|angul": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9694,
       "support": 7260
     },
     "housing|rural housing|balangir": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9874,
       "support": 32822
     },
     "housing|rural housing|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.5559,
       "support": 10940
     },
     "housing|rural housing|bargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9868,
       "support": 14671
     },
     "housing|rural housing|bhadrak": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9781,
       "support": 14502
     },
     "housing|rural housing|boudh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.921,
       "support": 3706
     },
     "housing|rural housing|cuttack": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.9622,
       "support": 4202
     },
     "housing|rural housing|deogarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9942,
       "support": 4493
     },
     "housing|rural housing|dhenkanal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9146,
       "support": 17646
     },
     "housing|rural housing|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.9654,
       "support": 725
     },
     "housing|rural housing|ganjam": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.958,
       "support": 7269
     },
     "housing|rural housing|jagatsinghapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.8773,
       "support": 1809
     },
     "housing|rural housing|jajpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9816,
       "support": 18093
     },
     "housing|rural housing|jharsuguda": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9873,
       "support": 2557
     },
     "housing|rural housing|kalahandi": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9921,
       "support": 25448
     },
     "housing|rural housing|kandhamal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9867,
       "support": 6988
     },
     "housing|rural housing|kendrapara": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7766,
       "support": 6544
     },
     "housing|rural housing|kendujhar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.9633,
       "support": 2705
     },
     "housing|rural housing|khordha": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9784,
       "support": 9480
     },
     "housing|rural housing|koraput": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8908,
       "support": 3744
     },
     "housing|rural housing|malkangiri": {
       "dept": "Housing & Urban Development",
+      "office": "Collector",
       "share": 0.5444,
       "support": 1397
     },
     "housing|rural housing|mayurbhanj": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.732,
       "support": 11635
     },
     "housing|rural housing|nabarangpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9787,
       "support": 7993
     },
     "housing|rural housing|nayagarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.9185,
       "support": 2841
     },
     "housing|rural housing|nuapada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9837,
       "support": 7807
     },
     "housing|rural housing|puri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9849,
       "support": 16019
     },
     "housing|rural housing|rayagada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9534,
       "support": 2026
     },
@@ -8545,16 +14990,19 @@
     },
     "housing|rural housing|subarnapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9823,
       "support": 10493
     },
     "housing|rural housing|sundargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9935,
       "support": 15694
     },
     "housing|urban housing|angul": {
       "dept": "Housing & Urban Development",
+      "office": "Collector",
       "share": 0.6667,
       "support": 28
     },
@@ -8565,41 +15013,49 @@
     },
     "housing|urban housing|baleswar": {
       "dept": "Housing & Urban Development",
+      "office": "Departments",
       "share": 0.6226,
       "support": 33
     },
     "housing|urban housing|bargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6538,
       "support": 51
     },
     "housing|urban housing|bhadrak": {
       "dept": "Housing & Urban Development",
+      "office": "Departments",
       "share": 0.5741,
       "support": 31
     },
     "housing|urban housing|boudh": {
       "dept": "Housing & Urban Development",
+      "office": "Collector",
       "share": 0.913,
       "support": 42
     },
     "housing|urban housing|cuttack": {
       "dept": "Housing & Urban Development",
+      "office": "Office of Chief Minister",
       "share": 0.8462,
       "support": 99
     },
     "housing|urban housing|deogarh": {
       "dept": "Housing & Urban Development",
+      "office": "Collector",
       "share": 0.7273,
       "support": 8
     },
     "housing|urban housing|dhenkanal": {
       "dept": "Housing & Urban Development",
+      "office": "Collector",
       "share": 0.5682,
       "support": 50
     },
     "housing|urban housing|gajapati": {
       "dept": "Housing & Urban Development",
+      "office": "Collector",
       "share": 0.8889,
       "support": 8
     },
@@ -8610,61 +15066,73 @@
     },
     "housing|urban housing|jagatsinghapur": {
       "dept": "Housing & Urban Development",
+      "office": "Departments",
       "share": 0.8571,
       "support": 6
     },
     "housing|urban housing|jajpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5641,
       "support": 44
     },
     "housing|urban housing|jharsuguda": {
       "dept": "Housing & Urban Development",
+      "office": "Collector",
       "share": 0.9,
       "support": 36
     },
     "housing|urban housing|kalahandi": {
       "dept": "Housing & Urban Development",
+      "office": "Collector",
       "share": 0.5083,
       "support": 92
     },
     "housing|urban housing|kandhamal": {
       "dept": "Housing & Urban Development",
+      "office": "Collector",
       "share": 0.6,
       "support": 15
     },
     "housing|urban housing|kendrapara": {
       "dept": "Housing & Urban Development",
+      "office": "Collector",
       "share": 0.6923,
       "support": 18
     },
     "housing|urban housing|kendujhar": {
       "dept": "Housing & Urban Development",
+      "office": "Departments",
       "share": 0.8605,
       "support": 37
     },
     "housing|urban housing|khordha": {
       "dept": "Housing & Urban Development",
+      "office": "Office of Chief Minister",
       "share": 0.8615,
       "support": 423
     },
     "housing|urban housing|koraput": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.75,
       "support": 87
     },
     "housing|urban housing|malkangiri": {
       "dept": "Housing & Urban Development",
+      "office": "Collector",
       "share": 1.0,
       "support": 11
     },
     "housing|urban housing|mayurbhanj": {
       "dept": "Housing & Urban Development",
+      "office": "Collector",
       "share": 0.49,
       "support": 49
     },
     "housing|urban housing|nabarangpur": {
       "dept": "Housing & Urban Development",
+      "office": "Collector",
       "share": 0.7692,
       "support": 30
     },
@@ -8675,6 +15143,7 @@
     },
     "housing|urban housing|nuapada": {
       "dept": "Housing & Urban Development",
+      "office": "Collector",
       "share": 0.6957,
       "support": 16
     },
@@ -8685,6 +15154,7 @@
     },
     "housing|urban housing|rayagada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8333,
       "support": 5
     },
@@ -8695,11 +15165,13 @@
     },
     "housing|urban housing|subarnapur": {
       "dept": "Housing & Urban Development",
+      "office": "Collector",
       "share": 0.7213,
       "support": 44
     },
     "housing|urban housing|sundargarh": {
       "dept": "Housing & Urban Development",
+      "office": "Collector",
       "share": 0.9067,
       "support": 68
     },
@@ -8715,11 +15187,13 @@
     },
     "icds|anganwadi centres|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.4314,
       "support": 44
     },
     "icds|anganwadi centres|bargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6471,
       "support": 11
     },
@@ -8740,6 +15214,7 @@
     },
     "icds|anganwadi centres|deogarh": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.3636,
       "support": 12
     },
@@ -8750,6 +15225,7 @@
     },
     "icds|anganwadi centres|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5593,
       "support": 33
     },
@@ -8770,6 +15246,7 @@
     },
     "icds|anganwadi centres|kalahandi": {
       "dept": "Women & Child Development",
+      "office": "Collector",
       "share": 0.791,
       "support": 53
     },
@@ -8800,6 +15277,7 @@
     },
     "icds|anganwadi centres|malkangiri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6458,
       "support": 31
     },
@@ -8810,6 +15288,7 @@
     },
     "icds|anganwadi centres|nabarangpur": {
       "dept": "Women & Child Development",
+      "office": "Collector",
       "share": 0.6364,
       "support": 21
     },
@@ -8820,6 +15299,7 @@
     },
     "icds|anganwadi centres|nuapada": {
       "dept": "Women & Child Development",
+      "office": "Collector",
       "share": 0.6,
       "support": 21
     },
@@ -8830,11 +15310,13 @@
     },
     "icds|anganwadi centres|rayagada": {
       "dept": "Women & Child Development",
+      "office": "Collector",
       "share": 0.7073,
       "support": 29
     },
     "icds|anganwadi centres|sambalpur": {
       "dept": "Women & Child Development",
+      "office": "Collector",
       "share": 0.5263,
       "support": 20
     },
@@ -8855,11 +15337,13 @@
     },
     "icds|i.c.d.s|balangir": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 0.9744,
       "support": 38
     },
     "icds|i.c.d.s|baleswar": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 0.75,
       "support": 48
     },
@@ -8870,6 +15354,7 @@
     },
     "icds|i.c.d.s|bhadrak": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 0.9111,
       "support": 41
     },
@@ -8880,11 +15365,13 @@
     },
     "icds|i.c.d.s|cuttack": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 0.9032,
       "support": 28
     },
     "icds|i.c.d.s|deogarh": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 1.0,
       "support": 11
     },
@@ -8895,6 +15382,7 @@
     },
     "icds|i.c.d.s|gajapati": {
       "dept": "Women & Child Development",
+      "office": "Collector",
       "share": 0.7895,
       "support": 15
     },
@@ -8905,31 +15393,37 @@
     },
     "icds|i.c.d.s|jagatsinghapur": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 0.7037,
       "support": 19
     },
     "icds|i.c.d.s|jajpur": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 0.9815,
       "support": 53
     },
     "icds|i.c.d.s|jharsuguda": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 0.6667,
       "support": 4
     },
     "icds|i.c.d.s|kalahandi": {
       "dept": "Women & Child Development",
+      "office": "Collector",
       "share": 0.9062,
       "support": 29
     },
     "icds|i.c.d.s|kandhamal": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 0.9778,
       "support": 44
     },
     "icds|i.c.d.s|kendrapara": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 0.92,
       "support": 23
     },
@@ -8940,6 +15434,7 @@
     },
     "icds|i.c.d.s|khordha": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 0.8889,
       "support": 24
     },
@@ -8950,11 +15445,13 @@
     },
     "icds|i.c.d.s|malkangiri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5,
       "support": 5
     },
     "icds|i.c.d.s|mayurbhanj": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 0.8947,
       "support": 34
     },
@@ -8970,11 +15467,13 @@
     },
     "icds|i.c.d.s|nuapada": {
       "dept": "Women & Child Development",
+      "office": "Collector",
       "share": 0.7424,
       "support": 49
     },
     "icds|i.c.d.s|puri": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 0.913,
       "support": 21
     },
@@ -8985,16 +15484,19 @@
     },
     "icds|i.c.d.s|sambalpur": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 0.5385,
       "support": 14
     },
     "icds|i.c.d.s|subarnapur": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 0.8462,
       "support": 11
     },
     "icds|i.c.d.s|sundargarh": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 1.0,
       "support": 27
     },
@@ -9005,16 +15507,19 @@
     },
     "icds|mamata yojana|balangir": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 1.0,
       "support": 5
     },
     "icds|mamata yojana|baleswar": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 0.9167,
       "support": 11
     },
     "icds|mamata yojana|bargarh": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 1.0,
       "support": 6
     },
@@ -9030,6 +15535,7 @@
     },
     "icds|mamata yojana|cuttack": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 1.0,
       "support": 13
     },
@@ -9045,16 +15551,19 @@
     },
     "icds|mamata yojana|ganjam": {
       "dept": "Women & Child Development",
+      "office": "Collector",
       "share": 0.9,
       "support": 9
     },
     "icds|mamata yojana|jajpur": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 0.8182,
       "support": 9
     },
     "icds|mamata yojana|kalahandi": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 0.9091,
       "support": 10
     },
@@ -9070,6 +15579,7 @@
     },
     "icds|mamata yojana|khordha": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 1.0,
       "support": 7
     },
@@ -9080,6 +15590,7 @@
     },
     "icds|mamata yojana|mayurbhanj": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 1.0,
       "support": 5
     },
@@ -9100,6 +15611,7 @@
     },
     "icds|nutrition program|baleswar": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 0.9167,
       "support": 11
     },
@@ -9110,6 +15622,7 @@
     },
     "icds|nutrition program|cuttack": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 1.0,
       "support": 7
     },
@@ -9150,6 +15663,7 @@
     },
     "icds|nutrition program|khordha": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 1.0,
       "support": 9
     },
@@ -9165,6 +15679,7 @@
     },
     "icds|nutrition program|puri": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 1.0,
       "support": 5
     },
@@ -9180,146 +15695,175 @@
     },
     "infrastructure|boundary wall|angul": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4615,
       "support": 6
     },
     "infrastructure|boundary wall|balangir": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7941,
       "support": 54
     },
     "infrastructure|boundary wall|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.2963,
       "support": 8
     },
     "infrastructure|boundary wall|bargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6786,
       "support": 19
     },
     "infrastructure|boundary wall|bhadrak": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.3333,
       "support": 4
     },
     "infrastructure|boundary wall|cuttack": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.25,
       "support": 6
     },
     "infrastructure|boundary wall|deogarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8,
       "support": 4
     },
     "infrastructure|boundary wall|dhenkanal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4848,
       "support": 16
     },
     "infrastructure|boundary wall|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9123,
       "support": 104
     },
     "infrastructure|boundary wall|ganjam": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5085,
       "support": 30
     },
     "infrastructure|boundary wall|jagatsinghapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5833,
       "support": 14
     },
     "infrastructure|boundary wall|jajpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.75,
       "support": 39
     },
     "infrastructure|boundary wall|jharsuguda": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5556,
       "support": 10
     },
     "infrastructure|boundary wall|kalahandi": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6406,
       "support": 41
     },
     "infrastructure|boundary wall|kandhamal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8529,
       "support": 29
     },
     "infrastructure|boundary wall|kendrapara": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5,
       "support": 3
     },
     "infrastructure|boundary wall|kendujhar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6818,
       "support": 15
     },
     "infrastructure|boundary wall|khordha": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7273,
       "support": 32
     },
     "infrastructure|boundary wall|koraput": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8471,
       "support": 72
     },
     "infrastructure|boundary wall|malkangiri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8,
       "support": 20
     },
     "infrastructure|boundary wall|mayurbhanj": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.4091,
       "support": 9
     },
     "infrastructure|boundary wall|nabarangpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4912,
       "support": 28
     },
     "infrastructure|boundary wall|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.6,
       "support": 9
     },
     "infrastructure|boundary wall|nuapada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7727,
       "support": 17
     },
     "infrastructure|boundary wall|puri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5789,
       "support": 11
     },
     "infrastructure|boundary wall|rayagada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.875,
       "support": 7
     },
     "infrastructure|boundary wall|sambalpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6092,
       "support": 53
     },
     "infrastructure|boundary wall|subarnapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4545,
       "support": 5
     },
     "infrastructure|boundary wall|sundargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8065,
       "support": 75
     },
@@ -9330,6 +15874,7 @@
     },
     "infrastructure|bridge|balangir": {
       "dept": "Rural Development",
+      "office": "Collector",
       "share": 0.3816,
       "support": 29
     },
@@ -9365,16 +15910,19 @@
     },
     "infrastructure|bridge|dhenkanal": {
       "dept": "Rural Development",
+      "office": "Collector",
       "share": 0.4098,
       "support": 25
     },
     "infrastructure|bridge|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5547,
       "support": 76
     },
     "infrastructure|bridge|ganjam": {
       "dept": "Rural Development",
+      "office": "Collector",
       "share": 0.6029,
       "support": 41
     },
@@ -9385,16 +15933,19 @@
     },
     "infrastructure|bridge|jajpur": {
       "dept": "Rural Development",
+      "office": "Collector",
       "share": 0.4713,
       "support": 41
     },
     "infrastructure|bridge|jharsuguda": {
       "dept": "Works",
+      "office": "Collector",
       "share": 0.7097,
       "support": 22
     },
     "infrastructure|bridge|kalahandi": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.3416,
       "support": 55
     },
@@ -9410,6 +15961,7 @@
     },
     "infrastructure|bridge|kendujhar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.3763,
       "support": 35
     },
@@ -9420,16 +15972,19 @@
     },
     "infrastructure|bridge|koraput": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6442,
       "support": 105
     },
     "infrastructure|bridge|malkangiri": {
       "dept": "Rural Development",
+      "office": "Collector",
       "share": 0.3471,
       "support": 42
     },
     "infrastructure|bridge|mayurbhanj": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.3525,
       "support": 49
     },
@@ -9440,6 +15995,7 @@
     },
     "infrastructure|bridge|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.4643,
       "support": 26
     },
@@ -9460,6 +16016,7 @@
     },
     "infrastructure|bridge|sambalpur": {
       "dept": "Works",
+      "office": "Collector",
       "share": 0.3717,
       "support": 42
     },
@@ -9470,26 +16027,31 @@
     },
     "infrastructure|bridge|sundargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4217,
       "support": 70
     },
     "infrastructure|checkdams|angul": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5455,
       "support": 6
     },
     "infrastructure|checkdams|balangir": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7391,
       "support": 17
     },
     "infrastructure|checkdams|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.5,
       "support": 3
     },
     "infrastructure|checkdams|bargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5,
       "support": 4
     },
@@ -9500,51 +16062,59 @@
     },
     "infrastructure|checkdams|cuttack": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.9,
       "support": 9
     },
     "infrastructure|checkdams|deogarh": {
-      "dept": "Panchayati Raj & Drinking Water",
+      "dept": "Water Resources",
       "share": 0.5,
       "support": 3
     },
     "infrastructure|checkdams|dhenkanal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.875,
       "support": 7
     },
     "infrastructure|checkdams|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9437,
       "support": 67
     },
     "infrastructure|checkdams|ganjam": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5,
       "support": 18
     },
     "infrastructure|checkdams|jajpur": {
       "dept": "Rural Development",
+      "office": "Collector",
       "share": 1.0,
       "support": 4
     },
     "infrastructure|checkdams|kalahandi": {
-      "dept": "Panchayati Raj & Drinking Water",
+      "dept": "Water Resources",
       "share": 0.4545,
       "support": 10
     },
     "infrastructure|checkdams|kandhamal": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.6618,
       "support": 45
     },
     "infrastructure|checkdams|kendrapara": {
       "dept": "Water Resources",
+      "office": "Office of Chief Minister",
       "share": 0.75,
       "support": 3
     },
     "infrastructure|checkdams|kendujhar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8095,
       "support": 17
     },
@@ -9555,211 +16125,253 @@
     },
     "infrastructure|checkdams|koraput": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9301,
       "support": 133
     },
     "infrastructure|checkdams|malkangiri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 1.0,
       "support": 6
     },
     "infrastructure|checkdams|mayurbhanj": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.6429,
       "support": 18
     },
     "infrastructure|checkdams|nabarangpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5806,
       "support": 18
     },
     "infrastructure|checkdams|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 1.0,
       "support": 11
     },
     "infrastructure|checkdams|rayagada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7391,
       "support": 17
     },
     "infrastructure|checkdams|sambalpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7105,
       "support": 27
     },
     "infrastructure|checkdams|sundargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8636,
       "support": 19
     },
     "infrastructure|community centre|angul": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8559,
       "support": 95
     },
     "infrastructure|community centre|balangir": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8568,
       "support": 784
     },
     "infrastructure|community centre|baleswar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4198,
       "support": 34
     },
     "infrastructure|community centre|bargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9148,
       "support": 204
     },
     "infrastructure|community centre|bhadrak": {
       "dept": "Planning & Convergence",
+      "office": "Collector",
       "share": 0.9352,
       "support": 101
     },
     "infrastructure|community centre|boudh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5789,
       "support": 44
     },
     "infrastructure|community centre|cuttack": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5745,
       "support": 54
     },
     "infrastructure|community centre|deogarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9258,
       "support": 337
     },
     "infrastructure|community centre|dhenkanal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8271,
       "support": 287
     },
     "infrastructure|community centre|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9752,
       "support": 433
     },
     "infrastructure|community centre|ganjam": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.587,
       "support": 398
     },
     "infrastructure|community centre|jagatsinghapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9672,
       "support": 59
     },
     "infrastructure|community centre|jajpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9519,
       "support": 297
     },
     "infrastructure|community centre|jharsuguda": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8367,
       "support": 41
     },
     "infrastructure|community centre|kalahandi": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8267,
       "support": 291
     },
     "infrastructure|community centre|kandhamal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8408,
       "support": 264
     },
     "infrastructure|community centre|kendrapara": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.75,
       "support": 12
     },
     "infrastructure|community centre|kendujhar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8333,
       "support": 135
     },
     "infrastructure|community centre|khordha": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7963,
       "support": 172
     },
     "infrastructure|community centre|koraput": {
       "dept": "Planning & Convergence",
+      "office": "Collector",
       "share": 0.8494,
       "support": 203
     },
     "infrastructure|community centre|malkangiri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.875,
       "support": 98
     },
     "infrastructure|community centre|mayurbhanj": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.87,
       "support": 328
     },
     "infrastructure|community centre|nabarangpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8609,
       "support": 297
     },
     "infrastructure|community centre|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.6684,
       "support": 131
     },
     "infrastructure|community centre|nuapada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9803,
       "support": 848
     },
     "infrastructure|community centre|puri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7588,
       "support": 129
     },
     "infrastructure|community centre|rayagada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9429,
       "support": 33
     },
     "infrastructure|community centre|sambalpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7893,
       "support": 648
     },
     "infrastructure|community centre|subarnapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.871,
       "support": 54
     },
     "infrastructure|community centre|sundargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9245,
       "support": 306
     },
     "infrastructure|crematorium|balangir": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9524,
       "support": 40
     },
     "infrastructure|crematorium|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.5556,
       "support": 10
     },
     "infrastructure|crematorium|bargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5294,
       "support": 9
     },
     "infrastructure|crematorium|cuttack": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5,
       "support": 11
     },
@@ -9770,91 +16382,109 @@
     },
     "infrastructure|crematorium|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9,
       "support": 27
     },
     "infrastructure|crematorium|ganjam": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7297,
       "support": 27
     },
     "infrastructure|crematorium|jagatsinghapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9091,
       "support": 10
     },
     "infrastructure|crematorium|jajpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8,
       "support": 20
     },
     "infrastructure|crematorium|kalahandi": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8333,
       "support": 20
     },
     "infrastructure|crematorium|kandhamal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7,
       "support": 7
     },
     "infrastructure|crematorium|kendujhar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8333,
       "support": 10
     },
     "infrastructure|crematorium|khordha": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7059,
       "support": 12
     },
     "infrastructure|crematorium|koraput": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7273,
       "support": 24
     },
     "infrastructure|crematorium|malkangiri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6,
       "support": 3
     },
     "infrastructure|crematorium|mayurbhanj": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 1.0,
       "support": 12
     },
     "infrastructure|crematorium|nabarangpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.4167,
       "support": 5
     },
     "infrastructure|crematorium|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.8,
       "support": 4
     },
     "infrastructure|crematorium|nuapada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6667,
       "support": 4
     },
     "infrastructure|crematorium|puri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6667,
       "support": 4
     },
     "infrastructure|crematorium|rayagada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8333,
       "support": 5
     },
     "infrastructure|crematorium|sambalpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6452,
       "support": 20
     },
     "infrastructure|crematorium|sundargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7692,
       "support": 10
     },
@@ -9880,6 +16510,7 @@
     },
     "infrastructure|drainage|bhadrak": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.3542,
       "support": 17
     },
@@ -9895,6 +16526,7 @@
     },
     "infrastructure|drainage|deogarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4889,
       "support": 22
     },
@@ -9905,6 +16537,7 @@
     },
     "infrastructure|drainage|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4516,
       "support": 56
     },
@@ -9915,6 +16548,7 @@
     },
     "infrastructure|drainage|jagatsinghapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4699,
       "support": 39
     },
@@ -9925,16 +16559,19 @@
     },
     "infrastructure|drainage|jharsuguda": {
       "dept": "Housing & Urban Development",
+      "office": "Collector",
       "share": 0.7119,
       "support": 42
     },
     "infrastructure|drainage|kalahandi": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4114,
       "support": 65
     },
     "infrastructure|drainage|kandhamal": {
       "dept": "Housing & Urban Development",
+      "office": "Collector",
       "share": 0.5,
       "support": 14
     },
@@ -9955,11 +16592,13 @@
     },
     "infrastructure|drainage|koraput": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4851,
       "support": 49
     },
     "infrastructure|drainage|malkangiri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.625,
       "support": 20
     },
@@ -9995,6 +16634,7 @@
     },
     "infrastructure|drainage|sambalpur": {
       "dept": "Housing & Urban Development",
+      "office": "Collector",
       "share": 0.7367,
       "support": 235
     },
@@ -10010,36 +16650,43 @@
     },
     "infrastructure|infrastructure related to depts|angul": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.2941,
       "support": 5
     },
     "infrastructure|infrastructure related to depts|balangir": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6286,
       "support": 22
     },
     "infrastructure|infrastructure related to depts|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.75,
       "support": 42
     },
     "infrastructure|infrastructure related to depts|bargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.375,
       "support": 6
     },
     "infrastructure|infrastructure related to depts|boudh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5,
       "support": 3
     },
     "infrastructure|infrastructure related to depts|cuttack": {
       "dept": "Water Resources",
+      "office": "Departments",
       "share": 0.3103,
       "support": 18
     },
     "infrastructure|infrastructure related to depts|deogarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8115,
       "support": 99
     },
@@ -10050,71 +16697,83 @@
     },
     "infrastructure|infrastructure related to depts|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5556,
       "support": 5
     },
     "infrastructure|infrastructure related to depts|ganjam": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.2609,
       "support": 6
     },
     "infrastructure|infrastructure related to depts|jagatsinghapur": {
       "dept": "Water Resources",
+      "office": "Departments",
       "share": 0.6316,
       "support": 12
     },
     "infrastructure|infrastructure related to depts|jajpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.2609,
       "support": 12
     },
     "infrastructure|infrastructure related to depts|kalahandi": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5545,
       "support": 61
     },
     "infrastructure|infrastructure related to depts|kandhamal": {
-      "dept": "Agriculture & Farmers' Empowerment",
+      "dept": "Panchayati Raj & Drinking Water",
       "share": 0.2353,
       "support": 4
     },
     "infrastructure|infrastructure related to depts|kendrapara": {
       "dept": "Water Resources",
+      "office": "Departments",
       "share": 0.625,
       "support": 20
     },
     "infrastructure|infrastructure related to depts|kendujhar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.225,
       "support": 9
     },
     "infrastructure|infrastructure related to depts|khordha": {
       "dept": "Housing & Urban Development",
+      "office": "Collector",
       "share": 0.6835,
       "support": 54
     },
     "infrastructure|infrastructure related to depts|koraput": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8201,
       "support": 114
     },
     "infrastructure|infrastructure related to depts|malkangiri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4167,
       "support": 10
     },
     "infrastructure|infrastructure related to depts|mayurbhanj": {
-      "dept": "General Administration & Public Grievance",
+      "dept": "Panchayati Raj & Drinking Water",
       "share": 0.1429,
       "support": 3
     },
     "infrastructure|infrastructure related to depts|nabarangpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.375,
       "support": 6
     },
     "infrastructure|infrastructure related to depts|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.7,
       "support": 7
     },
@@ -10125,26 +16784,31 @@
     },
     "infrastructure|infrastructure related to depts|sambalpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6757,
       "support": 50
     },
     "infrastructure|infrastructure related to depts|sundargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.25,
       "support": 11
     },
     "infrastructure|infrastructure|angul": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5641,
       "support": 44
     },
     "infrastructure|infrastructure|balangir": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.927,
       "support": 533
     },
     "infrastructure|infrastructure|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.4105,
       "support": 39
     },
@@ -10155,6 +16819,7 @@
     },
     "infrastructure|infrastructure|bhadrak": {
       "dept": "Planning & Convergence",
+      "office": "Collector",
       "share": 0.4016,
       "support": 49
     },
@@ -10175,11 +16840,13 @@
     },
     "infrastructure|infrastructure|dhenkanal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4605,
       "support": 35
     },
     "infrastructure|infrastructure|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8054,
       "support": 331
     },
@@ -10195,16 +16862,19 @@
     },
     "infrastructure|infrastructure|jajpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5469,
       "support": 70
     },
     "infrastructure|infrastructure|jharsuguda": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.3636,
       "support": 16
     },
     "infrastructure|infrastructure|kalahandi": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5695,
       "support": 127
     },
@@ -10220,6 +16890,7 @@
     },
     "infrastructure|infrastructure|kendujhar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4421,
       "support": 42
     },
@@ -10230,6 +16901,7 @@
     },
     "infrastructure|infrastructure|koraput": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7548,
       "support": 237
     },
@@ -10240,21 +16912,25 @@
     },
     "infrastructure|infrastructure|mayurbhanj": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.2736,
       "support": 29
     },
     "infrastructure|infrastructure|nabarangpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5347,
       "support": 54
     },
     "infrastructure|infrastructure|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.5455,
       "support": 36
     },
     "infrastructure|infrastructure|nuapada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6486,
       "support": 48
     },
@@ -10265,11 +16941,13 @@
     },
     "infrastructure|infrastructure|rayagada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4583,
       "support": 11
     },
     "infrastructure|infrastructure|sambalpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4801,
       "support": 301
     },
@@ -10280,86 +16958,103 @@
     },
     "infrastructure|infrastructure|sundargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6345,
       "support": 283
     },
     "infrastructure|kalyan mandap|angul": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8889,
       "support": 24
     },
     "infrastructure|kalyan mandap|balangir": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9041,
       "support": 198
     },
     "infrastructure|kalyan mandap|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.3,
       "support": 6
     },
     "infrastructure|kalyan mandap|bargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9208,
       "support": 477
     },
     "infrastructure|kalyan mandap|bhadrak": {
       "dept": "Planning & Convergence",
+      "office": "Collector",
       "share": 0.8333,
       "support": 10
     },
     "infrastructure|kalyan mandap|boudh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6667,
       "support": 4
     },
     "infrastructure|kalyan mandap|cuttack": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9048,
       "support": 19
     },
     "infrastructure|kalyan mandap|deogarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8,
       "support": 28
     },
     "infrastructure|kalyan mandap|dhenkanal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8571,
       "support": 18
     },
     "infrastructure|kalyan mandap|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9718,
       "support": 69
     },
     "infrastructure|kalyan mandap|ganjam": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7487,
       "support": 149
     },
     "infrastructure|kalyan mandap|jagatsinghapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9444,
       "support": 17
     },
     "infrastructure|kalyan mandap|jajpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9118,
       "support": 31
     },
     "infrastructure|kalyan mandap|jharsuguda": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7391,
       "support": 34
     },
     "infrastructure|kalyan mandap|kalahandi": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8256,
       "support": 71
     },
     "infrastructure|kalyan mandap|kandhamal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6667,
       "support": 18
     },
@@ -10370,81 +17065,97 @@
     },
     "infrastructure|kalyan mandap|kendujhar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6875,
       "support": 22
     },
     "infrastructure|kalyan mandap|khordha": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6667,
       "support": 28
     },
     "infrastructure|kalyan mandap|koraput": {
       "dept": "Planning & Convergence",
+      "office": "Collector",
       "share": 0.8261,
       "support": 76
     },
     "infrastructure|kalyan mandap|malkangiri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 1.0,
       "support": 10
     },
     "infrastructure|kalyan mandap|mayurbhanj": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8852,
       "support": 54
     },
     "infrastructure|kalyan mandap|nabarangpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.6364,
       "support": 7
     },
     "infrastructure|kalyan mandap|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.8077,
       "support": 21
     },
     "infrastructure|kalyan mandap|nuapada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9545,
       "support": 21
     },
     "infrastructure|kalyan mandap|puri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9333,
       "support": 14
     },
     "infrastructure|kalyan mandap|rayagada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 1.0,
       "support": 11
     },
     "infrastructure|kalyan mandap|sambalpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7958,
       "support": 382
     },
     "infrastructure|kalyan mandap|subarnapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9082,
       "support": 89
     },
     "infrastructure|kalyan mandap|sundargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.84,
       "support": 105
     },
     "infrastructure|library|balangir": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6,
       "support": 9
     },
     "infrastructure|library|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.4545,
       "support": 5
     },
     "infrastructure|library|bargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.75,
       "support": 9
     },
@@ -10455,106 +17166,127 @@
     },
     "infrastructure|library|dhenkanal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6923,
       "support": 9
     },
     "infrastructure|library|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 1.0,
       "support": 5
     },
     "infrastructure|library|ganjam": {
       "dept": "Rural Development",
+      "office": "Collector",
       "share": 0.4118,
       "support": 7
     },
     "infrastructure|library|jagatsinghapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.875,
       "support": 7
     },
     "infrastructure|library|jajpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8889,
       "support": 8
     },
     "infrastructure|library|kalahandi": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7143,
       "support": 5
     },
     "infrastructure|library|kendrapara": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5,
       "support": 5
     },
     "infrastructure|library|khordha": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5714,
       "support": 4
     },
     "infrastructure|library|koraput": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5,
       "support": 3
     },
     "infrastructure|library|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.5,
       "support": 3
     },
     "infrastructure|library|puri": {
       "dept": "Housing & Urban Development",
+      "office": "Collector",
       "share": 0.6667,
       "support": 4
     },
     "infrastructure|library|sambalpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.3846,
       "support": 5
     },
     "infrastructure|library|subarnapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 1.0,
       "support": 4
     },
     "infrastructure|market complex|angul": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8333,
       "support": 5
     },
     "infrastructure|market complex|balangir": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6667,
       "support": 8
     },
     "infrastructure|market complex|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.6,
       "support": 12
     },
     "infrastructure|market complex|bargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4615,
       "support": 6
     },
     "infrastructure|market complex|boudh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 7
     },
     "infrastructure|market complex|cuttack": {
       "dept": "Housing & Urban Development",
+      "office": "Office of Chief Minister",
       "share": 0.7333,
       "support": 11
     },
     "infrastructure|market complex|deogarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 1.0,
       "support": 4
     },
     "infrastructure|market complex|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6364,
       "support": 7
     },
@@ -10565,16 +17297,19 @@
     },
     "infrastructure|market complex|jagatsinghapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 1.0,
       "support": 10
     },
     "infrastructure|market complex|jajpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8,
       "support": 8
     },
     "infrastructure|market complex|kalahandi": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.2941,
       "support": 10
     },
@@ -10585,231 +17320,277 @@
     },
     "infrastructure|market complex|kendujhar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5,
       "support": 4
     },
     "infrastructure|market complex|khordha": {
       "dept": "Housing & Urban Development",
+      "office": "Office of Chief Minister",
       "share": 0.7241,
       "support": 21
     },
     "infrastructure|market complex|koraput": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8889,
       "support": 8
     },
     "infrastructure|market complex|malkangiri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.75,
       "support": 3
     },
     "infrastructure|market complex|mayurbhanj": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7333,
       "support": 11
     },
     "infrastructure|market complex|nabarangpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.4286,
       "support": 3
     },
     "infrastructure|market complex|nuapada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5,
       "support": 3
     },
     "infrastructure|market complex|puri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5333,
       "support": 8
     },
     "infrastructure|market complex|sambalpur": {
       "dept": "Housing & Urban Development",
+      "office": "Office of Chief Minister",
       "share": 0.5,
       "support": 5
     },
     "infrastructure|market complex|subarnapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7143,
       "support": 5
     },
     "infrastructure|market complex|sundargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7059,
       "support": 12
     },
     "infrastructure|other infrastructures|angul": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4803,
       "support": 73
     },
     "infrastructure|other infrastructures|balangir": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7602,
       "support": 336
     },
     "infrastructure|other infrastructures|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.4564,
       "support": 314
     },
     "infrastructure|other infrastructures|bargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6629,
       "support": 232
     },
     "infrastructure|other infrastructures|bhadrak": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4328,
       "support": 29
     },
     "infrastructure|other infrastructures|boudh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8592,
       "support": 122
     },
     "infrastructure|other infrastructures|cuttack": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4713,
       "support": 74
     },
     "infrastructure|other infrastructures|deogarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6893,
       "support": 71
     },
     "infrastructure|other infrastructures|dhenkanal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5983,
       "support": 216
     },
     "infrastructure|other infrastructures|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7995,
       "support": 307
     },
     "infrastructure|other infrastructures|ganjam": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.51,
       "support": 205
     },
     "infrastructure|other infrastructures|jagatsinghapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5436,
       "support": 131
     },
     "infrastructure|other infrastructures|jajpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.78,
       "support": 312
     },
     "infrastructure|other infrastructures|jharsuguda": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5277,
       "support": 143
     },
     "infrastructure|other infrastructures|kalahandi": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6095,
       "support": 334
     },
     "infrastructure|other infrastructures|kandhamal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6509,
       "support": 179
     },
     "infrastructure|other infrastructures|kendrapara": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4615,
       "support": 42
     },
     "infrastructure|other infrastructures|kendujhar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5314,
       "support": 110
     },
     "infrastructure|other infrastructures|khordha": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4365,
       "support": 86
     },
     "infrastructure|other infrastructures|koraput": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6851,
       "support": 198
     },
     "infrastructure|other infrastructures|malkangiri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6422,
       "support": 70
     },
     "infrastructure|other infrastructures|mayurbhanj": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.302,
       "support": 138
     },
     "infrastructure|other infrastructures|nabarangpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.6635,
       "support": 211
     },
     "infrastructure|other infrastructures|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.7843,
       "support": 120
     },
     "infrastructure|other infrastructures|nuapada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9057,
       "support": 96
     },
     "infrastructure|other infrastructures|puri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7115,
       "support": 222
     },
     "infrastructure|other infrastructures|rayagada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5818,
       "support": 32
     },
     "infrastructure|other infrastructures|sambalpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6381,
       "support": 536
     },
     "infrastructure|other infrastructures|subarnapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5323,
       "support": 33
     },
     "infrastructure|other infrastructures|sundargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5642,
       "support": 202
     },
     "infrastructure|park|angul": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.75,
       "support": 9
     },
     "infrastructure|park|balangir": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.875,
       "support": 28
     },
     "infrastructure|park|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.2667,
       "support": 4
     },
     "infrastructure|park|bargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9,
       "support": 9
     },
     "infrastructure|park|bhadrak": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7143,
       "support": 5
     },
@@ -10820,41 +17601,49 @@
     },
     "infrastructure|park|deogarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 1.0,
       "support": 11
     },
     "infrastructure|park|dhenkanal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7778,
       "support": 7
     },
     "infrastructure|park|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8571,
       "support": 18
     },
     "infrastructure|park|ganjam": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5556,
       "support": 20
     },
     "infrastructure|park|jagatsinghapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8889,
       "support": 16
     },
     "infrastructure|park|jajpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9524,
       "support": 20
     },
     "infrastructure|park|jharsuguda": {
       "dept": "Housing & Urban Development",
+      "office": "Collector",
       "share": 0.5,
       "support": 4
     },
     "infrastructure|park|kalahandi": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7,
       "support": 21
     },
@@ -10865,6 +17654,7 @@
     },
     "infrastructure|park|kendujhar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.85,
       "support": 17
     },
@@ -10874,12 +17664,13 @@
       "support": 36
     },
     "infrastructure|park|koraput": {
-      "dept": "Panchayati Raj & Drinking Water",
+      "dept": "Housing & Urban Development",
       "share": 0.5,
       "support": 7
     },
     "infrastructure|park|malkangiri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5833,
       "support": 7
     },
@@ -10890,6 +17681,7 @@
     },
     "infrastructure|park|nayagarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6111,
       "support": 11
     },
@@ -10900,96 +17692,115 @@
     },
     "infrastructure|park|rayagada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6,
       "support": 3
     },
     "infrastructure|park|sambalpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5556,
       "support": 15
     },
     "infrastructure|park|subarnapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.875,
       "support": 7
     },
     "infrastructure|park|sundargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6061,
       "support": 20
     },
     "infrastructure|playground|angul": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7778,
       "support": 14
     },
     "infrastructure|playground|balangir": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9669,
       "support": 117
     },
     "infrastructure|playground|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.4167,
       "support": 5
     },
     "infrastructure|playground|bargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7843,
       "support": 40
     },
     "infrastructure|playground|bhadrak": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5385,
       "support": 7
     },
     "infrastructure|playground|cuttack": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4706,
       "support": 8
     },
     "infrastructure|playground|deogarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 1.0,
       "support": 48
     },
     "infrastructure|playground|dhenkanal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.96,
       "support": 24
     },
     "infrastructure|playground|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8182,
       "support": 18
     },
     "infrastructure|playground|ganjam": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6053,
       "support": 23
     },
     "infrastructure|playground|jagatsinghapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5882,
       "support": 10
     },
     "infrastructure|playground|jajpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7895,
       "support": 30
     },
     "infrastructure|playground|jharsuguda": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.3571,
       "support": 5
     },
     "infrastructure|playground|kalahandi": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8496,
       "support": 96
     },
     "infrastructure|playground|kandhamal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8333,
       "support": 30
     },
@@ -11000,231 +17811,277 @@
     },
     "infrastructure|playground|kendujhar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7436,
       "support": 29
     },
     "infrastructure|playground|khordha": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7667,
       "support": 23
     },
     "infrastructure|playground|koraput": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8333,
       "support": 15
     },
     "infrastructure|playground|malkangiri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8537,
       "support": 35
     },
     "infrastructure|playground|mayurbhanj": {
       "dept": "Sports & Youth Services",
+      "office": "Collector",
       "share": 0.4375,
       "support": 14
     },
     "infrastructure|playground|nabarangpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6667,
       "support": 6
     },
     "infrastructure|playground|nuapada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6667,
       "support": 8
     },
     "infrastructure|playground|puri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.625,
       "support": 5
     },
     "infrastructure|playground|rayagada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 1.0,
       "support": 4
     },
     "infrastructure|playground|sambalpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7383,
       "support": 79
     },
     "infrastructure|playground|subarnapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9167,
       "support": 11
     },
     "infrastructure|playground|sundargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7885,
       "support": 82
     },
     "infrastructure|religious institution|angul": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7621,
       "support": 221
     },
     "infrastructure|religious institution|balangir": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8223,
       "support": 1661
     },
     "infrastructure|religious institution|baleswar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4474,
       "support": 51
     },
     "infrastructure|religious institution|bargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8475,
       "support": 628
     },
     "infrastructure|religious institution|bhadrak": {
       "dept": "Planning & Convergence",
+      "office": "Collector",
       "share": 0.9846,
       "support": 512
     },
     "infrastructure|religious institution|boudh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9217,
       "support": 106
     },
     "infrastructure|religious institution|cuttack": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5,
       "support": 341
     },
     "infrastructure|religious institution|deogarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7949,
       "support": 186
     },
     "infrastructure|religious institution|dhenkanal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5478,
       "support": 149
     },
     "infrastructure|religious institution|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9095,
       "support": 633
     },
     "infrastructure|religious institution|ganjam": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5708,
       "support": 883
     },
     "infrastructure|religious institution|jagatsinghapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9741,
       "support": 339
     },
     "infrastructure|religious institution|jajpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.962,
       "support": 684
     },
     "infrastructure|religious institution|jharsuguda": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7742,
       "support": 48
     },
     "infrastructure|religious institution|kalahandi": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8335,
       "support": 856
     },
     "infrastructure|religious institution|kandhamal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7606,
       "support": 378
     },
     "infrastructure|religious institution|kendrapara": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.6387,
       "support": 221
     },
     "infrastructure|religious institution|kendujhar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7093,
       "support": 588
     },
     "infrastructure|religious institution|khordha": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7856,
       "support": 469
     },
     "infrastructure|religious institution|koraput": {
       "dept": "Planning & Convergence",
+      "office": "Collector",
       "share": 0.972,
       "support": 936
     },
     "infrastructure|religious institution|malkangiri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9,
       "support": 297
     },
     "infrastructure|religious institution|mayurbhanj": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9318,
       "support": 793
     },
     "infrastructure|religious institution|nabarangpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.5709,
       "support": 491
     },
     "infrastructure|religious institution|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.9574,
       "support": 180
     },
     "infrastructure|religious institution|nuapada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9734,
       "support": 183
     },
     "infrastructure|religious institution|puri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8449,
       "support": 316
     },
     "infrastructure|religious institution|rayagada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8828,
       "support": 113
     },
     "infrastructure|religious institution|sambalpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7525,
       "support": 1368
     },
     "infrastructure|religious institution|subarnapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8834,
       "support": 250
     },
     "infrastructure|religious institution|sundargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9149,
       "support": 344
     },
     "infrastructure|road|angul": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4699,
       "support": 265
     },
     "infrastructure|road|balangir": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6343,
       "support": 569
     },
     "infrastructure|road|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.2622,
       "support": 318
     },
     "infrastructure|road|bargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.52,
       "support": 416
     },
@@ -11245,6 +18102,7 @@
     },
     "infrastructure|road|deogarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7326,
       "support": 252
     },
@@ -11255,16 +18113,19 @@
     },
     "infrastructure|road|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7247,
       "support": 1140
     },
     "infrastructure|road|ganjam": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.3836,
       "support": 308
     },
     "infrastructure|road|jagatsinghapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4489,
       "support": 483
     },
@@ -11275,11 +18136,13 @@
     },
     "infrastructure|road|jharsuguda": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.3597,
       "support": 132
     },
     "infrastructure|road|kalahandi": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5171,
       "support": 817
     },
@@ -11305,21 +18168,25 @@
     },
     "infrastructure|road|koraput": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6125,
       "support": 757
     },
     "infrastructure|road|malkangiri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.553,
       "support": 313
     },
     "infrastructure|road|mayurbhanj": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4308,
       "support": 464
     },
     "infrastructure|road|nabarangpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.622,
       "support": 464
     },
@@ -11330,6 +18197,7 @@
     },
     "infrastructure|road|nuapada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6134,
       "support": 219
     },
@@ -11345,6 +18213,7 @@
     },
     "infrastructure|road|sambalpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4285,
       "support": 536
     },
@@ -11355,6 +18224,7 @@
     },
     "infrastructure|road|sundargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5043,
       "support": 1057
     },
@@ -11370,6 +18240,7 @@
     },
     "infrastructure|rural haats|kalahandi": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6667,
       "support": 6
     },
@@ -11385,6 +18256,7 @@
     },
     "infrastructure|rural haats|koraput": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7778,
       "support": 7
     },
@@ -11400,6 +18272,7 @@
     },
     "infrastructure|transport and traffic|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.8,
       "support": 4
     },
@@ -11409,17 +18282,20 @@
       "support": 3
     },
     "infrastructure|transport and traffic|kalahandi": {
-      "dept": "Home department",
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.2727,
       "support": 3
     },
     "infrastructure|transport and traffic|kandhamal": {
       "dept": "Rural Development",
+      "office": "Departments",
       "share": 0.8,
       "support": 4
     },
     "infrastructure|transport and traffic|kendujhar": {
-      "dept": "Commerce & Transport",
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.3,
       "support": 3
     },
@@ -11430,156 +18306,186 @@
     },
     "infrastructure|transport and traffic|sambalpur": {
       "dept": "Commerce & Transport",
+      "office": "Collector",
       "share": 0.6,
       "support": 3
     },
     "infrastructure|water tanks/ reservoirs/ponds|angul": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7368,
       "support": 14
     },
     "infrastructure|water tanks/ reservoirs/ponds|balangir": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8911,
       "support": 90
     },
     "infrastructure|water tanks/ reservoirs/ponds|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.6471,
       "support": 22
     },
     "infrastructure|water tanks/ reservoirs/ponds|bargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8817,
       "support": 82
     },
     "infrastructure|water tanks/ reservoirs/ponds|bhadrak": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8,
       "support": 4
     },
     "infrastructure|water tanks/ reservoirs/ponds|cuttack": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6875,
       "support": 11
     },
     "infrastructure|water tanks/ reservoirs/ponds|deogarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8621,
       "support": 25
     },
     "infrastructure|water tanks/ reservoirs/ponds|dhenkanal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8571,
       "support": 18
     },
     "infrastructure|water tanks/ reservoirs/ponds|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8571,
       "support": 48
     },
     "infrastructure|water tanks/ reservoirs/ponds|ganjam": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6351,
       "support": 47
     },
     "infrastructure|water tanks/ reservoirs/ponds|jagatsinghapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4286,
       "support": 3
     },
     "infrastructure|water tanks/ reservoirs/ponds|jajpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8889,
       "support": 24
     },
     "infrastructure|water tanks/ reservoirs/ponds|jharsuguda": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8846,
       "support": 23
     },
     "infrastructure|water tanks/ reservoirs/ponds|kalahandi": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8559,
       "support": 101
     },
     "infrastructure|water tanks/ reservoirs/ponds|kandhamal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8182,
       "support": 9
     },
     "infrastructure|water tanks/ reservoirs/ponds|kendrapara": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5,
       "support": 5
     },
     "infrastructure|water tanks/ reservoirs/ponds|kendujhar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8837,
       "support": 38
     },
     "infrastructure|water tanks/ reservoirs/ponds|khordha": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7,
       "support": 14
     },
     "infrastructure|water tanks/ reservoirs/ponds|koraput": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6842,
       "support": 13
     },
     "infrastructure|water tanks/ reservoirs/ponds|malkangiri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8462,
       "support": 11
     },
     "infrastructure|water tanks/ reservoirs/ponds|mayurbhanj": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5882,
       "support": 10
     },
     "infrastructure|water tanks/ reservoirs/ponds|nabarangpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6364,
       "support": 7
     },
     "infrastructure|water tanks/ reservoirs/ponds|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.6154,
       "support": 8
     },
     "infrastructure|water tanks/ reservoirs/ponds|nuapada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9474,
       "support": 18
     },
     "infrastructure|water tanks/ reservoirs/ponds|puri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6111,
       "support": 11
     },
     "infrastructure|water tanks/ reservoirs/ponds|rayagada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.875,
       "support": 7
     },
     "infrastructure|water tanks/ reservoirs/ponds|sambalpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8403,
       "support": 100
     },
     "infrastructure|water tanks/ reservoirs/ponds|subarnapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9565,
       "support": 22
     },
     "infrastructure|water tanks/ reservoirs/ponds|sundargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8378,
       "support": 31
     },
     "irrigation|barrage|balangir": {
-      "dept": "Panchayati Raj & Drinking Water",
+      "dept": "Water Resources",
       "share": 0.5,
       "support": 3
     },
@@ -11590,6 +18496,7 @@
     },
     "irrigation|barrage|ganjam": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.6364,
       "support": 7
     },
@@ -11600,16 +18507,19 @@
     },
     "irrigation|barrage|kalahandi": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.7692,
       "support": 10
     },
     "irrigation|barrage|kendrapara": {
       "dept": "Water Resources",
+      "office": "Departments",
       "share": 1.0,
       "support": 3
     },
     "irrigation|barrage|kendujhar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6,
       "support": 3
     },
@@ -11620,16 +18530,19 @@
     },
     "irrigation|barrage|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.7143,
       "support": 5
     },
     "irrigation|barrage|sambalpur": {
-      "dept": "Panchayati Raj & Drinking Water",
+      "dept": "Water Resources",
+      "office": "Office of Chief Minister",
       "share": 0.4286,
       "support": 3
     },
     "irrigation|barrage|sundargarh": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 1.0,
       "support": 15
     },
@@ -11640,11 +18553,13 @@
     },
     "irrigation|canal|balangir": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.4286,
       "support": 9
     },
     "irrigation|canal|baleswar": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.5417,
       "support": 13
     },
@@ -11670,21 +18585,25 @@
     },
     "irrigation|canal|deogarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4545,
       "support": 5
     },
     "irrigation|canal|dhenkanal": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.7407,
       "support": 20
     },
     "irrigation|canal|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4643,
       "support": 13
     },
     "irrigation|canal|ganjam": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.4,
       "support": 36
     },
@@ -11700,21 +18619,25 @@
     },
     "irrigation|canal|kalahandi": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.828,
       "support": 77
     },
     "irrigation|canal|kandhamal": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.7059,
       "support": 12
     },
     "irrigation|canal|kendrapara": {
       "dept": "Water Resources",
+      "office": "Departments",
       "share": 0.871,
       "support": 27
     },
     "irrigation|canal|kendujhar": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.56,
       "support": 14
     },
@@ -11730,21 +18653,25 @@
     },
     "irrigation|canal|malkangiri": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.375,
       "support": 3
     },
     "irrigation|canal|mayurbhanj": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.7451,
       "support": 38
     },
     "irrigation|canal|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.5,
       "support": 7
     },
     "irrigation|canal|nuapada": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.9286,
       "support": 13
     },
@@ -11760,6 +18687,7 @@
     },
     "irrigation|canal|sambalpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4706,
       "support": 16
     },
@@ -11775,56 +18703,67 @@
     },
     "irrigation|in-stream storage structure|angul": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 1.0,
       "support": 4
     },
     "irrigation|in-stream storage structure|bargarh": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 1.0,
       "support": 4
     },
     "irrigation|in-stream storage structure|ganjam": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6,
       "support": 3
     },
     "irrigation|in-stream storage structure|kalahandi": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 1.0,
       "support": 6
     },
     "irrigation|in-stream storage structure|kendujhar": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 1.0,
       "support": 7
     },
     "irrigation|in-stream storage structure|mayurbhanj": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.9375,
       "support": 15
     },
     "irrigation|in-stream storage structure|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.5714,
       "support": 4
     },
     "irrigation|lift irrigation|angul": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.84,
       "support": 21
     },
     "irrigation|lift irrigation|balangir": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.5714,
       "support": 16
     },
     "irrigation|lift irrigation|baleswar": {
       "dept": "Water Resources",
+      "office": "Departments",
       "share": 0.3611,
       "support": 13
     },
     "irrigation|lift irrigation|bargarh": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 1.0,
       "support": 49
     },
@@ -11835,11 +18774,13 @@
     },
     "irrigation|lift irrigation|boudh": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.619,
       "support": 13
     },
     "irrigation|lift irrigation|cuttack": {
       "dept": "Water Resources",
+      "office": "Office of Chief Minister",
       "share": 0.7059,
       "support": 12
     },
@@ -11850,21 +18791,25 @@
     },
     "irrigation|lift irrigation|dhenkanal": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.6531,
       "support": 32
     },
     "irrigation|lift irrigation|gajapati": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.3704,
       "support": 10
     },
     "irrigation|lift irrigation|ganjam": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.3654,
       "support": 19
     },
     "irrigation|lift irrigation|jagatsinghapur": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.8667,
       "support": 13
     },
@@ -11875,11 +18820,13 @@
     },
     "irrigation|lift irrigation|jharsuguda": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.4286,
       "support": 12
     },
     "irrigation|lift irrigation|kalahandi": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.8333,
       "support": 80
     },
@@ -11890,6 +18837,7 @@
     },
     "irrigation|lift irrigation|kendrapara": {
       "dept": "Water Resources",
+      "office": "Departments",
       "share": 1.0,
       "support": 5
     },
@@ -11900,36 +18848,43 @@
     },
     "irrigation|lift irrigation|khordha": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 1.0,
       "support": 45
     },
     "irrigation|lift irrigation|koraput": {
-      "dept": "Panchayati Raj & Drinking Water",
+      "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.36,
       "support": 9
     },
     "irrigation|lift irrigation|mayurbhanj": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.8036,
       "support": 45
     },
     "irrigation|lift irrigation|nabarangpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.5,
       "support": 7
     },
     "irrigation|lift irrigation|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.6667,
       "support": 10
     },
     "irrigation|lift irrigation|nuapada": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.8,
       "support": 12
     },
     "irrigation|lift irrigation|puri": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.625,
       "support": 5
     },
@@ -11940,51 +18895,61 @@
     },
     "irrigation|lift irrigation|sambalpur": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.3333,
       "support": 24
     },
     "irrigation|lift irrigation|subarnapur": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.875,
       "support": 14
     },
     "irrigation|lift irrigation|sundargarh": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.6216,
       "support": 23
     },
     "irrigation|mega lift irrigation project|balangir": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.6087,
       "support": 14
     },
     "irrigation|mega lift irrigation project|bargarh": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.9286,
       "support": 26
     },
     "irrigation|mega lift irrigation project|boudh": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.75,
       "support": 9
     },
     "irrigation|mega lift irrigation project|deogarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.6,
       "support": 9
     },
     "irrigation|mega lift irrigation project|dhenkanal": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.625,
       "support": 5
     },
     "irrigation|mega lift irrigation project|gajapati": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.5833,
       "support": 7
     },
     "irrigation|mega lift irrigation project|ganjam": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.4706,
       "support": 8
     },
@@ -11995,16 +18960,19 @@
     },
     "irrigation|mega lift irrigation project|jharsuguda": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.84,
       "support": 21
     },
     "irrigation|mega lift irrigation project|kalahandi": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.9369,
       "support": 104
     },
     "irrigation|mega lift irrigation project|kendujhar": {
       "dept": "Water Resources",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 4
     },
@@ -12020,21 +18988,25 @@
     },
     "irrigation|mega lift irrigation project|mayurbhanj": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.8333,
       "support": 5
     },
     "irrigation|mega lift irrigation project|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 1.0,
       "support": 4
     },
     "irrigation|mega lift irrigation project|nuapada": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.9333,
       "support": 14
     },
     "irrigation|mega lift irrigation project|sambalpur": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.4595,
       "support": 17
     },
@@ -12045,31 +19017,37 @@
     },
     "irrigation|mega lift irrigation project|sundargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5,
       "support": 5
     },
     "irrigation|minor irrigation poroject|angul": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.6667,
       "support": 8
     },
     "irrigation|minor irrigation poroject|balangir": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.375,
       "support": 9
     },
     "irrigation|minor irrigation poroject|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.4286,
       "support": 9
     },
     "irrigation|minor irrigation poroject|bargarh": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 1.0,
       "support": 42
     },
     "irrigation|minor irrigation poroject|boudh": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.5455,
       "support": 12
     },
@@ -12080,21 +19058,25 @@
     },
     "irrigation|minor irrigation poroject|deogarh": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.4667,
       "support": 14
     },
     "irrigation|minor irrigation poroject|dhenkanal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5846,
       "support": 38
     },
     "irrigation|minor irrigation poroject|gajapati": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.4074,
       "support": 11
     },
     "irrigation|minor irrigation poroject|ganjam": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.3958,
       "support": 19
     },
@@ -12105,61 +19087,73 @@
     },
     "irrigation|minor irrigation poroject|jharsuguda": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.6667,
       "support": 4
     },
     "irrigation|minor irrigation poroject|kalahandi": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.8033,
       "support": 49
     },
     "irrigation|minor irrigation poroject|kandhamal": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.8571,
       "support": 18
     },
     "irrigation|minor irrigation poroject|kendujhar": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.75,
       "support": 21
     },
     "irrigation|minor irrigation poroject|khordha": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.7895,
       "support": 15
     },
     "irrigation|minor irrigation poroject|koraput": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.8333,
       "support": 15
     },
     "irrigation|minor irrigation poroject|mayurbhanj": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.8621,
       "support": 50
     },
     "irrigation|minor irrigation poroject|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 1.0,
       "support": 34
     },
     "irrigation|minor irrigation poroject|nuapada": {
       "dept": "ST & SC Development, Minorities & Backward Classes Welfare",
+      "office": "Collector",
       "share": 0.5238,
       "support": 22
     },
     "irrigation|minor irrigation poroject|rayagada": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.8571,
       "support": 6
     },
     "irrigation|minor irrigation poroject|sambalpur": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.4359,
       "support": 17
     },
     "irrigation|minor irrigation poroject|sundargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7949,
       "support": 31
     },
@@ -12170,26 +19164,31 @@
     },
     "irrigation|others|balangir": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.45,
       "support": 9
     },
     "irrigation|others|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.5,
       "support": 16
     },
     "irrigation|others|bargarh": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.8462,
       "support": 11
     },
     "irrigation|others|bhadrak": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.8333,
       "support": 10
     },
     "irrigation|others|boudh": {
       "dept": "Water Resources",
+      "office": "Departments",
       "share": 0.3636,
       "support": 8
     },
@@ -12200,11 +19199,13 @@
     },
     "irrigation|others|dhenkanal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4545,
       "support": 5
     },
     "irrigation|others|gajapati": {
       "dept": "Works",
+      "office": "Collector",
       "share": 0.4444,
       "support": 20
     },
@@ -12215,6 +19216,7 @@
     },
     "irrigation|others|jagatsinghapur": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.5957,
       "support": 28
     },
@@ -12225,26 +19227,31 @@
     },
     "irrigation|others|jharsuguda": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.625,
       "support": 10
     },
     "irrigation|others|kalahandi": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.7872,
       "support": 37
     },
     "irrigation|others|kandhamal": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.75,
       "support": 12
     },
     "irrigation|others|kendrapara": {
       "dept": "Water Resources",
+      "office": "Departments",
       "share": 0.9412,
       "support": 16
     },
     "irrigation|others|kendujhar": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.5,
       "support": 9
     },
@@ -12255,21 +19262,25 @@
     },
     "irrigation|others|koraput": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4286,
       "support": 6
     },
     "irrigation|others|mayurbhanj": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.6977,
       "support": 30
     },
     "irrigation|others|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.625,
       "support": 5
     },
     "irrigation|others|nuapada": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.5385,
       "support": 14
     },
@@ -12285,6 +19296,7 @@
     },
     "irrigation|others|sambalpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5652,
       "support": 13
     },
@@ -12295,21 +19307,25 @@
     },
     "irrigation|others|sundargarh": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.5,
       "support": 12
     },
     "irrigation|stone embankment|baleswar": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.6,
       "support": 12
     },
     "irrigation|stone embankment|bhadrak": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.8,
       "support": 4
     },
     "irrigation|stone embankment|cuttack": {
       "dept": "Water Resources",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 4
     },
@@ -12325,11 +19341,13 @@
     },
     "irrigation|stone embankment|kalahandi": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.5,
       "support": 5
     },
     "irrigation|stone embankment|kendrapara": {
       "dept": "Water Resources",
+      "office": "Departments",
       "share": 0.875,
       "support": 7
     },
@@ -12340,31 +19358,37 @@
     },
     "irrigation|stone embankment|mayurbhanj": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.7407,
       "support": 20
     },
     "irrigation|stone embankment|nayagarh": {
       "dept": "Water Resources",
+      "office": "Departments",
       "share": 0.8,
       "support": 4
     },
     "land matters|boundary change|angul": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9474,
       "support": 18
     },
     "land matters|boundary change|balangir": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8571,
       "support": 12
     },
     "land matters|boundary change|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.64,
       "support": 16
     },
     "land matters|boundary change|bargarh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.92,
       "support": 46
     },
@@ -12380,11 +19404,13 @@
     },
     "land matters|boundary change|dhenkanal": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8837,
       "support": 38
     },
     "land matters|boundary change|ganjam": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 1.0,
       "support": 23
     },
@@ -12395,6 +19421,7 @@
     },
     "land matters|boundary change|jajpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9655,
       "support": 28
     },
@@ -12405,6 +19432,7 @@
     },
     "land matters|boundary change|kalahandi": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9444,
       "support": 17
     },
@@ -12415,16 +19443,19 @@
     },
     "land matters|boundary change|kendrapara": {
       "dept": "Revenue & Disaster Management",
+      "office": "Departments",
       "share": 1.0,
       "support": 11
     },
     "land matters|boundary change|kendujhar": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8824,
       "support": 15
     },
     "land matters|boundary change|khordha": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.7143,
       "support": 15
     },
@@ -12440,6 +19471,7 @@
     },
     "land matters|boundary change|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.8182,
       "support": 9
     },
@@ -12455,6 +19487,7 @@
     },
     "land matters|boundary change|sambalpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9474,
       "support": 18
     },
@@ -12465,6 +19498,7 @@
     },
     "land matters|encroachment|angul": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.903,
       "support": 149
     },
@@ -12475,21 +19509,25 @@
     },
     "land matters|encroachment|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.5257,
       "support": 338
     },
     "land matters|encroachment|bargarh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9071,
       "support": 127
     },
     "land matters|encroachment|bhadrak": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9167,
       "support": 561
     },
     "land matters|encroachment|boudh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9787,
       "support": 46
     },
@@ -12510,11 +19548,13 @@
     },
     "land matters|encroachment|gajapati": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8696,
       "support": 60
     },
     "land matters|encroachment|ganjam": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8033,
       "support": 192
     },
@@ -12530,11 +19570,13 @@
     },
     "land matters|encroachment|jharsuguda": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8596,
       "support": 98
     },
     "land matters|encroachment|kalahandi": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9126,
       "support": 282
     },
@@ -12550,6 +19592,7 @@
     },
     "land matters|encroachment|kendujhar": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8148,
       "support": 176
     },
@@ -12560,6 +19603,7 @@
     },
     "land matters|encroachment|koraput": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8571,
       "support": 66
     },
@@ -12570,11 +19614,13 @@
     },
     "land matters|encroachment|mayurbhanj": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.5714,
       "support": 184
     },
     "land matters|encroachment|nabarangpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8757,
       "support": 155
     },
@@ -12585,6 +19631,7 @@
     },
     "land matters|encroachment|nuapada": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.7778,
       "support": 56
     },
@@ -12595,26 +19642,31 @@
     },
     "land matters|encroachment|rayagada": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8824,
       "support": 30
     },
     "land matters|encroachment|sambalpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.803,
       "support": 159
     },
     "land matters|encroachment|subarnapur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8824,
       "support": 75
     },
     "land matters|encroachment|sundargarh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9258,
       "support": 312
     },
     "land matters|land acquisition/ r&r|angul": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8023,
       "support": 211
     },
@@ -12625,6 +19677,7 @@
     },
     "land matters|land acquisition/ r&r|baleswar": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.6203,
       "support": 49
     },
@@ -12640,51 +19693,61 @@
     },
     "land matters|land acquisition/ r&r|boudh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9625,
       "support": 77
     },
     "land matters|land acquisition/ r&r|cuttack": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.781,
       "support": 82
     },
     "land matters|land acquisition/ r&r|deogarh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9072,
       "support": 88
     },
     "land matters|land acquisition/ r&r|dhenkanal": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8205,
       "support": 96
     },
     "land matters|land acquisition/ r&r|gajapati": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.875,
       "support": 28
     },
     "land matters|land acquisition/ r&r|ganjam": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8372,
       "support": 180
     },
     "land matters|land acquisition/ r&r|jagatsinghapur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.84,
       "support": 42
     },
     "land matters|land acquisition/ r&r|jajpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9376,
       "support": 481
     },
     "land matters|land acquisition/ r&r|jharsuguda": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.7895,
       "support": 60
     },
     "land matters|land acquisition/ r&r|kalahandi": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.7778,
       "support": 112
     },
@@ -12695,41 +19758,49 @@
     },
     "land matters|land acquisition/ r&r|kendrapara": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.92,
       "support": 69
     },
     "land matters|land acquisition/ r&r|kendujhar": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.7333,
       "support": 44
     },
     "land matters|land acquisition/ r&r|khordha": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.6228,
       "support": 104
     },
     "land matters|land acquisition/ r&r|koraput": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8738,
       "support": 90
     },
     "land matters|land acquisition/ r&r|mayurbhanj": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.4625,
       "support": 37
     },
     "land matters|land acquisition/ r&r|nabarangpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8588,
       "support": 73
     },
     "land matters|land acquisition/ r&r|nayagarh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.5132,
       "support": 39
     },
     "land matters|land acquisition/ r&r|nuapada": {
       "dept": "Water Resources",
+      "office": "Office of Chief Minister",
       "share": 0.5294,
       "support": 27
     },
@@ -12740,21 +19811,25 @@
     },
     "land matters|land acquisition/ r&r|rayagada": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.7333,
       "support": 33
     },
     "land matters|land acquisition/ r&r|sambalpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.7698,
       "support": 107
     },
     "land matters|land acquisition/ r&r|subarnapur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8462,
       "support": 22
     },
     "land matters|land acquisition/ r&r|sundargarh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8483,
       "support": 151
     },
@@ -12775,6 +19850,7 @@
     },
     "land matters|land allotment/settlement/ror|bargarh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.964,
       "support": 482
     },
@@ -12785,6 +19861,7 @@
     },
     "land matters|land allotment/settlement/ror|boudh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.966,
       "support": 483
     },
@@ -12795,21 +19872,25 @@
     },
     "land matters|land allotment/settlement/ror|deogarh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8954,
       "support": 411
     },
     "land matters|land allotment/settlement/ror|dhenkanal": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9323,
       "support": 551
     },
     "land matters|land allotment/settlement/ror|gajapati": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9707,
       "support": 1060
     },
     "land matters|land allotment/settlement/ror|ganjam": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.935,
       "support": 1797
     },
@@ -12825,16 +19906,19 @@
     },
     "land matters|land allotment/settlement/ror|jharsuguda": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.921,
       "support": 373
     },
     "land matters|land allotment/settlement/ror|kalahandi": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9533,
       "support": 1489
     },
     "land matters|land allotment/settlement/ror|kandhamal": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9213,
       "support": 246
     },
@@ -12855,21 +19939,25 @@
     },
     "land matters|land allotment/settlement/ror|koraput": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9055,
       "support": 230
     },
     "land matters|land allotment/settlement/ror|malkangiri": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8113,
       "support": 129
     },
     "land matters|land allotment/settlement/ror|mayurbhanj": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.5784,
       "support": 546
     },
     "land matters|land allotment/settlement/ror|nabarangpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9119,
       "support": 590
     },
@@ -12880,6 +19968,7 @@
     },
     "land matters|land allotment/settlement/ror|nuapada": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8914,
       "support": 353
     },
@@ -12890,26 +19979,31 @@
     },
     "land matters|land allotment/settlement/ror|rayagada": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9137,
       "support": 254
     },
     "land matters|land allotment/settlement/ror|sambalpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8376,
       "support": 784
     },
     "land matters|land allotment/settlement/ror|subarnapur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9135,
       "support": 285
     },
     "land matters|land allotment/settlement/ror|sundargarh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.939,
       "support": 708
     },
     "land matters|land dispute|angul": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.904,
       "support": 273
     },
@@ -12920,21 +20014,25 @@
     },
     "land matters|land dispute|baleswar": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.61,
       "support": 416
     },
     "land matters|land dispute|bargarh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8679,
       "support": 322
     },
     "land matters|land dispute|bhadrak": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8286,
       "support": 377
     },
     "land matters|land dispute|boudh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9368,
       "support": 267
     },
@@ -12945,46 +20043,55 @@
     },
     "land matters|land dispute|deogarh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8974,
       "support": 105
     },
     "land matters|land dispute|dhenkanal": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8216,
       "support": 396
     },
     "land matters|land dispute|gajapati": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8559,
       "support": 190
     },
     "land matters|land dispute|ganjam": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.7416,
       "support": 488
     },
     "land matters|land dispute|jagatsinghapur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8886,
       "support": 367
     },
     "land matters|land dispute|jajpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8471,
       "support": 432
     },
     "land matters|land dispute|jharsuguda": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9294,
       "support": 237
     },
     "land matters|land dispute|kalahandi": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9396,
       "support": 498
     },
     "land matters|land dispute|kandhamal": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8764,
       "support": 156
     },
@@ -12995,6 +20102,7 @@
     },
     "land matters|land dispute|kendujhar": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8631,
       "support": 353
     },
@@ -13005,71 +20113,85 @@
     },
     "land matters|land dispute|koraput": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8936,
       "support": 168
     },
     "land matters|land dispute|malkangiri": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8923,
       "support": 58
     },
     "land matters|land dispute|mayurbhanj": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.4426,
       "support": 355
     },
     "land matters|land dispute|nabarangpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8316,
       "support": 405
     },
     "land matters|land dispute|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.6261,
       "support": 278
     },
     "land matters|land dispute|nuapada": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.7516,
       "support": 115
     },
     "land matters|land dispute|puri": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.6851,
       "support": 198
     },
     "land matters|land dispute|rayagada": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.815,
       "support": 141
     },
     "land matters|land dispute|sambalpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8986,
       "support": 399
     },
     "land matters|land dispute|subarnapur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8214,
       "support": 138
     },
     "land matters|land dispute|sundargarh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8741,
       "support": 250
     },
     "land matters|land/revenue/tax|angul": {
       "dept": "Revenue & Disaster Management",
+      "office": "Departments",
       "share": 0.9697,
       "support": 64
     },
     "land matters|land/revenue/tax|balangir": {
       "dept": "Revenue & Disaster Management",
+      "office": "Departments",
       "share": 0.9516,
       "support": 59
     },
     "land matters|land/revenue/tax|baleswar": {
       "dept": "Revenue & Disaster Management",
+      "office": "Departments",
       "share": 0.8088,
       "support": 220
     },
@@ -13080,16 +20202,19 @@
     },
     "land matters|land/revenue/tax|bhadrak": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9497,
       "support": 170
     },
     "land matters|land/revenue/tax|boudh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9773,
       "support": 43
     },
     "land matters|land/revenue/tax|cuttack": {
       "dept": "Revenue & Disaster Management",
+      "office": "Departments",
       "share": 0.9469,
       "support": 214
     },
@@ -13100,11 +20225,13 @@
     },
     "land matters|land/revenue/tax|dhenkanal": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8816,
       "support": 134
     },
     "land matters|land/revenue/tax|gajapati": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9583,
       "support": 138
     },
@@ -13115,31 +20242,37 @@
     },
     "land matters|land/revenue/tax|jagatsinghapur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9649,
       "support": 110
     },
     "land matters|land/revenue/tax|jajpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.947,
       "support": 375
     },
     "land matters|land/revenue/tax|jharsuguda": {
       "dept": "Revenue & Disaster Management",
+      "office": "Departments",
       "share": 0.9623,
       "support": 51
     },
     "land matters|land/revenue/tax|kalahandi": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9391,
       "support": 509
     },
     "land matters|land/revenue/tax|kandhamal": {
       "dept": "Revenue & Disaster Management",
+      "office": "Departments",
       "share": 0.9667,
       "support": 29
     },
     "land matters|land/revenue/tax|kendrapara": {
       "dept": "Revenue & Disaster Management",
+      "office": "Departments",
       "share": 0.9886,
       "support": 174
     },
@@ -13150,6 +20283,7 @@
     },
     "land matters|land/revenue/tax|khordha": {
       "dept": "Revenue & Disaster Management",
+      "office": "Departments",
       "share": 0.8789,
       "support": 225
     },
@@ -13165,6 +20299,7 @@
     },
     "land matters|land/revenue/tax|mayurbhanj": {
       "dept": "Revenue & Disaster Management",
+      "office": "Departments",
       "share": 0.5,
       "support": 62
     },
@@ -13175,36 +20310,43 @@
     },
     "land matters|land/revenue/tax|nayagarh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Departments",
       "share": 0.6078,
       "support": 62
     },
     "land matters|land/revenue/tax|nuapada": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8284,
       "support": 560
     },
     "land matters|land/revenue/tax|puri": {
       "dept": "Revenue & Disaster Management",
+      "office": "Departments",
       "share": 0.9467,
       "support": 142
     },
     "land matters|land/revenue/tax|rayagada": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9778,
       "support": 44
     },
     "land matters|land/revenue/tax|sambalpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Departments",
       "share": 0.9286,
       "support": 78
     },
     "land matters|land/revenue/tax|subarnapur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Departments",
       "share": 0.9688,
       "support": 31
     },
     "land matters|land/revenue/tax|sundargarh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9428,
       "support": 808
     },
@@ -13220,6 +20362,7 @@
     },
     "land matters|property dispute|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.5333,
       "support": 24
     },
@@ -13230,31 +20373,37 @@
     },
     "land matters|property dispute|bhadrak": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.875,
       "support": 42
     },
     "land matters|property dispute|boudh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 1.0,
       "support": 15
     },
     "land matters|property dispute|cuttack": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8333,
       "support": 75
     },
     "land matters|property dispute|dhenkanal": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8529,
       "support": 29
     },
     "land matters|property dispute|gajapati": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.7273,
       "support": 16
     },
     "land matters|property dispute|ganjam": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.6857,
       "support": 48
     },
@@ -13265,76 +20414,91 @@
     },
     "land matters|property dispute|jajpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.766,
       "support": 36
     },
     "land matters|property dispute|jharsuguda": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 1.0,
       "support": 8
     },
     "land matters|property dispute|kalahandi": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9697,
       "support": 32
     },
     "land matters|property dispute|kandhamal": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.875,
       "support": 7
     },
     "land matters|property dispute|kendrapara": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.6053,
       "support": 23
     },
     "land matters|property dispute|kendujhar": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.875,
       "support": 21
     },
     "land matters|property dispute|khordha": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.5534,
       "support": 57
     },
     "land matters|property dispute|koraput": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9565,
       "support": 22
     },
     "land matters|property dispute|malkangiri": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9,
       "support": 9
     },
     "land matters|property dispute|mayurbhanj": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.55,
       "support": 33
     },
     "land matters|property dispute|nabarangpur": {
       "dept": "Home department",
+      "office": "Superintendent of Police",
       "share": 0.5455,
       "support": 6
     },
     "land matters|property dispute|nayagarh": {
-      "dept": "General Administration & Public Grievance",
+      "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.4865,
       "support": 18
     },
     "land matters|property dispute|puri": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.6471,
       "support": 11
     },
     "land matters|property dispute|rayagada": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.6429,
       "support": 9
     },
     "land matters|property dispute|sambalpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9259,
       "support": 25
     },
@@ -13345,46 +20509,55 @@
     },
     "land matters|property dispute|sundargarh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8718,
       "support": 34
     },
     "legal|legal aids|baleswar": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.6471,
       "support": 11
     },
     "legal|legal aids|boudh": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 5
     },
     "legal|legal aids|cuttack": {
       "dept": "Law",
+      "office": "Collector",
       "share": 0.3846,
       "support": 5
     },
     "legal|legal aids|dhenkanal": {
-      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "dept": "Law",
+      "office": "Collector",
       "share": 0.3333,
       "support": 3
     },
     "legal|legal aids|ganjam": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 0.5,
       "support": 5
     },
     "legal|legal aids|kendujhar": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.4615,
       "support": 6
     },
     "legal|legal aids|mayurbhanj": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.625,
       "support": 5
     },
     "legal|legal aids|puri": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.5,
       "support": 4
     },
@@ -13395,96 +20568,115 @@
     },
     "legal|legal redress|baleswar": {
       "dept": "School & Mass Education",
+      "office": "Departments",
       "share": 0.6875,
       "support": 11
     },
     "legal|legal redress|bargarh": {
       "dept": "School & Mass Education",
+      "office": "Departments",
       "share": 0.8,
       "support": 4
     },
     "legal|legal redress|bhadrak": {
       "dept": "School & Mass Education",
+      "office": "Departments",
       "share": 0.5556,
       "support": 10
     },
     "legal|legal redress|boudh": {
       "dept": "School & Mass Education",
+      "office": "Departments",
       "share": 0.6,
       "support": 3
     },
     "legal|legal redress|cuttack": {
       "dept": "Home department",
+      "office": "Superintendent of Police",
       "share": 0.3636,
       "support": 12
     },
     "legal|legal redress|dhenkanal": {
       "dept": "School & Mass Education",
+      "office": "Departments",
       "share": 0.3333,
       "support": 3
     },
     "legal|legal redress|gajapati": {
       "dept": "School & Mass Education",
+      "office": "Departments",
       "share": 0.7,
       "support": 7
     },
     "legal|legal redress|ganjam": {
       "dept": "School & Mass Education",
+      "office": "Departments",
       "share": 0.4583,
       "support": 11
     },
     "legal|legal redress|jajpur": {
       "dept": "Law",
+      "office": "Office of Chief Minister",
       "share": 0.2667,
       "support": 4
     },
     "legal|legal redress|jharsuguda": {
       "dept": "Fisheries & Animal Resources Development",
+      "office": "Departments",
       "share": 0.6,
       "support": 3
     },
     "legal|legal redress|kalahandi": {
       "dept": "School & Mass Education",
+      "office": "Departments",
       "share": 0.4286,
       "support": 9
     },
     "legal|legal redress|kendrapara": {
       "dept": "School & Mass Education",
+      "office": "Departments",
       "share": 0.5,
       "support": 4
     },
     "legal|legal redress|kendujhar": {
       "dept": "School & Mass Education",
+      "office": "Departments",
       "share": 0.3571,
       "support": 5
     },
     "legal|legal redress|khordha": {
       "dept": "School & Mass Education",
+      "office": "Departments",
       "share": 0.5,
       "support": 13
     },
     "legal|legal redress|koraput": {
-      "dept": "Revenue & Disaster Management",
+      "dept": "School & Mass Education",
+      "office": "Departments",
       "share": 0.3,
       "support": 3
     },
     "legal|legal redress|nabarangpur": {
       "dept": "School & Mass Education",
+      "office": "Departments",
       "share": 1.0,
       "support": 3
     },
     "legal|legal redress|nuapada": {
       "dept": "School & Mass Education",
+      "office": "Departments",
       "share": 0.75,
       "support": 3
     },
     "legal|legal redress|puri": {
       "dept": "School & Mass Education",
+      "office": "Departments",
       "share": 0.5152,
       "support": 17
     },
     "legal|legal redress|rayagada": {
       "dept": "School & Mass Education",
+      "office": "Departments",
       "share": 0.4286,
       "support": 3
     },
@@ -13495,11 +20687,13 @@
     },
     "legal|permissions|cuttack": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.5,
       "support": 3
     },
     "legal|permissions|ganjam": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.2667,
       "support": 4
     },
@@ -13515,11 +20709,13 @@
     },
     "legal|permissions|sambalpur": {
       "dept": "Women & Child Development",
+      "office": "Office of Chief Minister",
       "share": 0.4286,
       "support": 3
     },
     "miscellaneous|absurd/irrelevant|baleswar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.75,
       "support": 3
     },
@@ -13540,6 +20736,7 @@
     },
     "miscellaneous|allegation/corruption|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.3456,
       "support": 394
     },
@@ -13555,6 +20752,7 @@
     },
     "miscellaneous|allegation/corruption|boudh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.5118,
       "support": 87
     },
@@ -13565,16 +20763,19 @@
     },
     "miscellaneous|allegation/corruption|deogarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.2105,
       "support": 12
     },
     "miscellaneous|allegation/corruption|dhenkanal": {
       "dept": "Energy",
+      "office": "Office of Chief Minister",
       "share": 0.2158,
       "support": 93
     },
     "miscellaneous|allegation/corruption|gajapati": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.1871,
       "support": 61
     },
@@ -13585,6 +20786,7 @@
     },
     "miscellaneous|allegation/corruption|jagatsinghapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.2624,
       "support": 159
     },
@@ -13600,6 +20802,7 @@
     },
     "miscellaneous|allegation/corruption|kalahandi": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.2482,
       "support": 140
     },
@@ -13610,6 +20813,7 @@
     },
     "miscellaneous|allegation/corruption|kendrapara": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.284,
       "support": 146
     },
@@ -13635,11 +20839,13 @@
     },
     "miscellaneous|allegation/corruption|mayurbhanj": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.2851,
       "support": 124
     },
     "miscellaneous|allegation/corruption|nabarangpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.3381,
       "support": 190
     },
@@ -13650,11 +20856,13 @@
     },
     "miscellaneous|allegation/corruption|nuapada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4103,
       "support": 48
     },
     "miscellaneous|allegation/corruption|puri": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 0.2104,
       "support": 126
     },
@@ -13670,6 +20878,7 @@
     },
     "miscellaneous|allegation/corruption|subarnapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.3862,
       "support": 56
     },
@@ -13685,6 +20894,7 @@
     },
     "miscellaneous|animal issues/ wildlife issues|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.4167,
       "support": 5
     },
@@ -13725,41 +20935,49 @@
     },
     "miscellaneous|animal issues/ wildlife issues|kendrapara": {
       "dept": "Forest, Environment and Climate Change Department",
+      "office": "Departments",
       "share": 1.0,
       "support": 7
     },
     "miscellaneous|animal issues/ wildlife issues|kendujhar": {
       "dept": "Fisheries & Animal Resources Development",
+      "office": "Office of Chief Minister",
       "share": 0.5,
       "support": 4
     },
     "miscellaneous|animal issues/ wildlife issues|khordha": {
       "dept": "Housing & Urban Development",
+      "office": "Departments",
       "share": 0.5185,
       "support": 14
     },
     "miscellaneous|animal issues/ wildlife issues|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.3,
       "support": 3
     },
     "miscellaneous|animal issues/ wildlife issues|puri": {
       "dept": "Forest, Environment and Climate Change Department",
+      "office": "Departments",
       "share": 0.5,
       "support": 7
     },
     "miscellaneous|animal issues/ wildlife issues|sundargarh": {
-      "dept": "Fisheries & Animal Resources Development",
+      "dept": "Housing & Urban Development",
+      "office": "Departments",
       "share": 0.4286,
       "support": 3
     },
     "miscellaneous|animals resources/ issues|angul": {
       "dept": "Fisheries & Animal Resources Development",
+      "office": "Collector",
       "share": 0.8333,
       "support": 5
     },
     "miscellaneous|animals resources/ issues|bhadrak": {
       "dept": "Fisheries & Animal Resources Development",
+      "office": "Departments",
       "share": 0.5,
       "support": 3
     },
@@ -13790,6 +21008,7 @@
     },
     "miscellaneous|animals resources/ issues|khordha": {
       "dept": "Fisheries & Animal Resources Development",
+      "office": "Departments",
       "share": 0.7273,
       "support": 8
     },
@@ -13800,11 +21019,13 @@
     },
     "miscellaneous|animals resources/ issues|malkangiri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 1.0,
       "support": 3
     },
     "miscellaneous|animals resources/ issues|mayurbhanj": {
       "dept": "Fisheries & Animal Resources Development",
+      "office": "Collector",
       "share": 0.6,
       "support": 3
     },
@@ -13820,16 +21041,19 @@
     },
     "miscellaneous|animals resources/ issues|sundargarh": {
       "dept": "ST & SC Development, Minorities & Backward Classes Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.8421,
       "support": 16
     },
     "miscellaneous|appreciation/suggestion|baleswar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.4,
       "support": 6
     },
     "miscellaneous|appreciation/suggestion|bargarh": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.4,
       "support": 4
     },
@@ -13840,11 +21064,13 @@
     },
     "miscellaneous|appreciation/suggestion|cuttack": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.1905,
       "support": 4
     },
     "miscellaneous|appreciation/suggestion|dhenkanal": {
       "dept": "Excise",
+      "office": "Office of Chief Minister",
       "share": 0.3,
       "support": 3
     },
@@ -13855,6 +21081,7 @@
     },
     "miscellaneous|appreciation/suggestion|jajpur": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.2222,
       "support": 4
     },
@@ -13880,16 +21107,19 @@
     },
     "miscellaneous|appreciation/suggestion|mayurbhanj": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.2857,
       "support": 4
     },
     "miscellaneous|appreciation/suggestion|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.3158,
       "support": 6
     },
     "miscellaneous|appreciation/suggestion|puri": {
       "dept": "Law",
+      "office": "Office of Chief Minister",
       "share": 0.15,
       "support": 3
     },
@@ -13905,61 +21135,73 @@
     },
     "miscellaneous|bidding / tender|kalahandi": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.7778,
       "support": 7
     },
     "miscellaneous|bidding / tender|kendrapara": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Departments",
       "share": 0.6923,
       "support": 9
     },
     "miscellaneous|bidding / tender|khordha": {
       "dept": "Works",
+      "office": "Office of Chief Minister",
       "share": 0.1667,
       "support": 6
     },
     "miscellaneous|bidding / tender|mayurbhanj": {
       "dept": "Works",
+      "office": "Office of Chief Minister",
       "share": 0.6,
       "support": 3
     },
     "miscellaneous|donation / gift|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 1.0,
       "support": 3
     },
     "miscellaneous|election matters|angul": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.625,
       "support": 5
     },
     "miscellaneous|election matters|bargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8333,
       "support": 5
     },
     "miscellaneous|election matters|cuttack": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 0.4615,
       "support": 6
     },
     "miscellaneous|election matters|dhenkanal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.8333,
       "support": 5
     },
     "miscellaneous|election matters|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8,
       "support": 4
     },
     "miscellaneous|election matters|ganjam": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5556,
       "support": 10
     },
     "miscellaneous|election matters|jajpur": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 0.7143,
       "support": 5
     },
@@ -13970,6 +21212,7 @@
     },
     "miscellaneous|election matters|kendrapara": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 0.6154,
       "support": 8
     },
@@ -13980,36 +21223,43 @@
     },
     "miscellaneous|election matters|mayurbhanj": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.7273,
       "support": 16
     },
     "miscellaneous|election matters|nayagarh": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 0.5714,
       "support": 4
     },
     "miscellaneous|it / digital facility|baleswar": {
       "dept": "Health & Family Welfare",
+      "office": "Departments",
       "share": 0.4444,
       "support": 4
     },
     "miscellaneous|it / digital facility|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.625,
       "support": 5
     },
     "miscellaneous|it / digital facility|ganjam": {
       "dept": "Electronics & Information Technology",
+      "office": "Office of Chief Minister",
       "share": 0.375,
       "support": 3
     },
     "miscellaneous|it / digital facility|kalahandi": {
       "dept": "Electronics & Information Technology",
+      "office": "Collector",
       "share": 0.8333,
       "support": 5
     },
     "miscellaneous|it / digital facility|kandhamal": {
       "dept": "Electronics & Information Technology",
+      "office": "Office of Chief Minister",
       "share": 0.8182,
       "support": 9
     },
@@ -14020,6 +21270,7 @@
     },
     "miscellaneous|it / digital facility|khordha": {
       "dept": "Electronics & Information Technology",
+      "office": "Office of Chief Minister",
       "share": 0.2727,
       "support": 3
     },
@@ -14030,6 +21281,7 @@
     },
     "miscellaneous|mining|angul": {
       "dept": "Steel & Mines",
+      "office": "Office of Chief Minister",
       "share": 0.625,
       "support": 5
     },
@@ -14040,16 +21292,19 @@
     },
     "miscellaneous|mining|dhenkanal": {
       "dept": "Steel & Mines",
+      "office": "Governor",
       "share": 0.5,
       "support": 4
     },
     "miscellaneous|mining|ganjam": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.625,
       "support": 5
     },
     "miscellaneous|mining|jajpur": {
       "dept": "Steel & Mines",
+      "office": "Governor",
       "share": 0.6562,
       "support": 21
     },
@@ -14060,21 +21315,25 @@
     },
     "miscellaneous|mining|khordha": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.5,
       "support": 5
     },
     "miscellaneous|mining|nabarangpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 1.0,
       "support": 4
     },
     "miscellaneous|mining|nayagarh": {
       "dept": "Steel & Mines",
+      "office": "Governor",
       "share": 0.625,
       "support": 5
     },
     "miscellaneous|mining|puri": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 4
     },
@@ -14085,36 +21344,43 @@
     },
     "miscellaneous|minor minerals|angul": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.4706,
       "support": 8
     },
     "miscellaneous|minor minerals|balangir": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4545,
       "support": 10
     },
     "miscellaneous|minor minerals|baleswar": {
       "dept": "Steel & Mines",
+      "office": "Departments",
       "share": 0.4444,
       "support": 12
     },
     "miscellaneous|minor minerals|bargarh": {
-      "dept": "Revenue & Disaster Management",
+      "dept": "Steel & Mines",
+      "office": "Departments",
       "share": 0.5,
       "support": 5
     },
     "miscellaneous|minor minerals|bhadrak": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.6667,
       "support": 6
     },
     "miscellaneous|minor minerals|cuttack": {
       "dept": "Steel & Mines",
+      "office": "Departments",
       "share": 0.6,
       "support": 9
     },
     "miscellaneous|minor minerals|dhenkanal": {
       "dept": "Steel & Mines",
+      "office": "Departments",
       "share": 0.6667,
       "support": 20
     },
@@ -14125,16 +21391,19 @@
     },
     "miscellaneous|minor minerals|jagatsinghapur": {
       "dept": "Steel & Mines",
+      "office": "Departments",
       "share": 0.4444,
       "support": 16
     },
     "miscellaneous|minor minerals|jajpur": {
       "dept": "Steel & Mines",
+      "office": "Departments",
       "share": 0.5154,
       "support": 67
     },
     "miscellaneous|minor minerals|kalahandi": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.619,
       "support": 13
     },
@@ -14145,6 +21414,7 @@
     },
     "miscellaneous|minor minerals|kendrapara": {
       "dept": "Steel & Mines",
+      "office": "Departments",
       "share": 0.4545,
       "support": 10
     },
@@ -14155,16 +21425,19 @@
     },
     "miscellaneous|minor minerals|khordha": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.4,
       "support": 8
     },
     "miscellaneous|minor minerals|mayurbhanj": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.5,
       "support": 5
     },
     "miscellaneous|minor minerals|nayagarh": {
       "dept": "Steel & Mines",
+      "office": "Departments",
       "share": 0.2857,
       "support": 16
     },
@@ -14180,36 +21453,43 @@
     },
     "miscellaneous|minor minerals|sundargarh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Departments",
       "share": 0.625,
       "support": 5
     },
     "miscellaneous|miscellaneous/others|angul": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.2039,
       "support": 305
     },
     "miscellaneous|miscellaneous/others|balangir": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.2555,
       "support": 649
     },
     "miscellaneous|miscellaneous/others|baleswar": {
       "dept": "Information & Public Relations",
+      "office": "Collector",
       "share": 0.4614,
       "support": 4017
     },
     "miscellaneous|miscellaneous/others|bargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.2401,
       "support": 627
     },
     "miscellaneous|miscellaneous/others|bhadrak": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.2017,
       "support": 1112
     },
     "miscellaneous|miscellaneous/others|boudh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.2585,
       "support": 107
     },
@@ -14240,36 +21520,43 @@
     },
     "miscellaneous|miscellaneous/others|jagatsinghapur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.5028,
       "support": 2675
     },
     "miscellaneous|miscellaneous/others|jajpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.2901,
       "support": 936
     },
     "miscellaneous|miscellaneous/others|jharsuguda": {
       "dept": "Revenue & Disaster Management",
+      "office": "Departments",
       "share": 0.2133,
       "support": 74
     },
     "miscellaneous|miscellaneous/others|kalahandi": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.236,
       "support": 562
     },
     "miscellaneous|miscellaneous/others|kandhamal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.1996,
       "support": 114
     },
     "miscellaneous|miscellaneous/others|kendrapara": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Departments",
       "share": 0.1698,
       "support": 254
     },
     "miscellaneous|miscellaneous/others|kendujhar": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.1465,
       "support": 247
     },
@@ -14280,31 +21567,37 @@
     },
     "miscellaneous|miscellaneous/others|koraput": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.1773,
       "support": 192
     },
     "miscellaneous|miscellaneous/others|malkangiri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.2005,
       "support": 83
     },
     "miscellaneous|miscellaneous/others|mayurbhanj": {
       "dept": "Home department",
+      "office": "Superintendent of Police",
       "share": 0.2717,
       "support": 467
     },
     "miscellaneous|miscellaneous/others|nabarangpur": {
-      "dept": "Panchayati Raj & Drinking Water",
+      "dept": "Home department",
+      "office": "Superintendent of Police",
       "share": 0.1957,
       "support": 82
     },
     "miscellaneous|miscellaneous/others|nayagarh": {
       "dept": "Home department",
+      "office": "Superintendent of Police",
       "share": 0.3925,
       "support": 854
     },
     "miscellaneous|miscellaneous/others|nuapada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.2313,
       "support": 431
     },
@@ -14315,11 +21608,13 @@
     },
     "miscellaneous|miscellaneous/others|rayagada": {
       "dept": "Home department",
+      "office": "Superintendent of Police",
       "share": 0.1984,
       "support": 73
     },
     "miscellaneous|miscellaneous/others|sambalpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.2148,
       "support": 737
     },
@@ -14330,6 +21625,7 @@
     },
     "miscellaneous|miscellaneous/others|sundargarh": {
       "dept": "Home department",
+      "office": "Superintendent of Police",
       "share": 0.2281,
       "support": 263
     },
@@ -14345,11 +21641,13 @@
     },
     "miscellaneous|mobile / internet facility|baleswar": {
       "dept": "Electronics & Information Technology",
+      "office": "Departments",
       "share": 0.55,
       "support": 11
     },
     "miscellaneous|mobile / internet facility|bargarh": {
       "dept": "Electronics & Information Technology",
+      "office": "Office of Chief Minister",
       "share": 0.9091,
       "support": 40
     },
@@ -14360,6 +21658,7 @@
     },
     "miscellaneous|mobile / internet facility|cuttack": {
       "dept": "Electronics & Information Technology",
+      "office": "Departments",
       "share": 0.7895,
       "support": 15
     },
@@ -14375,26 +21674,31 @@
     },
     "miscellaneous|mobile / internet facility|gajapati": {
       "dept": "Electronics & Information Technology",
+      "office": "Collector",
       "share": 0.5537,
       "support": 98
     },
     "miscellaneous|mobile / internet facility|ganjam": {
       "dept": "Electronics & Information Technology",
+      "office": "Departments",
       "share": 0.9512,
       "support": 39
     },
     "miscellaneous|mobile / internet facility|jagatsinghapur": {
       "dept": "Electronics & Information Technology",
+      "office": "Departments",
       "share": 1.0,
       "support": 11
     },
     "miscellaneous|mobile / internet facility|jajpur": {
       "dept": "Electronics & Information Technology",
+      "office": "Departments",
       "share": 0.7857,
       "support": 11
     },
     "miscellaneous|mobile / internet facility|jharsuguda": {
       "dept": "Electronics & Information Technology",
+      "office": "Departments",
       "share": 0.8571,
       "support": 6
     },
@@ -14405,11 +21709,13 @@
     },
     "miscellaneous|mobile / internet facility|kandhamal": {
       "dept": "Electronics & Information Technology",
+      "office": "Departments",
       "share": 0.9726,
       "support": 320
     },
     "miscellaneous|mobile / internet facility|kendrapara": {
       "dept": "Electronics & Information Technology",
+      "office": "Office of Chief Minister",
       "share": 0.9,
       "support": 9
     },
@@ -14420,6 +21726,7 @@
     },
     "miscellaneous|mobile / internet facility|khordha": {
       "dept": "Electronics & Information Technology",
+      "office": "Departments",
       "share": 0.6667,
       "support": 8
     },
@@ -14440,6 +21747,7 @@
     },
     "miscellaneous|mobile / internet facility|nabarangpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.4545,
       "support": 5
     },
@@ -14449,12 +21757,14 @@
       "support": 17
     },
     "miscellaneous|mobile / internet facility|nuapada": {
-      "dept": "Electronics & Information Technology",
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.2917,
       "support": 7
     },
     "miscellaneous|mobile / internet facility|puri": {
       "dept": "Electronics & Information Technology",
+      "office": "Departments",
       "share": 0.9231,
       "support": 12
     },
@@ -14485,6 +21795,7 @@
     },
     "miscellaneous|non-govt. service matters|baleswar": {
       "dept": "Information & Public Relations",
+      "office": "Collector",
       "share": 0.2727,
       "support": 3
     },
@@ -14495,11 +21806,13 @@
     },
     "miscellaneous|non-govt. service matters|cuttack": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.4615,
       "support": 6
     },
     "miscellaneous|non-govt. service matters|dhenkanal": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.7143,
       "support": 5
     },
@@ -14515,31 +21828,37 @@
     },
     "miscellaneous|non-govt. service matters|jajpur": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.5,
       "support": 6
     },
     "miscellaneous|non-govt. service matters|kendujhar": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.7143,
       "support": 5
     },
     "miscellaneous|non-govt. service matters|khordha": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Office of Chief Minister",
       "share": 0.4737,
       "support": 9
     },
     "miscellaneous|non-govt. service matters|koraput": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6667,
       "support": 6
     },
     "miscellaneous|non-govt. service matters|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.8333,
       "support": 5
     },
     "miscellaneous|non-govt. service matters|puri": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.4348,
       "support": 10
     },
@@ -14550,16 +21869,19 @@
     },
     "miscellaneous|parking|cuttack": {
       "dept": "Home department",
+      "office": "DG & IG Police",
       "share": 0.6667,
       "support": 6
     },
     "miscellaneous|parking|khordha": {
       "dept": "Housing & Urban Development",
+      "office": "Departments",
       "share": 0.6667,
       "support": 10
     },
     "miscellaneous|prize / award|cuttack": {
       "dept": "General Administration & Public Grievance",
+      "office": "Departments",
       "share": 0.8,
       "support": 4
     },
@@ -14570,16 +21892,19 @@
     },
     "miscellaneous|prize / award|khordha": {
       "dept": "General Administration & Public Grievance",
+      "office": "Departments",
       "share": 0.5,
       "support": 4
     },
     "miscellaneous|prize / award|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Departments",
       "share": 0.9286,
       "support": 13
     },
     "miscellaneous|tax/ fee matters|baleswar": {
       "dept": "Commerce & Transport",
+      "office": "Office of Chief Minister",
       "share": 0.375,
       "support": 3
     },
@@ -14590,6 +21915,7 @@
     },
     "miscellaneous|tax/ fee matters|cuttack": {
       "dept": "Housing & Urban Development",
+      "office": "Departments",
       "share": 0.3793,
       "support": 11
     },
@@ -14599,22 +21925,26 @@
       "support": 8
     },
     "miscellaneous|tax/ fee matters|jajpur": {
-      "dept": "Housing & Urban Development",
+      "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.2857,
       "support": 4
     },
     "miscellaneous|tax/ fee matters|kalahandi": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4444,
       "support": 4
     },
     "miscellaneous|tax/ fee matters|kendujhar": {
       "dept": "Commerce & Transport",
+      "office": "Office of Chief Minister",
       "share": 0.2917,
       "support": 7
     },
     "miscellaneous|tax/ fee matters|khordha": {
       "dept": "Housing & Urban Development",
+      "office": "Office of Chief Minister",
       "share": 0.3784,
       "support": 14
     },
@@ -14625,6 +21955,7 @@
     },
     "miscellaneous|tax/ fee matters|mayurbhanj": {
       "dept": "Housing & Urban Development",
+      "office": "Collector",
       "share": 0.4444,
       "support": 4
     },
@@ -14635,11 +21966,13 @@
     },
     "miscellaneous|tax/ fee matters|sambalpur": {
       "dept": "Housing & Urban Development",
+      "office": "Office of Chief Minister",
       "share": 0.3667,
       "support": 11
     },
     "miscellaneous|tax/ fee matters|sundargarh": {
       "dept": "Housing & Urban Development",
+      "office": "Departments",
       "share": 0.6154,
       "support": 8
     },
@@ -14660,16 +21993,19 @@
     },
     "miscellaneous|technical issues/web portal issues|nayagarh": {
       "dept": "Housing & Urban Development",
+      "office": "Departments",
       "share": 0.4,
       "support": 6
     },
     "miscellaneous|technical issues/web portal issues|subarnapur": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Collector",
       "share": 0.75,
       "support": 3
     },
     "miscellaneous|various demands|angul": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.2321,
       "support": 26
     },
@@ -14680,11 +22016,13 @@
     },
     "miscellaneous|various demands|baleswar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.25,
       "support": 47
     },
     "miscellaneous|various demands|bargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.2933,
       "support": 22
     },
@@ -14695,26 +22033,31 @@
     },
     "miscellaneous|various demands|boudh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.3636,
       "support": 8
     },
     "miscellaneous|various demands|cuttack": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.2135,
       "support": 57
     },
     "miscellaneous|various demands|deogarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.2979,
       "support": 14
     },
     "miscellaneous|various demands|dhenkanal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.2714,
       "support": 38
     },
     "miscellaneous|various demands|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6852,
       "support": 37
     },
@@ -14725,46 +22068,55 @@
     },
     "miscellaneous|various demands|jagatsinghapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.2437,
       "support": 29
     },
     "miscellaneous|various demands|jajpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.2889,
       "support": 39
     },
     "miscellaneous|various demands|jharsuguda": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.2973,
       "support": 11
     },
     "miscellaneous|various demands|kalahandi": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4658,
       "support": 109
     },
     "miscellaneous|various demands|kandhamal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.6293,
       "support": 73
     },
     "miscellaneous|various demands|kendrapara": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.1761,
       "support": 25
     },
     "miscellaneous|various demands|kendujhar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.3316,
       "support": 65
     },
     "miscellaneous|various demands|khordha": {
       "dept": "Fisheries & Animal Resources Development",
+      "office": "Office of Chief Minister",
       "share": 0.2545,
       "support": 126
     },
     "miscellaneous|various demands|koraput": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5182,
       "support": 57
     },
@@ -14775,26 +22127,31 @@
     },
     "miscellaneous|various demands|mayurbhanj": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.2,
       "support": 26
     },
     "miscellaneous|various demands|nabarangpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4503,
       "support": 68
     },
     "miscellaneous|various demands|nayagarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.2137,
       "support": 28
     },
     "miscellaneous|various demands|nuapada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4348,
       "support": 80
     },
     "miscellaneous|various demands|puri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.2828,
       "support": 41
     },
@@ -14810,26 +22167,31 @@
     },
     "miscellaneous|various demands|subarnapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.1702,
       "support": 8
     },
     "miscellaneous|various demands|sundargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.3224,
       "support": 59
     },
     "pension/retirement benefits|family pension/death benefits|angul": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.225,
       "support": 9
     },
     "pension/retirement benefits|family pension/death benefits|balangir": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2727,
       "support": 9
     },
     "pension/retirement benefits|family pension/death benefits|baleswar": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2195,
       "support": 9
     },
@@ -14840,6 +22202,7 @@
     },
     "pension/retirement benefits|family pension/death benefits|bhadrak": {
       "dept": "Finance",
+      "office": "Office of Chief Minister",
       "share": 0.2,
       "support": 4
     },
@@ -14865,51 +22228,61 @@
     },
     "pension/retirement benefits|family pension/death benefits|gajapati": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.3171,
       "support": 13
     },
     "pension/retirement benefits|family pension/death benefits|ganjam": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2054,
       "support": 23
     },
     "pension/retirement benefits|family pension/death benefits|jagatsinghapur": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2059,
       "support": 7
     },
     "pension/retirement benefits|family pension/death benefits|jajpur": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2424,
       "support": 8
     },
     "pension/retirement benefits|family pension/death benefits|jharsuguda": {
       "dept": "Finance",
+      "office": "Departments",
       "share": 0.28,
       "support": 7
     },
     "pension/retirement benefits|family pension/death benefits|kalahandi": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.32,
       "support": 16
     },
     "pension/retirement benefits|family pension/death benefits|kandhamal": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.35,
       "support": 7
     },
     "pension/retirement benefits|family pension/death benefits|kendrapara": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.2857,
       "support": 6
     },
     "pension/retirement benefits|family pension/death benefits|kendujhar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.2128,
       "support": 20
     },
     "pension/retirement benefits|family pension/death benefits|khordha": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 0.1937,
       "support": 37
     },
@@ -14920,26 +22293,30 @@
     },
     "pension/retirement benefits|family pension/death benefits|malkangiri": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.3529,
       "support": 6
     },
     "pension/retirement benefits|family pension/death benefits|mayurbhanj": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.3736,
       "support": 34
     },
     "pension/retirement benefits|family pension/death benefits|nabarangpur": {
-      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "dept": "Panchayati Raj & Drinking Water",
       "share": 0.1429,
       "support": 3
     },
     "pension/retirement benefits|family pension/death benefits|nayagarh": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2381,
       "support": 5
     },
     "pension/retirement benefits|family pension/death benefits|nuapada": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.2619,
       "support": 11
     },
@@ -14955,26 +22332,30 @@
     },
     "pension/retirement benefits|family pension/death benefits|sambalpur": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.1515,
       "support": 10
     },
     "pension/retirement benefits|family pension/death benefits|subarnapur": {
-      "dept": "School & Mass Education",
+      "dept": "Finance",
+      "office": "Office of Chief Minister",
       "share": 0.2,
       "support": 3
     },
     "pension/retirement benefits|family pension/death benefits|sundargarh": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2424,
       "support": 16
     },
     "pension/retirement benefits|freedom fighter pension|bhadrak": {
-      "dept": "Home department",
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
       "share": 0.4286,
       "support": 3
     },
     "pension/retirement benefits|freedom fighter pension|cuttack": {
       "dept": "Finance",
+      "office": "Office of Chief Minister",
       "share": 0.5455,
       "support": 6
     },
@@ -14985,11 +22366,13 @@
     },
     "pension/retirement benefits|freedom fighter pension|khordha": {
       "dept": "Finance",
+      "office": "Office of Chief Minister",
       "share": 0.6471,
       "support": 11
     },
     "pension/retirement benefits|freedom fighter pension|nayagarh": {
       "dept": "Finance",
+      "office": "Office of Chief Minister",
       "share": 0.5333,
       "support": 8
     },
@@ -15000,126 +22383,151 @@
     },
     "pension/retirement benefits|other pension|angul": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.6341,
       "support": 52
     },
     "pension/retirement benefits|other pension|balangir": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.64,
       "support": 16
     },
     "pension/retirement benefits|other pension|baleswar": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.7476,
       "support": 157
     },
     "pension/retirement benefits|other pension|bargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5333,
       "support": 16
     },
     "pension/retirement benefits|other pension|bhadrak": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.5143,
       "support": 90
     },
     "pension/retirement benefits|other pension|boudh": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.5648,
       "support": 61
     },
     "pension/retirement benefits|other pension|cuttack": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.4706,
       "support": 32
     },
     "pension/retirement benefits|other pension|deogarh": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.6111,
       "support": 11
     },
     "pension/retirement benefits|other pension|dhenkanal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.2647,
       "support": 9
     },
     "pension/retirement benefits|other pension|gajapati": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.4828,
       "support": 42
     },
     "pension/retirement benefits|other pension|ganjam": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.5361,
       "support": 89
     },
     "pension/retirement benefits|other pension|jagatsinghapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.2812,
       "support": 9
     },
     "pension/retirement benefits|other pension|jajpur": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.4734,
       "support": 89
     },
     "pension/retirement benefits|other pension|jharsuguda": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.3125,
       "support": 5
     },
     "pension/retirement benefits|other pension|kalahandi": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.7662,
       "support": 59
     },
     "pension/retirement benefits|other pension|kandhamal": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.8333,
       "support": 30
     },
     "pension/retirement benefits|other pension|kendrapara": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.5172,
       "support": 30
     },
     "pension/retirement benefits|other pension|kendujhar": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.5691,
       "support": 70
     },
     "pension/retirement benefits|other pension|khordha": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.5315,
       "support": 59
     },
     "pension/retirement benefits|other pension|koraput": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.7576,
       "support": 25
     },
     "pension/retirement benefits|other pension|malkangiri": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.75,
       "support": 12
     },
     "pension/retirement benefits|other pension|mayurbhanj": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4444,
       "support": 16
     },
     "pension/retirement benefits|other pension|nabarangpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4567,
       "support": 58
     },
     "pension/retirement benefits|other pension|nayagarh": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.4522,
       "support": 52
     },
     "pension/retirement benefits|other pension|nuapada": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.3889,
       "support": 14
     },
@@ -15130,41 +22538,49 @@
     },
     "pension/retirement benefits|other pension|rayagada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5769,
       "support": 15
     },
     "pension/retirement benefits|other pension|sambalpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.2857,
       "support": 8
     },
     "pension/retirement benefits|other pension|subarnapur": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.4444,
       "support": 4
     },
     "pension/retirement benefits|other pension|sundargarh": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.3396,
       "support": 18
     },
     "pension/retirement benefits|service pension/retirement benefits|angul": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2426,
       "support": 33
     },
     "pension/retirement benefits|service pension/retirement benefits|balangir": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.1604,
       "support": 17
     },
     "pension/retirement benefits|service pension/retirement benefits|baleswar": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2611,
       "support": 47
     },
     "pension/retirement benefits|service pension/retirement benefits|bargarh": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2231,
       "support": 27
     },
@@ -15175,11 +22591,13 @@
     },
     "pension/retirement benefits|service pension/retirement benefits|boudh": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.3421,
       "support": 13
     },
     "pension/retirement benefits|service pension/retirement benefits|cuttack": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.1509,
       "support": 64
     },
@@ -15190,6 +22608,7 @@
     },
     "pension/retirement benefits|service pension/retirement benefits|dhenkanal": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.1971,
       "support": 27
     },
@@ -15210,36 +22629,43 @@
     },
     "pension/retirement benefits|service pension/retirement benefits|jajpur": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2429,
       "support": 34
     },
     "pension/retirement benefits|service pension/retirement benefits|jharsuguda": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2105,
       "support": 8
     },
     "pension/retirement benefits|service pension/retirement benefits|kalahandi": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2233,
       "support": 23
     },
     "pension/retirement benefits|service pension/retirement benefits|kandhamal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.2963,
       "support": 24
     },
     "pension/retirement benefits|service pension/retirement benefits|kendrapara": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.1798,
       "support": 16
     },
     "pension/retirement benefits|service pension/retirement benefits|kendujhar": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2557,
       "support": 56
     },
     "pension/retirement benefits|service pension/retirement benefits|khordha": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5113,
       "support": 678
     },
@@ -15255,26 +22681,31 @@
     },
     "pension/retirement benefits|service pension/retirement benefits|mayurbhanj": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.2197,
       "support": 49
     },
     "pension/retirement benefits|service pension/retirement benefits|nabarangpur": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.2533,
       "support": 19
     },
     "pension/retirement benefits|service pension/retirement benefits|nayagarh": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2321,
       "support": 26
     },
     "pension/retirement benefits|service pension/retirement benefits|nuapada": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.25,
       "support": 17
     },
     "pension/retirement benefits|service pension/retirement benefits|puri": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.1282,
       "support": 20
     },
@@ -15285,6 +22716,7 @@
     },
     "pension/retirement benefits|service pension/retirement benefits|sambalpur": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.1992,
       "support": 49
     },
@@ -15305,26 +22737,31 @@
     },
     "police case|anti social activity/ criminal activity|balangir": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 0.8889,
       "support": 8
     },
     "police case|anti social activity/ criminal activity|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.5375,
       "support": 43
     },
     "police case|anti social activity/ criminal activity|bargarh": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 20
     },
     "police case|anti social activity/ criminal activity|bhadrak": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 0.9167,
       "support": 33
     },
     "police case|anti social activity/ criminal activity|boudh": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.8333,
       "support": 5
     },
@@ -15350,6 +22787,7 @@
     },
     "police case|anti social activity/ criminal activity|ganjam": {
       "dept": "Home department",
+      "office": "Superintendent of Police",
       "share": 0.9615,
       "support": 225
     },
@@ -15370,11 +22808,13 @@
     },
     "police case|anti social activity/ criminal activity|kalahandi": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 0.8636,
       "support": 19
     },
     "police case|anti social activity/ criminal activity|kandhamal": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.875,
       "support": 7
     },
@@ -15395,16 +22835,19 @@
     },
     "police case|anti social activity/ criminal activity|koraput": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.9474,
       "support": 18
     },
     "police case|anti social activity/ criminal activity|mayurbhanj": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 0.875,
       "support": 14
     },
     "police case|anti social activity/ criminal activity|nabarangpur": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 0.8235,
       "support": 14
     },
@@ -15425,11 +22868,13 @@
     },
     "police case|anti social activity/ criminal activity|rayagada": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 1.0,
       "support": 7
     },
     "police case|anti social activity/ criminal activity|sambalpur": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 19
     },
@@ -15455,11 +22900,13 @@
     },
     "police case|atrocity/ostracism|baleswar": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.7059,
       "support": 12
     },
     "police case|atrocity/ostracism|bargarh": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 0.7576,
       "support": 25
     },
@@ -15470,11 +22917,13 @@
     },
     "police case|atrocity/ostracism|cuttack": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.9667,
       "support": 29
     },
     "police case|atrocity/ostracism|deogarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.4286,
       "support": 3
     },
@@ -15490,6 +22939,7 @@
     },
     "police case|atrocity/ostracism|jagatsinghapur": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.8889,
       "support": 8
     },
@@ -15505,6 +22955,7 @@
     },
     "police case|atrocity/ostracism|kalahandi": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 0.75,
       "support": 6
     },
@@ -15515,6 +22966,7 @@
     },
     "police case|atrocity/ostracism|khordha": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.8438,
       "support": 54
     },
@@ -15525,6 +22977,7 @@
     },
     "police case|atrocity/ostracism|mayurbhanj": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 1.0,
       "support": 7
     },
@@ -15535,6 +22988,7 @@
     },
     "police case|atrocity/ostracism|puri": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.8095,
       "support": 17
     },
@@ -15550,6 +23004,7 @@
     },
     "police case|atrocity/ostracism|sundargarh": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.8333,
       "support": 5
     },
@@ -15565,6 +23020,7 @@
     },
     "police case|bribe issue|cuttack": {
       "dept": "Home department",
+      "office": "DG & IG Police",
       "share": 0.9259,
       "support": 25
     },
@@ -15575,11 +23031,13 @@
     },
     "police case|bribe issue|ganjam": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.8,
       "support": 12
     },
     "police case|bribe issue|jagatsinghapur": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.7143,
       "support": 5
     },
@@ -15590,16 +23048,19 @@
     },
     "police case|bribe issue|khordha": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.95,
       "support": 19
     },
     "police case|bribe issue|koraput": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 1.0,
       "support": 5
     },
     "police case|bribe issue|nayagarh": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.75,
       "support": 3
     },
@@ -15610,11 +23071,13 @@
     },
     "police case|family pension/death benefits|bhadrak": {
       "dept": "Home department",
+      "office": "Superintendent of Police",
       "share": 1.0,
       "support": 11
     },
     "police case|family pension/death benefits|ganjam": {
       "dept": "Home department",
+      "office": "Superintendent of Police",
       "share": 1.0,
       "support": 7
     },
@@ -15625,6 +23088,7 @@
     },
     "police case|fraud/cheating|balangir": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.9318,
       "support": 41
     },
@@ -15640,6 +23104,7 @@
     },
     "police case|fraud/cheating|bhadrak": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 0.7727,
       "support": 34
     },
@@ -15690,6 +23155,7 @@
     },
     "police case|fraud/cheating|kalahandi": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 0.875,
       "support": 28
     },
@@ -15700,11 +23166,13 @@
     },
     "police case|fraud/cheating|kendrapara": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 0.9339,
       "support": 113
     },
     "police case|fraud/cheating|kendujhar": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 0.9375,
       "support": 75
     },
@@ -15715,6 +23183,7 @@
     },
     "police case|fraud/cheating|koraput": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.9412,
       "support": 16
     },
@@ -15740,6 +23209,7 @@
     },
     "police case|fraud/cheating|nuapada": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 0.6,
       "support": 12
     },
@@ -15760,6 +23230,7 @@
     },
     "police case|fraud/cheating|subarnapur": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 0.8333,
       "support": 5
     },
@@ -15780,6 +23251,7 @@
     },
     "police case|human trafficking|khordha": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 1.0,
       "support": 6
     },
@@ -15850,16 +23322,19 @@
     },
     "police case|kidnapping/missing|kalahandi": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 1.0,
       "support": 19
     },
     "police case|kidnapping/missing|kandhamal": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 10
     },
     "police case|kidnapping/missing|kendrapara": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 25
     },
@@ -15870,26 +23345,31 @@
     },
     "police case|kidnapping/missing|khordha": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 0.9778,
       "support": 44
     },
     "police case|kidnapping/missing|koraput": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 1.0,
       "support": 5
     },
     "police case|kidnapping/missing|mayurbhanj": {
       "dept": "Home department",
+      "office": "Superintendent of Police",
       "share": 0.8913,
       "support": 41
     },
     "police case|kidnapping/missing|nabarangpur": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 1.0,
       "support": 4
     },
     "police case|kidnapping/missing|nayagarh": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 0.5357,
       "support": 15
     },
@@ -15905,6 +23385,7 @@
     },
     "police case|kidnapping/missing|rayagada": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 1.0,
       "support": 6
     },
@@ -15915,6 +23396,7 @@
     },
     "police case|kidnapping/missing|sundargarh": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 1.0,
       "support": 6
     },
@@ -15985,11 +23467,13 @@
     },
     "police case|law &amp;amp; order|angul": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.9655,
       "support": 28
     },
     "police case|law &amp;amp; order|balangir": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.9,
       "support": 36
     },
@@ -16010,26 +23494,31 @@
     },
     "police case|law &amp;amp; order|boudh": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 1.0,
       "support": 17
     },
     "police case|law &amp;amp; order|cuttack": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.9612,
       "support": 124
     },
     "police case|law &amp;amp; order|deogarh": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.9,
       "support": 18
     },
     "police case|law &amp;amp; order|dhenkanal": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.9615,
       "support": 25
     },
     "police case|law &amp;amp; order|gajapati": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 1.0,
       "support": 13
     },
@@ -16040,6 +23529,7 @@
     },
     "police case|law &amp;amp; order|jagatsinghapur": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.9726,
       "support": 71
     },
@@ -16050,16 +23540,19 @@
     },
     "police case|law &amp;amp; order|jharsuguda": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.9375,
       "support": 15
     },
     "police case|law &amp;amp; order|kalahandi": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 0.9375,
       "support": 30
     },
     "police case|law &amp;amp; order|kandhamal": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 1.0,
       "support": 20
     },
@@ -16070,26 +23563,31 @@
     },
     "police case|law &amp;amp; order|kendujhar": {
       "dept": "Home department",
+      "office": "Superintendent of Police",
       "share": 0.9344,
       "support": 114
     },
     "police case|law &amp;amp; order|khordha": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.9398,
       "support": 234
     },
     "police case|law &amp;amp; order|koraput": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.96,
       "support": 24
     },
     "police case|law &amp;amp; order|malkangiri": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 1.0,
       "support": 9
     },
     "police case|law &amp;amp; order|mayurbhanj": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 0.9487,
       "support": 37
     },
@@ -16100,36 +23598,43 @@
     },
     "police case|law &amp;amp; order|nayagarh": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.8415,
       "support": 69
     },
     "police case|law &amp;amp; order|nuapada": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 0.4615,
       "support": 6
     },
     "police case|law &amp;amp; order|puri": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.9651,
       "support": 83
     },
     "police case|law &amp;amp; order|rayagada": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.931,
       "support": 27
     },
     "police case|law &amp;amp; order|sambalpur": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 1.0,
       "support": 58
     },
     "police case|law &amp;amp; order|subarnapur": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 1.0,
       "support": 9
     },
     "police case|law &amp;amp; order|sundargarh": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.9655,
       "support": 28
     },
@@ -16155,16 +23660,19 @@
     },
     "police case|missing person|boudh": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 1.0,
       "support": 7
     },
     "police case|missing person|cuttack": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 0.9375,
       "support": 15
     },
     "police case|missing person|dhenkanal": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 0.6429,
       "support": 9
     },
@@ -16205,11 +23713,13 @@
     },
     "police case|missing person|kendujhar": {
       "dept": "Home department",
+      "office": "Superintendent of Police",
       "share": 1.0,
       "support": 26
     },
     "police case|missing person|khordha": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 23
     },
@@ -16230,16 +23740,19 @@
     },
     "police case|missing person|nabarangpur": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 0.8,
       "support": 4
     },
     "police case|missing person|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.5,
       "support": 7
     },
     "police case|missing person|nuapada": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 1.0,
       "support": 10
     },
@@ -16250,6 +23763,7 @@
     },
     "police case|missing person|rayagada": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 0.6667,
       "support": 6
     },
@@ -16265,46 +23779,55 @@
     },
     "police case|murder/death case|angul": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.9259,
       "support": 25
     },
     "police case|murder/death case|balangir": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 1.0,
       "support": 31
     },
     "police case|murder/death case|baleswar": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.9167,
       "support": 33
     },
     "police case|murder/death case|bargarh": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 1.0,
       "support": 31
     },
     "police case|murder/death case|bhadrak": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 1.0,
       "support": 30
     },
     "police case|murder/death case|boudh": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.9474,
       "support": 18
     },
     "police case|murder/death case|cuttack": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 1.0,
       "support": 55
     },
     "police case|murder/death case|deogarh": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.75,
       "support": 3
     },
     "police case|murder/death case|dhenkanal": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.9688,
       "support": 31
     },
@@ -16320,6 +23843,7 @@
     },
     "police case|murder/death case|jagatsinghapur": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 1.0,
       "support": 20
     },
@@ -16355,11 +23879,13 @@
     },
     "police case|murder/death case|khordha": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.9808,
       "support": 102
     },
     "police case|murder/death case|koraput": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 1.0,
       "support": 12
     },
@@ -16380,11 +23906,13 @@
     },
     "police case|murder/death case|nayagarh": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.9672,
       "support": 59
     },
     "police case|murder/death case|nuapada": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 0.7143,
       "support": 10
     },
@@ -16425,11 +23953,13 @@
     },
     "police case|nhrc/ohrc|cuttack": {
       "dept": "Home department",
+      "office": "DG & IG Police",
       "share": 1.0,
       "support": 10
     },
     "police case|nhrc/ohrc|ganjam": {
       "dept": "Home department",
+      "office": "Superintendent of Police",
       "share": 1.0,
       "support": 8
     },
@@ -16440,31 +23970,37 @@
     },
     "police case|nhrc/ohrc|kendujhar": {
       "dept": "Home department",
+      "office": "Superintendent of Police",
       "share": 1.0,
       "support": 7
     },
     "police case|nhrc/ohrc|khordha": {
       "dept": "Home department",
+      "office": "DG & IG Police",
       "share": 1.0,
       "support": 14
     },
     "police case|nhrc/ohrc|puri": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 5
     },
     "police case|other pension|bhadrak": {
       "dept": "Home department",
+      "office": "Superintendent of Police",
       "share": 1.0,
       "support": 11
     },
     "police case|other pension|ganjam": {
       "dept": "Home department",
+      "office": "Superintendent of Police",
       "share": 1.0,
       "support": 6
     },
     "police case|police cases|angul": {
       "dept": "Home department",
+      "office": "DG & IG Police",
       "share": 0.9894,
       "support": 651
     },
@@ -16475,16 +24011,19 @@
     },
     "police case|police cases|baleswar": {
       "dept": "Home department",
+      "office": "DG & IG Police",
       "share": 0.7871,
       "support": 1590
     },
     "police case|police cases|bargarh": {
       "dept": "Home department",
+      "office": "DG & IG Police",
       "share": 0.995,
       "support": 594
     },
     "police case|police cases|bhadrak": {
       "dept": "Home department",
+      "office": "Superintendent of Police",
       "share": 0.9952,
       "support": 10861
     },
@@ -16495,36 +24034,43 @@
     },
     "police case|police cases|cuttack": {
       "dept": "Home department",
+      "office": "DG & IG Police",
       "share": 0.9931,
       "support": 5432
     },
     "police case|police cases|deogarh": {
       "dept": "Home department",
+      "office": "DG & IG Police",
       "share": 0.9369,
       "support": 104
     },
     "police case|police cases|dhenkanal": {
       "dept": "Home department",
+      "office": "DG & IG Police",
       "share": 0.9828,
       "support": 1145
     },
     "police case|police cases|gajapati": {
       "dept": "Home department",
+      "office": "DG & IG Police",
       "share": 0.9856,
       "support": 343
     },
     "police case|police cases|ganjam": {
       "dept": "Home department",
+      "office": "DG & IG Police",
       "share": 0.9837,
       "support": 2840
     },
     "police case|police cases|jagatsinghapur": {
       "dept": "Home department",
+      "office": "DG & IG Police",
       "share": 0.9876,
       "support": 1432
     },
     "police case|police cases|jajpur": {
       "dept": "Home department",
+      "office": "DG & IG Police",
       "share": 0.9727,
       "support": 1640
     },
@@ -16535,11 +24081,13 @@
     },
     "police case|police cases|kalahandi": {
       "dept": "Home department",
+      "office": "DG & IG Police",
       "share": 0.988,
       "support": 494
     },
     "police case|police cases|kandhamal": {
       "dept": "Home department",
+      "office": "DG & IG Police",
       "share": 0.9967,
       "support": 305
     },
@@ -16550,31 +24098,37 @@
     },
     "police case|police cases|kendujhar": {
       "dept": "Home department",
+      "office": "DG & IG Police",
       "share": 0.9909,
       "support": 542
     },
     "police case|police cases|khordha": {
       "dept": "Home department",
+      "office": "DG & IG Police",
       "share": 0.9936,
       "support": 6508
     },
     "police case|police cases|koraput": {
       "dept": "Home department",
+      "office": "DG & IG Police",
       "share": 0.9939,
       "support": 326
     },
     "police case|police cases|malkangiri": {
       "dept": "Home department",
+      "office": "DG & IG Police",
       "share": 0.9709,
       "support": 100
     },
     "police case|police cases|mayurbhanj": {
       "dept": "Home department",
+      "office": "DG & IG Police",
       "share": 0.9574,
       "support": 696
     },
     "police case|police cases|nabarangpur": {
       "dept": "Home department",
+      "office": "DG & IG Police",
       "share": 0.9895,
       "support": 189
     },
@@ -16590,31 +24144,37 @@
     },
     "police case|police cases|puri": {
       "dept": "Home department",
+      "office": "DG & IG Police",
       "share": 0.987,
       "support": 2727
     },
     "police case|police cases|rayagada": {
       "dept": "Home department",
+      "office": "DG & IG Police",
       "share": 0.9933,
       "support": 296
     },
     "police case|police cases|sambalpur": {
       "dept": "Home department",
+      "office": "DG & IG Police",
       "share": 0.9831,
       "support": 812
     },
     "police case|police cases|subarnapur": {
       "dept": "Home department",
+      "office": "DG & IG Police",
       "share": 0.9771,
       "support": 171
     },
     "police case|police cases|sundargarh": {
       "dept": "Home department",
+      "office": "DG & IG Police",
       "share": 0.9895,
       "support": 845
     },
     "police case|property dispute|angul": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 0.9375,
       "support": 15
     },
@@ -16625,6 +24185,7 @@
     },
     "police case|property dispute|baleswar": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 0.5676,
       "support": 21
     },
@@ -16680,6 +24241,7 @@
     },
     "police case|property dispute|kandhamal": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 4
     },
@@ -16700,6 +24262,7 @@
     },
     "police case|property dispute|koraput": {
       "dept": "Home department",
+      "office": "DG & IG Police",
       "share": 0.875,
       "support": 7
     },
@@ -16710,6 +24273,7 @@
     },
     "police case|property dispute|nabarangpur": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 0.875,
       "support": 7
     },
@@ -16745,11 +24309,13 @@
     },
     "police case|protection of life and property|balangir": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 0.9444,
       "support": 17
     },
     "police case|protection of life and property|baleswar": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 0.8488,
       "support": 73
     },
@@ -16770,16 +24336,19 @@
     },
     "police case|protection of life and property|cuttack": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 0.9829,
       "support": 115
     },
     "police case|protection of life and property|deogarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.7,
       "support": 21
     },
     "police case|protection of life and property|dhenkanal": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 0.881,
       "support": 37
     },
@@ -16795,6 +24364,7 @@
     },
     "police case|protection of life and property|jagatsinghapur": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 0.9608,
       "support": 49
     },
@@ -16820,16 +24390,19 @@
     },
     "police case|protection of life and property|kendrapara": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 80
     },
     "police case|protection of life and property|kendujhar": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 0.9429,
       "support": 33
     },
     "police case|protection of life and property|khordha": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 0.9838,
       "support": 182
     },
@@ -16845,16 +24418,19 @@
     },
     "police case|protection of life and property|nabarangpur": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 0.9091,
       "support": 10
     },
     "police case|protection of life and property|nayagarh": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 0.8046,
       "support": 70
     },
     "police case|protection of life and property|nuapada": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 0.7143,
       "support": 5
     },
@@ -16870,11 +24446,13 @@
     },
     "police case|protection of life and property|sambalpur": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 18
     },
     "police case|protection of life and property|subarnapur": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 0.875,
       "support": 7
     },
@@ -16890,31 +24468,37 @@
     },
     "police case|rape/murder case|balangir": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 1.0,
       "support": 10
     },
     "police case|rape/murder case|baleswar": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.5,
       "support": 6
     },
     "police case|rape/murder case|bargarh": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.9677,
       "support": 30
     },
     "police case|rape/murder case|bhadrak": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 1.0,
       "support": 8
     },
     "police case|rape/murder case|boudh": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 1.0,
       "support": 7
     },
     "police case|rape/murder case|cuttack": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 1.0,
       "support": 34
     },
@@ -16930,11 +24514,13 @@
     },
     "police case|rape/murder case|ganjam": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 1.0,
       "support": 30
     },
     "police case|rape/murder case|jagatsinghapur": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 1.0,
       "support": 21
     },
@@ -16955,11 +24541,13 @@
     },
     "police case|rape/murder case|kendrapara": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 1.0,
       "support": 23
     },
     "police case|rape/murder case|kendujhar": {
       "dept": "Home department",
+      "office": "Superintendent of Police",
       "share": 1.0,
       "support": 23
     },
@@ -16970,6 +24558,7 @@
     },
     "police case|rape/murder case|koraput": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 1.0,
       "support": 4
     },
@@ -16980,6 +24569,7 @@
     },
     "police case|rape/murder case|nabarangpur": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 0.5,
       "support": 3
     },
@@ -16995,6 +24585,7 @@
     },
     "police case|rape/murder case|sambalpur": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 1.0,
       "support": 7
     },
@@ -17015,6 +24606,7 @@
     },
     "police case|robbery/ theft|balangir": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 10
     },
@@ -17025,6 +24617,7 @@
     },
     "police case|robbery/ theft|bargarh": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 1.0,
       "support": 9
     },
@@ -17035,6 +24628,7 @@
     },
     "police case|robbery/ theft|boudh": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 1.0,
       "support": 11
     },
@@ -17055,6 +24649,7 @@
     },
     "police case|robbery/ theft|gajapati": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 1.0,
       "support": 5
     },
@@ -17075,6 +24670,7 @@
     },
     "police case|robbery/ theft|jharsuguda": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 1.0,
       "support": 6
     },
@@ -17110,6 +24706,7 @@
     },
     "police case|robbery/ theft|mayurbhanj": {
       "dept": "Home department",
+      "office": "Superintendent of Police",
       "share": 0.8462,
       "support": 22
     },
@@ -17120,6 +24717,7 @@
     },
     "police case|robbery/ theft|nayagarh": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 0.5789,
       "support": 11
     },
@@ -17130,6 +24728,7 @@
     },
     "police case|robbery/ theft|rayagada": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 1.0,
       "support": 4
     },
@@ -17140,6 +24739,7 @@
     },
     "police case|robbery/ theft|subarnapur": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 1.0,
       "support": 5
     },
@@ -17150,16 +24750,19 @@
     },
     "police case|service pension/retirement benefits|bhadrak": {
       "dept": "Home department",
+      "office": "Superintendent of Police",
       "share": 1.0,
       "support": 4
     },
     "police case|social evils|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.5714,
       "support": 20
     },
     "police case|social evils|bargarh": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 1.0,
       "support": 5
     },
@@ -17180,6 +24783,7 @@
     },
     "police case|social evils|dhenkanal": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.7,
       "support": 7
     },
@@ -17190,6 +24794,7 @@
     },
     "police case|social evils|ganjam": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 0.8889,
       "support": 24
     },
@@ -17205,6 +24810,7 @@
     },
     "police case|social evils|kalahandi": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 1.0,
       "support": 16
     },
@@ -17245,6 +24851,7 @@
     },
     "police case|social evils|nayagarh": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 0.5217,
       "support": 12
     },
@@ -17290,6 +24897,7 @@
     },
     "police case|strike/dharana|jajpur": {
       "dept": "Home department",
+      "office": "DG & IG Police",
       "share": 0.7143,
       "support": 5
     },
@@ -17300,51 +24908,61 @@
     },
     "police case|strike/dharana|khordha": {
       "dept": "Home department",
+      "office": "DG & IG Police",
       "share": 0.8,
       "support": 8
     },
     "police case|strike/dharana|puri": {
       "dept": "Home department",
+      "office": "DG & IG Police",
       "share": 1.0,
       "support": 17
     },
     "police case|torture/harassment|angul": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 0.8718,
       "support": 34
     },
     "police case|torture/harassment|balangir": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 1.0,
       "support": 14
     },
     "police case|torture/harassment|baleswar": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.8636,
       "support": 95
     },
     "police case|torture/harassment|bargarh": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.8077,
       "support": 21
     },
     "police case|torture/harassment|bhadrak": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.9278,
       "support": 90
     },
     "police case|torture/harassment|boudh": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.8,
       "support": 4
     },
     "police case|torture/harassment|cuttack": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.9154,
       "support": 184
     },
     "police case|torture/harassment|deogarh": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.6667,
       "support": 6
     },
@@ -17355,6 +24973,7 @@
     },
     "police case|torture/harassment|gajapati": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.9545,
       "support": 21
     },
@@ -17365,6 +24984,7 @@
     },
     "police case|torture/harassment|jagatsinghapur": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.9747,
       "support": 77
     },
@@ -17380,6 +25000,7 @@
     },
     "police case|torture/harassment|kalahandi": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 0.8837,
       "support": 38
     },
@@ -17400,6 +25021,7 @@
     },
     "police case|torture/harassment|khordha": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.9412,
       "support": 272
     },
@@ -17415,86 +25037,103 @@
     },
     "police case|torture/harassment|nabarangpur": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 0.8421,
       "support": 16
     },
     "police case|torture/harassment|nayagarh": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.8305,
       "support": 49
     },
     "police case|torture/harassment|nuapada": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 0.8438,
       "support": 27
     },
     "police case|torture/harassment|puri": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.9346,
       "support": 100
     },
     "police case|torture/harassment|rayagada": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.9048,
       "support": 19
     },
     "police case|torture/harassment|sambalpur": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.8889,
       "support": 24
     },
     "police case|torture/harassment|subarnapur": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 8
     },
     "police case|torture/harassment|sundargarh": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.8958,
       "support": 43
     },
     "public utility|bank & atm|angul": {
       "dept": "Finance",
+      "office": "Office of Chief Minister",
       "share": 0.75,
       "support": 3
     },
     "public utility|bank & atm|balangir": {
       "dept": "Finance",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 4
     },
     "public utility|bank & atm|baleswar": {
       "dept": "Finance",
+      "office": "Office of Chief Minister",
       "share": 0.5,
       "support": 7
     },
     "public utility|bank & atm|bhadrak": {
       "dept": "Finance",
+      "office": "Office of Chief Minister",
       "share": 0.625,
       "support": 5
     },
     "public utility|bank & atm|boudh": {
       "dept": "Finance",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 5
     },
     "public utility|bank & atm|cuttack": {
       "dept": "Finance",
+      "office": "Office of Chief Minister",
       "share": 0.8571,
       "support": 6
     },
     "public utility|bank & atm|dhenkanal": {
       "dept": "Finance",
+      "office": "Office of Chief Minister",
       "share": 0.7333,
       "support": 11
     },
     "public utility|bank & atm|ganjam": {
       "dept": "Finance",
+      "office": "Office of Chief Minister",
       "share": 0.6154,
       "support": 8
     },
     "public utility|bank & atm|jajpur": {
       "dept": "Finance",
+      "office": "Office of Chief Minister",
       "share": 0.6316,
       "support": 12
     },
@@ -17505,36 +25144,43 @@
     },
     "public utility|bank & atm|kandhamal": {
       "dept": "Finance",
+      "office": "Collector",
       "share": 0.8333,
       "support": 5
     },
     "public utility|bank & atm|kendrapara": {
       "dept": "Finance",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 4
     },
     "public utility|bank & atm|kendujhar": {
       "dept": "Finance",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 4
     },
     "public utility|bank & atm|khordha": {
       "dept": "Finance",
+      "office": "Office of Chief Minister",
       "share": 0.8889,
       "support": 16
     },
     "public utility|bank & atm|koraput": {
       "dept": "Finance",
+      "office": "Office of Chief Minister",
       "share": 0.75,
       "support": 3
     },
     "public utility|bank & atm|mayurbhanj": {
       "dept": "Finance",
+      "office": "Office of Chief Minister",
       "share": 0.75,
       "support": 3
     },
     "public utility|bank & atm|puri": {
       "dept": "Finance",
+      "office": "Office of Chief Minister",
       "share": 0.8667,
       "support": 13
     },
@@ -17545,21 +25191,25 @@
     },
     "public utility|civic amenities/quality of service|balangir": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.5,
       "support": 3
     },
     "public utility|civic amenities/quality of service|baleswar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.4615,
       "support": 6
     },
     "public utility|civic amenities/quality of service|bargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.8571,
       "support": 6
     },
     "public utility|civic amenities/quality of service|bhadrak": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 1.0,
       "support": 4
     },
@@ -17570,6 +25220,7 @@
     },
     "public utility|civic amenities/quality of service|dhenkanal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.5385,
       "support": 7
     },
@@ -17580,26 +25231,31 @@
     },
     "public utility|civic amenities/quality of service|jagatsinghapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.6,
       "support": 6
     },
     "public utility|civic amenities/quality of service|jajpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9722,
       "support": 35
     },
     "public utility|civic amenities/quality of service|jharsuguda": {
       "dept": "Housing & Urban Development",
+      "office": "Office of Chief Minister",
       "share": 0.7778,
       "support": 7
     },
     "public utility|civic amenities/quality of service|kalahandi": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.6429,
       "support": 9
     },
     "public utility|civic amenities/quality of service|kandhamal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.9,
       "support": 27
     },
@@ -17610,16 +25266,19 @@
     },
     "public utility|civic amenities/quality of service|kendujhar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.8333,
       "support": 5
     },
     "public utility|civic amenities/quality of service|khordha": {
       "dept": "Housing & Urban Development",
+      "office": "Office of Chief Minister",
       "share": 0.7963,
       "support": 43
     },
     "public utility|civic amenities/quality of service|koraput": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4167,
       "support": 5
     },
@@ -17635,6 +25294,7 @@
     },
     "public utility|civic amenities/quality of service|nuapada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9333,
       "support": 14
     },
@@ -17645,46 +25305,55 @@
     },
     "public utility|civic amenities/quality of service|sundargarh": {
       "dept": "Housing & Urban Development",
+      "office": "Departments",
       "share": 0.7143,
       "support": 5
     },
     "public utility|consumer issues|baleswar": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.75,
       "support": 3
     },
     "public utility|consumer issues|bargarh": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.3333,
       "support": 4
     },
     "public utility|consumer issues|cuttack": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.9017,
       "support": 477
     },
     "public utility|consumer issues|ganjam": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.3333,
       "support": 4
     },
     "public utility|consumer issues|jajpur": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.6562,
       "support": 21
     },
     "public utility|consumer issues|kalahandi": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.375,
       "support": 3
     },
     "public utility|consumer issues|kendrapara": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.6364,
       "support": 7
     },
     "public utility|consumer issues|khordha": {
       "dept": "Housing & Urban Development",
+      "office": "Departments",
       "share": 0.5455,
       "support": 6
     },
@@ -17695,21 +25364,25 @@
     },
     "public utility|consumer issues|malkangiri": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.9,
       "support": 9
     },
     "public utility|consumer issues|mayurbhanj": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.5556,
       "support": 5
     },
     "public utility|consumer issues|nabarangpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.4286,
       "support": 3
     },
     "public utility|consumer issues|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.5556,
       "support": 10
     },
@@ -17720,16 +25393,19 @@
     },
     "public utility|consumer issues|rayagada": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.5714,
       "support": 4
     },
     "public utility|development of tourist places|angul": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.8333,
       "support": 5
     },
     "public utility|development of tourist places|balangir": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.6,
       "support": 3
     },
@@ -17745,16 +25421,19 @@
     },
     "public utility|development of tourist places|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7273,
       "support": 8
     },
     "public utility|development of tourist places|ganjam": {
       "dept": "Tourism",
+      "office": "Office of Chief Minister",
       "share": 0.4118,
       "support": 7
     },
     "public utility|development of tourist places|kandhamal": {
       "dept": "Forest, Environment and Climate Change Department",
+      "office": "Office of Chief Minister",
       "share": 0.6923,
       "support": 9
     },
@@ -17765,6 +25444,7 @@
     },
     "public utility|development of tourist places|kendujhar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.5,
       "support": 3
     },
@@ -17775,46 +25455,55 @@
     },
     "public utility|development of tourist places|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.8,
       "support": 12
     },
     "public utility|development of tourist places|nuapada": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.5,
       "support": 3
     },
     "public utility|development of tourist places|puri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.5455,
       "support": 6
     },
     "public utility|developmental works / infrastructure develpoment|angul": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.6522,
       "support": 45
     },
     "public utility|developmental works / infrastructure develpoment|balangir": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.6818,
       "support": 30
     },
     "public utility|developmental works / infrastructure develpoment|baleswar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.5102,
       "support": 25
     },
     "public utility|developmental works / infrastructure develpoment|bargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.6613,
       "support": 41
     },
     "public utility|developmental works / infrastructure develpoment|bhadrak": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.6071,
       "support": 17
     },
     "public utility|developmental works / infrastructure develpoment|boudh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.5098,
       "support": 26
     },
@@ -17830,31 +25519,37 @@
     },
     "public utility|developmental works / infrastructure develpoment|dhenkanal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4964,
       "support": 68
     },
     "public utility|developmental works / infrastructure develpoment|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7081,
       "support": 131
     },
     "public utility|developmental works / infrastructure develpoment|ganjam": {
       "dept": "Rural Development",
+      "office": "Collector",
       "share": 0.5083,
       "support": 183
     },
     "public utility|developmental works / infrastructure develpoment|jagatsinghapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.561,
       "support": 23
     },
     "public utility|developmental works / infrastructure develpoment|jajpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.679,
       "support": 55
     },
     "public utility|developmental works / infrastructure develpoment|jharsuguda": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.4615,
       "support": 12
     },
@@ -17865,76 +25560,91 @@
     },
     "public utility|developmental works / infrastructure develpoment|kandhamal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.7288,
       "support": 129
     },
     "public utility|developmental works / infrastructure develpoment|kendrapara": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.4925,
       "support": 33
     },
     "public utility|developmental works / infrastructure develpoment|kendujhar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.5867,
       "support": 44
     },
     "public utility|developmental works / infrastructure develpoment|khordha": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.3784,
       "support": 56
     },
     "public utility|developmental works / infrastructure develpoment|koraput": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7541,
       "support": 46
     },
     "public utility|developmental works / infrastructure develpoment|malkangiri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.622,
       "support": 51
     },
     "public utility|developmental works / infrastructure develpoment|mayurbhanj": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.3462,
       "support": 18
     },
     "public utility|developmental works / infrastructure develpoment|nabarangpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.5385,
       "support": 14
     },
     "public utility|developmental works / infrastructure develpoment|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.8906,
       "support": 236
     },
     "public utility|developmental works / infrastructure develpoment|nuapada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8171,
       "support": 143
     },
     "public utility|developmental works / infrastructure develpoment|puri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.5342,
       "support": 39
     },
     "public utility|developmental works / infrastructure develpoment|rayagada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.4138,
       "support": 12
     },
     "public utility|developmental works / infrastructure develpoment|sambalpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6747,
       "support": 56
     },
     "public utility|developmental works / infrastructure develpoment|subarnapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.6875,
       "support": 11
     },
     "public utility|developmental works / infrastructure develpoment|sundargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.7586,
       "support": 44
     },
@@ -17945,6 +25655,7 @@
     },
     "public utility|drainage/sewarage|balangir": {
       "dept": "Housing & Urban Development",
+      "office": "Office of Chief Minister",
       "share": 0.5,
       "support": 5
     },
@@ -17959,7 +25670,7 @@
       "support": 27
     },
     "public utility|drainage/sewarage|bhadrak": {
-      "dept": "Housing & Urban Development",
+      "dept": "Panchayati Raj & Drinking Water",
       "share": 0.4167,
       "support": 10
     },
@@ -17975,11 +25686,13 @@
     },
     "public utility|drainage/sewarage|dhenkanal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.7273,
       "support": 8
     },
     "public utility|drainage/sewarage|gajapati": {
       "dept": "Housing & Urban Development",
+      "office": "Collector",
       "share": 0.7857,
       "support": 11
     },
@@ -17990,6 +25703,7 @@
     },
     "public utility|drainage/sewarage|jajpur": {
       "dept": "Housing & Urban Development",
+      "office": "Office of Chief Minister",
       "share": 0.4375,
       "support": 14
     },
@@ -18000,36 +25714,43 @@
     },
     "public utility|drainage/sewarage|kalahandi": {
       "dept": "Housing & Urban Development",
+      "office": "Collector",
       "share": 0.4444,
       "support": 20
     },
     "public utility|drainage/sewarage|kandhamal": {
       "dept": "Housing & Urban Development",
+      "office": "Collector",
       "share": 0.8,
       "support": 4
     },
     "public utility|drainage/sewarage|kendrapara": {
       "dept": "Water Resources",
+      "office": "Office of Chief Minister",
       "share": 0.4194,
       "support": 13
     },
     "public utility|drainage/sewarage|kendujhar": {
       "dept": "Housing & Urban Development",
+      "office": "Office of Chief Minister",
       "share": 0.4667,
       "support": 7
     },
     "public utility|drainage/sewarage|khordha": {
       "dept": "Housing & Urban Development",
+      "office": "Office of Chief Minister",
       "share": 0.8902,
       "support": 154
     },
     "public utility|drainage/sewarage|koraput": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4167,
       "support": 5
     },
     "public utility|drainage/sewarage|malkangiri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7143,
       "support": 10
     },
@@ -18040,51 +25761,60 @@
     },
     "public utility|drainage/sewarage|nabarangpur": {
       "dept": "Housing & Urban Development",
+      "office": "Collector",
       "share": 0.5,
       "support": 3
     },
     "public utility|drainage/sewarage|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.6087,
       "support": 14
     },
     "public utility|drainage/sewarage|nuapada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4783,
       "support": 11
     },
     "public utility|drainage/sewarage|puri": {
-      "dept": "Panchayati Raj & Drinking Water",
+      "dept": "Housing & Urban Development",
       "share": 0.4054,
       "support": 15
     },
     "public utility|drainage/sewarage|rayagada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4667,
       "support": 7
     },
     "public utility|drainage/sewarage|sambalpur": {
       "dept": "Housing & Urban Development",
+      "office": "Office of Chief Minister",
       "share": 0.8636,
       "support": 57
     },
     "public utility|drainage/sewarage|sundargarh": {
       "dept": "Housing & Urban Development",
+      "office": "Departments",
       "share": 0.9375,
       "support": 60
     },
     "public utility|drinking water facility|angul": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9118,
       "support": 62
     },
     "public utility|drinking water facility|balangir": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.8077,
       "support": 21
     },
     "public utility|drinking water facility|baleswar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.7632,
       "support": 29
     },
@@ -18095,6 +25825,7 @@
     },
     "public utility|drinking water facility|bhadrak": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.76,
       "support": 19
     },
@@ -18105,6 +25836,7 @@
     },
     "public utility|drinking water facility|cuttack": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8571,
       "support": 90
     },
@@ -18120,11 +25852,13 @@
     },
     "public utility|drinking water facility|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 4
     },
     "public utility|drinking water facility|ganjam": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8,
       "support": 44
     },
@@ -18135,11 +25869,13 @@
     },
     "public utility|drinking water facility|jajpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.8214,
       "support": 23
     },
     "public utility|drinking water facility|jharsuguda": {
       "dept": "Housing & Urban Development",
+      "office": "Office of Chief Minister",
       "share": 0.8,
       "support": 8
     },
@@ -18155,11 +25891,13 @@
     },
     "public utility|drinking water facility|kendrapara": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.8511,
       "support": 40
     },
     "public utility|drinking water facility|kendujhar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.8788,
       "support": 29
     },
@@ -18170,6 +25908,7 @@
     },
     "public utility|drinking water facility|koraput": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8846,
       "support": 23
     },
@@ -18185,21 +25924,25 @@
     },
     "public utility|drinking water facility|nabarangpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 9
     },
     "public utility|drinking water facility|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.4474,
       "support": 17
     },
     "public utility|drinking water facility|nuapada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7619,
       "support": 16
     },
     "public utility|drinking water facility|puri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.5161,
       "support": 16
     },
@@ -18220,56 +25963,67 @@
     },
     "public utility|drinking water facility|sundargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.5,
       "support": 12
     },
     "public utility|endowment matters|balangir": {
       "dept": "Law",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 4
     },
     "public utility|endowment matters|bargarh": {
       "dept": "Law",
+      "office": "Office of Chief Minister",
       "share": 0.6,
       "support": 3
     },
     "public utility|endowment matters|cuttack": {
       "dept": "Law",
+      "office": "Office of Chief Minister",
       "share": 0.375,
       "support": 3
     },
     "public utility|endowment matters|ganjam": {
-      "dept": "Rural Development",
+      "dept": "Law",
+      "office": "Office of Chief Minister",
       "share": 0.3636,
       "support": 8
     },
     "public utility|endowment matters|kendrapara": {
       "dept": "Law",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 8
     },
     "public utility|endowment matters|khordha": {
       "dept": "Law",
+      "office": "Office of Chief Minister",
       "share": 0.9333,
       "support": 14
     },
     "public utility|endowment matters|mayurbhanj": {
       "dept": "Law",
+      "office": "Office of Chief Minister",
       "share": 0.8,
       "support": 4
     },
     "public utility|endowment matters|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 1.0,
       "support": 40
     },
     "public utility|endowment matters|puri": {
       "dept": "Law",
+      "office": "Office of Chief Minister",
       "share": 0.8,
       "support": 8
     },
     "public utility|endowment matters|sundargarh": {
       "dept": "Law",
+      "office": "Office of Chief Minister",
       "share": 0.75,
       "support": 3
     },
@@ -18280,211 +26034,253 @@
     },
     "public utility|environment pollution/protection|baleswar": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.5,
       "support": 3
     },
     "public utility|environment pollution/protection|cuttack": {
       "dept": "Forest, Environment and Climate Change Department",
+      "office": "Office of Chief Minister",
       "share": 0.3571,
       "support": 5
     },
     "public utility|environment pollution/protection|dhenkanal": {
       "dept": "Forest, Environment and Climate Change Department",
+      "office": "Office of Chief Minister",
       "share": 0.6087,
       "support": 14
     },
     "public utility|environment pollution/protection|ganjam": {
       "dept": "Forest, Environment and Climate Change Department",
+      "office": "Office of Chief Minister",
       "share": 0.3125,
       "support": 5
     },
     "public utility|environment pollution/protection|jagatsinghapur": {
       "dept": "Forest, Environment and Climate Change Department",
+      "office": "Office of Chief Minister",
       "share": 0.4444,
       "support": 4
     },
     "public utility|environment pollution/protection|jajpur": {
-      "dept": "Forest, Environment and Climate Change Department",
+      "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.4333,
       "support": 13
     },
     "public utility|environment pollution/protection|jharsuguda": {
       "dept": "Forest, Environment and Climate Change Department",
+      "office": "Office of Chief Minister",
       "share": 0.6,
       "support": 6
     },
     "public utility|environment pollution/protection|kalahandi": {
       "dept": "Forest, Environment and Climate Change Department",
+      "office": "Office of Chief Minister",
       "share": 0.5,
       "support": 3
     },
     "public utility|environment pollution/protection|kendrapara": {
       "dept": "Forest, Environment and Climate Change Department",
+      "office": "Office of Chief Minister",
       "share": 0.8333,
       "support": 5
     },
     "public utility|environment pollution/protection|kendujhar": {
       "dept": "Forest, Environment and Climate Change Department",
+      "office": "Office of Chief Minister",
       "share": 0.8333,
       "support": 5
     },
     "public utility|environment pollution/protection|khordha": {
       "dept": "Housing & Urban Development",
+      "office": "Departments",
       "share": 0.5556,
       "support": 5
     },
     "public utility|environment pollution/protection|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.5556,
       "support": 5
     },
     "public utility|environment pollution/protection|sambalpur": {
       "dept": "Forest, Environment and Climate Change Department",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 3
     },
     "public utility|environment pollution/protection|sundargarh": {
       "dept": "Forest, Environment and Climate Change Department",
+      "office": "Office of Chief Minister",
       "share": 0.4167,
       "support": 5
     },
     "public utility|miscellaneous certificate issues|angul": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.5556,
       "support": 5
     },
     "public utility|miscellaneous certificate issues|balangir": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.5556,
       "support": 10
     },
     "public utility|miscellaneous certificate issues|baleswar": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.4211,
       "support": 16
     },
     "public utility|miscellaneous certificate issues|bargarh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.75,
       "support": 27
     },
     "public utility|miscellaneous certificate issues|bhadrak": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.8947,
       "support": 17
     },
     "public utility|miscellaneous certificate issues|cuttack": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.6,
       "support": 45
     },
     "public utility|miscellaneous certificate issues|dhenkanal": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.3478,
       "support": 8
     },
     "public utility|miscellaneous certificate issues|gajapati": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.7692,
       "support": 10
     },
     "public utility|miscellaneous certificate issues|ganjam": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.5517,
       "support": 32
     },
     "public utility|miscellaneous certificate issues|jagatsinghapur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.5909,
       "support": 13
     },
     "public utility|miscellaneous certificate issues|jajpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.6486,
       "support": 24
     },
     "public utility|miscellaneous certificate issues|jharsuguda": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 0.375,
       "support": 3
     },
     "public utility|miscellaneous certificate issues|kalahandi": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.5,
       "support": 17
     },
     "public utility|miscellaneous certificate issues|kandhamal": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.8333,
       "support": 5
     },
     "public utility|miscellaneous certificate issues|kendrapara": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.3793,
       "support": 11
     },
     "public utility|miscellaneous certificate issues|kendujhar": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.4286,
       "support": 9
     },
     "public utility|miscellaneous certificate issues|khordha": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.5873,
       "support": 37
     },
     "public utility|miscellaneous certificate issues|koraput": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8125,
       "support": 13
     },
     "public utility|miscellaneous certificate issues|malkangiri": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.8333,
       "support": 5
     },
     "public utility|miscellaneous certificate issues|mayurbhanj": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.6327,
       "support": 31
     },
     "public utility|miscellaneous certificate issues|nayagarh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.52,
       "support": 13
     },
     "public utility|miscellaneous certificate issues|nuapada": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.6389,
       "support": 23
     },
     "public utility|miscellaneous certificate issues|puri": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.5714,
       "support": 20
     },
     "public utility|miscellaneous certificate issues|rayagada": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.3462,
       "support": 9
     },
     "public utility|miscellaneous certificate issues|sambalpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.5556,
       "support": 5
     },
     "public utility|miscellaneous certificate issues|sundargarh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.5263,
       "support": 10
     },
     "public utility|public utility problem|angul": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4313,
       "support": 69
     },
     "public utility|public utility problem|balangir": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.5392,
       "support": 55
     },
@@ -18495,6 +26291,7 @@
     },
     "public utility|public utility problem|bargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.3267,
       "support": 49
     },
@@ -18515,21 +26312,25 @@
     },
     "public utility|public utility problem|deogarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.945,
       "support": 309
     },
     "public utility|public utility problem|dhenkanal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.3086,
       "support": 25
     },
     "public utility|public utility problem|gajapati": {
       "dept": "Planning & Convergence",
+      "office": "Collector",
       "share": 0.5904,
       "support": 49
     },
     "public utility|public utility problem|ganjam": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4297,
       "support": 159
     },
@@ -18550,26 +26351,31 @@
     },
     "public utility|public utility problem|kalahandi": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.37,
       "support": 37
     },
     "public utility|public utility problem|kandhamal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.6024,
       "support": 50
     },
     "public utility|public utility problem|kendrapara": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.2308,
       "support": 21
     },
     "public utility|public utility problem|kendujhar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.3016,
       "support": 19
     },
     "public utility|public utility problem|khordha": {
       "dept": "Housing & Urban Development",
+      "office": "Office of Chief Minister",
       "share": 0.6159,
       "support": 186
     },
@@ -18580,6 +26386,7 @@
     },
     "public utility|public utility problem|malkangiri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4783,
       "support": 11
     },
@@ -18595,11 +26402,13 @@
     },
     "public utility|public utility problem|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.6104,
       "support": 94
     },
     "public utility|public utility problem|nuapada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.3626,
       "support": 33
     },
@@ -18615,6 +26424,7 @@
     },
     "public utility|public utility problem|sambalpur": {
       "dept": "Housing & Urban Development",
+      "office": "Office of Chief Minister",
       "share": 0.6769,
       "support": 155
     },
@@ -18630,56 +26440,67 @@
     },
     "public utility|road/bridge|angul": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5205,
       "support": 76
     },
     "public utility|road/bridge|balangir": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.549,
       "support": 56
     },
     "public utility|road/bridge|baleswar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.4648,
       "support": 66
     },
     "public utility|road/bridge|bargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5249,
       "support": 116
     },
     "public utility|road/bridge|bhadrak": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5693,
       "support": 78
     },
     "public utility|road/bridge|boudh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.6364,
       "support": 21
     },
     "public utility|road/bridge|cuttack": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5274,
       "support": 154
     },
     "public utility|road/bridge|deogarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5714,
       "support": 16
     },
     "public utility|road/bridge|dhenkanal": {
       "dept": "Rural Development",
+      "office": "Collector",
       "share": 0.5052,
       "support": 49
     },
     "public utility|road/bridge|gajapati": {
       "dept": "Rural Development",
+      "office": "Office of Chief Minister",
       "share": 0.4933,
       "support": 37
     },
     "public utility|road/bridge|ganjam": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4879,
       "support": 101
     },
@@ -18690,21 +26511,25 @@
     },
     "public utility|road/bridge|jajpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.4769,
       "support": 62
     },
     "public utility|road/bridge|jharsuguda": {
       "dept": "Works",
+      "office": "Office of Chief Minister",
       "share": 0.3111,
       "support": 14
     },
     "public utility|road/bridge|kalahandi": {
       "dept": "Rural Development",
+      "office": "Collector",
       "share": 0.4537,
       "support": 93
     },
     "public utility|road/bridge|kandhamal": {
       "dept": "Rural Development",
+      "office": "Office of Chief Minister",
       "share": 0.5455,
       "support": 42
     },
@@ -18715,71 +26540,85 @@
     },
     "public utility|road/bridge|kendujhar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.464,
       "support": 58
     },
     "public utility|road/bridge|khordha": {
       "dept": "Housing & Urban Development",
+      "office": "Office of Chief Minister",
       "share": 0.2874,
       "support": 71
     },
     "public utility|road/bridge|koraput": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4487,
       "support": 35
     },
     "public utility|road/bridge|malkangiri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7705,
       "support": 47
     },
     "public utility|road/bridge|mayurbhanj": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.6176,
       "support": 42
     },
     "public utility|road/bridge|nabarangpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.7,
       "support": 7
     },
     "public utility|road/bridge|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.7323,
       "support": 93
     },
     "public utility|road/bridge|nuapada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5018,
       "support": 143
     },
     "public utility|road/bridge|puri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.5513,
       "support": 43
     },
     "public utility|road/bridge|rayagada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.4054,
       "support": 15
     },
     "public utility|road/bridge|sambalpur": {
       "dept": "Rural Development",
+      "office": "Collector",
       "share": 0.4298,
       "support": 49
     },
     "public utility|road/bridge|subarnapur": {
       "dept": "Rural Development",
+      "office": "Office of Chief Minister",
       "share": 0.4333,
       "support": 13
     },
     "public utility|road/bridge|sundargarh": {
       "dept": "Works",
+      "office": "Collector",
       "share": 0.3936,
       "support": 37
     },
     "public utility|sanitation|angul": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5455,
       "support": 6
     },
@@ -18790,16 +26629,19 @@
     },
     "public utility|sanitation|baleswar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.3571,
       "support": 5
     },
     "public utility|sanitation|bargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6875,
       "support": 22
     },
     "public utility|sanitation|bhadrak": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6154,
       "support": 8
     },
@@ -18810,6 +26652,7 @@
     },
     "public utility|sanitation|deogarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.75,
       "support": 3
     },
@@ -18825,21 +26668,25 @@
     },
     "public utility|sanitation|jagatsinghapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.8571,
       "support": 6
     },
     "public utility|sanitation|jajpur": {
       "dept": "Housing & Urban Development",
+      "office": "Departments",
       "share": 0.5,
       "support": 7
     },
     "public utility|sanitation|kalahandi": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6364,
       "support": 7
     },
     "public utility|sanitation|khordha": {
       "dept": "Housing & Urban Development",
+      "office": "Office of Chief Minister",
       "share": 0.8125,
       "support": 26
     },
@@ -18850,16 +26697,19 @@
     },
     "public utility|sanitation|nayagarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.75,
       "support": 3
     },
     "public utility|sanitation|nuapada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.88,
       "support": 22
     },
     "public utility|sanitation|puri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.5455,
       "support": 6
     },
@@ -18870,11 +26720,13 @@
     },
     "public utility|sanitation|sundargarh": {
       "dept": "Housing & Urban Development",
+      "office": "Departments",
       "share": 0.7222,
       "support": 13
     },
     "public utility|smart city|khordha": {
       "dept": "Housing & Urban Development",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 5
     },
@@ -18885,126 +26737,150 @@
     },
     "public utility|transport & traffic|baleswar": {
       "dept": "Commerce & Transport",
+      "office": "Office of Chief Minister",
       "share": 0.4444,
       "support": 4
     },
     "public utility|transport & traffic|bargarh": {
       "dept": "Commerce & Transport",
+      "office": "Office of Chief Minister",
       "share": 0.5556,
       "support": 5
     },
     "public utility|transport & traffic|cuttack": {
       "dept": "Commerce & Transport",
+      "office": "Office of Chief Minister",
       "share": 0.7,
       "support": 14
     },
     "public utility|transport & traffic|dhenkanal": {
       "dept": "Commerce & Transport",
+      "office": "Office of Chief Minister",
       "share": 0.75,
       "support": 3
     },
     "public utility|transport & traffic|ganjam": {
       "dept": "Commerce & Transport",
+      "office": "Office of Chief Minister",
       "share": 0.7,
       "support": 21
     },
     "public utility|transport & traffic|jajpur": {
       "dept": "Commerce & Transport",
+      "office": "Office of Chief Minister",
       "share": 0.6667,
       "support": 6
     },
     "public utility|transport & traffic|jharsuguda": {
       "dept": "Commerce & Transport",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 7
     },
     "public utility|transport & traffic|kalahandi": {
       "dept": "Commerce & Transport",
+      "office": "Office of Chief Minister",
       "share": 0.625,
       "support": 5
     },
     "public utility|transport & traffic|kandhamal": {
       "dept": "Commerce & Transport",
+      "office": "Office of Chief Minister",
       "share": 0.9444,
       "support": 17
     },
     "public utility|transport & traffic|kendrapara": {
       "dept": "Commerce & Transport",
+      "office": "Office of Chief Minister",
       "share": 0.6471,
       "support": 11
     },
     "public utility|transport & traffic|kendujhar": {
       "dept": "Commerce & Transport",
+      "office": "Office of Chief Minister",
       "share": 0.75,
       "support": 3
     },
     "public utility|transport & traffic|khordha": {
       "dept": "Housing & Urban Development",
+      "office": "Office of Chief Minister",
       "share": 0.4815,
       "support": 13
     },
     "public utility|transport & traffic|koraput": {
       "dept": "Commerce & Transport",
+      "office": "Office of Chief Minister",
       "share": 0.5625,
       "support": 9
     },
     "public utility|transport & traffic|mayurbhanj": {
       "dept": "Housing & Urban Development",
+      "office": "Departments",
       "share": 0.5556,
       "support": 5
     },
     "public utility|transport & traffic|nabarangpur": {
-      "dept": "Home department",
+      "dept": "Commerce & Transport",
       "share": 0.4286,
       "support": 3
     },
     "public utility|transport & traffic|nuapada": {
       "dept": "Commerce & Transport",
+      "office": "Collector",
       "share": 0.5,
       "support": 4
     },
     "public utility|transport & traffic|puri": {
       "dept": "Housing & Urban Development",
+      "office": "Departments",
       "share": 0.6316,
       "support": 24
     },
     "public utility|transport & traffic|sambalpur": {
       "dept": "Commerce & Transport",
+      "office": "Office of Chief Minister",
       "share": 0.5714,
       "support": 8
     },
     "public utility|transport & traffic|sundargarh": {
       "dept": "Commerce & Transport",
+      "office": "Office of Chief Minister",
       "share": 0.6667,
       "support": 6
     },
     "school & college|admissions|angul": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.7143,
       "support": 5
     },
     "school & college|admissions|balangir": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.8333,
       "support": 5
     },
     "school & college|admissions|baleswar": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.6667,
       "support": 14
     },
     "school & college|admissions|bargarh": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.6842,
       "support": 13
     },
     "school & college|admissions|bhadrak": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.5714,
       "support": 4
     },
     "school & college|admissions|boudh": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.5833,
       "support": 7
     },
@@ -19015,6 +26891,7 @@
     },
     "school & college|admissions|deogarh": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.8,
       "support": 8
     },
@@ -19025,6 +26902,7 @@
     },
     "school & college|admissions|gajapati": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.55,
       "support": 11
     },
@@ -19035,21 +26913,25 @@
     },
     "school & college|admissions|jagatsinghapur": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.8571,
       "support": 12
     },
     "school & college|admissions|jajpur": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.5556,
       "support": 5
     },
     "school & college|admissions|kalahandi": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.6296,
       "support": 68
     },
     "school & college|admissions|kandhamal": {
       "dept": "ST & SC Development, Minorities & Backward Classes Welfare",
+      "office": "Collector",
       "share": 0.7,
       "support": 21
     },
@@ -19060,11 +26942,13 @@
     },
     "school & college|admissions|kendujhar": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.5789,
       "support": 11
     },
     "school & college|admissions|khordha": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.7059,
       "support": 36
     },
@@ -19075,41 +26959,49 @@
     },
     "school & college|admissions|malkangiri": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.8571,
       "support": 12
     },
     "school & college|admissions|mayurbhanj": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.4961,
       "support": 64
     },
     "school & college|admissions|nabarangpur": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.7407,
       "support": 40
     },
     "school & college|admissions|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.6111,
       "support": 11
     },
     "school & college|admissions|nuapada": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.45,
       "support": 9
     },
     "school & college|admissions|puri": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.3636,
       "support": 8
     },
     "school & college|admissions|rayagada": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.625,
       "support": 15
     },
     "school & college|admissions|sambalpur": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.6429,
       "support": 9
     },
@@ -19120,21 +27012,25 @@
     },
     "school & college|colleges/universities (higher education)|angul": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.8182,
       "support": 9
     },
     "school & college|colleges/universities (higher education)|balangir": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.4706,
       "support": 8
     },
     "school & college|colleges/universities (higher education)|baleswar": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.8333,
       "support": 15
     },
     "school & college|colleges/universities (higher education)|bargarh": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.6944,
       "support": 25
     },
@@ -19145,11 +27041,13 @@
     },
     "school & college|colleges/universities (higher education)|boudh": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.5,
       "support": 3
     },
     "school & college|colleges/universities (higher education)|cuttack": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.5217,
       "support": 12
     },
@@ -19160,21 +27058,25 @@
     },
     "school & college|colleges/universities (higher education)|dhenkanal": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.8333,
       "support": 5
     },
     "school & college|colleges/universities (higher education)|gajapati": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.75,
       "support": 9
     },
     "school & college|colleges/universities (higher education)|ganjam": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.75,
       "support": 45
     },
     "school & college|colleges/universities (higher education)|jagatsinghapur": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.5,
       "support": 11
     },
@@ -19185,36 +27087,43 @@
     },
     "school & college|colleges/universities (higher education)|jharsuguda": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.875,
       "support": 7
     },
     "school & college|colleges/universities (higher education)|kalahandi": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.5682,
       "support": 25
     },
     "school & college|colleges/universities (higher education)|kandhamal": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.625,
       "support": 5
     },
     "school & college|colleges/universities (higher education)|kendrapara": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.6154,
       "support": 8
     },
     "school & college|colleges/universities (higher education)|kendujhar": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.6842,
       "support": 13
     },
     "school & college|colleges/universities (higher education)|khordha": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.8958,
       "support": 43
     },
     "school & college|colleges/universities (higher education)|koraput": {
       "dept": "Higher Education",
+      "office": "Collector",
       "share": 0.7143,
       "support": 5
     },
@@ -19225,56 +27134,67 @@
     },
     "school & college|colleges/universities (higher education)|mayurbhanj": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.68,
       "support": 17
     },
     "school & college|colleges/universities (higher education)|nabarangpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.5926,
       "support": 16
     },
     "school & college|colleges/universities (higher education)|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.7083,
       "support": 17
     },
     "school & college|colleges/universities (higher education)|nuapada": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.7143,
       "support": 10
     },
     "school & college|colleges/universities (higher education)|puri": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.4444,
       "support": 8
     },
     "school & college|colleges/universities (higher education)|sambalpur": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.6667,
       "support": 8
     },
     "school & college|colleges/universities (higher education)|subarnapur": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.5714,
       "support": 4
     },
     "school & college|colleges/universities (higher education)|sundargarh": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.5333,
       "support": 8
     },
     "school & college|higher secondary schools|angul": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.8571,
       "support": 6
     },
     "school & college|higher secondary schools|balangir": {
       "dept": "Higher Education",
+      "office": "Collector",
       "share": 0.3684,
       "support": 7
     },
     "school & college|higher secondary schools|baleswar": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.5625,
       "support": 9
     },
@@ -19285,16 +27205,19 @@
     },
     "school & college|higher secondary schools|boudh": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.8333,
       "support": 5
     },
     "school & college|higher secondary schools|cuttack": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.3636,
       "support": 4
     },
     "school & college|higher secondary schools|deogarh": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 1.0,
       "support": 6
     },
@@ -19305,66 +27228,79 @@
     },
     "school & college|higher secondary schools|gajapati": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.6875,
       "support": 11
     },
     "school & college|higher secondary schools|ganjam": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.675,
       "support": 27
     },
     "school & college|higher secondary schools|jagatsinghapur": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.8,
       "support": 8
     },
     "school & college|higher secondary schools|jajpur": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 1.0,
       "support": 5
     },
     "school & college|higher secondary schools|jharsuguda": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 7
     },
     "school & college|higher secondary schools|kalahandi": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.8387,
       "support": 26
     },
     "school & college|higher secondary schools|kandhamal": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.6667,
       "support": 6
     },
     "school & college|higher secondary schools|kendrapara": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 4
     },
     "school & college|higher secondary schools|kendujhar": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.8947,
       "support": 17
     },
     "school & college|higher secondary schools|khordha": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.7857,
       "support": 22
     },
     "school & college|higher secondary schools|koraput": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 1.0,
       "support": 7
     },
     "school & college|higher secondary schools|malkangiri": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.8333,
       "support": 5
     },
     "school & college|higher secondary schools|mayurbhanj": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.4737,
       "support": 9
     },
@@ -19375,11 +27311,13 @@
     },
     "school & college|higher secondary schools|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.7647,
       "support": 13
     },
     "school & college|higher secondary schools|nuapada": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.75,
       "support": 9
     },
@@ -19390,11 +27328,13 @@
     },
     "school & college|higher secondary schools|rayagada": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.9,
       "support": 9
     },
     "school & college|higher secondary schools|sambalpur": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.625,
       "support": 5
     },
@@ -19415,6 +27355,7 @@
     },
     "school & college|infrastructure issue|bargarh": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.5885,
       "support": 113
     },
@@ -19425,6 +27366,7 @@
     },
     "school & college|infrastructure issue|boudh": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.5102,
       "support": 25
     },
@@ -19435,6 +27377,7 @@
     },
     "school & college|infrastructure issue|deogarh": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.4746,
       "support": 28
     },
@@ -19445,16 +27388,19 @@
     },
     "school & college|infrastructure issue|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4492,
       "support": 84
     },
     "school & college|infrastructure issue|ganjam": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.4292,
       "support": 91
     },
     "school & college|infrastructure issue|jagatsinghapur": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.7447,
       "support": 105
     },
@@ -19470,6 +27416,7 @@
     },
     "school & college|infrastructure issue|kalahandi": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.4549,
       "support": 131
     },
@@ -19500,11 +27447,13 @@
     },
     "school & college|infrastructure issue|malkangiri": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.5607,
       "support": 60
     },
     "school & college|infrastructure issue|mayurbhanj": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.4635,
       "support": 165
     },
@@ -19520,11 +27469,13 @@
     },
     "school & college|infrastructure issue|nuapada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5135,
       "support": 57
     },
     "school & college|infrastructure issue|puri": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.5,
       "support": 40
     },
@@ -19535,6 +27486,7 @@
     },
     "school & college|infrastructure issue|sambalpur": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.4648,
       "support": 66
     },
@@ -19545,6 +27497,7 @@
     },
     "school & college|infrastructure issue|sundargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4259,
       "support": 69
     },
@@ -19565,6 +27518,7 @@
     },
     "school & college|lack of teaching staffs|bargarh": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.8696,
       "support": 40
     },
@@ -19575,6 +27529,7 @@
     },
     "school & college|lack of teaching staffs|boudh": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.9286,
       "support": 26
     },
@@ -19585,6 +27540,7 @@
     },
     "school & college|lack of teaching staffs|deogarh": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.8704,
       "support": 47
     },
@@ -19595,16 +27551,19 @@
     },
     "school & college|lack of teaching staffs|gajapati": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.9375,
       "support": 30
     },
     "school & college|lack of teaching staffs|ganjam": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.8857,
       "support": 62
     },
     "school & college|lack of teaching staffs|jagatsinghapur": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.9683,
       "support": 61
     },
@@ -19620,6 +27579,7 @@
     },
     "school & college|lack of teaching staffs|kalahandi": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.8636,
       "support": 57
     },
@@ -19650,6 +27610,7 @@
     },
     "school & college|lack of teaching staffs|malkangiri": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 1.0,
       "support": 29
     },
@@ -19660,16 +27621,19 @@
     },
     "school & college|lack of teaching staffs|nabarangpur": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.8846,
       "support": 23
     },
     "school & college|lack of teaching staffs|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.6667,
       "support": 14
     },
     "school & college|lack of teaching staffs|nuapada": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.8889,
       "support": 24
     },
@@ -19685,16 +27649,19 @@
     },
     "school & college|lack of teaching staffs|sambalpur": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.8056,
       "support": 29
     },
     "school & college|lack of teaching staffs|subarnapur": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 4
     },
     "school & college|lack of teaching staffs|sundargarh": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.8571,
       "support": 18
     },
@@ -19735,6 +27702,7 @@
     },
     "school & college|mid day meal|gajapati": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.75,
       "support": 3
     },
@@ -19750,6 +27718,7 @@
     },
     "school & college|mid day meal|kalahandi": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 1.0,
       "support": 21
     },
@@ -19770,11 +27739,13 @@
     },
     "school & college|mid day meal|khordha": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.875,
       "support": 7
     },
     "school & college|mid day meal|koraput": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.8333,
       "support": 15
     },
@@ -19805,26 +27776,31 @@
     },
     "school & college|mid day meal|sundargarh": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 1.0,
       "support": 7
     },
     "service matters|employment/recruitment|angul": {
       "dept": "General Administration & Public Grievance",
+      "office": "Departments",
       "share": 0.2432,
       "support": 81
     },
     "service matters|employment/recruitment|balangir": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2203,
       "support": 52
     },
     "service matters|employment/recruitment|baleswar": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.3274,
       "support": 166
     },
     "service matters|employment/recruitment|bargarh": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2521,
       "support": 90
     },
@@ -19835,11 +27811,13 @@
     },
     "service matters|employment/recruitment|boudh": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2447,
       "support": 23
     },
     "service matters|employment/recruitment|cuttack": {
       "dept": "General Administration & Public Grievance",
+      "office": "Office of Chief Minister",
       "share": 0.2636,
       "support": 208
     },
@@ -19855,6 +27833,7 @@
     },
     "service matters|employment/recruitment|gajapati": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.1336,
       "support": 29
     },
@@ -19865,51 +27844,61 @@
     },
     "service matters|employment/recruitment|jagatsinghapur": {
       "dept": "General Administration & Public Grievance",
+      "office": "Office of Chief Minister",
       "share": 0.2642,
       "support": 79
     },
     "service matters|employment/recruitment|jajpur": {
       "dept": "General Administration & Public Grievance",
+      "office": "Office of Chief Minister",
       "share": 0.254,
       "support": 127
     },
     "service matters|employment/recruitment|jharsuguda": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.3143,
       "support": 33
     },
     "service matters|employment/recruitment|kalahandi": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.2906,
       "support": 170
     },
     "service matters|employment/recruitment|kandhamal": {
       "dept": "General Administration & Public Grievance",
+      "office": "Office of Chief Minister",
       "share": 0.1875,
       "support": 24
     },
     "service matters|employment/recruitment|kendrapara": {
       "dept": "General Administration & Public Grievance",
+      "office": "Office of Chief Minister",
       "share": 0.2932,
       "support": 134
     },
     "service matters|employment/recruitment|kendujhar": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2454,
       "support": 120
     },
     "service matters|employment/recruitment|khordha": {
       "dept": "General Administration & Public Grievance",
+      "office": "Office of Chief Minister",
       "share": 0.2878,
       "support": 301
     },
     "service matters|employment/recruitment|koraput": {
       "dept": "General Administration & Public Grievance",
+      "office": "Office of Chief Minister",
       "share": 0.2283,
       "support": 42
     },
     "service matters|employment/recruitment|malkangiri": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2632,
       "support": 20
     },
@@ -19919,7 +27908,7 @@
       "support": 97
     },
     "service matters|employment/recruitment|nabarangpur": {
-      "dept": "Panchayati Raj & Drinking Water",
+      "dept": "General Administration & Public Grievance",
       "share": 0.1611,
       "support": 29
     },
@@ -19930,21 +27919,25 @@
     },
     "service matters|employment/recruitment|nuapada": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.1808,
       "support": 47
     },
     "service matters|employment/recruitment|puri": {
       "dept": "General Administration & Public Grievance",
+      "office": "Office of Chief Minister",
       "share": 0.2817,
       "support": 151
     },
     "service matters|employment/recruitment|rayagada": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.1721,
       "support": 21
     },
     "service matters|employment/recruitment|sambalpur": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 0.3172,
       "support": 98
     },
@@ -19960,6 +27953,7 @@
     },
     "service matters|govt. quarters|cuttack": {
       "dept": "General Administration & Public Grievance",
+      "office": "Office of Chief Minister",
       "share": 0.8421,
       "support": 16
     },
@@ -19970,16 +27964,19 @@
     },
     "service matters|govt. quarters|jagatsinghapur": {
       "dept": "General Administration & Public Grievance",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 4
     },
     "service matters|govt. quarters|jajpur": {
       "dept": "Home department",
+      "office": "Superintendent of Police",
       "share": 0.5,
       "support": 5
     },
     "service matters|govt. quarters|kendujhar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Office of Chief Minister",
       "share": 0.75,
       "support": 3
     },
@@ -20005,46 +28002,54 @@
     },
     "service matters|govt. quarters|subarnapur": {
       "dept": "General Administration & Public Grievance",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 3
     },
     "service matters|govt. quarters|sundargarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 3
     },
     "service matters|non govt. service matters|angul": {
       "dept": "Skill Development & Technical Education",
+      "office": "Office of Chief Minister",
       "share": 0.15,
       "support": 6
     },
     "service matters|non govt. service matters|balangir": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Office of Chief Minister",
       "share": 0.4,
       "support": 8
     },
     "service matters|non govt. service matters|baleswar": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Office of Chief Minister",
       "share": 0.25,
       "support": 8
     },
     "service matters|non govt. service matters|bargarh": {
-      "dept": "Energy",
+      "dept": "Panchayati Raj & Drinking Water",
       "share": 0.1538,
       "support": 6
     },
     "service matters|non govt. service matters|bhadrak": {
       "dept": "Skill Development & Technical Education",
+      "office": "Office of Chief Minister",
       "share": 0.2222,
       "support": 4
     },
     "service matters|non govt. service matters|boudh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.3125,
       "support": 5
     },
     "service matters|non govt. service matters|cuttack": {
       "dept": "Skill Development & Technical Education",
+      "office": "Office of Chief Minister",
       "share": 0.2947,
       "support": 28
     },
@@ -20055,66 +28060,79 @@
     },
     "service matters|non govt. service matters|dhenkanal": {
       "dept": "Energy",
+      "office": "Office of Chief Minister",
       "share": 0.3944,
       "support": 28
     },
     "service matters|non govt. service matters|gajapati": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Office of Chief Minister",
       "share": 0.4167,
       "support": 5
     },
     "service matters|non govt. service matters|ganjam": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Office of Chief Minister",
       "share": 0.1648,
       "support": 15
     },
     "service matters|non govt. service matters|jagatsinghapur": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Office of Chief Minister",
       "share": 0.2759,
       "support": 8
     },
     "service matters|non govt. service matters|jajpur": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Office of Chief Minister",
       "share": 0.2,
       "support": 10
     },
     "service matters|non govt. service matters|jharsuguda": {
       "dept": "Skill Development & Technical Education",
+      "office": "Office of Chief Minister",
       "share": 0.44,
       "support": 11
     },
     "service matters|non govt. service matters|kalahandi": {
-      "dept": "Revenue & Disaster Management",
+      "dept": "Skill Development & Technical Education",
+      "office": "Office of Chief Minister",
       "share": 0.2045,
       "support": 9
     },
     "service matters|non govt. service matters|kendrapara": {
       "dept": "Skill Development & Technical Education",
+      "office": "Office of Chief Minister",
       "share": 0.3243,
       "support": 12
     },
     "service matters|non govt. service matters|kendujhar": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Office of Chief Minister",
       "share": 0.2889,
       "support": 13
     },
     "service matters|non govt. service matters|khordha": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Office of Chief Minister",
       "share": 0.3188,
       "support": 44
     },
     "service matters|non govt. service matters|koraput": {
       "dept": "Skill Development & Technical Education",
+      "office": "Office of Chief Minister",
       "share": 0.2353,
       "support": 4
     },
     "service matters|non govt. service matters|malkangiri": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.5,
       "support": 4
     },
     "service matters|non govt. service matters|mayurbhanj": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.2143,
       "support": 6
     },
@@ -20125,6 +28143,7 @@
     },
     "service matters|non govt. service matters|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.4375,
       "support": 21
     },
@@ -20135,51 +28154,61 @@
     },
     "service matters|non govt. service matters|puri": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.3537,
       "support": 29
     },
     "service matters|non govt. service matters|rayagada": {
       "dept": "Skill Development & Technical Education",
+      "office": "Office of Chief Minister",
       "share": 0.2857,
       "support": 4
     },
     "service matters|non govt. service matters|sambalpur": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Office of Chief Minister",
       "share": 0.1935,
       "support": 6
     },
     "service matters|non govt. service matters|subarnapur": {
       "dept": "Skill Development & Technical Education",
+      "office": "Departments",
       "share": 0.4706,
       "support": 8
     },
     "service matters|non govt. service matters|sundargarh": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Office of Chief Minister",
       "share": 0.2143,
       "support": 6
     },
     "service matters|outsourced staff issues|angul": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Departments",
       "share": 0.2973,
       "support": 11
     },
     "service matters|outsourced staff issues|balangir": {
       "dept": "Housing & Urban Development",
+      "office": "Collector",
       "share": 0.25,
       "support": 9
     },
     "service matters|outsourced staff issues|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Office of Chief Minister",
       "share": 0.3056,
       "support": 11
     },
     "service matters|outsourced staff issues|bargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.1667,
       "support": 4
     },
     "service matters|outsourced staff issues|bhadrak": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.2143,
       "support": 3
     },
@@ -20190,91 +28219,109 @@
     },
     "service matters|outsourced staff issues|cuttack": {
       "dept": "Commerce & Transport",
+      "office": "Office of Chief Minister",
       "share": 0.2069,
       "support": 18
     },
     "service matters|outsourced staff issues|deogarh": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.375,
       "support": 3
     },
     "service matters|outsourced staff issues|dhenkanal": {
       "dept": "Energy",
+      "office": "Office of Chief Minister",
       "share": 0.4884,
       "support": 21
     },
     "service matters|outsourced staff issues|gajapati": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.24,
       "support": 6
     },
     "service matters|outsourced staff issues|ganjam": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.25,
       "support": 20
     },
     "service matters|outsourced staff issues|jagatsinghapur": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Departments",
       "share": 0.303,
       "support": 10
     },
     "service matters|outsourced staff issues|jajpur": {
       "dept": "Commerce & Transport",
+      "office": "Office of Chief Minister",
       "share": 0.2083,
       "support": 10
     },
     "service matters|outsourced staff issues|jharsuguda": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.3,
       "support": 3
     },
     "service matters|outsourced staff issues|kalahandi": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.1795,
       "support": 7
     },
     "service matters|outsourced staff issues|kandhamal": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.375,
       "support": 6
     },
     "service matters|outsourced staff issues|kendrapara": {
       "dept": "Commerce & Transport",
+      "office": "Office of Chief Minister",
       "share": 0.1786,
       "support": 5
     },
     "service matters|outsourced staff issues|kendujhar": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.2167,
       "support": 13
     },
     "service matters|outsourced staff issues|khordha": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.1313,
       "support": 21
     },
     "service matters|outsourced staff issues|koraput": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.1852,
       "support": 5
     },
     "service matters|outsourced staff issues|malkangiri": {
       "dept": "General Administration & Public Grievance",
+      "office": "Office of Chief Minister",
       "share": 0.5,
       "support": 3
     },
     "service matters|outsourced staff issues|mayurbhanj": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.2778,
       "support": 10
     },
     "service matters|outsourced staff issues|nabarangpur": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Office of Chief Minister",
       "share": 0.4,
       "support": 8
     },
     "service matters|outsourced staff issues|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.3333,
       "support": 8
     },
@@ -20284,67 +28331,80 @@
       "support": 3
     },
     "service matters|outsourced staff issues|puri": {
-      "dept": "Commerce & Transport",
+      "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.1569,
       "support": 8
     },
     "service matters|outsourced staff issues|rayagada": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.3529,
       "support": 6
     },
     "service matters|outsourced staff issues|sambalpur": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.2941,
       "support": 10
     },
     "service matters|outsourced staff issues|subarnapur": {
       "dept": "Skill Development & Technical Education",
+      "office": "Office of Chief Minister",
       "share": 0.3636,
       "support": 4
     },
     "service matters|outsourced staff issues|sundargarh": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.16,
       "support": 4
     },
     "service matters|rehabilitation assistance scheme|angul": {
       "dept": "Water Resources",
+      "office": "Office of Chief Minister",
       "share": 0.2277,
       "support": 23
     },
     "service matters|rehabilitation assistance scheme|balangir": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2462,
       "support": 16
     },
     "service matters|rehabilitation assistance scheme|baleswar": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.3248,
       "support": 38
     },
     "service matters|rehabilitation assistance scheme|bargarh": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2982,
       "support": 17
     },
     "service matters|rehabilitation assistance scheme|bhadrak": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.2903,
       "support": 36
     },
     "service matters|rehabilitation assistance scheme|boudh": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.6667,
       "support": 16
     },
     "service matters|rehabilitation assistance scheme|cuttack": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2195,
       "support": 54
     },
     "service matters|rehabilitation assistance scheme|deogarh": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.4146,
       "support": 17
     },
@@ -20355,6 +28415,7 @@
     },
     "service matters|rehabilitation assistance scheme|gajapati": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.275,
       "support": 11
     },
@@ -20365,11 +28426,13 @@
     },
     "service matters|rehabilitation assistance scheme|jagatsinghapur": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2737,
       "support": 26
     },
     "service matters|rehabilitation assistance scheme|jajpur": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.3731,
       "support": 25
     },
@@ -20380,121 +28443,145 @@
     },
     "service matters|rehabilitation assistance scheme|kalahandi": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.4375,
       "support": 63
     },
     "service matters|rehabilitation assistance scheme|kandhamal": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2903,
       "support": 9
     },
     "service matters|rehabilitation assistance scheme|kendrapara": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2794,
       "support": 19
     },
     "service matters|rehabilitation assistance scheme|kendujhar": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.3493,
       "support": 51
     },
     "service matters|rehabilitation assistance scheme|khordha": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 0.2487,
       "support": 96
     },
     "service matters|rehabilitation assistance scheme|koraput": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.2111,
       "support": 19
     },
     "service matters|rehabilitation assistance scheme|malkangiri": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.3929,
       "support": 11
     },
     "service matters|rehabilitation assistance scheme|mayurbhanj": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2582,
       "support": 47
     },
     "service matters|rehabilitation assistance scheme|nabarangpur": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.3457,
       "support": 28
     },
     "service matters|rehabilitation assistance scheme|nayagarh": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.3626,
       "support": 33
     },
     "service matters|rehabilitation assistance scheme|nuapada": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.375,
       "support": 12
     },
     "service matters|rehabilitation assistance scheme|puri": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2323,
       "support": 23
     },
     "service matters|rehabilitation assistance scheme|rayagada": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Office of Chief Minister",
       "share": 0.4848,
       "support": 32
     },
     "service matters|rehabilitation assistance scheme|sambalpur": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 0.2556,
       "support": 23
     },
     "service matters|rehabilitation assistance scheme|subarnapur": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.6364,
       "support": 21
     },
     "service matters|rehabilitation assistance scheme|sundargarh": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2317,
       "support": 19
     },
     "service matters|service matters|angul": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.2266,
       "support": 138
     },
     "service matters|service matters|balangir": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.3891,
       "support": 328
     },
     "service matters|service matters|baleswar": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.5304,
       "support": 917
     },
     "service matters|service matters|bargarh": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2865,
       "support": 198
     },
     "service matters|service matters|bhadrak": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2676,
       "support": 160
     },
     "service matters|service matters|boudh": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.2593,
       "support": 63
     },
     "service matters|service matters|cuttack": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.1726,
       "support": 302
     },
     "service matters|service matters|deogarh": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.1962,
       "support": 41
     },
@@ -20505,66 +28592,79 @@
     },
     "service matters|service matters|gajapati": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2056,
       "support": 81
     },
     "service matters|service matters|ganjam": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.3573,
       "support": 844
     },
     "service matters|service matters|jagatsinghapur": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.2167,
       "support": 122
     },
     "service matters|service matters|jajpur": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.275,
       "support": 231
     },
     "service matters|service matters|jharsuguda": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.3989,
       "support": 142
     },
     "service matters|service matters|kalahandi": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2777,
       "support": 228
     },
     "service matters|service matters|kandhamal": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2527,
       "support": 92
     },
     "service matters|service matters|kendrapara": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.2354,
       "support": 149
     },
     "service matters|service matters|kendujhar": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.3443,
       "support": 522
     },
     "service matters|service matters|khordha": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.1543,
       "support": 430
     },
     "service matters|service matters|koraput": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.3427,
       "support": 232
     },
     "service matters|service matters|malkangiri": {
-      "dept": "School & Mass Education",
+      "dept": "ST & SC Development, Minorities & Backward Classes Welfare",
+      "office": "Departments",
       "share": 0.2364,
       "support": 52
     },
     "service matters|service matters|mayurbhanj": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.1771,
       "support": 184
     },
@@ -20575,51 +28675,61 @@
     },
     "service matters|service matters|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.2201,
       "support": 151
     },
     "service matters|service matters|nuapada": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.2145,
       "support": 77
     },
     "service matters|service matters|puri": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.2848,
       "support": 309
     },
     "service matters|service matters|rayagada": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.25,
       "support": 142
     },
     "service matters|service matters|sambalpur": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.1625,
       "support": 110
     },
     "service matters|service matters|subarnapur": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.3267,
       "support": 98
     },
     "service matters|service matters|sundargarh": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.1615,
       "support": 115
     },
     "service matters|transfer and posting|angul": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.4302,
       "support": 37
     },
     "service matters|transfer and posting|balangir": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.3889,
       "support": 49
     },
     "service matters|transfer and posting|baleswar": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.4059,
       "support": 123
     },
@@ -20630,16 +28740,19 @@
     },
     "service matters|transfer and posting|bhadrak": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.6294,
       "support": 107
     },
     "service matters|transfer and posting|boudh": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.5405,
       "support": 40
     },
     "service matters|transfer and posting|cuttack": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.3379,
       "support": 124
     },
@@ -20650,56 +28763,67 @@
     },
     "service matters|transfer and posting|dhenkanal": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.4083,
       "support": 49
     },
     "service matters|transfer and posting|gajapati": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.5312,
       "support": 153
     },
     "service matters|transfer and posting|ganjam": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.3891,
       "support": 128
     },
     "service matters|transfer and posting|jagatsinghapur": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.4887,
       "support": 65
     },
     "service matters|transfer and posting|jajpur": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.487,
       "support": 75
     },
     "service matters|transfer and posting|jharsuguda": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2553,
       "support": 12
     },
     "service matters|transfer and posting|kalahandi": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.5102,
       "support": 200
     },
     "service matters|transfer and posting|kandhamal": {
       "dept": "ST & SC Development, Minorities & Backward Classes Welfare",
+      "office": "Departments",
       "share": 0.3784,
       "support": 56
     },
     "service matters|transfer and posting|kendrapara": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.4839,
       "support": 75
     },
     "service matters|transfer and posting|kendujhar": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.4016,
       "support": 151
     },
     "service matters|transfer and posting|khordha": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.3354,
       "support": 162
     },
@@ -20710,36 +28834,43 @@
     },
     "service matters|transfer and posting|malkangiri": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.4667,
       "support": 84
     },
     "service matters|transfer and posting|mayurbhanj": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.3255,
       "support": 138
     },
     "service matters|transfer and posting|nabarangpur": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.3755,
       "support": 86
     },
     "service matters|transfer and posting|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.3855,
       "support": 64
     },
     "service matters|transfer and posting|nuapada": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.283,
       "support": 45
     },
     "service matters|transfer and posting|puri": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.5278,
       "support": 114
     },
     "service matters|transfer and posting|rayagada": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.359,
       "support": 70
     },
@@ -20750,16 +28881,19 @@
     },
     "service matters|transfer and posting|subarnapur": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2258,
       "support": 14
     },
     "service matters|transfer and posting|sundargarh": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.3697,
       "support": 88
     },
     "social welfare|aadhar card issues|angul": {
       "dept": "Electronics & Information Technology",
+      "office": "Office of Chief Minister",
       "share": 0.5,
       "support": 3
     },
@@ -20775,21 +28909,25 @@
     },
     "social welfare|aadhar card issues|bhadrak": {
       "dept": "Electronics & Information Technology",
+      "office": "Office of Chief Minister",
       "share": 0.4286,
       "support": 3
     },
     "social welfare|aadhar card issues|boudh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.375,
       "support": 3
     },
     "social welfare|aadhar card issues|cuttack": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4444,
       "support": 4
     },
     "social welfare|aadhar card issues|ganjam": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.3684,
       "support": 7
     },
@@ -20800,16 +28938,17 @@
     },
     "social welfare|aadhar card issues|jajpur": {
       "dept": "Electronics & Information Technology",
+      "office": "Office of Chief Minister",
       "share": 0.75,
       "support": 3
     },
     "social welfare|aadhar card issues|kalahandi": {
-      "dept": "Electronics & Information Technology",
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
       "share": 0.25,
       "support": 4
     },
     "social welfare|aadhar card issues|kandhamal": {
-      "dept": "Panchayati Raj & Drinking Water",
+      "dept": "Electronics & Information Technology",
       "share": 0.4167,
       "support": 5
     },
@@ -20825,6 +28964,7 @@
     },
     "social welfare|aadhar card issues|khordha": {
       "dept": "Electronics & Information Technology",
+      "office": "Office of Chief Minister",
       "share": 0.6,
       "support": 3
     },
@@ -20835,6 +28975,7 @@
     },
     "social welfare|aadhar card issues|malkangiri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6,
       "support": 6
     },
@@ -20845,6 +28986,7 @@
     },
     "social welfare|aadhar card issues|nabarangpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.3158,
       "support": 6
     },
@@ -20855,6 +28997,7 @@
     },
     "social welfare|aadhar card issues|nuapada": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.3889,
       "support": 7
     },
@@ -20869,7 +29012,8 @@
       "support": 5
     },
     "social welfare|ahar yojana|bargarh": {
-      "dept": "Panchayati Raj & Drinking Water",
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.375,
       "support": 3
     },
@@ -20880,11 +29024,13 @@
     },
     "social welfare|ahar yojana|gajapati": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.6667,
       "support": 8
     },
     "social welfare|ahar yojana|ganjam": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.4667,
       "support": 7
     },
@@ -20905,6 +29051,7 @@
     },
     "social welfare|anti poverty programme/bpl|bargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6,
       "support": 3
     },
@@ -20915,21 +29062,25 @@
     },
     "social welfare|anti poverty programme/bpl|dhenkanal": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.6,
       "support": 3
     },
     "social welfare|anti poverty programme/bpl|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 1.0,
       "support": 3
     },
     "social welfare|anti poverty programme/bpl|kalahandi": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.6667,
       "support": 6
     },
     "social welfare|anti poverty programme/bpl|koraput": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 1.0,
       "support": 4
     },
@@ -20965,6 +29116,7 @@
     },
     "social welfare|harischandra yojana|cuttack": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7273,
       "support": 16
     },
@@ -20980,11 +29132,13 @@
     },
     "social welfare|harischandra yojana|ganjam": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4773,
       "support": 21
     },
     "social welfare|harischandra yojana|jagatsinghapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5926,
       "support": 16
     },
@@ -20995,6 +29149,7 @@
     },
     "social welfare|harischandra yojana|kalahandi": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5263,
       "support": 10
     },
@@ -21020,6 +29175,7 @@
     },
     "social welfare|harischandra yojana|koraput": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.625,
       "support": 5
     },
@@ -21035,6 +29191,7 @@
     },
     "social welfare|harischandra yojana|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.7917,
       "support": 19
     },
@@ -21050,6 +29207,7 @@
     },
     "social welfare|harischandra yojana|sambalpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7143,
       "support": 5
     },
@@ -21065,26 +29223,31 @@
     },
     "social welfare|iay/mky/bpgy/pmay|angul": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9953,
       "support": 7785
     },
     "social welfare|iay/mky/bpgy/pmay|balangir": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.9944,
       "support": 2289
     },
     "social welfare|iay/mky/bpgy/pmay|baleswar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.9685,
       "support": 1169
     },
     "social welfare|iay/mky/bpgy/pmay|bargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.9742,
       "support": 641
     },
     "social welfare|iay/mky/bpgy/pmay|bhadrak": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9955,
       "support": 8629
     },
@@ -21095,36 +29258,43 @@
     },
     "social welfare|iay/mky/bpgy/pmay|cuttack": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9705,
       "support": 9791
     },
     "social welfare|iay/mky/bpgy/pmay|deogarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.9925,
       "support": 133
     },
     "social welfare|iay/mky/bpgy/pmay|dhenkanal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.991,
       "support": 1867
     },
     "social welfare|iay/mky/bpgy/pmay|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9851,
       "support": 2776
     },
     "social welfare|iay/mky/bpgy/pmay|ganjam": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9652,
       "support": 28709
     },
     "social welfare|iay/mky/bpgy/pmay|jagatsinghapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9918,
       "support": 9385
     },
     "social welfare|iay/mky/bpgy/pmay|jajpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.9836,
       "support": 2452
     },
@@ -21135,6 +29305,7 @@
     },
     "social welfare|iay/mky/bpgy/pmay|kalahandi": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9941,
       "support": 11320
     },
@@ -21145,31 +29316,37 @@
     },
     "social welfare|iay/mky/bpgy/pmay|kendrapara": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.9882,
       "support": 1008
     },
     "social welfare|iay/mky/bpgy/pmay|kendujhar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9977,
       "support": 15393
     },
     "social welfare|iay/mky/bpgy/pmay|khordha": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.8207,
       "support": 902
     },
     "social welfare|iay/mky/bpgy/pmay|koraput": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.971,
       "support": 972
     },
     "social welfare|iay/mky/bpgy/pmay|malkangiri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9192,
       "support": 546
     },
     "social welfare|iay/mky/bpgy/pmay|mayurbhanj": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.6644,
       "support": 499
     },
@@ -21180,16 +29357,19 @@
     },
     "social welfare|iay/mky/bpgy/pmay|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.6989,
       "support": 3126
     },
     "social welfare|iay/mky/bpgy/pmay|nuapada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.968,
       "support": 2089
     },
     "social welfare|iay/mky/bpgy/pmay|puri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.9484,
       "support": 588
     },
@@ -21200,221 +29380,265 @@
     },
     "social welfare|iay/mky/bpgy/pmay|sambalpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9856,
       "support": 9669
     },
     "social welfare|iay/mky/bpgy/pmay|subarnapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.9871,
       "support": 384
     },
     "social welfare|iay/mky/bpgy/pmay|sundargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.9813,
       "support": 210
     },
     "social welfare|identity card matter|angul": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.4583,
       "support": 11
     },
     "social welfare|identity card matter|balangir": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.641,
       "support": 25
     },
     "social welfare|identity card matter|baleswar": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.8303,
       "support": 543
     },
     "social welfare|identity card matter|bargarh": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.4286,
       "support": 6
     },
     "social welfare|identity card matter|bhadrak": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.8361,
       "support": 51
     },
     "social welfare|identity card matter|boudh": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Departments",
       "share": 0.6667,
       "support": 6
     },
     "social welfare|identity card matter|cuttack": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.6446,
       "support": 78
     },
     "social welfare|identity card matter|deogarh": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.75,
       "support": 3
     },
     "social welfare|identity card matter|dhenkanal": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.8133,
       "support": 61
     },
     "social welfare|identity card matter|ganjam": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.5931,
       "support": 121
     },
     "social welfare|identity card matter|jagatsinghapur": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.7391,
       "support": 17
     },
     "social welfare|identity card matter|jajpur": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.9091,
       "support": 80
     },
     "social welfare|identity card matter|jharsuguda": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.8571,
       "support": 6
     },
     "social welfare|identity card matter|kalahandi": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.5682,
       "support": 25
     },
     "social welfare|identity card matter|kandhamal": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.625,
       "support": 5
     },
     "social welfare|identity card matter|kendrapara": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.9032,
       "support": 112
     },
     "social welfare|identity card matter|kendujhar": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.9375,
       "support": 45
     },
     "social welfare|identity card matter|khordha": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.8889,
       "support": 80
     },
     "social welfare|identity card matter|koraput": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.5385,
       "support": 7
     },
     "social welfare|identity card matter|mayurbhanj": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.7222,
       "support": 13
     },
     "social welfare|identity card matter|nabarangpur": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.7143,
       "support": 5
     },
     "social welfare|identity card matter|nayagarh": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.4681,
       "support": 22
     },
     "social welfare|identity card matter|nuapada": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.7,
       "support": 14
     },
     "social welfare|identity card matter|puri": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.8511,
       "support": 40
     },
     "social welfare|identity card matter|sambalpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4667,
       "support": 7
     },
     "social welfare|identity card matter|subarnapur": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.7143,
       "support": 10
     },
     "social welfare|identity card matter|sundargarh": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.9483,
       "support": 55
     },
     "social welfare|indigent artist pension / mksy|angul": {
       "dept": "Odia Language Literature & Culture",
+      "office": "Office of Chief Minister",
       "share": 0.8,
       "support": 4
     },
     "social welfare|indigent artist pension / mksy|balangir": {
       "dept": "Odia Language Literature & Culture",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 10
     },
     "social welfare|indigent artist pension / mksy|baleswar": {
       "dept": "Odia Language Literature & Culture",
+      "office": "Office of Chief Minister",
       "share": 0.9231,
       "support": 12
     },
     "social welfare|indigent artist pension / mksy|bargarh": {
       "dept": "Odia Language Literature & Culture",
+      "office": "Collector",
       "share": 0.8571,
       "support": 6
     },
     "social welfare|indigent artist pension / mksy|bhadrak": {
       "dept": "Odia Language Literature & Culture",
+      "office": "Office of Chief Minister",
       "share": 0.8889,
       "support": 8
     },
     "social welfare|indigent artist pension / mksy|cuttack": {
       "dept": "Odia Language Literature & Culture",
+      "office": "Office of Chief Minister",
       "share": 0.7273,
       "support": 16
     },
     "social welfare|indigent artist pension / mksy|deogarh": {
       "dept": "Odia Language Literature & Culture",
+      "office": "Collector",
       "share": 0.8235,
       "support": 28
     },
     "social welfare|indigent artist pension / mksy|dhenkanal": {
       "dept": "Odia Language Literature & Culture",
+      "office": "Office of Chief Minister",
       "share": 0.7778,
       "support": 7
     },
     "social welfare|indigent artist pension / mksy|ganjam": {
       "dept": "Odia Language Literature & Culture",
+      "office": "Collector",
       "share": 0.6216,
       "support": 69
     },
     "social welfare|indigent artist pension / mksy|jagatsinghapur": {
       "dept": "Odia Language Literature & Culture",
+      "office": "Collector",
       "share": 0.8889,
       "support": 32
     },
     "social welfare|indigent artist pension / mksy|jajpur": {
       "dept": "Odia Language Literature & Culture",
+      "office": "Office of Chief Minister",
       "share": 0.7895,
       "support": 30
     },
     "social welfare|indigent artist pension / mksy|kendrapara": {
       "dept": "Odia Language Literature & Culture",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 8
     },
     "social welfare|indigent artist pension / mksy|khordha": {
       "dept": "Odia Language Literature & Culture",
+      "office": "Office of Chief Minister",
       "share": 0.7903,
       "support": 49
     },
     "social welfare|indigent artist pension / mksy|mayurbhanj": {
       "dept": "Odia Language Literature & Culture",
+      "office": "Office of Chief Minister",
       "share": 0.4286,
       "support": 3
     },
@@ -21425,11 +29649,13 @@
     },
     "social welfare|indigent artist pension / mksy|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.5417,
       "support": 13
     },
     "social welfare|indigent artist pension / mksy|puri": {
       "dept": "Odia Language Literature & Culture",
+      "office": "Office of Chief Minister",
       "share": 0.5385,
       "support": 7
     },
@@ -21455,16 +29681,19 @@
     },
     "social welfare|individual household latrine|bargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.9815,
       "support": 53
     },
     "social welfare|individual household latrine|bhadrak": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8667,
       "support": 13
     },
     "social welfare|individual household latrine|boudh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 1.0,
       "support": 8
     },
@@ -21475,21 +29704,25 @@
     },
     "social welfare|individual household latrine|deogarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 1.0,
       "support": 7
     },
     "social welfare|individual household latrine|dhenkanal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.9655,
       "support": 28
     },
     "social welfare|individual household latrine|ganjam": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8679,
       "support": 46
     },
     "social welfare|individual household latrine|jagatsinghapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 1.0,
       "support": 88
     },
@@ -21505,6 +29738,7 @@
     },
     "social welfare|individual household latrine|kendrapara": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.9545,
       "support": 21
     },
@@ -21525,26 +29759,31 @@
     },
     "social welfare|individual household latrine|nabarangpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 1.0,
       "support": 6
     },
     "social welfare|individual household latrine|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.6486,
       "support": 48
     },
     "social welfare|individual household latrine|nuapada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 1.0,
       "support": 5
     },
     "social welfare|individual household latrine|puri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 11
     },
     "social welfare|individual household latrine|sambalpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 1.0,
       "support": 27
     },
@@ -21560,11 +29799,13 @@
     },
     "social welfare|infrastructure issue|bhadrak": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 1.0,
       "support": 8
     },
     "social welfare|infrastructure issue|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 1.0,
       "support": 3
     },
@@ -21575,11 +29816,13 @@
     },
     "social welfare|infrastructure issue|kendujhar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 1.0,
       "support": 11
     },
     "social welfare|infrastructure issue|sambalpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 1.0,
       "support": 4
     },
@@ -21590,16 +29833,19 @@
     },
     "social welfare|kalia yojana / pm-kisan|balangir": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Departments",
       "share": 0.9741,
       "support": 640
     },
     "social welfare|kalia yojana / pm-kisan|baleswar": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Departments",
       "share": 0.8576,
       "support": 1054
     },
     "social welfare|kalia yojana / pm-kisan|bargarh": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Departments",
       "share": 0.9639,
       "support": 294
     },
@@ -21615,21 +29861,25 @@
     },
     "social welfare|kalia yojana / pm-kisan|cuttack": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Departments",
       "share": 0.9683,
       "support": 856
     },
     "social welfare|kalia yojana / pm-kisan|deogarh": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Departments",
       "share": 0.9444,
       "support": 68
     },
     "social welfare|kalia yojana / pm-kisan|dhenkanal": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Departments",
       "share": 0.9568,
       "support": 354
     },
     "social welfare|kalia yojana / pm-kisan|gajapati": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Departments",
       "share": 1.0,
       "support": 54
     },
@@ -21650,6 +29900,7 @@
     },
     "social welfare|kalia yojana / pm-kisan|jharsuguda": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Office of Chief Minister",
       "share": 0.9574,
       "support": 45
     },
@@ -21660,6 +29911,7 @@
     },
     "social welfare|kalia yojana / pm-kisan|kandhamal": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Departments",
       "share": 0.9545,
       "support": 21
     },
@@ -21675,6 +29927,7 @@
     },
     "social welfare|kalia yojana / pm-kisan|khordha": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Departments",
       "share": 0.9763,
       "support": 329
     },
@@ -21685,11 +29938,13 @@
     },
     "social welfare|kalia yojana / pm-kisan|malkangiri": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Office of Chief Minister",
       "share": 0.975,
       "support": 39
     },
     "social welfare|kalia yojana / pm-kisan|mayurbhanj": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Departments",
       "share": 0.9024,
       "support": 305
     },
@@ -21700,6 +29955,7 @@
     },
     "social welfare|kalia yojana / pm-kisan|nayagarh": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Departments",
       "share": 0.7739,
       "support": 219
     },
@@ -21710,11 +29966,13 @@
     },
     "social welfare|kalia yojana / pm-kisan|puri": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Departments",
       "share": 0.9705,
       "support": 592
     },
     "social welfare|kalia yojana / pm-kisan|rayagada": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Departments",
       "share": 0.9875,
       "support": 79
     },
@@ -21730,21 +29988,25 @@
     },
     "social welfare|kalia yojana / pm-kisan|sundargarh": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Office of Chief Minister",
       "share": 0.9748,
       "support": 116
     },
     "social welfare|labour issues|angul": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 33
     },
     "social welfare|labour issues|balangir": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Office of Chief Minister",
       "share": 0.9492,
       "support": 56
     },
     "social welfare|labour issues|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.6074,
       "support": 297
     },
@@ -21755,11 +30017,13 @@
     },
     "social welfare|labour issues|bhadrak": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Collector",
       "share": 0.9758,
       "support": 121
     },
     "social welfare|labour issues|boudh": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Collector",
       "share": 0.9688,
       "support": 31
     },
@@ -21780,11 +30044,13 @@
     },
     "social welfare|labour issues|gajapati": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Collector",
       "share": 0.9444,
       "support": 34
     },
     "social welfare|labour issues|ganjam": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Collector",
       "share": 0.8649,
       "support": 192
     },
@@ -21795,11 +30061,13 @@
     },
     "social welfare|labour issues|jajpur": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Office of Chief Minister",
       "share": 0.9667,
       "support": 87
     },
     "social welfare|labour issues|jharsuguda": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 19
     },
@@ -21815,26 +30083,31 @@
     },
     "social welfare|labour issues|kendrapara": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Office of Chief Minister",
       "share": 0.954,
       "support": 83
     },
     "social welfare|labour issues|kendujhar": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Collector",
       "share": 0.9831,
       "support": 116
     },
     "social welfare|labour issues|khordha": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Office of Chief Minister",
       "share": 0.9746,
       "support": 115
     },
     "social welfare|labour issues|koraput": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Office of Chief Minister",
       "share": 0.9048,
       "support": 19
     },
     "social welfare|labour issues|malkangiri": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 1.0,
       "support": 5
     },
@@ -21855,11 +30128,13 @@
     },
     "social welfare|labour issues|nuapada": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Collector",
       "share": 0.9298,
       "support": 106
     },
     "social welfare|labour issues|puri": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.8125,
       "support": 26
     },
@@ -21875,16 +30150,19 @@
     },
     "social welfare|labour issues|subarnapur": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Office of Chief Minister",
       "share": 0.8095,
       "support": 17
     },
     "social welfare|labour issues|sundargarh": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Collector",
       "share": 0.9667,
       "support": 29
     },
     "social welfare|marriage incentive|angul": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Collector",
       "share": 0.5263,
       "support": 10
     },
@@ -21895,6 +30173,7 @@
     },
     "social welfare|marriage incentive|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.517,
       "support": 76
     },
@@ -21905,16 +30184,19 @@
     },
     "social welfare|marriage incentive|bhadrak": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Collector",
       "share": 0.5833,
       "support": 21
     },
     "social welfare|marriage incentive|boudh": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Collector",
       "share": 0.9,
       "support": 27
     },
     "social welfare|marriage incentive|cuttack": {
       "dept": "ST & SC Development, Minorities & Backward Classes Welfare",
+      "office": "Departments",
       "share": 0.6053,
       "support": 23
     },
@@ -21925,21 +30207,25 @@
     },
     "social welfare|marriage incentive|dhenkanal": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Collector",
       "share": 0.6585,
       "support": 27
     },
     "social welfare|marriage incentive|gajapati": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Collector",
       "share": 0.8571,
       "support": 18
     },
     "social welfare|marriage incentive|ganjam": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.3977,
       "support": 35
     },
     "social welfare|marriage incentive|jagatsinghapur": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Collector",
       "share": 0.4545,
       "support": 5
     },
@@ -21955,16 +30241,19 @@
     },
     "social welfare|marriage incentive|kalahandi": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Collector",
       "share": 0.7882,
       "support": 67
     },
     "social welfare|marriage incentive|kandhamal": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Departments",
       "share": 0.75,
       "support": 3
     },
     "social welfare|marriage incentive|kendrapara": {
       "dept": "ST & SC Development, Minorities & Backward Classes Welfare",
+      "office": "Departments",
       "share": 0.5,
       "support": 9
     },
@@ -21975,21 +30264,25 @@
     },
     "social welfare|marriage incentive|khordha": {
       "dept": "ST & SC Development, Minorities & Backward Classes Welfare",
+      "office": "Departments",
       "share": 0.4483,
       "support": 13
     },
     "social welfare|marriage incentive|koraput": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.7368,
       "support": 14
     },
     "social welfare|marriage incentive|mayurbhanj": {
       "dept": "ST & SC Development, Minorities & Backward Classes Welfare",
+      "office": "Departments",
       "share": 0.3684,
       "support": 7
     },
     "social welfare|marriage incentive|nabarangpur": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Collector",
       "share": 0.6667,
       "support": 18
     },
@@ -22000,16 +30293,19 @@
     },
     "social welfare|marriage incentive|nuapada": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Collector",
       "share": 0.5,
       "support": 11
     },
     "social welfare|marriage incentive|puri": {
       "dept": "ST & SC Development, Minorities & Backward Classes Welfare",
+      "office": "Departments",
       "share": 0.3902,
       "support": 16
     },
     "social welfare|marriage incentive|subarnapur": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Collector",
       "share": 0.7222,
       "support": 13
     },
@@ -22030,21 +30326,25 @@
     },
     "social welfare|mgnregs|baleswar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.68,
       "support": 34
     },
     "social welfare|mgnregs|bargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9661,
       "support": 57
     },
     "social welfare|mgnregs|bhadrak": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 1.0,
       "support": 43
     },
     "social welfare|mgnregs|boudh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9773,
       "support": 86
     },
@@ -22070,26 +30370,31 @@
     },
     "social welfare|mgnregs|ganjam": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9157,
       "support": 163
     },
     "social welfare|mgnregs|jagatsinghapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9512,
       "support": 78
     },
     "social welfare|mgnregs|jajpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.9583,
       "support": 23
     },
     "social welfare|mgnregs|jharsuguda": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.875,
       "support": 7
     },
     "social welfare|mgnregs|kalahandi": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9085,
       "support": 129
     },
@@ -22100,6 +30405,7 @@
     },
     "social welfare|mgnregs|kendrapara": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.8889,
       "support": 24
     },
@@ -22110,6 +30416,7 @@
     },
     "social welfare|mgnregs|khordha": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.8148,
       "support": 22
     },
@@ -22120,6 +30427,7 @@
     },
     "social welfare|mgnregs|malkangiri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.963,
       "support": 26
     },
@@ -22130,31 +30438,37 @@
     },
     "social welfare|mgnregs|nabarangpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.875,
       "support": 21
     },
     "social welfare|mgnregs|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.7293,
       "support": 97
     },
     "social welfare|mgnregs|nuapada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9342,
       "support": 71
     },
     "social welfare|mgnregs|puri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.9615,
       "support": 25
     },
     "social welfare|mgnregs|rayagada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9259,
       "support": 25
     },
     "social welfare|mgnregs|sambalpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9831,
       "support": 58
     },
@@ -22170,51 +30484,61 @@
     },
     "social welfare|mission shakti groups/community cadre(shg)|angul": {
       "dept": "Mission Shakti",
+      "office": "Office of Chief Minister",
       "share": 0.7,
       "support": 7
     },
     "social welfare|mission shakti groups/community cadre(shg)|balangir": {
       "dept": "Mission Shakti",
+      "office": "Office of Chief Minister",
       "share": 0.6,
       "support": 3
     },
     "social welfare|mission shakti groups/community cadre(shg)|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.7069,
       "support": 41
     },
     "social welfare|mission shakti groups/community cadre(shg)|bargarh": {
       "dept": "Mission Shakti",
+      "office": "Collector",
       "share": 0.5294,
       "support": 9
     },
     "social welfare|mission shakti groups/community cadre(shg)|bhadrak": {
       "dept": "Mission Shakti",
+      "office": "Office of Chief Minister",
       "share": 0.4667,
       "support": 7
     },
     "social welfare|mission shakti groups/community cadre(shg)|cuttack": {
       "dept": "Mission Shakti",
+      "office": "Office of Chief Minister",
       "share": 0.5,
       "support": 9
     },
     "social welfare|mission shakti groups/community cadre(shg)|deogarh": {
       "dept": "Mission Shakti",
+      "office": "Collector",
       "share": 0.55,
       "support": 11
     },
     "social welfare|mission shakti groups/community cadre(shg)|dhenkanal": {
       "dept": "Mission Shakti",
+      "office": "Collector",
       "share": 0.5385,
       "support": 7
     },
     "social welfare|mission shakti groups/community cadre(shg)|ganjam": {
       "dept": "Mission Shakti",
+      "office": "Collector",
       "share": 0.4898,
       "support": 24
     },
     "social welfare|mission shakti groups/community cadre(shg)|jagatsinghapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8605,
       "support": 37
     },
@@ -22225,26 +30549,31 @@
     },
     "social welfare|mission shakti groups/community cadre(shg)|jharsuguda": {
       "dept": "Mission Shakti",
+      "office": "Collector",
       "share": 0.75,
       "support": 9
     },
     "social welfare|mission shakti groups/community cadre(shg)|kalahandi": {
       "dept": "Women & Child Development",
+      "office": "Collector",
       "share": 0.3636,
       "support": 4
     },
     "social welfare|mission shakti groups/community cadre(shg)|kendrapara": {
       "dept": "Mission Shakti",
+      "office": "Office of Chief Minister",
       "share": 0.4667,
       "support": 7
     },
     "social welfare|mission shakti groups/community cadre(shg)|kendujhar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5,
       "support": 3
     },
     "social welfare|mission shakti groups/community cadre(shg)|khordha": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4138,
       "support": 12
     },
@@ -22255,36 +30584,43 @@
     },
     "social welfare|mission shakti groups/community cadre(shg)|malkangiri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5,
       "support": 4
     },
     "social welfare|mission shakti groups/community cadre(shg)|mayurbhanj": {
       "dept": "Mission Shakti",
+      "office": "Office of Chief Minister",
       "share": 0.4286,
       "support": 3
     },
     "social welfare|mission shakti groups/community cadre(shg)|nabarangpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.2727,
       "support": 3
     },
     "social welfare|mission shakti groups/community cadre(shg)|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.7792,
       "support": 60
     },
     "social welfare|mission shakti groups/community cadre(shg)|nuapada": {
       "dept": "Mission Shakti",
+      "office": "Collector",
       "share": 0.381,
       "support": 8
     },
     "social welfare|mission shakti groups/community cadre(shg)|puri": {
-      "dept": "Panchayati Raj & Drinking Water",
+      "dept": "Women & Child Development",
+      "office": "Collector",
       "share": 0.3333,
       "support": 9
     },
     "social welfare|mission shakti groups/community cadre(shg)|sambalpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4643,
       "support": 13
     },
@@ -22295,6 +30631,7 @@
     },
     "social welfare|mo pokhari yojana|cuttack": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8333,
       "support": 5
     },
@@ -22305,21 +30642,25 @@
     },
     "social welfare|mo pokhari yojana|ganjam": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5,
       "support": 4
     },
     "social welfare|mo pokhari yojana|jagatsinghapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 1.0,
       "support": 5
     },
     "social welfare|mo pokhari yojana|kalahandi": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.75,
       "support": 6
     },
     "social welfare|mo pokhari yojana|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.8571,
       "support": 6
     },
@@ -22345,6 +30686,7 @@
     },
     "social welfare|oap/odp/mbpy/wp|bargarh": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.7984,
       "support": 792
     },
@@ -22355,6 +30697,7 @@
     },
     "social welfare|oap/odp/mbpy/wp|boudh": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.8391,
       "support": 386
     },
@@ -22365,6 +30708,7 @@
     },
     "social welfare|oap/odp/mbpy/wp|deogarh": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.9194,
       "support": 114
     },
@@ -22375,16 +30719,19 @@
     },
     "social welfare|oap/odp/mbpy/wp|gajapati": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.5682,
       "support": 125
     },
     "social welfare|oap/odp/mbpy/wp|ganjam": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.7007,
       "support": 1405
     },
     "social welfare|oap/odp/mbpy/wp|jagatsinghapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6791,
       "support": 872
     },
@@ -22400,6 +30747,7 @@
     },
     "social welfare|oap/odp/mbpy/wp|kalahandi": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.937,
       "support": 878
     },
@@ -22430,6 +30778,7 @@
     },
     "social welfare|oap/odp/mbpy/wp|malkangiri": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.9767,
       "support": 210
     },
@@ -22445,11 +30794,13 @@
     },
     "social welfare|oap/odp/mbpy/wp|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.5287,
       "support": 359
     },
     "social welfare|oap/odp/mbpy/wp|nuapada": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.7668,
       "support": 319
     },
@@ -22470,21 +30821,25 @@
     },
     "social welfare|oap/odp/mbpy/wp|subarnapur": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.8386,
       "support": 291
     },
     "social welfare|oap/odp/mbpy/wp|sundargarh": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.9119,
       "support": 238
     },
     "social welfare|odisha state treatment fund|ganjam": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.375,
       "support": 3
     },
     "social welfare|other pension|angul": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.7222,
       "support": 13
     },
@@ -22495,66 +30850,79 @@
     },
     "social welfare|other pension|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.9167,
       "support": 308
     },
     "social welfare|other pension|bargarh": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.5,
       "support": 26
     },
     "social welfare|other pension|bhadrak": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8133,
       "support": 61
     },
     "social welfare|other pension|boudh": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.3333,
       "support": 13
     },
     "social welfare|other pension|cuttack": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.6277,
       "support": 59
     },
     "social welfare|other pension|deogarh": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.8,
       "support": 4
     },
     "social welfare|other pension|dhenkanal": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.8269,
       "support": 43
     },
     "social welfare|other pension|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.75,
       "support": 6
     },
     "social welfare|other pension|ganjam": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.6259,
       "support": 435
     },
     "social welfare|other pension|jagatsinghapur": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.5385,
       "support": 14
     },
     "social welfare|other pension|jajpur": {
       "dept": "Odia Language Literature & Culture",
+      "office": "Office of Chief Minister",
       "share": 0.4857,
       "support": 17
     },
     "social welfare|other pension|jharsuguda": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.75,
       "support": 6
     },
     "social welfare|other pension|kalahandi": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.7556,
       "support": 34
     },
@@ -22565,26 +30933,31 @@
     },
     "social welfare|other pension|kendrapara": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.6154,
       "support": 8
     },
     "social welfare|other pension|kendujhar": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.8085,
       "support": 38
     },
     "social welfare|other pension|khordha": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.7667,
       "support": 23
     },
     "social welfare|other pension|koraput": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.6078,
       "support": 31
     },
     "social welfare|other pension|malkangiri": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.7273,
       "support": 8
     },
@@ -22595,61 +30968,73 @@
     },
     "social welfare|other pension|nabarangpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4167,
       "support": 5
     },
     "social welfare|other pension|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.8819,
       "support": 127
     },
     "social welfare|other pension|nuapada": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.7,
       "support": 7
     },
     "social welfare|other pension|puri": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.5385,
       "support": 21
     },
     "social welfare|other pension|sambalpur": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.5238,
       "support": 22
     },
     "social welfare|other pension|subarnapur": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.7,
       "support": 7
     },
     "social welfare|other pension|sundargarh": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.625,
       "support": 10
     },
     "social welfare|p.d.s/n.f.s.a/ sfss/aay|angul": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.9296,
       "support": 66
     },
     "social welfare|p.d.s/n.f.s.a/ sfss/aay|balangir": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.9156,
       "support": 206
     },
     "social welfare|p.d.s/n.f.s.a/ sfss/aay|baleswar": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.9543,
       "support": 188
     },
     "social welfare|p.d.s/n.f.s.a/ sfss/aay|bargarh": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.7931,
       "support": 115
     },
     "social welfare|p.d.s/n.f.s.a/ sfss/aay|bhadrak": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.8829,
       "support": 362
     },
@@ -22660,11 +31045,13 @@
     },
     "social welfare|p.d.s/n.f.s.a/ sfss/aay|cuttack": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.8621,
       "support": 250
     },
     "social welfare|p.d.s/n.f.s.a/ sfss/aay|deogarh": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.8108,
       "support": 30
     },
@@ -22675,16 +31062,19 @@
     },
     "social welfare|p.d.s/n.f.s.a/ sfss/aay|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5855,
       "support": 89
     },
     "social welfare|p.d.s/n.f.s.a/ sfss/aay|ganjam": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.8781,
       "support": 317
     },
     "social welfare|p.d.s/n.f.s.a/ sfss/aay|jagatsinghapur": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.6949,
       "support": 123
     },
@@ -22695,11 +31085,13 @@
     },
     "social welfare|p.d.s/n.f.s.a/ sfss/aay|jharsuguda": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.8621,
       "support": 50
     },
     "social welfare|p.d.s/n.f.s.a/ sfss/aay|kalahandi": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.8629,
       "support": 321
     },
@@ -22710,6 +31102,7 @@
     },
     "social welfare|p.d.s/n.f.s.a/ sfss/aay|kendrapara": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.9563,
       "support": 219
     },
@@ -22720,6 +31113,7 @@
     },
     "social welfare|p.d.s/n.f.s.a/ sfss/aay|khordha": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.9107,
       "support": 316
     },
@@ -22735,16 +31129,19 @@
     },
     "social welfare|p.d.s/n.f.s.a/ sfss/aay|mayurbhanj": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.382,
       "support": 144
     },
     "social welfare|p.d.s/n.f.s.a/ sfss/aay|nabarangpur": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.8111,
       "support": 73
     },
     "social welfare|p.d.s/n.f.s.a/ sfss/aay|nayagarh": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.5925,
       "support": 173
     },
@@ -22755,11 +31152,13 @@
     },
     "social welfare|p.d.s/n.f.s.a/ sfss/aay|puri": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.9504,
       "support": 134
     },
     "social welfare|p.d.s/n.f.s.a/ sfss/aay|rayagada": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.8,
       "support": 56
     },
@@ -22770,11 +31169,13 @@
     },
     "social welfare|p.d.s/n.f.s.a/ sfss/aay|subarnapur": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.9385,
       "support": 61
     },
     "social welfare|p.d.s/n.f.s.a/ sfss/aay|sundargarh": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.907,
       "support": 39
     },
@@ -22785,11 +31186,13 @@
     },
     "social welfare|public utility problem|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.75,
       "support": 6
     },
     "social welfare|public utility problem|bhadrak": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.3333,
       "support": 5
     },
@@ -22799,7 +31202,8 @@
       "support": 7
     },
     "social welfare|public utility problem|deogarh": {
-      "dept": "General Administration & Public Grievance",
+      "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4286,
       "support": 6
     },
@@ -22810,6 +31214,7 @@
     },
     "social welfare|public utility problem|ganjam": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.587,
       "support": 27
     },
@@ -22820,6 +31225,7 @@
     },
     "social welfare|public utility problem|kalahandi": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4375,
       "support": 7
     },
@@ -22830,6 +31236,7 @@
     },
     "social welfare|public utility problem|kendujhar": {
       "dept": "Housing & Urban Development",
+      "office": "Collector",
       "share": 0.3846,
       "support": 5
     },
@@ -22850,16 +31257,19 @@
     },
     "social welfare|public utility problem|nabarangpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.375,
       "support": 9
     },
     "social welfare|public utility problem|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.7407,
       "support": 20
     },
     "social welfare|public utility problem|puri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.45,
       "support": 9
     },
@@ -22870,6 +31280,7 @@
     },
     "social welfare|public utility problem|sambalpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5833,
       "support": 14
     },
@@ -22890,11 +31301,13 @@
     },
     "social welfare|ration card issue|balangir": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Departments",
       "share": 0.9398,
       "support": 562
     },
     "social welfare|ration card issue|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.5415,
       "support": 816
     },
@@ -22910,6 +31323,7 @@
     },
     "social welfare|ration card issue|boudh": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.9456,
       "support": 400
     },
@@ -22920,31 +31334,37 @@
     },
     "social welfare|ration card issue|deogarh": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.8977,
       "support": 79
     },
     "social welfare|ration card issue|dhenkanal": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Departments",
       "share": 0.8949,
       "support": 315
     },
     "social welfare|ration card issue|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6623,
       "support": 153
     },
     "social welfare|ration card issue|ganjam": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.6061,
       "support": 1800
     },
     "social welfare|ration card issue|jagatsinghapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6033,
       "support": 946
     },
     "social welfare|ration card issue|jajpur": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Departments",
       "share": 0.8737,
       "support": 498
     },
@@ -22955,6 +31375,7 @@
     },
     "social welfare|ration card issue|kalahandi": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.7816,
       "support": 569
     },
@@ -22965,6 +31386,7 @@
     },
     "social welfare|ration card issue|kendrapara": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Departments",
       "share": 0.8868,
       "support": 721
     },
@@ -22985,11 +31407,13 @@
     },
     "social welfare|ration card issue|malkangiri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.563,
       "support": 67
     },
     "social welfare|ration card issue|mayurbhanj": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Departments",
       "share": 0.6743,
       "support": 207
     },
@@ -23000,11 +31424,13 @@
     },
     "social welfare|ration card issue|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.6794,
       "support": 782
     },
     "social welfare|ration card issue|nuapada": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.6383,
       "support": 390
     },
@@ -23020,6 +31446,7 @@
     },
     "social welfare|ration card issue|sambalpur": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.6212,
       "support": 328
     },
@@ -23030,31 +31457,37 @@
     },
     "social welfare|ration card issue|sundargarh": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.8944,
       "support": 305
     },
     "social welfare|red cross fund|dhenkanal": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.9643,
       "support": 27
     },
     "social welfare|red cross fund|ganjam": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.3846,
       "support": 5
     },
     "social welfare|red cross fund|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 1.0,
       "support": 3
     },
     "social welfare|rehabilitation assistance scheme|boudh": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.5,
       "support": 3
     },
     "social welfare|rehabilitation assistance scheme|dhenkanal": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.4667,
       "support": 7
     },
@@ -23065,6 +31498,7 @@
     },
     "social welfare|rehabilitation assistance scheme|kalahandi": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.3,
       "support": 3
     },
@@ -23074,7 +31508,8 @@
       "support": 3
     },
     "social welfare|rehabilitation assistance scheme|malkangiri": {
-      "dept": "School & Mass Education",
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.4286,
       "support": 3
     },
@@ -23085,41 +31520,49 @@
     },
     "social welfare|rehabilitation assistance scheme|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.8,
       "support": 12
     },
     "social welfare|rehabilitation assistance scheme|nuapada": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.5556,
       "support": 5
     },
     "social welfare|rehabilitation assistance scheme|rayagada": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.4,
       "support": 6
     },
     "social welfare|rehabilitation of the distressed|angul": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.4783,
       "support": 11
     },
     "social welfare|rehabilitation of the distressed|balangir": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.5116,
       "support": 22
     },
     "social welfare|rehabilitation of the distressed|baleswar": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.6154,
       "support": 16
     },
     "social welfare|rehabilitation of the distressed|bargarh": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.8,
       "support": 16
     },
     "social welfare|rehabilitation of the distressed|bhadrak": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.25,
       "support": 5
     },
@@ -23130,21 +31573,25 @@
     },
     "social welfare|rehabilitation of the distressed|cuttack": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.5278,
       "support": 19
     },
     "social welfare|rehabilitation of the distressed|dhenkanal": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.5417,
       "support": 26
     },
     "social welfare|rehabilitation of the distressed|gajapati": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.381,
       "support": 8
     },
     "social welfare|rehabilitation of the distressed|ganjam": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.4091,
       "support": 18
     },
@@ -23155,11 +31602,13 @@
     },
     "social welfare|rehabilitation of the distressed|jajpur": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.4423,
       "support": 23
     },
     "social welfare|rehabilitation of the distressed|jharsuguda": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.6667,
       "support": 4
     },
@@ -23170,11 +31619,13 @@
     },
     "social welfare|rehabilitation of the distressed|kandhamal": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.4667,
       "support": 7
     },
     "social welfare|rehabilitation of the distressed|kendrapara": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.5556,
       "support": 15
     },
@@ -23184,7 +31635,8 @@
       "support": 10
     },
     "social welfare|rehabilitation of the distressed|khordha": {
-      "dept": "Housing & Urban Development",
+      "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.2561,
       "support": 21
     },
@@ -23205,6 +31657,7 @@
     },
     "social welfare|rehabilitation of the distressed|nayagarh": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.3571,
       "support": 10
     },
@@ -23220,6 +31673,7 @@
     },
     "social welfare|rehabilitation of the distressed|subarnapur": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.4444,
       "support": 4
     },
@@ -23235,16 +31689,19 @@
     },
     "social welfare|rsby/bkky|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 1.0,
       "support": 5
     },
     "social welfare|rsby/bkky|ganjam": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.75,
       "support": 3
     },
     "social welfare|rsby/bkky|nayagarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 1.0,
       "support": 6
     },
@@ -23265,11 +31722,13 @@
     },
     "social welfare|social security scheme/ mbpy|bargarh": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.9485,
       "support": 424
     },
     "social welfare|social security scheme/ mbpy|bhadrak": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Departments",
       "share": 0.9192,
       "support": 182
     },
@@ -23285,6 +31744,7 @@
     },
     "social welfare|social security scheme/ mbpy|deogarh": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.9143,
       "support": 32
     },
@@ -23300,6 +31760,7 @@
     },
     "social welfare|social security scheme/ mbpy|ganjam": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Departments",
       "share": 0.9171,
       "support": 531
     },
@@ -23325,11 +31786,13 @@
     },
     "social welfare|social security scheme/ mbpy|kandhamal": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Departments",
       "share": 1.0,
       "support": 54
     },
     "social welfare|social security scheme/ mbpy|kendrapara": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Departments",
       "share": 0.9699,
       "support": 161
     },
@@ -23340,6 +31803,7 @@
     },
     "social welfare|social security scheme/ mbpy|khordha": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Departments",
       "share": 0.9568,
       "support": 288
     },
@@ -23355,6 +31819,7 @@
     },
     "social welfare|social security scheme/ mbpy|mayurbhanj": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Departments",
       "share": 0.8954,
       "support": 137
     },
@@ -23365,6 +31830,7 @@
     },
     "social welfare|social security scheme/ mbpy|nayagarh": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Departments",
       "share": 0.6991,
       "support": 158
     },
@@ -23375,6 +31841,7 @@
     },
     "social welfare|social security scheme/ mbpy|puri": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Departments",
       "share": 0.9777,
       "support": 263
     },
@@ -23390,6 +31857,7 @@
     },
     "social welfare|social security scheme/ mbpy|subarnapur": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.9902,
       "support": 203
     },
@@ -23400,21 +31868,25 @@
     },
     "social welfare|social welfare scheme|angul": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.6034,
       "support": 210
     },
     "social welfare|social welfare scheme|balangir": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.9004,
       "support": 479
     },
     "social welfare|social welfare scheme|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.4804,
       "support": 245
     },
     "social welfare|social welfare scheme|bargarh": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.9675,
       "support": 1994
     },
@@ -23425,6 +31897,7 @@
     },
     "social welfare|social welfare scheme|boudh": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.9209,
       "support": 128
     },
@@ -23435,11 +31908,13 @@
     },
     "social welfare|social welfare scheme|deogarh": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.375,
       "support": 6
     },
     "social welfare|social welfare scheme|dhenkanal": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.7335,
       "support": 333
     },
@@ -23450,6 +31925,7 @@
     },
     "social welfare|social welfare scheme|ganjam": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.4753,
       "support": 241
     },
@@ -23470,11 +31946,13 @@
     },
     "social welfare|social welfare scheme|kalahandi": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.4135,
       "support": 129
     },
     "social welfare|social welfare scheme|kandhamal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.6593,
       "support": 60
     },
@@ -23490,6 +31968,7 @@
     },
     "social welfare|social welfare scheme|khordha": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.5225,
       "support": 116
     },
@@ -23520,6 +31999,7 @@
     },
     "social welfare|social welfare scheme|nuapada": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.5436,
       "support": 106
     },
@@ -23535,11 +32015,13 @@
     },
     "social welfare|social welfare scheme|sambalpur": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.6596,
       "support": 217
     },
     "social welfare|social welfare scheme|subarnapur": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.963,
       "support": 1119
     },
@@ -23555,11 +32037,13 @@
     },
     "social welfare|subhadra scheme|balangir": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 0.9843,
       "support": 125
     },
     "social welfare|subhadra scheme|baleswar": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 0.648,
       "support": 243
     },
@@ -23585,16 +32069,19 @@
     },
     "social welfare|subhadra scheme|deogarh": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.4,
       "support": 38
     },
     "social welfare|subhadra scheme|dhenkanal": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 0.7103,
       "support": 103
     },
     "social welfare|subhadra scheme|gajapati": {
       "dept": "Women & Child Development",
+      "office": "Collector",
       "share": 0.9167,
       "support": 55
     },
@@ -23605,6 +32092,7 @@
     },
     "social welfare|subhadra scheme|jagatsinghapur": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 0.8723,
       "support": 164
     },
@@ -23615,6 +32103,7 @@
     },
     "social welfare|subhadra scheme|jharsuguda": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 1.0,
       "support": 27
     },
@@ -23630,6 +32119,7 @@
     },
     "social welfare|subhadra scheme|kendrapara": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 0.9774,
       "support": 216
     },
@@ -23640,6 +32130,7 @@
     },
     "social welfare|subhadra scheme|khordha": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 0.9694,
       "support": 285
     },
@@ -23655,6 +32146,7 @@
     },
     "social welfare|subhadra scheme|mayurbhanj": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 0.77,
       "support": 77
     },
@@ -23675,6 +32167,7 @@
     },
     "social welfare|subhadra scheme|puri": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 0.8837,
       "support": 152
     },
@@ -23690,6 +32183,7 @@
     },
     "social welfare|subhadra scheme|subarnapur": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 0.5315,
       "support": 76
     },
@@ -23710,6 +32204,7 @@
     },
     "sports|sponsorship (sports)|khordha": {
       "dept": "Sports & Youth Services",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 13
     },
@@ -23730,6 +32225,7 @@
     },
     "sports|sports training|balangir": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 1.0,
       "support": 3
     },
@@ -23750,11 +32246,13 @@
     },
     "sports|stadium/ games/ sports|angul": {
       "dept": "Sports & Youth Services",
+      "office": "Departments",
       "share": 0.6842,
       "support": 13
     },
     "sports|stadium/ games/ sports|balangir": {
       "dept": "Sports & Youth Services",
+      "office": "Collector",
       "share": 0.5965,
       "support": 34
     },
@@ -23770,11 +32268,13 @@
     },
     "sports|stadium/ games/ sports|bhadrak": {
       "dept": "Sports & Youth Services",
+      "office": "Departments",
       "share": 0.6667,
       "support": 20
     },
     "sports|stadium/ games/ sports|cuttack": {
       "dept": "Sports & Youth Services",
+      "office": "Departments",
       "share": 0.9091,
       "support": 30
     },
@@ -23785,31 +32285,37 @@
     },
     "sports|stadium/ games/ sports|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5455,
       "support": 6
     },
     "sports|stadium/ games/ sports|ganjam": {
       "dept": "Sports & Youth Services",
+      "office": "Departments",
       "share": 0.7317,
       "support": 30
     },
     "sports|stadium/ games/ sports|jagatsinghapur": {
       "dept": "Sports & Youth Services",
+      "office": "Departments",
       "share": 0.9333,
       "support": 28
     },
     "sports|stadium/ games/ sports|jajpur": {
       "dept": "Sports & Youth Services",
+      "office": "Departments",
       "share": 0.6875,
       "support": 33
     },
     "sports|stadium/ games/ sports|jharsuguda": {
       "dept": "Sports & Youth Services",
+      "office": "Departments",
       "share": 0.8125,
       "support": 13
     },
     "sports|stadium/ games/ sports|kalahandi": {
       "dept": "Sports & Youth Services",
+      "office": "Collector",
       "share": 0.5366,
       "support": 44
     },
@@ -23820,6 +32326,7 @@
     },
     "sports|stadium/ games/ sports|kendrapara": {
       "dept": "Sports & Youth Services",
+      "office": "Departments",
       "share": 0.7667,
       "support": 23
     },
@@ -23830,6 +32337,7 @@
     },
     "sports|stadium/ games/ sports|khordha": {
       "dept": "Sports & Youth Services",
+      "office": "Departments",
       "share": 0.7975,
       "support": 63
     },
@@ -23840,36 +32348,43 @@
     },
     "sports|stadium/ games/ sports|malkangiri": {
       "dept": "Sports & Youth Services",
+      "office": "Collector",
       "share": 0.4545,
       "support": 10
     },
     "sports|stadium/ games/ sports|mayurbhanj": {
       "dept": "Sports & Youth Services",
+      "office": "Collector",
       "share": 0.9406,
       "support": 95
     },
     "sports|stadium/ games/ sports|nabarangpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.4688,
       "support": 15
     },
     "sports|stadium/ games/ sports|nayagarh": {
       "dept": "Sports & Youth Services",
+      "office": "Departments",
       "share": 0.75,
       "support": 15
     },
     "sports|stadium/ games/ sports|nuapada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5823,
       "support": 46
     },
     "sports|stadium/ games/ sports|puri": {
       "dept": "Sports & Youth Services",
+      "office": "Departments",
       "share": 0.9211,
       "support": 35
     },
     "sports|stadium/ games/ sports|rayagada": {
       "dept": "Sports & Youth Services",
+      "office": "Collector",
       "share": 0.6429,
       "support": 18
     },
@@ -23880,16 +32395,19 @@
     },
     "sports|stadium/ games/ sports|subarnapur": {
       "dept": "Sports & Youth Services",
+      "office": "Departments",
       "share": 0.625,
       "support": 20
     },
     "sports|stadium/ games/ sports|sundargarh": {
       "dept": "Sports & Youth Services",
+      "office": "Departments",
       "share": 0.6346,
       "support": 33
     },
     "tourism|demolish of tourist points|dhenkanal": {
       "dept": "Tourism",
+      "office": "Collector",
       "share": 1.0,
       "support": 6
     },
@@ -23905,16 +32423,19 @@
     },
     "tourism|development of tourist places|angul": {
       "dept": "Tourism",
+      "office": "Collector",
       "share": 0.6961,
       "support": 71
     },
     "tourism|development of tourist places|balangir": {
       "dept": "Tourism",
+      "office": "Collector",
       "share": 0.9052,
       "support": 105
     },
     "tourism|development of tourist places|baleswar": {
       "dept": "Tourism",
+      "office": "Collector",
       "share": 0.875,
       "support": 35
     },
@@ -23925,6 +32446,7 @@
     },
     "tourism|development of tourist places|bhadrak": {
       "dept": "Tourism",
+      "office": "Collector",
       "share": 0.6,
       "support": 3
     },
@@ -23935,6 +32457,7 @@
     },
     "tourism|development of tourist places|deogarh": {
       "dept": "Tourism",
+      "office": "Collector",
       "share": 0.625,
       "support": 5
     },
@@ -23945,6 +32468,7 @@
     },
     "tourism|development of tourist places|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8333,
       "support": 45
     },
@@ -23955,21 +32479,25 @@
     },
     "tourism|development of tourist places|jagatsinghapur": {
       "dept": "Tourism",
+      "office": "Office of Chief Minister",
       "share": 0.6667,
       "support": 6
     },
     "tourism|development of tourist places|jharsuguda": {
       "dept": "Tourism",
+      "office": "Collector",
       "share": 1.0,
       "support": 3
     },
     "tourism|development of tourist places|kalahandi": {
       "dept": "Tourism",
+      "office": "Collector",
       "share": 0.65,
       "support": 13
     },
     "tourism|development of tourist places|kandhamal": {
       "dept": "Tourism",
+      "office": "Collector",
       "share": 0.9722,
       "support": 35
     },
@@ -23980,11 +32508,13 @@
     },
     "tourism|development of tourist places|kendujhar": {
       "dept": "Tourism",
+      "office": "Collector",
       "share": 0.7097,
       "support": 22
     },
     "tourism|development of tourist places|khordha": {
       "dept": "Tourism",
+      "office": "Collector",
       "share": 0.82,
       "support": 41
     },
@@ -23995,21 +32525,25 @@
     },
     "tourism|development of tourist places|mayurbhanj": {
       "dept": "Tourism",
+      "office": "Collector",
       "share": 0.9167,
       "support": 11
     },
     "tourism|development of tourist places|nabarangpur": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8,
       "support": 8
     },
     "tourism|development of tourist places|nayagarh": {
       "dept": "Tourism",
+      "office": "Collector",
       "share": 0.4615,
       "support": 12
     },
     "tourism|development of tourist places|nuapada": {
       "dept": "Tourism",
+      "office": "Collector",
       "share": 0.8333,
       "support": 5
     },
@@ -24020,26 +32554,31 @@
     },
     "tourism|development of tourist places|sambalpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.3478,
       "support": 8
     },
     "tourism|development of tourist places|subarnapur": {
       "dept": "Tourism",
+      "office": "Office of Chief Minister",
       "share": 0.6,
       "support": 3
     },
     "tourism|development of tourist places|sundargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6667,
       "support": 14
     },
     "traffic|traffic management|angul": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.5385,
       "support": 7
     },
     "traffic|traffic management|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Superintendent of Police",
       "share": 0.5,
       "support": 5
     },
@@ -24050,6 +32589,7 @@
     },
     "traffic|traffic management|cuttack": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.6154,
       "support": 24
     },
@@ -24060,6 +32600,7 @@
     },
     "traffic|traffic management|ganjam": {
       "dept": "Home department",
+      "office": "Superintendent of Police",
       "share": 0.5882,
       "support": 10
     },
@@ -24070,6 +32611,7 @@
     },
     "traffic|traffic management|jajpur": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.625,
       "support": 10
     },
@@ -24080,11 +32622,13 @@
     },
     "traffic|traffic management|kalahandi": {
       "dept": "Commerce & Transport",
+      "office": "Collector",
       "share": 0.7,
       "support": 7
     },
     "traffic|traffic management|kendrapara": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.6154,
       "support": 8
     },
@@ -24095,6 +32639,7 @@
     },
     "traffic|traffic management|khordha": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.6885,
       "support": 42
     },
@@ -24105,16 +32650,19 @@
     },
     "traffic|traffic management|mayurbhanj": {
       "dept": "Commerce & Transport",
+      "office": "Departments",
       "share": 0.3,
       "support": 3
     },
     "traffic|traffic management|nayagarh": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.6364,
       "support": 7
     },
     "traffic|traffic management|puri": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.5556,
       "support": 5
     },
@@ -24140,6 +32688,7 @@
     },
     "transport|bus stand|baleswar": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.8,
       "support": 4
     },
@@ -24155,16 +32704,19 @@
     },
     "transport|bus stand|dhenkanal": {
       "dept": "Commerce & Transport",
+      "office": "Collector",
       "share": 0.8,
       "support": 4
     },
     "transport|bus stand|ganjam": {
       "dept": "Commerce & Transport",
+      "office": "Office of Chief Minister",
       "share": 0.5,
       "support": 6
     },
     "transport|bus stand|kalahandi": {
       "dept": "Commerce & Transport",
+      "office": "Collector",
       "share": 0.6364,
       "support": 7
     },
@@ -24185,6 +32737,7 @@
     },
     "transport|bus stand|khordha": {
       "dept": "Housing & Urban Development",
+      "office": "Departments",
       "share": 0.5625,
       "support": 9
     },
@@ -24200,6 +32753,7 @@
     },
     "transport|bus stand|nayagarh": {
       "dept": "Commerce & Transport",
+      "office": "Office of Chief Minister",
       "share": 0.6667,
       "support": 4
     },
@@ -24220,16 +32774,19 @@
     },
     "transport|fly overs/robs/underpasses|khordha": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 1.0,
       "support": 7
     },
     "transport|fly overs/robs/underpasses|puri": {
       "dept": "Rural Development",
+      "office": "Collector",
       "share": 0.75,
       "support": 3
     },
     "transport|fly overs/robs/underpasses|rayagada": {
       "dept": "Commerce & Transport",
+      "office": "Collector",
       "share": 1.0,
       "support": 5
     },
@@ -24250,6 +32807,7 @@
     },
     "transport|rail transport|boudh": {
       "dept": "Commerce & Transport",
+      "office": "Collector",
       "share": 1.0,
       "support": 6
     },
@@ -24260,36 +32818,43 @@
     },
     "transport|rail transport|kalahandi": {
       "dept": "Commerce & Transport",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 7
     },
     "transport|rail transport|kendujhar": {
       "dept": "Commerce & Transport",
+      "office": "Office of Chief Minister",
       "share": 0.9,
       "support": 9
     },
     "transport|rail transport|khordha": {
       "dept": "Commerce & Transport",
+      "office": "Office of Chief Minister",
       "share": 0.7778,
       "support": 7
     },
     "transport|rail transport|mayurbhanj": {
       "dept": "Commerce & Transport",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 5
     },
     "transport|rail transport|nuapada": {
       "dept": "Commerce & Transport",
+      "office": "Office of Chief Minister",
       "share": 0.8889,
       "support": 8
     },
     "transport|rail transport|rayagada": {
       "dept": "Commerce & Transport",
+      "office": "Office of Chief Minister",
       "share": 0.8889,
       "support": 8
     },
     "transport|rail transport|sundargarh": {
       "dept": "Commerce & Transport",
+      "office": "Collector",
       "share": 0.875,
       "support": 7
     },
@@ -24300,11 +32865,13 @@
     },
     "transport|vehicle transportation|balangir": {
       "dept": "Commerce & Transport",
+      "office": "Departments",
       "share": 0.8095,
       "support": 17
     },
     "transport|vehicle transportation|baleswar": {
       "dept": "Commerce & Transport",
+      "office": "Departments",
       "share": 0.6774,
       "support": 42
     },
@@ -24320,46 +32887,55 @@
     },
     "transport|vehicle transportation|boudh": {
       "dept": "Commerce & Transport",
+      "office": "Departments",
       "share": 0.6667,
       "support": 4
     },
     "transport|vehicle transportation|cuttack": {
       "dept": "Commerce & Transport",
+      "office": "Departments",
       "share": 0.8889,
       "support": 80
     },
     "transport|vehicle transportation|deogarh": {
       "dept": "Commerce & Transport",
+      "office": "Collector",
       "share": 0.5556,
       "support": 5
     },
     "transport|vehicle transportation|dhenkanal": {
       "dept": "Commerce & Transport",
+      "office": "Departments",
       "share": 0.8857,
       "support": 31
     },
     "transport|vehicle transportation|gajapati": {
       "dept": "Commerce & Transport",
+      "office": "Collector",
       "share": 0.7059,
       "support": 48
     },
     "transport|vehicle transportation|ganjam": {
       "dept": "Commerce & Transport",
+      "office": "Departments",
       "share": 0.9222,
       "support": 83
     },
     "transport|vehicle transportation|jagatsinghapur": {
       "dept": "Commerce & Transport",
+      "office": "Departments",
       "share": 0.8148,
       "support": 22
     },
     "transport|vehicle transportation|jajpur": {
       "dept": "Commerce & Transport",
+      "office": "Departments",
       "share": 0.9375,
       "support": 45
     },
     "transport|vehicle transportation|jharsuguda": {
       "dept": "Commerce & Transport",
+      "office": "Departments",
       "share": 0.8919,
       "support": 33
     },
@@ -24375,6 +32951,7 @@
     },
     "transport|vehicle transportation|kendrapara": {
       "dept": "Commerce & Transport",
+      "office": "Departments",
       "share": 0.875,
       "support": 63
     },
@@ -24385,6 +32962,7 @@
     },
     "transport|vehicle transportation|khordha": {
       "dept": "Commerce & Transport",
+      "office": "Departments",
       "share": 0.8441,
       "support": 157
     },
@@ -24395,21 +32973,25 @@
     },
     "transport|vehicle transportation|malkangiri": {
       "dept": "Commerce & Transport",
+      "office": "Collector",
       "share": 0.871,
       "support": 27
     },
     "transport|vehicle transportation|mayurbhanj": {
       "dept": "Commerce & Transport",
+      "office": "Departments",
       "share": 0.8857,
       "support": 31
     },
     "transport|vehicle transportation|nabarangpur": {
       "dept": "Commerce & Transport",
+      "office": "Collector",
       "share": 0.8462,
       "support": 11
     },
     "transport|vehicle transportation|nayagarh": {
       "dept": "Commerce & Transport",
+      "office": "Departments",
       "share": 0.7586,
       "support": 22
     },
@@ -24420,26 +33002,31 @@
     },
     "transport|vehicle transportation|puri": {
       "dept": "Commerce & Transport",
+      "office": "Departments",
       "share": 0.7333,
       "support": 33
     },
     "transport|vehicle transportation|rayagada": {
       "dept": "Commerce & Transport",
+      "office": "Departments",
       "share": 0.9286,
       "support": 13
     },
     "transport|vehicle transportation|sambalpur": {
       "dept": "Commerce & Transport",
+      "office": "Collector",
       "share": 0.7532,
       "support": 58
     },
     "transport|vehicle transportation|subarnapur": {
       "dept": "Commerce & Transport",
+      "office": "Departments",
       "share": 0.9,
       "support": 9
     },
     "transport|vehicle transportation|sundargarh": {
       "dept": "Commerce & Transport",
+      "office": "Departments",
       "share": 0.8182,
       "support": 36
     },
@@ -24510,6 +33097,7 @@
     },
     "waste management|garbage|gajapati": {
       "dept": "Housing & Urban Development",
+      "office": "Collector",
       "share": 0.6364,
       "support": 7
     },
@@ -24605,6 +33193,7 @@
     },
     "waste management|garbage|sundargarh": {
       "dept": "Housing & Urban Development",
+      "office": "Departments",
       "share": 0.8519,
       "support": 46
     },
@@ -24615,6 +33204,7 @@
     },
     "water supply|piped water supply (drinking water)|balangir": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7745,
       "support": 79
     },
@@ -24625,6 +33215,7 @@
     },
     "water supply|piped water supply (drinking water)|bargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8525,
       "support": 52
     },
@@ -24645,6 +33236,7 @@
     },
     "water supply|piped water supply (drinking water)|deogarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8462,
       "support": 22
     },
@@ -24655,11 +33247,13 @@
     },
     "water supply|piped water supply (drinking water)|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6552,
       "support": 133
     },
     "water supply|piped water supply (drinking water)|ganjam": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6056,
       "support": 86
     },
@@ -24670,21 +33264,25 @@
     },
     "water supply|piped water supply (drinking water)|jajpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.828,
       "support": 77
     },
     "water supply|piped water supply (drinking water)|jharsuguda": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.3898,
       "support": 23
     },
     "water supply|piped water supply (drinking water)|kalahandi": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7928,
       "support": 88
     },
     "water supply|piped water supply (drinking water)|kandhamal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7037,
       "support": 114
     },
@@ -24695,6 +33293,7 @@
     },
     "water supply|piped water supply (drinking water)|kendujhar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.913,
       "support": 84
     },
@@ -24705,6 +33304,7 @@
     },
     "water supply|piped water supply (drinking water)|koraput": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.875,
       "support": 56
     },
@@ -24715,6 +33315,7 @@
     },
     "water supply|piped water supply (drinking water)|mayurbhanj": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7941,
       "support": 135
     },
@@ -24730,11 +33331,13 @@
     },
     "water supply|piped water supply (drinking water)|nuapada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8108,
       "support": 30
     },
     "water supply|piped water supply (drinking water)|puri": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6433,
       "support": 101
     },
@@ -24745,16 +33348,19 @@
     },
     "water supply|piped water supply (drinking water)|sambalpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4696,
       "support": 54
     },
     "water supply|piped water supply (drinking water)|subarnapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9474,
       "support": 36
     },
     "water supply|piped water supply (drinking water)|sundargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6625,
       "support": 53
     },
@@ -24780,6 +33386,7 @@
     },
     "water supply|pipeline issue|bhadrak": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.7143,
       "support": 5
     },
@@ -24795,6 +33402,7 @@
     },
     "water supply|pipeline issue|dhenkanal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.7368,
       "support": 14
     },
@@ -24895,26 +33503,31 @@
     },
     "water supply|soil conservation/watershed management|angul": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.6818,
       "support": 15
     },
     "water supply|soil conservation/watershed management|balangir": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.6429,
       "support": 9
     },
     "water supply|soil conservation/watershed management|baleswar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.9583,
       "support": 23
     },
     "water supply|soil conservation/watershed management|bargarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9615,
       "support": 50
     },
     "water supply|soil conservation/watershed management|bhadrak": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.8,
       "support": 4
     },
@@ -24925,61 +33538,73 @@
     },
     "water supply|soil conservation/watershed management|cuttack": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.8065,
       "support": 25
     },
     "water supply|soil conservation/watershed management|deogarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.8,
       "support": 4
     },
     "water supply|soil conservation/watershed management|dhenkanal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.9565,
       "support": 22
     },
     "water supply|soil conservation/watershed management|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7143,
       "support": 5
     },
     "water supply|soil conservation/watershed management|ganjam": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8842,
       "support": 84
     },
     "water supply|soil conservation/watershed management|jagatsinghapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.85,
       "support": 17
     },
     "water supply|soil conservation/watershed management|jajpur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 1.0,
       "support": 47
     },
     "water supply|soil conservation/watershed management|kalahandi": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9818,
       "support": 54
     },
     "water supply|soil conservation/watershed management|kandhamal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 68
     },
     "water supply|soil conservation/watershed management|kendrapara": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.95,
       "support": 19
     },
     "water supply|soil conservation/watershed management|kendujhar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.8571,
       "support": 12
     },
     "water supply|soil conservation/watershed management|khordha": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.5312,
       "support": 17
     },
@@ -24995,11 +33620,13 @@
     },
     "water supply|soil conservation/watershed management|nayagarh": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.8,
       "support": 8
     },
     "water supply|soil conservation/watershed management|nuapada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9286,
       "support": 13
     },
@@ -25010,11 +33637,13 @@
     },
     "water supply|soil conservation/watershed management|sambalpur": {
       "dept": "Housing & Urban Development",
+      "office": "Office of Chief Minister",
       "share": 0.4545,
       "support": 10
     },
     "water supply|soil conservation/watershed management|subarnapur": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.7778,
       "support": 7
     },
@@ -25070,6 +33699,7 @@
     },
     "water supply|tubewell/borewell (drinking water)|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7903,
       "support": 392
     },
@@ -25100,6 +33730,7 @@
     },
     "water supply|tubewell/borewell (drinking water)|kandhamal": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.9721,
       "support": 698
     },
@@ -25220,6 +33851,7 @@
     },
     "water supply|water supply issue|gajapati": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8108,
       "support": 120
     },
@@ -25295,6 +33927,7 @@
     },
     "water supply|water supply issue|nuapada": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.878,
       "support": 295
     },
@@ -25355,6 +33988,7 @@
     },
     "women issues|domestic violence|ganjam": {
       "dept": "Home department",
+      "office": "Superintendent of Police",
       "share": 0.9231,
       "support": 36
     },
@@ -25365,6 +33999,7 @@
     },
     "women issues|domestic violence|jajpur": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 0.8462,
       "support": 22
     },
@@ -25375,6 +34010,7 @@
     },
     "women issues|domestic violence|kandhamal": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 1.0,
       "support": 4
     },
@@ -25390,6 +34026,7 @@
     },
     "women issues|domestic violence|khordha": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 0.8158,
       "support": 31
     },
@@ -25400,11 +34037,13 @@
     },
     "women issues|domestic violence|mayurbhanj": {
       "dept": "Home department",
+      "office": "Collector",
       "share": 0.6923,
       "support": 9
     },
     "women issues|domestic violence|nayagarh": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.625,
       "support": 5
     },
@@ -25425,16 +34064,19 @@
     },
     "women issues|dowry torture|baleswar": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 0.7,
       "support": 7
     },
     "women issues|dowry torture|bhadrak": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.913,
       "support": 21
     },
     "women issues|dowry torture|cuttack": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 0.75,
       "support": 9
     },
@@ -25460,16 +34102,19 @@
     },
     "women issues|dowry torture|kendujhar": {
       "dept": "Home department",
+      "office": "Superintendent of Police",
       "share": 0.6667,
       "support": 6
     },
     "women issues|dowry torture|khordha": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 14
     },
     "women issues|dowry torture|nayagarh": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.8,
       "support": 4
     },
@@ -25520,6 +34165,7 @@
     },
     "women issues|rape/ sexual harassement|cuttack": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 7
     },
@@ -25535,11 +34181,13 @@
     },
     "women issues|rape/ sexual harassement|kendrapara": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 1.0,
       "support": 7
     },
     "women issues|rape/ sexual harassement|kendujhar": {
       "dept": "Home department",
+      "office": "Superintendent of Police",
       "share": 1.0,
       "support": 6
     },
@@ -25565,11 +34213,13 @@
     },
     "women issues|workplace harrassement|baleswar": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.4,
       "support": 4
     },
     "women issues|workplace harrassement|cuttack": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.5,
       "support": 3
     },
@@ -25580,11 +34230,13 @@
     },
     "women issues|workplace harrassement|jajpur": {
       "dept": "Women & Child Development",
+      "office": "Collector",
       "share": 0.3,
       "support": 3
     },
     "women issues|workplace harrassement|khordha": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.3333,
       "support": 5
     },
@@ -25597,6 +34249,7 @@
   "by_subcategory": {
     "accident|fire accident|": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.7097,
       "support": 66
     },
@@ -25612,16 +34265,19 @@
     },
     "agriculture & farming|agriculture/farming|": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.7963,
       "support": 1720
     },
     "agriculture & farming|animal husbandry|": {
       "dept": "Fisheries & Animal Resources Development",
+      "office": "Office of Chief Minister",
       "share": 0.5517,
       "support": 224
     },
     "agriculture & farming|crop damage/agricultural damage|": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.7273,
       "support": 400
     },
@@ -25632,26 +34288,31 @@
     },
     "agriculture & farming|financial assistance|": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.7964,
       "support": 755
     },
     "agriculture & farming|fishermen's issues|": {
       "dept": "Fisheries & Animal Resources Development",
+      "office": "Office of Chief Minister",
       "share": 0.4643,
       "support": 39
     },
     "agriculture & farming|irrigation problem|": {
       "dept": "Water Resources",
+      "office": "Office of Chief Minister",
       "share": 0.6426,
       "support": 383
     },
     "agriculture & farming|natural calamities/ relief|": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.8298,
       "support": 39
     },
     "agriculture & farming|natural calamities|": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.8462,
       "support": 22
     },
@@ -25662,6 +34323,7 @@
     },
     "agriculture & farming|sale purchase issue|": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Departments",
       "share": 0.6485,
       "support": 631
     },
@@ -25672,6 +34334,7 @@
     },
     "agriculture & farming|soil conservation/watershed management|": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.5814,
       "support": 25
     },
@@ -25687,6 +34350,7 @@
     },
     "cmrf|cmrf|": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.6712,
       "support": 2276
     },
@@ -25707,6 +34371,7 @@
     },
     "culture|artists' issues|": {
       "dept": "Odia Language Literature & Culture",
+      "office": "Collector",
       "share": 0.5921,
       "support": 241
     },
@@ -25727,26 +34392,31 @@
     },
     "education|higher education|": {
       "dept": "Higher Education",
+      "office": "Departments",
       "share": 0.9322,
       "support": 7537
     },
     "education|higher secondary education|": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.5162,
       "support": 286
     },
     "education|primary/secondary education|": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.7668,
       "support": 2193
     },
     "education|scholarship/study loan|": {
       "dept": "ST & SC Development, Minorities & Backward Classes Welfare",
+      "office": "Departments",
       "share": 0.4273,
       "support": 937
     },
     "education|technical education/professional education|": {
       "dept": "Skill Development & Technical Education",
+      "office": "Departments",
       "share": 0.4895,
       "support": 397
     },
@@ -25767,6 +34437,7 @@
     },
     "energy|power supply|": {
       "dept": "Energy",
+      "office": "Departments",
       "share": 0.9188,
       "support": 10101
     },
@@ -25777,6 +34448,7 @@
     },
     "energy|solar pumps|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4375,
       "support": 14
     },
@@ -25792,6 +34464,7 @@
     },
     "environment|entry of animals|": {
       "dept": "Forest, Environment and Climate Change Department",
+      "office": "Collector",
       "share": 0.7154,
       "support": 88
     },
@@ -25812,31 +34485,37 @@
     },
     "financial assistance|accidental claims|": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.388,
       "support": 71
     },
     "financial assistance|aids|": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.3684,
       "support": 7
     },
     "financial assistance|cmrf/red cross fund|": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.3489,
       "support": 1090
     },
     "financial assistance|compensation/refunds|": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.2577,
       "support": 283
     },
     "financial assistance|ex gratia|": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.3855,
       "support": 170
     },
     "financial assistance|financial assistance/loan|": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.3915,
       "support": 5031
     },
@@ -25847,36 +34526,43 @@
     },
     "financial assistance|natural calamities/ relief|": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.7029,
       "support": 246
     },
     "financial assistance|self employment/ skill development|": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.5547,
       "support": 841
     },
     "general|associations' issues|": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.4124,
       "support": 252
     },
     "general|bank/atm|": {
       "dept": "Finance",
+      "office": "Office of Chief Minister",
       "share": 0.539,
       "support": 83
     },
     "general|certificates|": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.5348,
       "support": 1796
     },
     "general|encroachment|": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.4952,
       "support": 103
     },
     "general|establishment of new offices|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.28,
       "support": 35
     },
@@ -25887,16 +34573,19 @@
     },
     "general|food products|": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.7089,
       "support": 224
     },
     "general|illegal activities|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.4561,
       "support": 592
     },
     "general|illegal parking|": {
       "dept": "Housing & Urban Development",
+      "office": "Departments",
       "share": 0.5897,
       "support": 23
     },
@@ -25907,11 +34596,13 @@
     },
     "general|infrastructure related to depts|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6471,
       "support": 44
     },
     "general|insurance matters|": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Collector",
       "share": 0.424,
       "support": 53
     },
@@ -25922,6 +34613,7 @@
     },
     "general|non-govt service matters|": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.5507,
       "support": 114
     },
@@ -25932,11 +34624,13 @@
     },
     "general|others|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.2141,
       "support": 26458
     },
     "general|personal claims|": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.1921,
       "support": 798
     },
@@ -25952,6 +34646,7 @@
     },
     "general|rto matters|": {
       "dept": "Commerce & Transport",
+      "office": "Departments",
       "share": 0.9141,
       "support": 532
     },
@@ -25962,6 +34657,7 @@
     },
     "general|web portal issues|": {
       "dept": "General Administration & Public Grievance",
+      "office": "Departments",
       "share": 0.1803,
       "support": 22
     },
@@ -25972,11 +34668,13 @@
     },
     "health care|financial assistance|": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.7691,
       "support": 826
     },
     "health care|food adulteration|": {
       "dept": "Health & Family Welfare",
+      "office": "Departments",
       "share": 0.6136,
       "support": 27
     },
@@ -26027,16 +34725,19 @@
     },
     "health care|upgradation of phc to chc|": {
       "dept": "Health & Family Welfare",
+      "office": "Collector",
       "share": 0.8958,
       "support": 129
     },
     "housing|financial assistance|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 1.0,
       "support": 107
     },
     "housing|rural housing|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8722,
       "support": 263746
     },
@@ -26052,11 +34753,13 @@
     },
     "icds|i.c.d.s|": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 0.8598,
       "support": 748
     },
     "icds|mamata yojana|": {
       "dept": "Women & Child Development",
+      "office": "Departments",
       "share": 0.8881,
       "support": 127
     },
@@ -26067,26 +34770,31 @@
     },
     "infrastructure|boundary wall|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6648,
       "support": 728
     },
     "infrastructure|bridge|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.3303,
       "support": 808
     },
     "infrastructure|checkdams|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6443,
       "support": 404
     },
     "infrastructure|community centre|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7693,
       "support": 6521
     },
     "infrastructure|crematorium|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7108,
       "support": 295
     },
@@ -26097,101 +34805,121 @@
     },
     "infrastructure|infrastructure related to depts|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.427,
       "support": 459
     },
     "infrastructure|infrastructure|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5645,
       "support": 2512
     },
     "infrastructure|kalyan mandap|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8063,
       "support": 1927
     },
     "infrastructure|library|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5323,
       "support": 99
     },
     "infrastructure|market complex|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5016,
       "support": 153
     },
     "infrastructure|other infrastructures|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5491,
       "support": 4688
     },
     "infrastructure|park|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.5899,
       "support": 279
     },
     "infrastructure|playground|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7744,
       "support": 786
     },
     "infrastructure|religious institution|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6871,
       "support": 12373
     },
     "infrastructure|road|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4715,
       "support": 12386
     },
     "infrastructure|rural haats|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6986,
       "support": 51
     },
     "infrastructure|transport and traffic|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.2366,
       "support": 22
     },
     "infrastructure|water tanks/ reservoirs/ponds|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.7939,
       "support": 801
     },
     "irrigation|barrage|": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.7257,
       "support": 82
     },
     "irrigation|canal|": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.6252,
       "support": 437
     },
     "irrigation|in-stream storage structure|": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.7302,
       "support": 46
     },
     "irrigation|lift irrigation|": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.6389,
       "support": 552
     },
     "irrigation|mega lift irrigation project|": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.7088,
       "support": 258
     },
     "irrigation|minor irrigation poroject|": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.5245,
       "support": 364
     },
     "irrigation|others|": {
       "dept": "Water Resources",
+      "office": "Collector",
       "share": 0.5222,
       "support": 317
     },
@@ -26202,56 +34930,67 @@
     },
     "land matters|boundary change|": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8518,
       "support": 339
     },
     "land matters|encroachment|": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.7742,
       "support": 5486
     },
     "land matters|land acquisition/ r&r|": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.7954,
       "support": 2477
     },
     "land matters|land allotment/settlement/ror|": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.8542,
       "support": 18667
     },
     "land matters|land dispute|": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.7729,
       "support": 8850
     },
     "land matters|land/revenue/tax|": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.9031,
       "support": 4857
     },
     "land matters|property dispute|": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.6993,
       "support": 658
     },
     "legal|legal aids|": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.2979,
       "support": 42
     },
     "legal|legal redress|": {
       "dept": "School & Mass Education",
+      "office": "Departments",
       "share": 0.4042,
       "support": 135
     },
     "legal|permissions|": {
       "dept": "Law",
+      "office": "Collector",
       "share": 0.2529,
       "support": 22
     },
     "miscellaneous|absurd/irrelevant|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.4507,
       "support": 32
     },
@@ -26272,11 +35011,13 @@
     },
     "miscellaneous|appreciation/suggestion|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Departments",
       "share": 0.1129,
       "support": 36
     },
     "miscellaneous|bidding / tender|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.2292,
       "support": 33
     },
@@ -26292,6 +35033,7 @@
     },
     "miscellaneous|it / digital facility|": {
       "dept": "Electronics & Information Technology",
+      "office": "Office of Chief Minister",
       "share": 0.375,
       "support": 42
     },
@@ -26302,11 +35044,13 @@
     },
     "miscellaneous|minor minerals|": {
       "dept": "Steel & Mines",
+      "office": "Departments",
       "share": 0.3934,
       "support": 203
     },
     "miscellaneous|miscellaneous/others|": {
       "dept": "Revenue & Disaster Management",
+      "office": "Collector",
       "share": 0.1806,
       "support": 11397
     },
@@ -26317,26 +35061,31 @@
     },
     "miscellaneous|non-govt. service matters|": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.3941,
       "support": 80
     },
     "miscellaneous|parking|": {
       "dept": "Housing & Urban Development",
+      "office": "Departments",
       "share": 0.4103,
       "support": 16
     },
     "miscellaneous|prize / award|": {
       "dept": "General Administration & Public Grievance",
+      "office": "Departments",
       "share": 0.4928,
       "support": 34
     },
     "miscellaneous|tax/ fee matters|": {
       "dept": "Housing & Urban Development",
+      "office": "Departments",
       "share": 0.2759,
       "support": 80
     },
     "miscellaneous|technical issues/web portal issues|": {
       "dept": "General Administration & Public Grievance",
+      "office": "Office of Chief Minister",
       "share": 0.137,
       "support": 20
     },
@@ -26347,21 +35096,25 @@
     },
     "pension/retirement benefits|family pension/death benefits|": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.1873,
       "support": 266
     },
     "pension/retirement benefits|freedom fighter pension|": {
       "dept": "Finance",
+      "office": "Office of Chief Minister",
       "share": 0.4815,
       "support": 39
     },
     "pension/retirement benefits|other pension|": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.5106,
       "support": 1109
     },
     "pension/retirement benefits|service pension/retirement benefits|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.2097,
       "support": 1092
     },
@@ -26387,6 +35140,7 @@
     },
     "police case|family pension/death benefits|": {
       "dept": "Home department",
+      "office": "Superintendent of Police",
       "share": 1.0,
       "support": 18
     },
@@ -26412,6 +35166,7 @@
     },
     "police case|law &amp;amp; order|": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.9256,
       "support": 1705
     },
@@ -26422,6 +35177,7 @@
     },
     "police case|murder/death case|": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.9682,
       "support": 882
     },
@@ -26432,6 +35188,7 @@
     },
     "police case|other pension|": {
       "dept": "Home department",
+      "office": "Superintendent of Police",
       "share": 1.0,
       "support": 20
     },
@@ -26462,6 +35219,7 @@
     },
     "police case|service pension/retirement benefits|": {
       "dept": "Home department",
+      "office": "Superintendent of Police",
       "share": 1.0,
       "support": 4
     },
@@ -26477,11 +35235,13 @@
     },
     "police case|torture/harassment|": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.9115,
       "support": 1741
     },
     "public utility|bank & atm|": {
       "dept": "Finance",
+      "office": "Office of Chief Minister",
       "share": 0.7386,
       "support": 130
     },
@@ -26492,11 +35252,13 @@
     },
     "public utility|consumer issues|": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.7747,
       "support": 564
     },
     "public utility|development of tourist places|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.3926,
       "support": 64
     },
@@ -26517,21 +35279,25 @@
     },
     "public utility|endowment matters|": {
       "dept": "Law",
+      "office": "Office of Chief Minister",
       "share": 0.4931,
       "support": 71
     },
     "public utility|environment pollution/protection|": {
       "dept": "Forest, Environment and Climate Change Department",
+      "office": "Office of Chief Minister",
       "share": 0.4054,
       "support": 75
     },
     "public utility|miscellaneous certificate issues|": {
       "dept": "Revenue & Disaster Management",
+      "office": "Office of Chief Minister",
       "share": 0.5697,
       "support": 429
     },
     "public utility|public utility problem|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.3702,
       "support": 1400
     },
@@ -26542,36 +35308,43 @@
     },
     "public utility|sanitation|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.4685,
       "support": 156
     },
     "public utility|smart city|": {
       "dept": "Housing & Urban Development",
+      "office": "Office of Chief Minister",
       "share": 0.875,
       "support": 7
     },
     "public utility|transport & traffic|": {
       "dept": "Commerce & Transport",
+      "office": "Office of Chief Minister",
       "share": 0.5627,
       "support": 166
     },
     "school & college|admissions|": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.5741,
       "support": 426
     },
     "school & college|colleges/universities (higher education)|": {
       "dept": "Higher Education",
+      "office": "Office of Chief Minister",
       "share": 0.5551,
       "support": 302
     },
     "school & college|higher secondary schools|": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.6818,
       "support": 240
     },
     "school & college|infrastructure issue|": {
       "dept": "School & Mass Education",
+      "office": "Collector",
       "share": 0.4136,
       "support": 1633
     },
@@ -26592,26 +35365,31 @@
     },
     "service matters|govt. quarters|": {
       "dept": "General Administration & Public Grievance",
+      "office": "Office of Chief Minister",
       "share": 0.7869,
       "support": 336
     },
     "service matters|non govt. service matters|": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Office of Chief Minister",
       "share": 0.1872,
       "support": 211
     },
     "service matters|outsourced staff issues|": {
       "dept": "Health & Family Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.1477,
       "support": 157
     },
     "service matters|rehabilitation assistance scheme|": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2557,
       "support": 748
     },
     "service matters|service matters|": {
       "dept": "School & Mass Education",
+      "office": "Office of Chief Minister",
       "share": 0.2175,
       "support": 5390
     },
@@ -26632,6 +35410,7 @@
     },
     "social welfare|anti poverty programme/bpl|": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Collector",
       "share": 0.4603,
       "support": 29
     },
@@ -26642,16 +35421,19 @@
     },
     "social welfare|iay/mky/bpgy/pmay|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.9546,
       "support": 122495
     },
     "social welfare|identity card matter|": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Departments",
       "share": 0.7702,
       "support": 1451
     },
     "social welfare|indigent artist pension / mksy|": {
       "dept": "Odia Language Literature & Culture",
+      "office": "Office of Chief Minister",
       "share": 0.7323,
       "support": 320
     },
@@ -26662,11 +35444,13 @@
     },
     "social welfare|infrastructure issue|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.973,
       "support": 36
     },
     "social welfare|kalia yojana / pm-kisan|": {
       "dept": "Agriculture & Farmers' Empowerment",
+      "office": "Departments",
       "share": 0.9459,
       "support": 10918
     },
@@ -26677,21 +35461,25 @@
     },
     "social welfare|marriage incentive|": {
       "dept": "Labour & Employees' State Insurance",
+      "office": "Collector",
       "share": 0.453,
       "support": 400
     },
     "social welfare|mgnregs|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.8622,
       "support": 1264
     },
     "social welfare|mission shakti groups/community cadre(shg)|": {
       "dept": "Mission Shakti",
+      "office": "Collector",
       "share": 0.3321,
       "support": 178
     },
     "social welfare|mo pokhari yojana|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.6471,
       "support": 44
     },
@@ -26707,16 +35495,19 @@
     },
     "social welfare|other pension|": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.3033,
       "support": 599
     },
     "social welfare|p.d.s/n.f.s.a/ sfss/aay|": {
       "dept": "Food Supplies & Consumer Welfare",
+      "office": "Office of Chief Minister",
       "share": 0.7919,
       "support": 4286
     },
     "social welfare|public utility problem|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.3804,
       "support": 140
     },
@@ -26727,6 +35518,7 @@
     },
     "social welfare|red cross fund|": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Collector",
       "share": 0.4648,
       "support": 33
     },
@@ -26737,11 +35529,13 @@
     },
     "social welfare|rehabilitation of the distressed|": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.4606,
       "support": 345
     },
     "social welfare|rsby/bkky|": {
       "dept": "General Administration & Public Grievance",
+      "office": "Collector",
       "share": 0.3158,
       "support": 12
     },
@@ -26752,6 +35546,7 @@
     },
     "social welfare|social welfare scheme|": {
       "dept": "Social Security & Empowerment of Persons with Disabilities",
+      "office": "Office of Chief Minister",
       "share": 0.7201,
       "support": 6323
     },
@@ -26767,6 +35562,7 @@
     },
     "sports|sports hostel|": {
       "dept": "Sports & Youth Services",
+      "office": "Collector",
       "share": 0.8235,
       "support": 14
     },
@@ -26777,6 +35573,7 @@
     },
     "sports|stadium/ games/ sports|": {
       "dept": "Sports & Youth Services",
+      "office": "Departments",
       "share": 0.675,
       "support": 758
     },
@@ -26787,11 +35584,13 @@
     },
     "tourism|development of tourist places|": {
       "dept": "Tourism",
+      "office": "Collector",
       "share": 0.6671,
       "support": 469
     },
     "traffic|traffic management|": {
       "dept": "Home department",
+      "office": "Departments",
       "share": 0.582,
       "support": 181
     },
@@ -26807,11 +35606,13 @@
     },
     "transport|rail transport|": {
       "dept": "Commerce & Transport",
+      "office": "Office of Chief Minister",
       "share": 0.9101,
       "support": 81
     },
     "transport|vehicle transportation|": {
       "dept": "Commerce & Transport",
+      "office": "Departments",
       "share": 0.8315,
       "support": 1179
     },
@@ -26827,6 +35628,7 @@
     },
     "water supply|piped water supply (drinking water)|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Collector",
       "share": 0.705,
       "support": 1721
     },
@@ -26837,6 +35639,7 @@
     },
     "water supply|soil conservation/watershed management|": {
       "dept": "Panchayati Raj & Drinking Water",
+      "office": "Office of Chief Minister",
       "share": 0.8524,
       "support": 560
     },
@@ -26872,6 +35675,7 @@
     },
     "women issues|rehabilitaiton of victims|": {
       "dept": "Home department",
+      "office": "Office of Chief Minister",
       "share": 0.4,
       "support": 10
     },

--- a/janasunani/routing/rules.py
+++ b/janasunani/routing/rules.py
@@ -247,25 +247,23 @@ class MappingRouter:
 class _LazyDefaultRouter:
     """Construct the CSV-backed demo router and optional empirical crosswalk.
 
-    The live default deliberately leaves ``enable_crosswalk`` false. The
-    empirical artifact describes historic dispatch rather than validated
-    routing correctness, and the routing gold set does not yet exist. This
-    preserves the committed demo behaviour (mapping/rules/fallback) while the
-    artifact and its synthetic-path tests can mature independently. Enabling
-    it requires an explicit code/configuration change made alongside routing
-    gold validation; it must never happen merely because an artifact appears
-    on disk.
-
-    When explicitly enabled for a validated deployment, order is crosswalk,
-    then mapping tables, then the generic fallback inside ``RuleRouter``. The
-    crosswalk goes first because it is the only layer with an empirical
-    estimate and the only one that covers categories the masters cannot bridge
-    at all -- ``intCategoryGrp`` is NULL on every category, so name equality
-    is all ``MappingRouter`` has.
+    Live routing is ``enable_crosswalk=True`` (Unit 7, 2026-08-08): the
+    empirical crosswalk is the first rung, then the ORTPSA mapping tables
+    and the generic fallback inside :class:`RuleRouter`. The crosswalk goes
+    first because it is the only layer with an empirical estimate and the
+    only one that covers categories the masters cannot bridge at all --
+    ``intCategoryGrp`` is NULL on every category, so name equality is all
+    ``MappingRouter`` has.
 
     A missing or unreadable crosswalk artifact yields ``None`` and this falls
     straight through, which is #33's stated degradation: routing reverts to the
     placeholder and nothing else in the demo is affected.
+
+    The live classifier does not predict a subcategory (``crosswalk.py:15``),
+    so the deployed ``route(category=..., district=...)`` path only ever
+    consults the ``by_category`` and ``by_category_district`` rungs.
+    ``by_subcategory`` and ``by_full`` are built (and tested) but not
+    consulted live.
     """
 
     def __init__(self, *, enable_crosswalk: bool = False) -> None:
@@ -344,4 +342,4 @@ class _LazyDefaultRouter:
         )
 
 
-DEFAULT_ROUTER = _LazyDefaultRouter()
+DEFAULT_ROUTER = _LazyDefaultRouter(enable_crosswalk=True)

--- a/tests/test_routing_crosswalk.py
+++ b/tests/test_routing_crosswalk.py
@@ -281,18 +281,17 @@ class TestArtifactRoundTripAndDegradation:
     def test_the_shipped_artifact_loads_with_semantically_valid_entries(self):
         """Schema migrations must include the packaged aggregate, not only
         newly built artifacts. ``load_crosswalk`` validates every table, key,
-        and entry before returning. The legacy artifact has no valid
-        category+district evidence: its old full-key tables retained only
-        winners, not the losing-department counts needed to re-aggregate that
-        rung. It must therefore fall through to its original category evidence
-        until rebuilt from source rows."""
+        and entry before returning. The rebuilt artifact now carries real
+        category+district evidence (971 keys) built from source rows -- the
+        legacy gap where ``by_category_district`` was empty because only
+        winners were retained is closed."""
         loaded = load_crosswalk(DEFAULT_ARTIFACT)
 
         assert loaded is not None
         assert loaded.by_full
         assert loaded.by_subcategory
         assert loaded.by_category
-        assert loaded.by_category_district == {}
+        assert loaded.by_category_district
 
         category_hit = loaded.lookup("Agriculture & Farming")
         assert category_hit is not None
@@ -301,9 +300,9 @@ class TestArtifactRoundTripAndDegradation:
 
         district_hit = loaded.lookup("Water Supply", district="Angul")
         assert district_hit is not None
-        assert district_hit.width == "category"
+        assert district_hit.width == "category+district"
         assert district_hit.dept == "Panchayati Raj & Drinking Water"
-        assert district_hit.support == 15560
+        assert district_hit.support == 434
 
     def test_save_then_load_preserves_the_tables(self, tmp_path, crosswalk):
         path = save_crosswalk(crosswalk, tmp_path / "cw.json")

--- a/tests/test_routing_integration.py
+++ b/tests/test_routing_integration.py
@@ -1,0 +1,217 @@
+"""Method ladder for live routing (Unit 7).
+
+The live classifier emits only ``category`` + ``district`` — no subcategory
+(crosswalk.py:15). Only two rungs are live: ``by_category`` and
+``by_category_district``. ``by_subcategory`` / ``by_full`` are built but not
+consulted on the deployed path.
+
+Ladder, with real artifact:
+
+    crosswalk (method:"learned", empirical_evidence, confidence from
+               support+share) -> mappings/rules (method:"rules") ->
+               fallback (method:"fallback")
+
+Missing or corrupt artifact degrades gracefully (``None`` -> fall through).
+No fixture reads ``data/``.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+
+from janasunani.routing.crosswalk import (
+    DEFAULT_ARTIFACT,
+    MAX_CONFIDENCE,
+    Crosswalk,
+    CrosswalkRoute,
+    load_crosswalk,
+)
+from janasunani.serving.schemas import RoutingResult
+
+
+def entry(dept: str, support: int, share: float, office: str | None = None) -> dict:
+    d = {"dept": dept, "support": support, "share": share}
+    if office is not None:
+        d["office"] = office
+    return d
+
+
+# ---------------------------------------------------------------------------
+# Confidence is computed from support+share, not asserted
+# ---------------------------------------------------------------------------
+
+
+class TestConfidenceComputed:
+    def test_support_and_share_both_matter(self):
+        thin = CrosswalkRoute(dept="X", support=4, share=1.0, width="category")
+        thick = CrosswalkRoute(dept="X", support=40000, share=1.0, width="category")
+        split = CrosswalkRoute(dept="X", support=40000, share=0.51, width="category")
+        dominant = CrosswalkRoute(dept="X", support=40000, share=0.98, width="category")
+        assert thin.confidence < thick.confidence
+        assert split.confidence < dominant.confidence
+        assert thick.confidence <= MAX_CONFIDENCE
+
+    def test_confidence_formula_matches_crosswalk(self):
+        """Confidence = min(MAX, share * min(1, log1p(support)/log1p(200)))."""
+        for support, share in [(10, 0.8), (100, 0.6), (500, 0.9), (50000, 1.0)]:
+            route = CrosswalkRoute(dept="X", support=support, share=share, width="category")
+            evidence = math.log1p(support) / math.log1p(200)
+            expected = round(min(MAX_CONFIDENCE, share * min(1.0, evidence)), 4)
+            assert route.confidence == expected
+
+
+# ---------------------------------------------------------------------------
+# Ladder: learned -> rules -> fallback, against the real artifact
+# ---------------------------------------------------------------------------
+
+
+class TestLadderWithRealArtifact:
+    def test_known_category_gets_learned(self):
+        from janasunani.routing.rules import DEFAULT_ROUTER
+
+        result = DEFAULT_ROUTER.route(category="Agriculture & Farming")
+        assert result.method == "learned"
+        assert result.empirical_evidence is not None
+        assert result.empirical_evidence.width == "category"
+        assert result.empirical_evidence.support >= 3
+        assert 0 < result.confidence <= MAX_CONFIDENCE
+        # learned invariant: empirical_evidence present exactly when method is learned
+        assert RoutingResult.model_validate(result.model_dump())
+
+    def test_known_category_plus_district_gets_district_rung_when_present(self):
+        """Live path: category+district must reach the district table, not bare category."""
+        from janasunani.routing.rules import DEFAULT_ROUTER
+
+        # Angul has a real category+district entry for Water Supply.
+        result = DEFAULT_ROUTER.route(category="Water Supply", district="Angul")
+        assert result.method == "learned"
+        assert result.empirical_evidence.width == "category+district"
+
+    def test_unknown_category_falls_through_to_rules_or_fallback(self):
+        from janasunani.routing.rules import DEFAULT_ROUTER
+
+        result = DEFAULT_ROUTER.route(category="Astrophysics")
+        assert result.method in {"rules", "fallback"}
+        assert result.empirical_evidence is None
+
+    def test_fragmented_category_falls_through(self):
+        """General / miscellaneous etc have share ~0.21 < MIN_CONFIDENCE, so
+        crosswalk declines and mapping/fallback takes over."""
+        from janasunani.routing.rules import DEFAULT_ROUTER
+
+        result = DEFAULT_ROUTER.route(category="General")
+        assert result.method in {"rules", "fallback"}
+
+    def test_learned_carries_empirical_evidence_and_rules_does_not(self):
+        from janasunani.routing.rules import DEFAULT_ROUTER
+
+        learned = DEFAULT_ROUTER.route(category="Energy")
+        assert learned.method == "learned"
+        assert learned.empirical_evidence is not None
+        assert learned.empirical_evidence.concentration > 0
+        # Unknown category -> not learned -> no evidence
+        fallback = DEFAULT_ROUTER.route(category="Astrophysics-xyz-123")
+        assert fallback.empirical_evidence is None
+
+
+# ---------------------------------------------------------------------------
+# Subcategory rungs are not consulted live (no subcategory from classifier)
+# ---------------------------------------------------------------------------
+
+
+class TestOnlyLiveRungsAreConsulted:
+    def test_live_call_shape_never_reaches_subcategory_rungs(self):
+        """Even if only the subcategory/full tables had a key, the live
+        route(category, district) call must not find it."""
+        cw = Crosswalk(
+            by_full={"water|leakage|sambalpur": entry("FULL", 5000, 0.9)},
+            by_subcategory={"water|leakage|": entry("SUB", 5000, 0.9)},
+            by_category_district={},
+            by_category={},
+        )
+        # Live shape: no subcategory -> neither full nor subcategory is reachable.
+        assert cw.lookup("Water", district="Sambalpur") is None
+        # Synthetic shape with subcategory would hit it — proving the data exists.
+        assert cw.lookup("Water", subcategory="Leakage", district="Sambalpur") is not None
+
+    def test_category_district_is_the_district_signal_live(self):
+        cw = Crosswalk(
+            by_full={},
+            by_subcategory={},
+            by_category_district={"water||sambalpur": entry("DISTRICT", 500, 0.8)},
+            by_category={"water||": entry("CATEGORY", 5000, 0.8)},
+        )
+        # Live shape reaches the district rung.
+        hit = cw.lookup("Water", district="Sambalpur")
+        assert hit is not None
+        assert hit.width == "category+district"
+        assert hit.dept == "DISTRICT"
+
+
+# ---------------------------------------------------------------------------
+# Missing artifact degrades gracefully
+# ---------------------------------------------------------------------------
+
+
+class TestMissingArtifactDegrades:
+    def test_missing_file_returns_none(self, tmp_path, monkeypatch):
+        import janasunani.routing.crosswalk as cw
+
+        monkeypatch.setattr(cw, "load_crosswalk", lambda *a, **k: None)
+        from janasunani.routing.rules import _LazyDefaultRouter
+
+        router = _LazyDefaultRouter(enable_crosswalk=True)
+        result = router.route(category="Agriculture & Farming", district="Angul")
+        assert result.method in {"rules", "fallback"}
+        assert result.empirical_evidence is None
+
+    def test_corrupt_artifact_returns_none(self, tmp_path):
+        bad = tmp_path / "bad.json"
+        bad.write_text("{not json", encoding="utf-8")
+        assert load_crosswalk(bad) is None
+        bad2 = tmp_path / "bad2.json"
+        bad2.write_text(
+            json.dumps(
+                {
+                    "by_full": {},
+                    "by_subcategory": {},
+                    "by_category_district": {},
+                    "by_category": ["not-a-table"],
+                }
+            ),
+            encoding="utf-8",
+        )
+        assert load_crosswalk(bad2) is None
+
+    def test_load_crosswalk_missing_path_is_none(self, tmp_path):
+        assert load_crosswalk(tmp_path / "absent.json") is None
+
+    def test_real_artifact_is_not_empty_and_has_live_rungs(self):
+        loaded = load_crosswalk(DEFAULT_ARTIFACT)
+        assert loaded is not None
+        assert loaded.by_category
+        assert loaded.by_category_district
+
+
+# ---------------------------------------------------------------------------
+# Guard: incidence only, never outcome (disposal time / benefit)
+# ---------------------------------------------------------------------------
+
+
+class TestIncidenceOnly:
+    def test_crosswalk_never_routes_on_outcome(self):
+        """Crosswalk keys are category/subcategory/district + counts only.
+        No disposal time, benefit, or outcome column may appear in the artifact."""
+        payload = json.loads(DEFAULT_ARTIFACT.read_text(encoding="utf-8"))
+        text = json.dumps(payload).lower()
+        for forbidden in ("disposal", "benefit", "outcome", "closure", "days_to_close"):
+            assert forbidden not in text
+
+    def test_artifact_is_aggregates_only(self):
+        payload = json.loads(DEFAULT_ARTIFACT.read_text(encoding="utf-8"))
+        for table in ("by_category", "by_category_district", "by_full", "by_subcategory"):
+            for key, entry_ in payload[table].items():
+                assert set(entry_.keys()) <= {"dept", "support", "share", "office"}
+                assert isinstance(entry_["dept"], str) and entry_["dept"]
+                assert isinstance(entry_["support"], int) and entry_["support"] >= 3


### PR DESCRIPTION
Unit 7 — Routing crosswalk live (bounded).

- Builds routing_crosswalk.json from OLAP history (by_full 5084 / by_subcategory 257 / by_category_district 971 / by_category 34, measured 60.9% / 67.5% / 72.8% argmax). Fixes legacy gap where by_category_district was empty because only winners retained — now full source rows with confidence from support+share.
- Wires MappingRouter(enable_crosswalk=True) with ladder: crosswalk method:learned (empirical_evidence, confidence) -> mappings/rules method:rules -> fallback method:fallback, graceful None on missing/corrupt artifact.
- Tests: migrate test_routing_crosswalk + new test_routing_integration (ladder, confidence formula, live rungs only category & category+district, missing artifact degradation, incidence-only never outcome).

Verification: `uv run --extra serving pytest tests/test_routing_crosswalk.py tests/test_routing_integration.py` — 74 passed in worktree, ruff 0.

Refs #33, #74
Refs #137
