### PR TITLE
feat(sarvam): paired Vision-vs-pytesseract + categorizer scorecard with egress control (Unit 5)

### DIFF
--- a/janasunani/config.py
+++ b/janasunani/config.py
@@ -149,6 +149,15 @@ class Settings(BaseSettings):
         "SARVAM_API_SUBSCRIPTION_KEY"
     )
 
+    # Tier declaration for the single authorized-external egress route.
+    # The hosted Sarvam endpoint is the only third-party destination that may
+    # receive citizen document bytes, per the GoO-Sarvam MoU + ACS Vishal Dev
+    # sign-off. Value is the trust_tier recorded alongside the route
+    # declaration in janasunani/egress/sarvam.py (PROVIDER_REGISTRY) and is
+    # asserted by tests/test_egress_boundary.py — keep the two in sync.
+    SARVAM_TRUST_TIER: str = "authorized-external"
+    SARVAM_AUTHORIZATION_REFERENCE: str = "GoO-Sarvam MoU; ACS Vishal Dev (IT) sign-off"
+
     model_config = SettingsConfigDict(env_file=ROOT_DIR / ".env", extra="ignore")
 
     @field_validator("DEBUG", mode="before")

--- a/janasunani/egress/sarvam.py
+++ b/janasunani/egress/sarvam.py
@@ -593,6 +593,220 @@ class SarvamVisionAdapter:
             )
             return DigitiseOutcome(text=fallback(), ocr_model="pytesseract")
 
+    # ------------------------------------------------------------------
+    # Transliteration probe — romanized Odia ↔ Odia script (Phase 17)
+    # ------------------------------------------------------------------
+    # Sarvam's transliteration surface is a synchronous text API (Roman ↔
+    # native script, bidirectional, Odia is od-IN, 1 000 chars per
+    # request) — distinct from the async Vision job API above. It is still
+    # authorized-external (same MoU, same audit log, same kill switch), and
+    # is the probe that lets romanized-Odia grievances be hashed/indexed in
+    # the same script as native Odia. The chunking and per-chunk audit
+    # follow the provider's documented limit; the fallback is identity
+    # (dpic-infra IndicXlit would be the production counterpart, but
+    # returning the original text keeps the contract fallback-safe).
+    TRANSLITERATION_MAX_CHARS = 1000
+
+    def transliterate(
+        self,
+        text: str,
+        source_language_code: str,
+        target_language_code: str,
+        context: SarvamAuditContext,
+    ) -> str:
+        """Transliterate via Sarvam text API with chunking at 1000 chars.
+
+        One audit row per chunk. Raises SarvamDisabled / SarvamGovernanceError
+        / SarvamError like the Vision path; callers that need a fallback
+        should use transliterate_or_fallback.
+        """
+        if not self.enabled:
+            raise SarvamDisabled("Sarvam hosted egress is disabled")
+        if not self.route.egress_permitted:
+            controls = ", ".join(self.route.unverified_controls)
+            raise SarvamGovernanceError(
+                f"Sarvam hosted egress is gated by unverified controls: {controls}"
+            )
+        if not self.api_key:
+            raise SarvamError(
+                "SARVAM_API_KEY is required when Sarvam is enabled "
+                "(SARVAM_API_SUBSCRIPTION_KEY is accepted for compatibility)"
+            )
+        if not text:
+            return ""
+        # Chunk at the provider's documented limit — Indic→Indic is not
+        # supported, so callers must ensure source/target are valid.
+        chunks = [
+            text[i : i + self.TRANSLITERATION_MAX_CHARS]
+            for i in range(0, len(text), self.TRANSLITERATION_MAX_CHARS)
+        ]
+        results: list[str] = []
+        for idx, chunk in enumerate(chunks):
+            # Idempotency key per chunk: same derivation as Vision, but with
+            # the transliteration form (+ chunk index for chunking stability).
+            form: dict[str, Any] = {
+                "input": chunk,
+                "source_language_code": source_language_code,
+                "target_language_code": target_language_code,
+                "chunk_index": idx,
+                "chunk_count": len(chunks),
+            }
+            idempotency_key = self._idempotency_key(
+                context,
+                "transliterate",
+                chunk.encode("utf-8"),
+                filename=f"transliterate-chunk-{idx}",
+                form=form,
+            )
+            chunk_bytes = len(chunk.encode("utf-8"))
+            payload = self._post_transliterate(
+                chunk=chunk,
+                source_language_code=source_language_code,
+                target_language_code=target_language_code,
+                context=context,
+                idempotency_key=idempotency_key,
+                bytes_sent=chunk_bytes,
+            )
+            # Sarvam returns {"transliterated_text": "..."} or {"output": "..."}
+            transliterated = (
+                payload.get("transliterated_text")
+                or payload.get("output")
+                or payload.get("text")
+                or ""
+            )
+            if not isinstance(transliterated, str):
+                raise SarvamError("Sarvam transliteration response missing text")
+            results.append(transliterated)
+        return "".join(results)
+
+    def transliterate_or_fallback(
+        self,
+        text: str,
+        source_language_code: str,
+        target_language_code: str,
+        context: SarvamAuditContext,
+        fallback: Callable[[str], str],
+    ) -> str:
+        """Transliterate if enabled, else return fallback (dpic-infra).
+
+        Disabled path logs one audit row (bytes 0, event disabled) and
+        returns fallback(text) without any network call. Enabled path that
+        raises logs fallback and returns fallback(text). The fallback is the
+        kill-switch contract: every authorized-external call has a
+        maintained dpic-infra counterpart.
+        """
+        # Use a single idempotency key for the disabled audit — consistent
+        # with digitise_or_fallback's single audit row for disabled.
+        form: dict[str, Any] = {
+            "input": text[: self.TRANSLITERATION_MAX_CHARS],
+            "source_language_code": source_language_code,
+            "target_language_code": target_language_code,
+            "chunk_index": 0,
+            "chunk_count": 1,
+        }
+        # For disabled we don't need chunk-accurate bytes; 0 signals no egress.
+        idempotency_key = self._idempotency_key(
+            context,
+            "transliterate",
+            text.encode("utf-8"),
+            filename="transliterate",
+            form=form,
+        )
+        if not self.enabled:
+            self._audit(
+                context,
+                "transliterate",
+                "disabled",
+                target_language_code,
+                0,
+                None,
+                {},
+                idempotency_key,
+            )
+            return fallback(text)
+        try:
+            return self.transliterate(
+                text, source_language_code, target_language_code, context
+            )
+        except SarvamError as exc:
+            self._audit(
+                context,
+                "transliterate",
+                "fallback",
+                target_language_code,
+                0,
+                None,
+                {"reason": type(exc).__name__},
+                idempotency_key,
+            )
+            return fallback(text)
+
+    def _post_transliterate(
+        self,
+        *,
+        chunk: str,
+        source_language_code: str,
+        target_language_code: str,
+        context: SarvamAuditContext,
+        idempotency_key: str,
+        bytes_sent: int,
+    ) -> dict[str, Any]:
+        self._wait_for_submission_slot()
+        try:
+            response = self._transport().post(
+                f"{self.route.endpoint}/transliterate",
+                headers={
+                    "api-subscription-key": self.api_key,
+                    "Idempotency-Key": idempotency_key,
+                },
+                json={
+                    "input": chunk,
+                    "source_language_code": source_language_code,
+                    "target_language_code": target_language_code,
+                },
+            )
+        except Exception as exc:
+            self._audit(
+                context,
+                "transliterate",
+                "transliterate_error",
+                target_language_code,
+                bytes_sent,
+                None,
+                {"error": type(exc).__name__},
+                idempotency_key,
+            )
+            if isinstance(exc, SarvamError):
+                raise
+            raise SarvamError("Sarvam transliterate request failed") from exc
+        try:
+            payload = self._json_response(response, "transliterate")
+        except Exception as exc:
+            self._audit(
+                context,
+                "transliterate",
+                "transliterate_error",
+                target_language_code,
+                bytes_sent,
+                None,
+                {"error": type(exc).__name__},
+                idempotency_key,
+            )
+            if isinstance(exc, SarvamError):
+                raise
+            raise SarvamError("Sarvam transliterate request failed") from exc
+        self._audit(
+            context,
+            "transliterate",
+            "transliterate",
+            target_language_code,
+            bytes_sent,
+            None,
+            self._response_metadata(payload, response.status_code),
+            idempotency_key,
+        )
+        return payload
+
     def _run_job(
         self,
         *,

--- a/janasunani/evaluation/sarvam_scorecard.py
+++ b/janasunani/evaluation/sarvam_scorecard.py
@@ -37,6 +37,7 @@ recorded Sarvam markdown fixtures; no live network call is made.
 from __future__ import annotations
 
 import math
+import random
 import re
 import unicodedata
 from collections import defaultdict
@@ -44,7 +45,19 @@ from dataclasses import asdict, dataclass
 from statistics import NormalDist
 from typing import Any
 
+from janasunani.config import DEMO_SLICE_DISTRICT, DEMO_SLICE_LABEL, DEMO_SLICE_YEAR
+
 NORMALIZER_VERSION = "1.0"
+
+# Benchmark sampling — few hundred pages from Sambalpur/2024 slice,
+# stratified handwritten/printed per #127/#84. Cost at 50p/page digitise
+# is few-hundred rupees; size is powered for ~10-point category gaps.
+BENCHMARK_SAMPLE_SIZE = 300
+BENCHMARK_MIN_SAMPLE = 200
+BENCHMARK_MAX_SAMPLE = 400
+# Deterministic seed so the same Sambalpur/2024 slice sample is reproducible
+# across runs; the stratification, not the randomness, is the control.
+BENCHMARK_SAMPLE_SEED = 42
 
 # ---------------------------------------------------------------------------
 # Normaliser — frozen before output is read
@@ -294,6 +307,219 @@ def required_pages_mcnemar(gap: float, discordance: float, alpha: float = 0.05, 
 
 
 # ---------------------------------------------------------------------------
+# Sampling — stratified few-hundred-page sample from Sambalpur/2024 (few hundred)
+# ---------------------------------------------------------------------------
+
+def stratified_sample(
+    pages: list[PageRecord],
+    n: int = BENCHMARK_SAMPLE_SIZE,
+    seed: int = BENCHMARK_SAMPLE_SEED,
+) -> list[PageRecord]:
+    """Stratified sample of *n* pages, balanced handwritten vs printed.
+
+    The Sambalpur/2024 slice is the demo source; its handwritten share is
+    not 50/50 in the wild, but a braided sample ensures both surfaces are
+    reportable separately (per #84). The implementation is deterministic
+    (seeded) so the same slice produces the same audit-cost sample across
+    runs.
+
+    Stratification key is PageRecord.handwritten_bucket(). Buckets with no
+    members are omitted; allocation is proportional to bucket size, with at
+    least one per present bucket when n permits. Within each bucket the
+    selection is a seeded shuffle. If n >= len(pages), returns a shuffled
+    copy.
+
+    Few-hundred-page invariant: callers should use 200–400; the function
+    accepts any positive n but the report flags compliance separately.
+    """
+    if n <= 0:
+        raise ValueError("n must be positive")
+    if not pages:
+        return []
+    if n >= len(pages):
+        rng = random.Random(seed)
+        shuffled = list(pages)
+        rng.shuffle(shuffled)
+        return shuffled
+    # bucket by handwritten status
+    buckets: dict[str, list[PageRecord]] = defaultdict(list)
+    for p in pages:
+        buckets[p.handwritten_bucket()].append(p)
+    # proportional allocation
+    total = len(pages)
+    # initial proportional floor
+    allocation: dict[str, int] = {}
+    remaining = n
+    # sort buckets by size descending for stable allocation of remainders
+    sorted_buckets = sorted(buckets.items(), key=lambda kv: len(kv[1]), reverse=True)
+    for bucket_name, members in sorted_buckets:
+        # at least 1 per present bucket when possible
+        prop = len(members) / total
+        count = max(1, int(round(prop * n))) if n >= len(buckets) else int(round(prop * n))
+        # clamp to bucket size and remaining
+        count = min(count, len(members), remaining - (len(sorted_buckets) - len(allocation) - 1))
+        # ensure at least 1 if possible
+        if count < 1 and len(members) > 0 and remaining > 0:
+            count = 1
+        allocation[bucket_name] = count
+        remaining -= count
+    # adjust for rounding drift
+    # if we overshot or undershot due to rounding, fix by moving 1s
+    while remaining != 0 and allocation:
+        # find bucket that can give or take
+        if remaining > 0:
+            # give to largest bucket that still has headroom
+            for bucket_name, members in sorted_buckets:
+                if allocation[bucket_name] < len(members):
+                    allocation[bucket_name] += 1
+                    remaining -= 1
+                    if remaining == 0:
+                        break
+            if remaining > 0:
+                break  # no headroom
+        else:
+            # remaining < 0 : take from largest allocation
+            for bucket_name, _ in sorted(sorted_buckets, key=lambda kv: allocation[kv[0]], reverse=True):
+                if allocation[bucket_name] > 1:
+                    allocation[bucket_name] -= 1
+                    remaining += 1
+                    if remaining == 0:
+                        break
+            if remaining < 0:
+                break
+    rng = random.Random(seed)
+    sampled: list[PageRecord] = []
+    for bucket_name, members in buckets.items():
+        count = allocation.get(bucket_name, 0)
+        if count <= 0:
+            continue
+        shuffled = list(members)
+        rng.shuffle(shuffled)
+        sampled.extend(shuffled[:count])
+    # final shuffle so output is not bucket-grouped
+    rng.shuffle(sampled)
+    return sampled
+
+
+def sample_compliance(n_pages: int) -> dict[str, Any]:
+    """Whether the sample size is the intended few hundred (200–400)."""
+    return {
+        "n_pages": n_pages,
+        "is_few_hundred": BENCHMARK_MIN_SAMPLE <= n_pages <= BENCHMARK_MAX_SAMPLE,
+        "recommended": BENCHMARK_SAMPLE_SIZE,
+        "min": BENCHMARK_MIN_SAMPLE,
+        "max": BENCHMARK_MAX_SAMPLE,
+        "slice": DEMO_SLICE_LABEL,
+        "slice_district": DEMO_SLICE_DISTRICT,
+        "slice_year": DEMO_SLICE_YEAR,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Per-category accuracy — the spread that headlines hide
+# ---------------------------------------------------------------------------
+
+def per_category_table(pages: list[PageRecord]) -> dict[str, dict[str, Any]]:
+    """Per-category accuracy for pipeline vs Sarvam, grouped by gold label.
+
+    One row per gold_category value (e.g. Police 0.85 vs Welfare 0.51).
+    De-duplicated by ticket like the headline metric (one category per
+    ticket). Tickets without a gold label are omitted.
+
+    Returns mapping category -> {n_tickets, pipeline_accuracy,
+    sarvam_accuracy, pipeline_correct, sarvam_correct, difference}.
+    """
+    ticket_gold: dict[str, str | None] = {}
+    ticket_pipe: dict[str, str | None] = {}
+    ticket_sarvam: dict[str, str | None] = {}
+    for p in pages:
+        for d, val in [
+            (ticket_gold, p.gold_category),
+            (ticket_pipe, p.pipeline_category),
+            (ticket_sarvam, p.sarvam_category),
+        ]:
+            if p.ticket not in d:
+                d[p.ticket] = val
+            elif d[p.ticket] is None and val is not None:
+                d[p.ticket] = val
+    # group tickets by gold category
+    groups: dict[str, list[str]] = defaultdict(list)
+    for ticket, gold in ticket_gold.items():
+        if gold is not None:
+            groups[gold].append(ticket)
+    out: dict[str, dict[str, Any]] = {}
+    for category in sorted(groups):
+        tickets = groups[category]
+        pipe_correct = [1 if ticket_pipe.get(t) == category else 0 for t in tickets]
+        sarv_correct = [1 if ticket_sarvam.get(t) == category else 0 for t in tickets]
+        pipe_acc = sum(pipe_correct) / len(pipe_correct) if pipe_correct else 0.0
+        sarv_acc = sum(sarv_correct) / len(sarv_correct) if sarv_correct else 0.0
+        out[category] = {
+            "n_tickets": len(tickets),
+            "pipeline_correct": sum(pipe_correct),
+            "sarvam_correct": sum(sarv_correct),
+            "pipeline_accuracy": pipe_acc,
+            "sarvam_accuracy": sarv_acc,
+            "difference": sarv_acc - pipe_acc,
+        }
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Transliteration probe — romanized Odia if present (Phase 17 → Phase 21)
+# ---------------------------------------------------------------------------
+
+_ODIA_SCRIPT_RE = re.compile(r"[\u0B00-\u0B7F]")
+
+def is_romanized_odia_candidate(page: PageRecord) -> bool:
+    """Heuristic for a page that is Odia content in Latin script.
+
+    True when the page's language signals Odia but its text has Latin
+    without Odia script — i.e. romanized Odia that transliteration would
+    need to normalize before hashing/embedding. English pages are not
+    candidates; only Odia-language pages rendered in Latin.
+    """
+    lang = (page.language or "").lower()
+    is_odia_lang = "odia" in lang or "oriya" in lang or "od-in" in lang
+    if not is_odia_lang:
+        return False
+    text = page.pytesseract_text or page.sarvam_markdown or ""
+    if not text.strip():
+        return False
+    has_latin = bool(re.search(r"[A-Za-z]", text))
+    has_odia = bool(_ODIA_SCRIPT_RE.search(text))
+    # romanized = Odia language but latin script, no native script
+    return has_latin and not has_odia
+
+
+def transliteration_probe(pages: list[PageRecord]) -> dict[str, Any]:
+    """Probe for romanized Odia presence and the action it triggers.
+
+    If any page is a romanized-Odia candidate, the report notes that a
+    Sarvam transliteration probe (od-IN, 1000 chars/chunk) would be the
+    next step; otherwise it is not applicable. No network call is made
+    here — the probe is a corpus-conditional recommendation, and the actual
+    transliteration goes through janasunani/egress/sarvam.py with its audit
+    log and kill switch.
+    """
+    romanized = [p for p in pages if is_romanized_odia_candidate(p)]
+    return {
+        "n_total": len(pages),
+        "n_romanized_candidates": len(romanized),
+        "probe_applicable": len(romanized) > 0,
+        "romanized_ticket_ids": [p.ticket for p in romanized[:5]],
+        "note": (
+            "If romanized Odia present, run Sarvam transliteration "
+            "(source en-IN, target od-IN, 1000 chars/chunk) via "
+            "janasunani/egress/sarvam.py (authorized-external, audit-logged, "
+            "kill-switch to dpic-infra IndicXlit) before hashing/embedding."
+            if romanized
+            else "No romanized Odia detected in this sample; transliteration probe not applicable."
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
 # Scorecard assembly
 # ---------------------------------------------------------------------------
 
@@ -321,6 +547,12 @@ class ScorecardReport:
     by_handwritten: dict[str, dict[str, Any]]
     by_language: dict[str, dict[str, Any]]
     notes: str
+    # Phase 17 extensions — per-category spread, transliteration probe,
+    # and sample compliance (few-hundred, stratified from Sambalpur/2024).
+    # Optional with defaults so existing callers stay green.
+    per_category: dict[str, Any] | None = None
+    transliteration_probe_result: dict[str, Any] | None = None
+    sample_info: dict[str, Any] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -471,6 +703,43 @@ def build_scorecard(pages: list[PageRecord]) -> ScorecardReport:
             "Transcription cannot be produced by an agent because it is the ground truth "
             "an agent would be measured against."
         )
+    # Phase 17 extensions
+    per_cat = per_category_table(pages)
+    trans_probe = transliteration_probe(pages)
+    samp_info = sample_compliance(n_pages)
+    # augment notes with per-category spread headline if available
+    if per_cat:
+        # headline spread like Police 0.85 vs Welfare 0.51 — report in notes for discoverability
+        best = max(per_cat.items(), key=lambda kv: kv[1]["sarvam_accuracy"])
+        worst = min(per_cat.items(), key=lambda kv: kv[1]["sarvam_accuracy"])
+        notes_parts.append(
+            f"Per-category spread: {best[0]} {best[1]['sarvam_accuracy']:.2f} vs "
+            f"{worst[0]} {worst[1]['sarvam_accuracy']:.2f} (Sarvam) — "
+            "headline accuracy hides this; see per_category table."
+        )
+    if trans_probe["probe_applicable"]:
+        notes_parts.append(
+            f"Romanized Odia probe applicable: {trans_probe['n_romanized_candidates']}/"
+            f"{trans_probe['n_total']} pages are romanized Odia candidates; "
+            "Sarvam transliteration (od-IN, 1000 chars/chunk) via "
+            "janasunani/egress/sarvam.py is the next step before hashing/embedding."
+        )
+    # few-hundred compliance note
+    if not samp_info["is_few_hundred"]:
+        notes_parts.append(
+            f"Sample size {n_pages} is outside the intended few-hundred "
+            f"({BENCHMARK_MIN_SAMPLE}–{BENCHMARK_MAX_SAMPLE}) window for the "
+            f"{DEMO_SLICE_LABEL} stratified benchmark; "
+            "cost and power are calibrated for 200–400 at 10 req/min Vision."
+        )
+    else:
+        notes_parts.append(
+            f"Sample size {n_pages} is within the few-hundred "
+            f"({BENCHMARK_MIN_SAMPLE}–{BENCHMARK_MAX_SAMPLE}) benchmark window for "
+            f"{DEMO_SLICE_LABEL} (stratified handwritten/printed); "
+            "Vision divergence reported per-surface with no accuracy verdict "
+            "(no transcription ground truth)."
+        )
     notes = " ".join(notes_parts)
 
     return ScorecardReport(
@@ -487,4 +756,7 @@ def build_scorecard(pages: list[PageRecord]) -> ScorecardReport:
         by_handwritten=by_handwritten,
         by_language=by_language,
         notes=notes,
+        per_category=per_cat if per_cat else None,
+        transliteration_probe_result=trans_probe,
+        sample_info=samp_info,
     )

--- a/tests/test_egress_boundary.py
+++ b/tests/test_egress_boundary.py
@@ -15,6 +15,7 @@ editing the allowlist below in the same diff.
 from __future__ import annotations
 
 import ast
+import pathlib
 from pathlib import Path
 
 PACKAGE = Path(__file__).resolve().parent.parent / "janasunani"
@@ -91,3 +92,209 @@ def test_the_provider_endpoint_is_only_named_in_egress():
     assert offenders == [], (
         f"the Sarvam endpoint is referenced outside egress/: {offenders}"
     )
+
+
+def test_sarvam_route_declares_authorized_external_tier():
+    """Every authorized-external route must declare its tier explicitly."""
+    from janasunani.egress.sarvam import PROVIDER_REGISTRY
+
+    route = PROVIDER_REGISTRY["sarvam-vision"]
+    assert route.trust_tier == "authorized-external"
+    assert route.fallback == "pytesseract"
+    # fallback is a maintained dpic-infra counterpart
+    assert route.provider == "sarvam-hosted"
+
+
+def test_sarvam_route_records_authorization_ref_and_retention_encryption_audit():
+    """Authorization ref (GoO MoU + Vishal Dev sign-off), retention, encryption, audit."""
+    from janasunani.egress.sarvam import AUTHORIZATION_REFERENCE, PROVIDER_REGISTRY
+
+    route = PROVIDER_REGISTRY["sarvam-vision"]
+    assert "MoU" in route.authorization_reference
+    assert "Vishal Dev" in route.authorization_reference
+    assert AUTHORIZATION_REFERENCE in route.authorization_reference
+    # retention and encryption controls must be declared (even if unverified)
+    assert route.retention_terms.statement.strip() != ""
+    assert route.encryption_in_transit.statement.strip() != ""
+    assert route.encryption_at_rest.statement.strip() != ""
+    assert route.audit_policy.strip() != ""
+    assert route.data_class.strip() != ""
+
+
+def test_sarvam_settings_tier_declaration_matches_registry():
+    """Settings centralizes the key and declares the tier (config.py)."""
+    from janasunani.config import Settings
+    from janasunani.egress.sarvam import PROVIDER_REGISTRY, TRUST_TIER
+
+    settings = Settings()
+    # Settings declares the tier — keeps config and registry in sync
+    assert settings.SARVAM_TRUST_TIER == "authorized-external"
+    assert settings.SARVAM_TRUST_TIER == TRUST_TIER
+    assert settings.SARVAM_TRUST_TIER == PROVIDER_REGISTRY["sarvam-vision"].trust_tier
+    assert "MoU" in settings.SARVAM_AUTHORIZATION_REFERENCE
+    assert "Vishal Dev" in settings.SARVAM_AUTHORIZATION_REFERENCE
+
+
+def test_sarvam_api_key_only_in_config_and_egress():
+    """SARVAM_API_KEY must not be hardcoded or referenced outside config/egress."""
+    package = pathlib.Path(__file__).resolve().parent.parent / "janasunani"
+    offenders = []
+    for p in package.rglob("*.py"):
+        if "__pycache__" in p.parts:
+            continue
+        rel = p.relative_to(package).as_posix()
+        if rel in ("config.py", "egress/sarvam.py"):
+            continue
+        text = p.read_text(encoding="utf-8")
+        if "SARVAM_API_KEY" in text or "SARVAM_API_SUBSCRIPTION_KEY" in text:
+            offenders.append(rel)
+    assert offenders == [], f"SARVAM_API_KEY referenced outside config/egress: {offenders}"
+    # also ensure no hardcoded key literal (heuristic: 30+ char alphanum near sarvam)
+    # We don't check literals here; the centralization above is the control.
+
+
+def test_kill_switch_falls_back_to_dpic_infra_and_audit_logs():
+    """Kill switch (enabled=False) never calls remote transport and logs disabled."""
+    import tempfile
+    from pathlib import Path as _Path
+
+    from janasunani.egress.sarvam import SarvamAuditContext, SarvamVisionAdapter, SqliteAuditLog
+
+    with tempfile.TemporaryDirectory() as tmp:
+        audit_path = _Path(tmp) / "audit.sqlite"
+
+        class NoCallTransport:
+            def post(self, *a, **kw):
+                raise AssertionError("kill switch must not call transport")
+            def get(self, *a, **kw):
+                raise AssertionError("kill switch must not call transport")
+
+        adapter = SarvamVisionAdapter(
+            enabled=False,
+            audit_log=SqliteAuditLog(audit_path),
+            transport=NoCallTransport(),
+        )
+        ctx = SarvamAuditContext(ticket="T-1", stage="ocr_extraction", document_id="doc:1")
+        outcome = adapter.digitise_or_fallback(b"bytes", "page.png", "od-IN", ctx, lambda: "fallback-text")
+        assert outcome.text == "fallback-text"
+        assert outcome.ocr_model == "pytesseract"
+        # audit row for disabled
+        import sqlite3
+        rows = list(sqlite3.connect(audit_path).execute("SELECT event, bytes_sent FROM authorized_external_audit"))
+        assert any(r[0] == "disabled" for r in rows)
+        assert all(r[1] == 0 for r in rows if r[0] == "disabled")
+
+
+def test_transliteration_also_via_egress_and_kill_switch():
+    """Transliteration probe also goes through the single egress module and kill switch."""
+    import tempfile
+    from pathlib import Path as _Path
+
+    from janasunani.egress.sarvam import SarvamAuditContext, SarvamVisionAdapter, SqliteAuditLog
+
+    with tempfile.TemporaryDirectory() as tmp:
+        audit_path = _Path(tmp) / "audit.sqlite"
+
+        class NoCallTransport:
+            def post(self, *a, **kw):
+                raise AssertionError("kill switch must not call transport for transliteration")
+            def get(self, *a, **kw):
+                raise AssertionError("kill switch must not call transport for transliteration")
+
+        adapter = SarvamVisionAdapter(
+            enabled=False,
+            audit_log=SqliteAuditLog(audit_path),
+            transport=NoCallTransport(),
+        )
+        ctx = SarvamAuditContext(ticket="T-2", stage="transliteration_probe", document_id="doc:2")
+        result = adapter.transliterate_or_fallback("mu ghara", "en-IN", "od-IN", ctx, lambda x: x.upper())
+        assert result == "MU GHARA"
+        import sqlite3
+        rows = list(sqlite3.connect(audit_path).execute("SELECT operation, event FROM authorized_external_audit"))
+        assert any(op == "transliterate" and ev == "disabled" for op, ev in rows)
+
+
+def test_audit_log_row_per_call_contains_required_fields():
+    """Every Sarvam call must create an audit row with ticket, stage, provider, model, bytes, etc."""
+    import tempfile
+    import sqlite3
+    from pathlib import Path as _Path
+
+    from janasunani.egress.sarvam import SarvamAuditContext, SarvamVisionAdapter, SqliteAuditLog
+
+    # use a recorded transport that succeeds for transliteration
+    class RecordedTransliterate:
+        def post(self, url, **kwargs):
+            assert "transliterate" in url
+            class R:
+                status_code = 200
+                def json(self_inner):
+                    return {"transliterated_text": "translated"}
+                headers = {}
+            return R()
+        def get(self, *a, **kw):
+            raise AssertionError
+
+
+    # Use a verified route so governance doesn't block
+    from janasunani.egress.sarvam import GovernanceControl, PROVIDER_REGISTRY
+    from dataclasses import replace
+
+    control = GovernanceControl(statement="verified test", verified=True)
+    route = replace(PROVIDER_REGISTRY["sarvam-vision"], retention_terms=control, encryption_in_transit=control, encryption_at_rest=control)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        audit_path = _Path(tmp) / "audit.sqlite"
+        adapter = SarvamVisionAdapter(
+            enabled=True,
+            api_key="test-key",
+            audit_log=SqliteAuditLog(audit_path),
+            route=route,
+            transport=RecordedTransliterate(),
+            poll_interval_seconds=0,
+        )
+        ctx = SarvamAuditContext(ticket="T-AUDIT", stage="test", document_id="doc:audit")
+        # One transliteration call should create at least one audit row with required columns
+        adapter.transliterate("hello world", "en-IN", "od-IN", ctx)
+        rows = list(sqlite3.connect(audit_path).execute(
+            "SELECT ticket, stage, provider, model_id, bytes_sent, timestamp, authorization_reference, operation FROM authorized_external_audit"
+        ))
+        assert len(rows) >= 1
+        for ticket, stage, provider, model_id, bytes_sent, timestamp, auth_ref, operation in rows:
+            assert ticket == "T-AUDIT"
+            assert stage == "test"
+            assert provider == "sarvam-hosted"
+            assert model_id != ""
+            assert bytes_sent > 0
+            assert timestamp != ""
+            assert auth_ref != ""
+            assert operation == "transliterate"
+
+
+def test_no_citizen_data_leaves_box_except_via_egress():
+    """No module outside egress should directly handle raw grievance bytes for external calls.
+
+    The check is structural: only egress/sarvam.py may carry the authorized-external
+    trust tier and the citizen PII data class. Any other module declaring such a route
+    would be a second way out.
+    """
+    from janasunani.egress.sarvam import PROVIDER_REGISTRY
+
+    for name, route in PROVIDER_REGISTRY.items():
+        assert route.trust_tier in ("same-host", "dpic-infra", "authorized-external")
+        if route.trust_tier == "authorized-external":
+            assert route.data_class != ""
+            assert "PII" in route.data_class or "citizen" in route.data_class.lower()
+            assert route.fallback.strip() != ""
+
+    # Ensure only egress defines such a registry
+    import pathlib
+    package = pathlib.Path(__file__).resolve().parent.parent / "janasunani"
+    offenders = []
+    for p in package.rglob("*.py"):
+        if p.relative_to(package).parts[0] == "egress":
+            continue
+        text = p.read_text(encoding="utf-8")
+        if "authorized-external" in text and "PROVIDER_REGISTRY = {" in text:
+            offenders.append(p.relative_to(package).as_posix())
+    assert offenders == [], f"authorized-external registry outside egress/: {offenders}"

--- a/tests/test_sarvam_scorecard.py
+++ b/tests/test_sarvam_scorecard.py
@@ -157,3 +157,248 @@ def test_required_pages_mcnemar_honours_alpha_and_power():
             required_pages_mcnemar(0.10, 0.25, alpha=bad)
         with pytest.raises(ValueError):
             required_pages_mcnemar(0.10, 0.25, power=bad)
+
+
+def test_stratified_sample_few_hundred_and_handwritten_printed_split():
+    """Few-hundred-page sample must be stratified handwritten/printed."""
+    from janasunani.evaluation.sarvam_scorecard import (
+        BENCHMARK_SAMPLE_SIZE,
+        BENCHMARK_MIN_SAMPLE,
+        BENCHMARK_MAX_SAMPLE,
+        PageRecord,
+        stratified_sample,
+        sample_compliance,
+    )
+
+    # Build a synthetic Sambalpur/2024-like pool: 60% printed, 40% handwritten
+    pages = []
+    for i in range(300):
+        handwritten = "yes" if i % 5 < 2 else "no"  # 40% handwritten
+        pages.append(PageRecord(ticket=f"T{i}", page_id=f"P{i}", handwritten=handwritten, language="Odia", pytesseract_text="a", sarvam_markdown="a"))
+
+    sampled = stratified_sample(pages, n=250, seed=42)
+    assert len(sampled) == 250
+    # stratified: both buckets present
+    buckets = {"handwritten": 0, "printed": 0}
+    for p in sampled:
+        buckets[p.handwritten_bucket()] += 1
+    assert buckets["handwritten"] > 0
+    assert buckets["printed"] > 0
+    # few-hundred compliance
+    comp = sample_compliance(len(sampled))
+    assert comp["is_few_hundred"] is True
+    assert comp["slice"] == "Sambalpur/2024"
+    assert BENCHMARK_MIN_SAMPLE <= BENCHMARK_SAMPLE_SIZE <= BENCHMARK_MAX_SAMPLE
+    # deterministic: same seed same result
+    sampled2 = stratified_sample(pages, n=250, seed=42)
+    assert [p.page_id for p in sampled] == [p.page_id for p in sampled2]
+    # different seed may differ (not required but smoke)
+    sampled3 = stratified_sample(pages, n=250, seed=99)
+    assert len(sampled3) == 250
+
+
+def test_per_category_table_reports_spread():
+    """Per-category accuracy must report the police 0.85 vs welfare 0.51 style spread."""
+    from janasunani.evaluation.sarvam_scorecard import PageRecord, per_category_table, build_scorecard
+
+    # Simulate police high accuracy, welfare low — the pattern in DELIVERY
+    pages = []
+    # Police: 20 tickets, pipeline 0.85 (17/20), sarvam 0.90 (18/20)
+    for i in range(20):
+        gold = "Police"
+        pipe = "Police" if i < 17 else "Revenue"
+        sarv = "Police" if i < 18 else "Revenue"
+        pages.append(PageRecord(ticket=f"POL{i}", page_id=f"POL{i}P1", gold_category=gold, pipeline_category=pipe, sarvam_category=sarv))
+
+    # Welfare: 20 tickets, pipeline 0.51 ~(10/20), sarvam 0.55 (11/20)
+    for i in range(20):
+        gold = "Social Welfare"
+        pipe = "Social Welfare" if i < 10 else "Revenue"
+        sarv = "Social Welfare" if i < 11 else "Revenue"
+        pages.append(PageRecord(ticket=f"WEL{i}", page_id=f"WEL{i}P1", gold_category=gold, pipeline_category=pipe, sarvam_category=sarv))
+
+    table = per_category_table(pages)
+    assert "Police" in table
+    assert "Social Welfare" in table
+    assert table["Police"]["n_tickets"] == 20
+    assert table["Social Welfare"]["n_tickets"] == 20
+    # police higher than welfare
+    assert table["Police"]["pipeline_accuracy"] > table["Social Welfare"]["pipeline_accuracy"]
+    assert table["Police"]["sarvam_accuracy"] > table["Social Welfare"]["sarvam_accuracy"]
+    # headline spread visible
+    assert abs(table["Police"]["pipeline_accuracy"] - 0.85) < 0.01
+    assert abs(table["Social Welfare"]["pipeline_accuracy"] - 0.50) < 0.01
+
+    # build_scorecard includes per_category
+    report = build_scorecard(pages)
+    assert report.per_category is not None
+    assert "Police" in report.per_category
+    assert "Social Welfare" in report.per_category
+    assert report.sample_info is not None
+    assert report.sample_info["slice"] == "Sambalpur/2024"
+
+
+def test_transliteration_probe_on_romanized_odia_if_present():
+    """Probe must detect romanized Odia and report probe_applicable; no network call."""
+    from janasunani.evaluation.sarvam_scorecard import PageRecord, transliteration_probe, is_romanized_odia_candidate, build_scorecard
+
+    # Romanized Odia: language Odia but text is Latin without Odia script
+    roman_page = PageRecord(ticket="T-ROM", page_id="P-ROM", language="Odia", handwritten="no", pytesseract_text="mu ghara samasya achi", sarvam_markdown="mu ghara samasya achi")
+    odia_script_page = PageRecord(ticket="T-OD", page_id="P-OD", language="Odia", handwritten="no", pytesseract_text="ମୁ ଘର ସମସ୍ୟା", sarvam_markdown="ମୁ ଘର ସମସ୍ୟା")
+    english_page = PageRecord(ticket="T-EN", page_id="P-EN", language="English", handwritten="no", pytesseract_text="my house problem", sarvam_markdown="my house problem")
+
+    assert is_romanized_odia_candidate(roman_page) is True
+    assert is_romanized_odia_candidate(odia_script_page) is False
+    assert is_romanized_odia_candidate(english_page) is False
+
+    probe = transliteration_probe([roman_page, odia_script_page, english_page])
+    assert probe["n_total"] == 3
+    assert probe["n_romanized_candidates"] == 1
+    assert probe["probe_applicable"] is True
+    assert "T-ROM" in probe["romanized_ticket_ids"]
+
+    # No romanized in sample
+    probe2 = transliteration_probe([odia_script_page, english_page])
+    assert probe2["probe_applicable"] is False
+    assert probe2["n_romanized_candidates"] == 0
+
+    # build_scorecard includes probe
+    report = build_scorecard([roman_page, odia_script_page])
+    assert report.transliteration_probe_result is not None
+    assert report.transliteration_probe_result["probe_applicable"] is True
+
+
+def test_build_scorecard_handwritten_printed_divergence_no_accuracy_verdict():
+    """OCR divergence must be reported handwritten vs printed separately with no accuracy verdict."""
+    from janasunani.evaluation.sarvam_scorecard import PageRecord, build_scorecard
+
+    # No transcription ground truth -> divergence only, handwritten vs printed separate
+    pages = [
+        PageRecord(ticket="T1", page_id="P1", handwritten="yes", language="Odia", pytesseract_text="a", sarvam_markdown="a"),
+        PageRecord(ticket="T1", page_id="P2", handwritten="yes", language="Odia", pytesseract_text="a", sarvam_markdown="b"),
+        PageRecord(ticket="T2", page_id="P3", handwritten="no", language="Odia", pytesseract_text="same", sarvam_markdown="same"),
+        PageRecord(ticket="T2", page_id="P4", handwritten="no", language="Odia", pytesseract_text="same", sarvam_markdown="different"),
+    ]
+    report = build_scorecard(pages)
+    assert report.transcription_available is False
+    assert report.transcription_accuracy is None
+    # handwritten vs printed divergence reported separately
+    assert "handwritten" in report.by_handwritten
+    assert "printed" in report.by_handwritten
+    assert report.by_handwritten["handwritten"]["divergence"]["rate"] == 0.5
+    assert report.by_handwritten["printed"]["divergence"]["rate"] == 0.5
+    # no accuracy verdict in notes beyond divergence
+    assert "DIVERGENCE ONLY" in report.notes
+
+
+def test_audit_log_row_per_call_for_scorecard_pages():
+    """Every Sarvam Vision call for the benchmark must be audit-logged (ticket, stage, provider, bytes)."""
+    import tempfile
+    import sqlite3
+    from pathlib import Path as _Path
+    from dataclasses import replace
+
+    from janasunani.egress.sarvam import (
+        GovernanceControl,
+        PROVIDER_REGISTRY,
+        SarvamAuditContext,
+        SarvamVisionAdapter,
+        SqliteAuditLog,
+    )
+    from janasunani.evaluation.sarvam_scorecard import PageRecord
+
+    # simulate few-hundred sample: 3 pages, each will be a digitise call
+    pages = [
+        PageRecord(ticket=f"T{i}", page_id=f"P{i}", handwritten="yes" if i % 2 == 0 else "no", language="Odia", pytesseract_text="a", sarvam_markdown="a")
+        for i in range(3)
+    ]
+
+    control = GovernanceControl(statement="verified test", verified=True)
+    route = replace(PROVIDER_REGISTRY["sarvam-vision"], retention_terms=control, encryption_in_transit=control, encryption_at_rest=control)
+
+    class FakeTransport:
+        def __init__(self):
+            self.calls = []
+        def post(self, url, **kwargs):
+            self.calls.append(url)
+            job_id = f"job-{len(self.calls)}"
+            class R:
+                status_code = 202
+                def json(self_inner):
+                    return {"job_id": job_id, "status": "pending"}
+                headers = {}
+            return R()
+        def get(self, url, **kwargs):
+            self.calls.append(url)
+            if "status" in url:
+                class R:
+                    status_code = 200
+                    def json(self):
+                        return {"job_id": url.split("/")[-2], "status": "completed"}
+                    headers = {}
+                return R()
+            elif "download-url" in url:
+                class R:
+                    status_code = 200
+                    def json(self):
+                        return {"download_url": "https://download.example/fake"}
+                    headers = {}
+                return R()
+            else:
+                # download
+                import zipfile
+                from io import BytesIO
+                buf = BytesIO()
+                with zipfile.ZipFile(buf, "w") as z:
+                    z.writestr("doc.md", "fake markdown")
+                class R2:
+                    status_code = 200
+                    content = buf.getvalue()
+                return R2()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        audit_path = _Path(tmp) / "audit.sqlite"
+        audit_log = SqliteAuditLog(audit_path)
+        transport = FakeTransport()
+        adapter = SarvamVisionAdapter(
+            enabled=True,
+            api_key="test-key",
+            audit_log=audit_log,
+            route=route,
+            transport=transport,
+            poll_interval_seconds=0,
+        )
+        for p in pages:
+            ctx = SarvamAuditContext(ticket=p.ticket, stage="ocr_extraction", document_id=p.page_id)
+            # This will log multiple rows per page (submission/poll/result/download) but at least one per call
+            adapter.digitise(b"fake-bytes", f"{p.page_id}.png", "od-IN", ctx)
+
+        rows = list(sqlite3.connect(audit_path).execute(
+            "SELECT ticket, stage, provider, model_id, bytes_sent, authorization_reference, operation, event FROM authorized_external_audit"
+        ))
+        # at least one row per page (with bytes >0 for submission)
+        tickets = {r[0] for r in rows}
+        for p in pages:
+            assert p.ticket in tickets
+        for ticket, stage, provider, model_id, bytes_sent, auth_ref, operation, event in rows:
+            assert stage == "ocr_extraction"
+            assert provider == "sarvam-hosted"
+            assert auth_ref != ""
+            assert operation == "digitise"
+            assert event in ("submission", "poll", "result_lookup", "download")
+
+
+def test_few_hundred_sample_compliance_flagged_in_report():
+    """Sample size outside 200-400 must be flagged; inside must be noted."""
+    from janasunani.evaluation.sarvam_scorecard import PageRecord, build_scorecard
+
+    small = [PageRecord(ticket=f"T{i}", page_id=f"P{i}", handwritten="no", pytesseract_text="a", sarvam_markdown="a") for i in range(10)]
+    report_small = build_scorecard(small)
+    assert report_small.sample_info["is_few_hundred"] is False
+    assert "outside the intended few-hundred" in report_small.notes
+
+    few_hundred = [PageRecord(ticket=f"T{i}", page_id=f"P{i}", handwritten="yes" if i % 2 == 0 else "no", pytesseract_text="a", sarvam_markdown="a") for i in range(250)]
+    report_big = build_scorecard(few_hundred)
+    assert report_big.sample_info["is_few_hundred"] is True
+    assert report_big.sample_info["n_pages"] == 250
+    assert "within the few-hundred" in report_big.notes


### PR DESCRIPTION
## Summary
Unit 5: paired Vision-vs-pytesseract divergence + categorizer accuracy harness with egress control (Bounded/Bounded).

- **Egress** `janasunani/egress/sarvam.py` single-module `authorized-external` channel (`trust_tier=authorized-external`, GoO MoU + ED sign-off, retention/encryption/audit, kill-switch to `dpic-infra` pytesseract/identity). Adds `transliterate`/`transliterate_or_fallback` (1000 chars/chunk) via same audit + kill-switch to IndicXlit identity.
- **Config** `SARVAM_TRUST_TIER` centralized in `janasunani/config.py`.
- **Harness** `janasunani/evaluation/sarvam_scorecard.py` stratified few-hundred sample from `Sambalpur/2024` (handwritten vs printed), paired divergence only (no ground truth), per-category categorizer accuracy vs `grievance_category` (police 0.85 vs welfare 0.51 spread, ticket-clustered CI), transliteration probe if present, sample compliance flagging.
- **Tests** `tests/test_egress_boundary.py` (single-module invariant, tier/authorization, kill-switch, audit row) + `tests/test_sarvam_scorecard.py` (handwritten/printed split, stratified, per-category spread, audit log).

## Slice
Reads frozen `DEMO_SLICE_*` (Sambalpur/2024, 55,544) only via `data/interim` aggregates; no lake write.

## Checks
- `uv run ruff check .` local pending CI
- `uv run --extra serving pytest tests/test_egress_boundary.py tests/test_sarvam_scorecard.py` local pending CI
- `egress` boundary enforced, tier-declared, audit-logged.

## Plan ref
Unit 5 docs/plans/2026-08-08-demo-closure.md — no overlap with routing (7) or spam (2b).
