### PR TITLE
feat(spam): bounded spam scorer with triage wiring and prevalence harness

### DIFF
--- a/janasunani/evaluation/spam_scorecard.py
+++ b/janasunani/evaluation/spam_scorecard.py
@@ -1,0 +1,347 @@
+"""Spam prevalence + PPV/false-positive harness (Unit 2b).
+
+Prevalence is measured over the lake slice's ``grievance_redacted`` column
+only — never over ``complaints.grievance`` raw.  Reporting is by
+district/category/mode/year so the demo can show where low-signal filings
+concentrate.
+
+PPV / false-positive rate is measured against officer-confirmed spam-like
+discards (the two low-signal families from ROADMAP §5.2):
+
+- details inadequate  39,943
+- no specific grievance  16,340
+
+Distinct from duplicate families (case already taken up 19,904 +
+duplicate copy 14,767) which are dedup, never spam.  Also distinct from
+not within purview (8,455) + documents not attached (29,029) + needs
+policy decision (9,090) + address not given (4,110) which are
+incomplete/routing failures, never spam.  The harness never counts those
+as positives.
+
+Held-out evaluation is reported, not gated — a deterministic 30% holdout
+by ticket hash so the same slice always yields the same numbers.
+
+This module is the evaluation counterpart to :mod:`pipeline.spam`; the
+latter scores one text, this one aggregates a corpus and reconciles
+against the officer labels.  It reuses the same bounded scorer so
+prevalence and PPV are on the same scale the live triage will use.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import polars as pl
+
+from janasunani.olap import lake as lake_mod
+from janasunani.pipeline.spam import SPAM_VERSION, score_spam
+
+# Officer-confirmed spam-like families (the only two that map to spam)
+SPAM_LIKE_FAMILIES = ("details_inadequate", "no_specific_grievance")
+
+# Families that must never be counted as spam (guard)
+NON_SPAM_FAMILIES = (
+    "case_already_taken_up",
+    "duplicate_copy",
+    "outside_grievance_cell_purview",
+    "documents_not_attached",
+    "policy_decision_required",
+    "address_not_given",
+)
+
+
+def _parse_slice(value: str) -> tuple[str, int]:
+    if "/" not in value:
+        raise argparse.ArgumentTypeError("--slice must be DISTRICT/YEAR, e.g. Sambalpur/2024")
+    district, year_s = value.split("/", 1)
+    district = district.strip()
+    if not district:
+        raise argparse.ArgumentTypeError("district part of --slice is empty")
+    try:
+        year = int(year_s.strip())
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"year part of --slice must be int, got {year_s!r}") from exc
+    return district, year
+
+
+def compute_prevalence(
+    lake_dir: Path | None,
+    district: str,
+    year: int,
+    threshold: float = 0.5,
+) -> dict[str, Any]:
+    """Score the slice and return prevalence aggregates.
+
+    Reads ``grievance_redacted`` only — never ``complaints.grievance``.
+    """
+    district_lit = "'" + district.replace("'", "''") + "'"
+    sql = f"""
+        SELECT
+            c.ticket_no,
+            c.district,
+            c.category,
+            c.mode,
+            c.created_year,
+            g.grievance_redacted AS redacted_text
+        FROM complaints c
+        JOIN grievance_redactions g USING (ticket_no)
+        WHERE lower(c.district) = lower({district_lit})
+          AND c.created_year = {year}
+          AND g.grievance_redacted IS NOT NULL
+    """
+    try:
+        frame = lake_mod.query(sql, lake_dir, tables=("complaints", "grievance_redactions"))
+    except FileNotFoundError:
+        return {
+            "slice": f"{district}/{year}",
+            "method": SPAM_VERSION,
+            "total": 0,
+            "flagged": 0,
+            "prevalence": 0.0,
+            "threshold": threshold,
+            "by_district": [],
+            "by_category": [],
+            "by_mode": [],
+            "by_year": [],
+            "note": "lake tables missing",
+        }
+
+    if frame.height == 0:
+        return {
+            "slice": f"{district}/{year}",
+            "method": SPAM_VERSION,
+            "total": 0,
+            "flagged": 0,
+            "prevalence": 0.0,
+            "threshold": threshold,
+            "by_district": [],
+            "by_category": [],
+            "by_mode": [],
+            "by_year": [],
+            "note": "no rows in slice",
+        }
+
+    scores = [score_spam(r["redacted_text"] or "") for r in frame.iter_rows(named=True)]
+    frame = frame.with_columns(
+        [
+            pl.Series("spam_score", [s.spam_score for s in scores]),
+            pl.Series("spam_reason", [s.spam_reason for s in scores]),
+            pl.Series("flagged", [1 if s.spam_score >= threshold else 0 for s in scores]),
+        ]
+    )
+    total = frame.height
+    flagged = int(frame["flagged"].sum())
+    prevalence = flagged / total if total else 0.0
+
+    def _group(by: str) -> list[dict]:
+        if by not in frame.columns:
+            return []
+        g = (
+            frame.group_by(by)
+            .agg([pl.len().alias("total"), pl.col("flagged").sum().alias("flagged")])
+            .with_columns((pl.col("flagged") / pl.col("total")).alias("prevalence"))
+            .sort(by)
+        )
+        return g.to_dicts()
+
+    return {
+        "slice": f"{district}/{year}",
+        "method": SPAM_VERSION,
+        "total": total,
+        "flagged": flagged,
+        "prevalence": prevalence,
+        "threshold": threshold,
+        "by_district": _group("district"),
+        "by_category": _group("category"),
+        "by_mode": _group("mode"),
+        "by_year": _group("created_year"),
+    }
+
+
+def compute_ppv(
+    lake_dir: Path | None,
+    district: str,
+    year: int,
+    threshold: float = 0.5,
+) -> dict[str, Any]:
+    """Held-out PPV / false-positive vs officer spam-like labels.
+
+    Positive = officer used one of the two spam-like templates.
+    Negatives are all other slice rows (including duplicate and
+    not-within-purview families, which are never counted as spam).
+    Reported, not gated.
+    """
+    prevalence = compute_prevalence(lake_dir, district, year, threshold=threshold)
+    # Re-load frame with scores for holdout split
+    district_lit = "'" + district.replace("'", "''") + "'"
+    sql = f"""
+        SELECT
+            c.ticket_no,
+            g.grievance_redacted AS redacted_text
+        FROM complaints c
+        JOIN grievance_redactions g USING (ticket_no)
+        WHERE lower(c.district) = lower({district_lit})
+          AND c.created_year = {year}
+          AND g.grievance_redacted IS NOT NULL
+    """
+    try:
+        frame = lake_mod.query(sql, lake_dir, tables=("complaints", "grievance_redactions"))
+    except FileNotFoundError:
+        return {**prevalence, "ppv_holdout": None, "false_positive_rate_holdout": None, "holdout_n": 0}
+
+    if frame.height == 0:
+        return {**prevalence, "ppv_holdout": None, "false_positive_rate_holdout": None, "holdout_n": 0}
+
+    scores = [score_spam(r["redacted_text"] or "") for r in frame.iter_rows(named=True)]
+    frame = frame.with_columns(
+        [
+            pl.Series("spam_score", [s.spam_score for s in scores]),
+            pl.Series("flagged", [1 if s.spam_score >= threshold else 0 for s in scores]),
+        ]
+    )
+
+    # Officer positives: the two spam-like families only
+    officer_sql = """
+        WITH discard_template(family, template) AS (
+            VALUES
+                ('details_inadequate', 'complaint details inadequate'),
+                ('details_inadequate', 'complaint details inadequate. may file a detail grievance'),
+                ('no_specific_grievance', 'no specific grievance'),
+                ('no_specific_grievance', 'no specific grievance. may file a detail grievance')
+        ),
+        normalized_action AS (
+            SELECT ticket_no,
+                   regexp_replace(regexp_replace(lower(trim(action_taken_remark)), '\\s+', ' ', 'g'), '\\.$', '') AS norm
+            FROM action_history
+            WHERE action_taken_remark IS NOT NULL
+        )
+        SELECT DISTINCT ticket_no FROM normalized_action
+        INNER JOIN discard_template d ON d.template = norm
+        WHERE d.family IN ('details_inadequate', 'no_specific_grievance')
+    """
+    try:
+        officer_frame = lake_mod.query(officer_sql, lake_dir, tables=("action_history",))
+        officer_positive = set(officer_frame["ticket_no"].to_list()) if officer_frame.height else set()
+    except Exception:
+        officer_positive = set()
+
+    def is_holdout(t: str) -> bool:
+        return (int(hashlib.sha256(t.encode()).hexdigest(), 16) % 10) < 3
+
+    holdout = frame.filter(pl.col("ticket_no").map_elements(is_holdout, return_dtype=pl.Boolean))
+    if holdout.height == 0 or not officer_positive:
+        return {**prevalence, "ppv_holdout": None, "false_positive_rate_holdout": None, "holdout_n": holdout.height}
+
+    tp = holdout.filter((pl.col("flagged") == 1) & pl.col("ticket_no").is_in(list(officer_positive))).height
+    fp = holdout.filter((pl.col("flagged") == 1) & (~pl.col("ticket_no").is_in(list(officer_positive)))).height
+    tn = holdout.filter((pl.col("flagged") == 0) & (~pl.col("ticket_no").is_in(list(officer_positive)))).height
+
+    ppv = tp / (tp + fp) if (tp + fp) > 0 else None
+    fpr = fp / (fp + tn) if (fp + tn) > 0 else None
+
+    return {
+        **prevalence,
+        "ppv_holdout": ppv,
+        "false_positive_rate_holdout": fpr,
+        "holdout_n": holdout.height,
+        "officer_positive_in_holdout": holdout.filter(pl.col("ticket_no").is_in(list(officer_positive))).height,
+        "note": "duplicate/not-within-purview never counted as spam; PPV reported not gated",
+    }
+
+
+def render_markdown(result: dict[str, Any]) -> str:
+    lines = [
+        f"# Spam prevalence — {result.get('slice', '')}",
+        "",
+        f"Method: `{result.get('method', SPAM_VERSION)}` (threshold {result.get('threshold', 0.5)})",
+        f"Total with redacted text: {result.get('total', 0)}",
+        f"Flagged: {result.get('flagged', 0)} ({result.get('prevalence', 0):.2%})",
+        "",
+    ]
+    if result.get("ppv_holdout") is not None:
+        lines += [
+            f"PPV (holdout, officer spam-like): {result['ppv_holdout']:.3f}",
+            f"False-positive rate (holdout): {result['false_positive_rate_holdout']:.3f}",
+            f"Holdout n: {result.get('holdout_n', 0)}",
+            "",
+        ]
+    else:
+        lines += ["PPV: not computed (no holdout or no officer labels in slice)", ""]
+
+    for key, label in [
+        ("by_district", "By district"),
+        ("by_category", "By category"),
+        ("by_mode", "By mode"),
+        ("by_year", "By year"),
+    ]:
+        rows = result.get(key) or []
+        if rows:
+            lines += [f"## {label}", "", "| Group | Total | Flagged | Prevalence |", "|---|---:|---:|---:|"]
+            for r in rows:
+                grp = r.get("district") or r.get("category") or r.get("mode") or r.get("created_year")
+                lines.append(f"| {grp} | {r['total']} | {r['flagged']} | {r['prevalence']:.2%} |")
+            lines.append("")
+
+    # Guard statement
+    lines += [
+        "These counts are over `grievance_redacted` only — never `complaints.grievance` raw.",
+        "Duplicate families (`case already taken up`, `duplicate copy`) and",
+        "`not within purview` / incomplete families are never scored as spam.",
+        "Status is never mutated; this is an advisory signal only.",
+    ]
+    return "\n".join(lines)
+
+
+def write_outputs(result: dict[str, Any], out_dir: Path) -> dict[str, Path]:
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    json_path = out / "spam_prevalence.json"
+    md_path = out / "spam_prevalence.md"
+    csv_path = out / "spam_prevalence.csv"
+    json_path.write_text(json.dumps(result, indent=2, default=str))
+    md_path.write_text(render_markdown(result))
+
+    # Also write a by-group CSV (flattened)
+    rows: list[dict[str, Any]] = []
+    for key in ("by_district", "by_category", "by_mode", "by_year"):
+        for r in result.get(key) or []:
+            rows.append({"group_kind": key, **r})
+    if rows:
+        pl.DataFrame(rows).write_csv(csv_path)
+    else:
+        pl.DataFrame({"note": ["no groups"]}).write_csv(csv_path)
+    return {"json": json_path, "markdown": md_path, "csv": csv_path}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Spam prevalence + PPV harness (redacted text only).")
+    g = parser.add_mutually_exclusive_group(required=True)
+    g.add_argument("--slice", type=str, help="District/year slice, e.g. Sambalpur/2024")
+    g.add_argument("--district", type=str, help="District (requires --year)")
+    parser.add_argument("--year", type=int, default=None, help="Year (requires --district)")
+    parser.add_argument("--lake-dir", type=Path, default=None, help="Lake dir (default: data/interim)")
+    parser.add_argument("--threshold", type=float, default=0.5, help="Flag threshold")
+    parser.add_argument("--out-dir", type=Path, default=None, help="Write outputs under this dir")
+    args = parser.parse_args()
+
+    if args.slice:
+        district, year = _parse_slice(args.slice)
+    else:
+        if args.year is None:
+            parser.error("--year is required with --district")
+        district, year = args.district, args.year
+
+    result = compute_ppv(args.lake_dir, district, year, threshold=args.threshold)
+    print(render_markdown(result))
+    if args.out_dir:
+        paths = write_outputs(result, Path(args.out_dir))
+        for kind, path in paths.items():
+            print(f"{kind} -> {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/janasunani/pipeline/spam.py
+++ b/janasunani/pipeline/spam.py
@@ -1,0 +1,491 @@
+"""Bounded spam-signal scorer over redacted text (Phase 14, Unit 2b).
+
+Inputs (bounded, import-light):
+- redacted_text (str) — Presidio output, never raw grievance column
+- is_repetition_collapsed (bool, optional) — from :func:`ocr_quality.is_repetition_collapsed`
+- len(redacted_text) — derived
+- lookup against the 8 discard-reason families from ``action_taken_remark``
+  (ROADMAP §5.2) — used only for *evaluation* (scorecard), never at
+  scoring time.  Only two families are spam-like.
+
+Guard:
+- Never reads raw grievance column — callers pass ``grievance_redacted``
+  only.
+- Never scores duplicate families (case already taken up / duplicate copy)
+  or not-within-purview / incomplete families as spam — those are dedup or
+  routing failures, not low-signal, and the evaluation harness keeps them
+  distinct.  The scorer itself only flags low-signal repetition/length
+  patterns; legitimate duplicate or routing-failure prose scores ``clean``.
+- Never mutates status, advisory only — the score is a review signal,
+  not a gate.
+
+Emits ``spam_score`` in [0,1] + ``spam_reason`` in the 5-value set with
+evidence, via :func:`score_spam`.  The 5 reason codes map to the two
+spam-like discard families plus technical guards:
+
+- ``repetition_collapse`` — OCR loop
+- ``length_too_short`` — too few chars/words to be actionable
+- ``low_signal_details_inadequate`` — short/vague, closest to "details inadequate" (39,943)
+- ``low_signal_no_grievance`` — generic/test-like, closest to "no specific grievance" (16,340)
+- ``clean`` — no low-signal flag
+
+The remaining discard families are *never* scored as spam:
+  duplicate copy / case already taken up (dedup),
+  not within purview / documents not attached / needs policy decision /
+  address not given (incomplete/routing).
+
+This module is import-light (stdlib + ocr_quality only) so it can run in
+the ``pipeline-core`` extra and in CI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, Optional
+
+from janasunani.pipeline.ocr_quality import is_repetition_collapsed
+
+SPAM_VERSION = "spam-v1-bounded"
+
+
+def _check_collapsed(text: str) -> bool:
+    return is_repetition_collapsed(text)
+
+
+def is_repetition_collapsed_text(text: str) -> bool:
+    return is_repetition_collapsed(text)
+
+SpamReason = Literal[
+    "low_signal_details_inadequate",
+    "low_signal_no_grievance",
+    "repetition_collapse",
+    "length_too_short",
+    "clean",
+]
+
+SPAM_REASONS: tuple[SpamReason, ...] = (
+    "low_signal_details_inadequate",
+    "low_signal_no_grievance",
+    "repetition_collapse",
+    "length_too_short",
+    "clean",
+)
+
+# --- thresholds (bounded, deterministic) ---
+
+# Below this many non-space chars the filing cannot be actionable.
+MIN_CHARS_FOR_CONTENT = 20
+# Below this many words the filing cannot be actionable.
+MIN_WORDS_FOR_CONTENT = 4
+# Below this many words/40 chars the filing is vague -> details inadequate.
+DETAILS_INADEQUATE_WORDS = 8
+DETAILS_INADEQUATE_CHARS = 40
+
+# --- generic/test-like patterns that map to "no specific grievance" ---
+
+_NO_GRIEVANCE_RE = re.compile(
+    r"^\W*(test|demo|asdf+|hello|hi|no\s*specific\s*grievance|no\s*grievance|"
+    r"blank|empty|nothing|na|n/a|nil|none)\W*$",
+    re.IGNORECASE,
+)
+
+# After placeholder stripping, a text that is only placeholders/brackets
+# and whitespace carries no grievance.
+_PLACEHOLDER_ONLY_RE = re.compile(r"^[\s\[\]<>A-Z_]*$")
+
+
+@dataclass(frozen=True)
+class SpamEvidence:
+    """Auditable observation that contributed to the spam score."""
+
+    kind: str
+    observed: bool | int | float | str
+
+
+@dataclass(frozen=True)
+class SpamScore:
+    """Bounded spam signal over one redacted text."""
+
+    spam_score: float
+    spam_reason: SpamReason
+    evidence: tuple[SpamEvidence, ...]
+    method: str = SPAM_VERSION
+
+    def to_review_fields(self) -> dict:
+        """Map to :class:`SpamReview` kwargs."""
+        from janasunani.serving.schemas import OcrQualityEvidence
+
+        # Collapse evidence to the OcrQualityEvidence shape for the wire
+        # contract; extra length/pattern observations are kept in the
+        # score's own evidence but only repetition is a validated OCR guard.
+        rep = next(
+            (e for e in self.evidence if e.kind == "repetition_collapse"),
+            None,
+        )
+        ocr_evidence = (
+            OcrQualityEvidence(
+                kind="repetition_collapse",
+                observed=bool(rep.observed) if rep else False,
+            ),
+        )
+        # Advisory decision: review when score >= 0.5, else abstained.
+        # This never blocks submission — it is an officer-review flag.
+        decision = "review" if self.spam_score >= 0.5 else "abstained"
+        # reason_code mirrors spam_reason for the bounded scorer; the
+        # legacy validator in SpamReview now allows these codes.
+        return {
+            "decision": decision,
+            "reason_code": self.spam_reason,
+            "spam_score": self.spam_score,
+            "spam_reason": self.spam_reason,
+            "evidence": ocr_evidence,
+            "method": self.method,
+        }
+
+
+def _is_no_grievance_like(text: str) -> bool:
+    stripped = text.strip()
+    if not stripped:
+        return True
+    # Placeholder-only (e.g., "[NAME] [PHONE]") carries no grievance
+    if _PLACEHOLDER_ONLY_RE.fullmatch(stripped) and stripped:
+        # If after removing placeholders nothing remains, it's empty
+        no_brackets = re.sub(r"\[.*?\]", "", stripped).strip()
+        if not no_brackets:
+            return True
+    low = stripped.lower()
+    # Exact generic tokens
+    if _NO_GRIEVANCE_RE.match(stripped):
+        return True
+    if low in {"test", "demo", "asdf", "blank"}:
+        return True
+    return False
+
+
+def score_spam(
+    redacted_text: str,
+    *,
+    is_repetition_collapsed: Optional[bool] = None,
+) -> SpamScore:
+    """Score one redacted text; never touches raw grievance.
+
+    Returns a bounded ``SpamScore`` with ``spam_score`` in [0,1] and a
+    5-value ``spam_reason``.  Deterministic, no model, no I/O.
+
+    The 8 discard-reason families are *not* consulted here — they are the
+    evaluation harness's reference (see :mod:`evaluation.spam_scorecard`).
+    Scoring uses only redacted text, repetition flag, and length.  Duplicate
+    and not-within-purview families are never scored as spam because their
+    prose is legitimate and will fall through to ``clean`` here.
+    """
+    if redacted_text is None:
+        redacted_text = ""
+    text = str(redacted_text)
+    stripped = text.strip()
+    char_len = len(stripped)
+    word_count = len(stripped.split()) if stripped else 0
+
+    collapsed = (
+        bool(is_repetition_collapsed)
+        if is_repetition_collapsed is not None
+        else _check_collapsed(text)
+    )
+
+    evidence: list[SpamEvidence] = [
+        SpamEvidence(kind="repetition_collapse", observed=collapsed),
+        SpamEvidence(kind="char_len", observed=char_len),
+        SpamEvidence(kind="word_count", observed=word_count),
+    ]
+
+    # 1. Repetition collapse — highest signal
+    if collapsed:
+        return SpamScore(
+            spam_score=0.92,
+            spam_reason="repetition_collapse",
+            evidence=tuple(evidence),
+        )
+
+    # 2. Too short to be actionable (very short filings)
+    if char_len < MIN_CHARS_FOR_CONTENT:
+        return SpamScore(
+            spam_score=0.85,
+            spam_reason="length_too_short",
+            evidence=tuple(evidence),
+        )
+
+    # 3. Generic / test-like -> "no specific grievance"
+    if _is_no_grievance_like(stripped):
+        evidence.append(SpamEvidence(kind="pattern", observed="no_grievance"))
+        return SpamScore(
+            spam_score=0.78,
+            spam_reason="low_signal_no_grievance",
+            evidence=tuple(evidence),
+        )
+
+    # 4. Short/vague -> "details inadequate"
+    if word_count < DETAILS_INADEQUATE_WORDS or char_len < DETAILS_INADEQUATE_CHARS:
+        return SpamScore(
+            spam_score=0.68,
+            spam_reason="low_signal_details_inadequate",
+            evidence=tuple(evidence),
+        )
+
+    # 5. Clean — no low-signal flag
+    return SpamScore(
+        spam_score=0.07,
+        spam_reason="clean",
+        evidence=tuple(evidence),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lightweight helpers for evaluation — kept here so scorecard can reuse
+# the same bounded logic without touching raw grievance.
+# ---------------------------------------------------------------------------
+
+
+def is_spam_flagged(score: SpamScore, threshold: float = 0.5) -> bool:
+    return score.spam_score >= threshold
+
+
+# ---------------------------------------------------------------------------
+# CLI — corpus prevalence + optional scoring over the lake slice
+# ---------------------------------------------------------------------------
+
+
+def _parse_slice(value: str) -> tuple[str, int]:
+    if "/" not in value:
+        raise argparse.ArgumentTypeError("--slice must be DISTRICT/YEAR, e.g. Sambalpur/2024")
+    district, year_s = value.split("/", 1)
+    district = district.strip()
+    if not district:
+        raise argparse.ArgumentTypeError("district part of --slice is empty")
+    try:
+        year = int(year_s.strip())
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"year part of --slice must be int, got {year_s!r}") from exc
+    return district, year
+
+
+def _score_corpus(
+    lake_dir: Path | None,
+    district: str,
+    year: int,
+    threshold: float = 0.5,
+) -> dict:
+    """Score the slice's grievance_redacted rows; return counts + PPV."""
+
+    # Imported lazily so `import janasunani.pipeline.spam` stays light.
+    import polars as pl
+
+    from janasunani.olap import lake as lake_mod
+
+    # --- load slice over lake (reads grievance_redacted only) ---
+    # Join complaints (for district/year/category/mode) with
+    # grievance_redactions (for redacted text). Never selects raw grievance.
+    district_lit = "'" + district.replace("'", "''") + "'"
+    sql_inlined = f"""
+        SELECT
+            c.ticket_no,
+            c.district,
+            c.category,
+            c.mode,
+            c.created_year,
+            g.grievance_redacted AS redacted_text
+        FROM complaints c
+        JOIN grievance_redactions g USING (ticket_no)
+        WHERE lower(c.district) = lower({district_lit})
+          AND c.created_year = {year}
+          AND g.grievance_redacted IS NOT NULL
+    """
+
+    try:
+        frame = lake_mod.query(sql_inlined, lake_dir, tables=("complaints", "grievance_redactions"))
+    except FileNotFoundError:
+        return {
+            "slice": f"{district}/{year}",
+            "total": 0,
+            "flagged": 0,
+            "prevalence": 0.0,
+            "by_district": [],
+            "by_category": [],
+            "by_mode": [],
+            "by_year": [],
+            "ppv": None,
+            "false_positive_rate": None,
+            "note": "lake tables missing — run materialize first",
+        }
+
+    if frame.height == 0:
+        return {
+            "slice": f"{district}/{year}",
+            "total": 0,
+            "flagged": 0,
+            "prevalence": 0.0,
+            "by_district": [],
+            "by_category": [],
+            "by_mode": [],
+            "by_year": [],
+            "ppv": None,
+            "false_positive_rate": None,
+            "note": "no rows in slice",
+        }
+
+    # Score each row
+    scores = []
+    for row in frame.iter_rows(named=True):
+        s = score_spam(row["redacted_text"] or "")
+        scores.append((s.spam_score, s.spam_reason))
+    frame = frame.with_columns(
+        [
+            pl.Series("spam_score", [s for s, _ in scores]),
+            pl.Series("spam_reason", [r for _, r in scores]),
+            pl.Series("flagged", [1 if s >= threshold else 0 for s, _ in scores]),
+        ]
+    )
+
+    total = frame.height
+    flagged = int(frame["flagged"].sum())
+    prevalence = flagged / total if total else 0.0
+
+    def _group(by: str) -> list[dict]:
+        if by not in frame.columns:
+            return []
+        g = (
+            frame.group_by(by)
+            .agg([pl.len().alias("total"), pl.col("flagged").sum().alias("flagged")])
+            .with_columns((pl.col("flagged") / pl.col("total")).alias("prevalence"))
+            .sort(by)
+        )
+        return g.to_dicts()
+
+    # --- PPV vs officer-confirmed spam-like discards (held-out) ---
+    # Officer labels are the two spam-like families only; duplicate and
+    # not-within-purview families are explicitly excluded from the positive
+    # set (guard: never score them as spam).
+    ppv = None
+    fpr = None
+    try:
+        # Normalize action_taken_remark the same way discards.py does
+        # (lowercase, trim, collapse whitespace, strip trailing period)
+        # and join to the slice's ticket_nos.
+        family_sql = """
+            WITH discard_template(family, template) AS (
+                VALUES
+                    ('details_inadequate', 'complaint details inadequate'),
+                    ('details_inadequate', 'complaint details inadequate. may file a detail grievance'),
+                    ('no_specific_grievance', 'no specific grievance'),
+                    ('no_specific_grievance', 'no specific grievance. may file a detail grievance')
+            ),
+            normalized_action AS (
+                SELECT ticket_no,
+                       regexp_replace(regexp_replace(lower(trim(action_taken_remark)), '\\s+', ' ', 'g'), '\\.$', '') AS norm
+                FROM action_history
+                WHERE action_taken_remark IS NOT NULL
+            ),
+            matched AS (
+                SELECT DISTINCT ticket_no FROM normalized_action
+                INNER JOIN discard_template d ON d.template = norm
+                WHERE d.family IN ('details_inadequate', 'no_specific_grievance')
+            )
+            SELECT ticket_no FROM matched
+        """
+        officer_frame = lake_mod.query(family_sql, lake_dir, tables=("action_history",))
+        officer_positive = set(officer_frame["ticket_no"].to_list()) if officer_frame.height else set()
+
+        # Held-out split: deterministic hash of ticket_no -> 30% holdout
+        def is_holdout(t: str) -> bool:
+            return (int(hashlib.sha256(t.encode()).hexdigest(), 16) % 10) < 3
+
+        holdout = frame.filter(pl.col("ticket_no").map_elements(is_holdout, return_dtype=pl.Boolean))
+        if holdout.height > 0 and officer_positive:
+            tp = holdout.filter(
+                (pl.col("flagged") == 1) & pl.col("ticket_no").is_in(list(officer_positive))
+            ).height
+            fp = holdout.filter(
+                (pl.col("flagged") == 1) & (~pl.col("ticket_no").is_in(list(officer_positive)))
+            ).height
+            tn = holdout.filter(
+                (pl.col("flagged") == 0) & (~pl.col("ticket_no").is_in(list(officer_positive)))
+            ).height
+            ppv = tp / (tp + fp) if (tp + fp) > 0 else None
+            fpr = fp / (fp + tn) if (fp + tn) > 0 else None
+        elif holdout.height == 0:
+            ppv = None
+            fpr = None
+    except Exception:
+        ppv = None
+        fpr = None
+
+    return {
+        "slice": f"{district}/{year}",
+        "total": total,
+        "flagged": flagged,
+        "prevalence": prevalence,
+        "threshold": threshold,
+        "by_district": _group("district"),
+        "by_category": _group("category"),
+        "by_mode": _group("mode"),
+        "by_year": _group("created_year"),
+        "ppv_holdout": ppv,
+        "false_positive_rate_holdout": fpr,
+        "note": "PPV reported, not gated; duplicate/not-within-purview never counted as spam",
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Score spam signal over a lake slice (redacted text only).")
+    g = parser.add_mutually_exclusive_group(required=True)
+    g.add_argument("--slice", type=str, help="District/year slice, e.g. Sambalpur/2024")
+    g.add_argument("--district", type=str, help="District (requires --year)")
+    parser.add_argument("--year", type=int, default=None, help="Year (requires --district)")
+    parser.add_argument("--lake-dir", type=Path, default=None, help="Lake dir (default: data/interim)")
+    parser.add_argument("--threshold", type=float, default=0.5, help="Flag threshold on spam_score")
+    parser.add_argument("--out-dir", type=Path, default=None, help="Write prevalence CSV/Markdown under this dir")
+    args = parser.parse_args()
+
+    if args.slice:
+        district, year = _parse_slice(args.slice)
+    else:
+        if args.year is None:
+            parser.error("--year is required with --district")
+        district, year = args.district, args.year
+
+    result = _score_corpus(args.lake_dir, district, year, threshold=args.threshold)
+
+    # Human-readable summary (stdout is the contract for the demo)
+    print(f"Slice: {result['slice']}")
+    print(f"Total with redacted text: {result['total']}")
+    print(f"Flagged (score >= {result['threshold']}): {result['flagged']} ({result['prevalence']:.2%})")
+    if result.get("ppv_holdout") is not None:
+        print(f"PPV (holdout vs officer spam-like): {result['ppv_holdout']:.3f}")
+        print(f"False-positive rate (holdout): {result['false_positive_rate_holdout']:.3f}")
+    else:
+        print("PPV: not computed (no holdout or no officer labels in slice)")
+    if result.get("by_category"):
+        print("\nBy category:")
+        for row in result["by_category"]:
+            print(f"  {row['category']}: {row['flagged']}/{row['total']} ({row['prevalence']:.2%})")
+
+    if args.out_dir:
+        import json
+
+        out = Path(args.out_dir)
+        out.mkdir(parents=True, exist_ok=True)
+        (out / "spam_prevalence.json").write_text(json.dumps(result, indent=2, default=str))
+        # Also delegate to scorecard harness if available
+        try:
+            from janasunani.evaluation.spam_scorecard import write_outputs
+
+            write_outputs(result, out)
+        except Exception:
+            pass
+        print(f"\nWrote {out / 'spam_prevalence.json'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/janasunani/serving/schemas.py
+++ b/janasunani/serving/schemas.py
@@ -156,12 +156,14 @@ class OcrQualityEvidence(BaseModel):
 
 
 class SpamReview(BaseModel):
-    """Officer-review state for the deliberately narrow low-signal advisory.
+    """Officer-review state for the bounded low-signal scorer.
 
-    ``review`` is reserved for a future, redacted human-adjudicated validation
-    release.  The current provider always abstains, even if the OCR quality
-    guard observes repetition collapse.  There is intentionally no score:
-    no calibrated or trained spam model has been authorized for this service.
+    The bounded scorer (pipeline/spam.py, spam-v1-bounded) emits
+    ``spam_score`` in [0,1] + ``spam_reason`` in the 5-value set with
+    evidence, advisory only (never blocks submission).  The provider
+    remains unavailable outside a scored path: ``advisory_provider_unavailable``
+    carries no score.  Legacy ``flagged``/``not_scored`` records are still
+    read as an explicit abstention.
     """
 
     decision: Literal["review", "abstained"]
@@ -171,8 +173,22 @@ class SpamReview(BaseModel):
         "live_review_disabled_pending_redacted_adjudication",
         "mock_low_signal_review_unavailable",
         "advisory_provider_unavailable",
+        "low_signal_details_inadequate",
+        "low_signal_no_grievance",
+        "repetition_collapse",
+        "length_too_short",
+        "clean",
     ]
+    spam_score: float | None = Field(default=None, ge=0.0, le=1.0)
+    spam_reason: Literal[
+        "low_signal_details_inadequate",
+        "low_signal_no_grievance",
+        "repetition_collapse",
+        "length_too_short",
+        "clean",
+    ] | None = None
     evidence: tuple[OcrQualityEvidence, ...] = ()
+    method: str | None = None
 
     @model_validator(mode="before")
     @classmethod
@@ -183,6 +199,8 @@ class SpamReview(BaseModel):
         ``not_scored`` status plus a numeric ``spam_score``.  Neither is
         defensible as a live decision, so old records become an explicit
         abstention instead of preserving a pseudo-score on the new wire shape.
+        Legacy records that are not on the new bounded contract lose their
+        score; new bounded records (with a new reason_code) keep theirs.
         """
 
         if not isinstance(value, dict):
@@ -191,6 +209,7 @@ class SpamReview(BaseModel):
         if legacy_decision not in {"flagged", "not_scored", "abstained"}:
             return value
         if legacy_decision == "abstained" and "reason_code" in value:
+            # New contract: abstained with any valid reason_code keeps its score
             return value
         normalized = dict(value)
         normalized.update(
@@ -200,22 +219,44 @@ class SpamReview(BaseModel):
         )
         normalized.pop("spam_reason", None)
         normalized.pop("spam_score", None)
+        normalized.pop("method", None)
         return normalized
 
     @model_validator(mode="after")
     def _decision_matches_the_reason_code(self) -> "SpamReview":
-        if (
-            self.decision == "review"
-            and self.reason_code != "validated_low_signal_evidence"
-        ):
-            raise ValueError("review requires validated_low_signal_evidence")
-        if (
-            self.decision == "abstained"
-            and self.reason_code == "validated_low_signal_evidence"
-        ):
+        # New bounded scorer: review when flagged (score >= 0.5), with any
+        # of the 5 spam reasons (including repetition/length).  Clean is
+        # abstained.  Keep legacy validated path as before.
+        bounded_review_reasons = {
+            "low_signal_details_inadequate",
+            "low_signal_no_grievance",
+            "repetition_collapse",
+            "length_too_short",
+        }
+        if self.decision == "review":
+            if self.reason_code == "validated_low_signal_evidence":
+                if not self.evidence:
+                    raise ValueError("review requires auditable low-signal evidence")
+                return self
+            if self.reason_code in bounded_review_reasons:
+                if not self.evidence:
+                    raise ValueError("review requires auditable low-signal evidence")
+                # spam_score/reason coherence when present
+                if self.spam_reason is not None and self.spam_reason != self.reason_code:
+                    # allow reason_code to mirror spam_reason for bounded path
+                    pass
+                if self.spam_score is not None and not (0.0 <= self.spam_score <= 1.0):
+                    raise ValueError("spam_score must be in [0,1]")
+                return self
+            raise ValueError("review requires validated_low_signal_evidence or a bounded spam reason")
+        # abstained
+        if self.reason_code == "validated_low_signal_evidence":
             raise ValueError("validated_low_signal_evidence requires review")
-        if self.decision == "review" and not self.evidence:
-            raise ValueError("review requires auditable low-signal evidence")
+        if self.reason_code in bounded_review_reasons:
+            raise ValueError(f"{self.reason_code} requires review (score >= 0.5)")
+        # clean and advisory abstentions are allowed with or without score
+        if self.spam_score is not None and not (0.0 <= self.spam_score <= 1.0):
+            raise ValueError("spam_score must be in [0,1]")
         return self
 
 

--- a/janasunani/serving/triage.py
+++ b/janasunani/serving/triage.py
@@ -1,9 +1,10 @@
-"""Safe seam for advisory live triage.
+"""Advisory live triage with bounded spam scoring.
 
-The historical duplicate index is slice-scoped and does not yet provide a
-matcher for a newly submitted grievance.  This module makes that absence
-explicit while reserving a narrow future integration point: providers receive
-only redacted text, never the raw grievance or direct identity fields.
+Live submissions are scored over redacted text only (never raw
+``complaints.grievance``).  The spam signal is bounded
+(pipeline/spam.py, spam-v1-bounded) — repetition collapse, length, and
+low-signal patterns — and is advisory only (never blocks submission).
+Duplicate matching remains slice-scoped and unavailable live.
 """
 
 from __future__ import annotations
@@ -18,6 +19,12 @@ from janasunani.serving.schemas import (
     SpamReview,
     TriageResult,
 )
+
+try:
+    from janasunani.pipeline.spam import SPAM_VERSION, score_spam
+except Exception:  # pragma: no cover — scorer absent in minimal env
+    SPAM_VERSION = "unavailable"  # type: ignore
+    score_spam = None  # type: ignore
 
 
 class TriageUnavailableError(RuntimeError):
@@ -49,18 +56,33 @@ def unavailable_triage() -> TriageResult:
         spam=SpamReview(
             decision="abstained",
             reason_code="advisory_provider_unavailable",
+            spam_score=0.0,
+            spam_reason="clean",
+            method="unavailable",
         ),
     )
 
 
-def low_signal_advisory(redacted_text: str) -> SpamReview:
-    """Return the current fail-closed low-signal advisory.
+def score_spam_review(redacted_text: str) -> SpamReview:
+    """Score one redacted text with the bounded scorer; advisory only.
 
-    The sole observation is the existing OCR repetition-collapse guard.  It
-    runs over already-redacted text and is recorded for audit, but it cannot
-    create a review flag until a redacted, human-adjudicated validation release
-    authorizes a rule.  This is not a score, spam model, classifier, or a
-    pipeline gate.
+    Never reads raw grievance, never mutates status, never scores duplicate
+    or not-within-purview families as spam (those are dedup/routing, not
+    low-signal, and their prose scores ``clean`` here).
+    """
+    if score_spam is None:
+        raise TriageUnavailableError("spam scorer unavailable")
+    scored = score_spam(redacted_text)
+    fields = scored.to_review_fields()
+    return SpamReview(**fields)
+
+
+def low_signal_advisory(redacted_text: str) -> SpamReview:
+    """Legacy fail-closed advisory (retained for tests and fallback).
+
+    Prefer :func:`score_spam_review` for live scoring; this remains as the
+    fallback when the scorer is unavailable and as the pre-validation
+    contract that always abstains.
     """
 
     collapsed = is_repetition_collapsed(redacted_text)
@@ -72,16 +94,22 @@ def low_signal_advisory(redacted_text: str) -> SpamReview:
             decision="abstained",
             reason_code="ocr_repetition_collapse_unvalidated",
             evidence=evidence,
+            spam_score=0.0,
+            spam_reason="clean" if not collapsed else "repetition_collapse",
+            method="legacy-advisory",
         )
     return SpamReview(
         decision="abstained",
         reason_code="live_review_disabled_pending_redacted_adjudication",
         evidence=evidence,
+        spam_score=0.0,
+        spam_reason="clean",
+        method="legacy-advisory",
     )
 
 
 class UnwiredTriageProvider:
-    """Current production default before a validated low-signal release."""
+    """Current production default — now wired to the bounded scorer."""
 
     def assess(
         self,
@@ -94,4 +122,12 @@ class UnwiredTriageProvider:
         # redacted text; district and submission time cannot become proxies
         # for identity, routing, or filing history.
         del district, submitted_on
-        return TriageResult(spam=low_signal_advisory(redacted_text))
+        try:
+            spam = score_spam_review(redacted_text)
+        except TriageUnavailableError:
+            return unavailable_triage()
+        except Exception:
+            # Scoring errors must not block submission — fall back to
+            # unavailable rather than surfacing an internal trace.
+            return unavailable_triage()
+        return TriageResult(spam=spam)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,8 @@ janasunani-dedup-index = "janasunani.pipeline.dedup_index:main"
 janasunani-api = "janasunani.serving.api:main"
 janasunani-api-live = "janasunani.inference.serve:main"
 janasunani-demo-preflight = "janasunani.inference.serve:preflight_main"
+janasunani-spam-score = "janasunani.pipeline.spam:main"
+janasunani-spam-scorecard = "janasunani.evaluation.spam_scorecard:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/test_inference_service.py
+++ b/tests/test_inference_service.py
@@ -162,12 +162,17 @@ def test_default_live_triage_is_explicitly_abstained_pending_validation():
     assert result.triage.duplicate is None
     assert result.triage.duplicate_review.decision == "not_indexed"
     assert result.triage.duplicate_review.reason
-    assert result.triage.spam.decision == "abstained"
-    assert result.triage.spam.reason_code == (
-        "live_review_disabled_pending_redacted_adjudication"
-    )
+    # Now wired to bounded scorer: long enough legitimate text scores clean with a bounded score
+    assert result.triage.spam.spam_score is not None
+    assert 0.0 <= result.triage.spam.spam_score <= 1.0
+    assert result.triage.spam.spam_reason in {
+        "low_signal_details_inadequate",
+        "low_signal_no_grievance",
+        "repetition_collapse",
+        "length_too_short",
+        "clean",
+    }
     assert result.triage.spam.evidence[0].kind == "repetition_collapse"
-    assert "spam_score" not in result.triage.spam.model_dump()
 
 
 def test_triage_provider_outage_is_nonblocking_and_explicit():

--- a/tests/test_serving_api.py
+++ b/tests/test_serving_api.py
@@ -73,8 +73,12 @@ def test_submit_text_returns_full_result_shape(client):
         "not_indexed",
         "unavailable",
     }
-    assert body["triage"]["spam"]["decision"] == "abstained"
-    assert "spam_score" not in body["triage"]["spam"]
+    # Mock triage is advisory; now includes bounded spam_score/method
+    assert body["triage"]["spam"]["decision"] in {"abstained", "review"}
+    # spam_score is bounded and method present when scorer wiring is live; mock may be None
+    spam = body["triage"]["spam"]
+    if "spam_score" in spam and spam["spam_score"] is not None:
+        assert 0.0 <= spam["spam_score"] <= 1.0
 
 
 def test_submit_file_reports_document_source(client):

--- a/tests/test_serving_triage_contract.py
+++ b/tests/test_serving_triage_contract.py
@@ -97,7 +97,8 @@ def test_low_signal_abstention_is_visible_and_has_a_deterministic_reason_code():
     )
     assert review.decision == "abstained"
     assert review.reason_code
-    assert "spam_score" not in review.model_dump()
+    # Bounded scorer now carries spam_score/spam_reason; unset fields default to None
+    assert review.spam_score is None or 0.0 <= review.spam_score <= 1.0
 
     with pytest.raises(ValidationError, match="validated_low_signal_evidence requires review"):
         SpamReview(
@@ -119,7 +120,7 @@ def test_low_signal_abstention_is_visible_and_has_a_deterministic_reason_code():
     )
     assert legacy.decision == "abstained"
     assert legacy.reason_code == "live_review_disabled_pending_redacted_adjudication"
-    assert "spam_score" not in legacy.model_dump()
+    assert legacy.spam_score is None
 
     reserved_review = SpamReview(
         decision="review",
@@ -144,26 +145,21 @@ def test_low_signal_advisory_records_ocr_quality_evidence_but_still_abstains():
         "live_review_disabled_pending_redacted_adjudication"
     )
     assert ordinary.evidence[0].observed is False
-    assert "spam_score" not in collapsed.model_dump()
+    # Bounded scorer now populates spam_score/spam_reason on the advisory path as well
+    assert collapsed.spam_score is not None
+    assert 0.0 <= collapsed.spam_score <= 1.0
 
 
 def test_unwired_live_triage_is_explicitly_abstained_pending_validation():
     triage = TriageResult()
-    assert triage.model_dump(mode="json") == {
-        "duplicate": None,
-        "duplicate_review": {
-            "decision": "not_indexed",
-            "reason": (
-                "Duplicate matching has not been run for this submission because "
-                "the live submission path is not connected to a completed index."
-            ),
-        },
-        "spam": {
-            "decision": "abstained",
-            "reason_code": "live_review_disabled_pending_redacted_adjudication",
-            "evidence": [],
-        },
-    }
+    dumped = triage.model_dump(mode="json")
+    assert dumped["duplicate"] is None
+    assert dumped["duplicate_review"]["decision"] == "not_indexed"
+    assert dumped["spam"]["decision"] == "abstained"
+    assert dumped["spam"]["reason_code"] == "live_review_disabled_pending_redacted_adjudication"
+    # Bounded scorer now adds spam_score/spam_reason/method; allow None or bounded value
+    assert dumped["spam"]["evidence"] == []
+    assert dumped["spam"]["spam_score"] is None or 0.0 <= dumped["spam"]["spam_score"] <= 1.0
 
 
 def test_older_persisted_result_gets_the_explicit_low_signal_abstention_default():
@@ -202,7 +198,7 @@ def test_legacy_persisted_duplicate_signal_gets_the_matched_review_state():
     assert triage.duplicate is not None
     assert triage.duplicate_review.decision == "matched"
     assert triage.spam.decision == "abstained"
-    assert "spam_score" not in triage.spam.model_dump()
+    assert triage.spam.spam_score is None or 0.0 <= triage.spam.spam_score <= 1.0
 
 
 def test_mock_contract_never_claims_a_low_signal_review():

--- a/tests/test_spam_scorer.py
+++ b/tests/test_spam_scorer.py
@@ -1,0 +1,134 @@
+"""Bounded spam scorer — contract tests (Unit 2b)."""
+
+import pathlib
+
+from janasunani.pipeline import spam
+from janasunani.pipeline.spam import (
+    SPAM_REASONS,
+    SPAM_VERSION,
+    _parse_slice,
+    score_spam,
+)
+
+
+def test_score_bounded_and_reason_valid():
+    cases = [
+        "",
+        "hi",
+        "test",
+        "The hand pump in our village has been broken for two months and we request repair.",
+        "no specific grievance",
+        "repeat this phrase " * 30,
+        "A" * 500,
+    ]
+    for text in cases:
+        s = score_spam(text)
+        assert 0.0 <= s.spam_score <= 1.0, f"score out of bounds for {text!r}"
+        assert s.spam_reason in SPAM_REASONS
+        assert s.method == SPAM_VERSION
+        assert s.evidence
+
+
+def test_repetition_collapse_flagged():
+    collapsed_text = "repeat this phrase " * 40
+    s = score_spam(collapsed_text, is_repetition_collapsed=True)
+    assert s.spam_reason == "repetition_collapse"
+    assert s.spam_score >= 0.5
+    # Evidence must record the collapse observation
+    assert any(e.kind == "repetition_collapse" and e.observed is True for e in s.evidence)
+
+
+def test_length_too_short_flagged():
+    s = score_spam("hi")
+    assert s.spam_reason == "length_too_short"
+    assert s.spam_score >= 0.5
+    s2 = score_spam("a b")
+    assert s2.spam_reason == "length_too_short"
+
+
+def test_low_signal_no_grievance():
+    s = score_spam("no specific grievance")
+    assert s.spam_reason == "low_signal_no_grievance"
+    assert s.spam_score >= 0.5
+
+
+def test_low_signal_details_inadequate():
+    # Short/vague but not empty and not generic test token
+    s = score_spam("need help")
+    assert s.spam_reason in {"low_signal_details_inadequate", "length_too_short", "low_signal_no_grievance"}
+    # A slightly longer but still short text should map to details inadequate
+    s2 = score_spam("road broken")
+    assert s2.spam_reason in {"low_signal_details_inadequate", "length_too_short"}
+
+
+def test_clean_long_grievance():
+    long_text = (
+        "The drinking water supply in our village has been disrupted for over a month. "
+        "The hand pump installed last year is broken and the pipeline has not been "
+        "repaired despite multiple complaints to the block office. Residents are "
+        "forced to fetch water from a distant pond. Kindly arrange urgent repair."
+    )
+    s = score_spam(long_text)
+    assert s.spam_reason == "clean"
+    assert s.spam_score < 0.5
+    assert 0.0 <= s.spam_score <= 1.0
+
+
+def test_duplicate_family_never_scored_as_spam():
+    # Legitimate grievance prose that happens to be a duplicate should score clean,
+    # not as spam. The scorer must not flag duplicate-like legitimate text.
+    duplicate_like = (
+        "Respected sir, the road from our village to the block headquarters has been "
+        "damaged for six months and school children face difficulty. Kindly repair it."
+    )
+    s = score_spam(duplicate_like)
+    # Must be clean / low score — never spam
+    assert s.spam_score < 0.5
+    assert s.spam_reason == "clean"
+
+
+def test_not_within_purview_never_scored_as_spam():
+    # A legitimate grievance discarded as "not within purview" is a routing
+    # failure, not spam. Its text is still legitimate and must score clean.
+    purview_like = (
+        "I applied for a central government pension scheme and my application is pending "
+        "with the central office. The state grievance cell may not have jurisdiction but "
+        "the grievance itself is well-formed and detailed."
+    )
+    s = score_spam(purview_like)
+    assert s.spam_score < 0.5
+    assert s.spam_reason == "clean"
+
+
+def test_evidence_present():
+    s = score_spam("hello world this is a test of the emergency broadcast system with enough words to be clean")
+    assert any(e.kind == "repetition_collapse" for e in s.evidence)
+    assert any(e.kind == "char_len" for e in s.evidence)
+    assert any(e.kind == "word_count" for e in s.evidence)
+
+
+def test_never_reads_grievance_raw():
+    src = pathlib.Path(spam.__file__).read_text(encoding="utf-8")
+    # Guard: scorer must never touch the raw grievance column
+    assert "complaints.grievance" not in src
+    assert "Complaint.grievance" not in src
+    assert "grievance_raw" not in src.lower()
+
+
+def test_parse_slice():
+    d, y = _parse_slice("Sambalpur/2024")
+    assert d == "Sambalpur" and y == 2024
+    # also via CLI pathtested elsewhere
+
+
+def test_is_repetition_collapsed_param():
+    text = "ordinary grievance text with enough length to be clean and not collapsed"
+    s_true = score_spam(text, is_repetition_collapsed=True)
+    s_false = score_spam(text, is_repetition_collapsed=False)
+    assert s_true.spam_reason == "repetition_collapse"
+    assert s_false.spam_reason == "clean"
+
+
+def test_spam_score_v1_version():
+    s = score_spam("clean text " * 10)
+    assert s.method == "spam-v1-bounded"

--- a/tests/test_triage_spam.py
+++ b/tests/test_triage_spam.py
@@ -1,0 +1,142 @@
+"""Triage wiring for bounded spam scorer (Unit 2b)."""
+
+from datetime import UTC, datetime
+
+from janasunani.pipeline.spam import SPAM_VERSION
+from janasunani.serving.schemas import SpamReview, TriageResult
+from janasunani.serving.triage import (
+    UnwiredTriageProvider,
+    score_spam_review,
+    unavailable_triage,
+)
+
+
+def test_assess_returns_spam_with_score():
+    provider = UnwiredTriageProvider()
+    result = provider.assess(
+        redacted_text="The village road has been broken for months and needs repair.",
+        district="Sambalpur",
+        submitted_on=datetime.now(UTC),
+    )
+    assert isinstance(result, TriageResult)
+    spam = result.spam
+    assert isinstance(spam, SpamReview)
+    assert 0.0 <= spam.spam_score <= 1.0
+    assert spam.spam_reason in {
+        "low_signal_details_inadequate",
+        "low_signal_no_grievance",
+        "repetition_collapse",
+        "length_too_short",
+        "clean",
+    }
+    assert spam.method == SPAM_VERSION
+    assert spam.evidence
+
+
+def test_assess_short_text_flagged_but_advisory():
+    provider = UnwiredTriageProvider()
+    result = provider.assess(
+        redacted_text="hi",
+        district="Sambalpur",
+        submitted_on=datetime.now(UTC),
+    )
+    # Flagged as length_too_short, decision review, but still advisory — not blocking
+    assert result.spam.spam_score >= 0.5
+    assert result.spam.decision == "review"
+    assert result.spam.reason_code == "length_too_short"
+
+
+def test_assess_clean_text_abstained():
+    provider = UnwiredTriageProvider()
+    long_text = (
+        "The drinking water hand pump in our village has been broken for two months. "
+        "We have complained to the block office but no action was taken. Kindly repair urgently."
+    )
+    result = provider.assess(
+        redacted_text=long_text,
+        district="Sambalpur",
+        submitted_on=datetime.now(UTC),
+    )
+    assert result.spam.spam_score < 0.5
+    assert result.spam.spam_reason == "clean"
+    assert result.spam.decision == "abstained"
+
+
+def test_unavailable_fallback():
+    result = unavailable_triage()
+    assert result.spam.decision == "abstained"
+    assert result.spam.reason_code == "advisory_provider_unavailable"
+    assert result.spam.spam_score == 0.0
+    assert result.spam.spam_reason == "clean"
+    assert result.spam.method == "unavailable"
+    assert result.duplicate_review.decision == "unavailable"
+
+
+def test_method_reflects_scorer_version():
+    review = score_spam_review("The village road needs repair urgently with sufficient length.")
+    assert review.method == SPAM_VERSION
+
+
+def test_score_spam_review_evidence():
+    review = score_spam_review("repeat this phrase " * 40)
+    assert review.evidence
+    assert review.evidence[0].kind == "repetition_collapse"
+    assert review.spam_score is not None
+
+
+def test_triage_never_blocks_on_exception(monkeypatch):
+    # Simulate scorer raising; should fall back to unavailable rather than raise
+    import janasunani.serving.triage as triage_mod
+
+    def failing_score(_text):
+        raise RuntimeError("scorer blew up")
+
+    monkeypatch.setattr(triage_mod, "score_spam", failing_score)
+    provider = UnwiredTriageProvider()
+    result = provider.assess(
+        redacted_text="anything",
+        district="Sambalpur",
+        submitted_on=datetime.now(UTC),
+    )
+    assert result.spam.reason_code == "advisory_provider_unavailable"
+    assert result.spam.decision == "abstained"
+
+
+def test_duplicate_prose_never_flagged_via_triage():
+    provider = UnwiredTriageProvider()
+    legit = (
+        "Respected sir, the road to our village has been damaged for months and "
+        "children cannot reach school. Please repair it on priority."
+    )
+    result = provider.assess(redacted_text=legit, district="Sambalpur", submitted_on=datetime.now(UTC))
+    assert result.spam.spam_reason == "clean"
+    assert result.spam.spam_score < 0.5
+
+
+def test_not_within_purview_prose_never_flagged_via_triage():
+    provider = UnwiredTriageProvider()
+    legit = (
+        "My application for a central scheme is pending at the central ministry. "
+        "The state cell may not have jurisdiction but the filing is detailed and legitimate."
+    )
+    result = provider.assess(redacted_text=legit, district="Sambalpur", submitted_on=datetime.now(UTC))
+    assert result.spam.spam_reason == "clean"
+    assert result.spam.spam_score < 0.5
+
+
+def test_spam_review_model_valid():
+    review = score_spam_review("hi")
+    # Should be valid pydantic model
+    assert review.model_dump()
+    assert 0.0 <= review.spam_score <= 1.0
+
+
+def test_ppv_reported_over_synthetic_lake(tmp_path):
+    # PPV harness should run without error even on missing lake (reported not gated)
+    from janasunani.evaluation.spam_scorecard import compute_ppv
+
+    result = compute_ppv(tmp_path, "Sambalpur", 2024)
+    # Missing lake -> total 0 but keys present, ppv None is allowed
+    assert "ppv_holdout" in result
+    assert "false_positive_rate_holdout" in result
+    assert "slice" in result


### PR DESCRIPTION
Unit 2b — Spam signal scorer (bounded).

- pipeline/spam.py: bounded score_spam(redacted_text, is_repetition_collapsed) using only redacted_text + len (repetition 0.92, length <20 0.85, no-grievance lexicon, etc.), emits spam_score in [0,1] + spam_reason in 5-value set with evidence, never reads raw grievance, never scores duplicate/not-within-purview as spam, advisory only.
- serving/triage.py: wire score_spam_review, unavailable fallback, TriageResult.spam carries score.
- evaluation/spam_scorecard.py: prevalence + PPV harness.
- tests/test_spam_scorer.py + test_triage_spam.py: bounded, repetition, length, low_signal, duplicate never spam, etc. + pyproject console script janasunani-spam-score.

Verification: ruff 0, pytest 40+ cases green in worktree (import-light).

Refs #74, #50
