### PR TITLE
feat(sarvam): extract benchmark arm with pinned schema and metadata join

### DIFF
--- a/janasunani/evaluation/sarvam_evaluate.py
+++ b/janasunani/evaluation/sarvam_evaluate.py
@@ -327,15 +327,17 @@ def main(argv: list[str] | None = None) -> int:
         render_import_error = exc
 
     # Fail fast for live runs where renderer is required (would otherwise
-    # silently skip every Sarvam call and report pages_submitted with no work)
-    if render_page is None and adapter is not None:
+    # silently skip every Sarvam call and report pages_submitted with no work).
+    # For --dry-run (CI) and for mocked tests that inject a fake adapter, allow
+    # empty images so `uv run --extra serving pytest` stays green.
+    if render_page is None and adapter is not None and not args.dry_run:
         logger.error(
             "page_renderer not available — install pipeline-core extra: "
             f"uv run --extra pipeline-core janasunani-evaluate-sarvam ({type(render_import_error).__name__}: {render_import_error})"
         )
         return 1
     if render_page is None and render_import_error is not None:
-        # Dry-run without renderer: keep going with empty images (CI)
+        # Dry-run or mocked test without renderer: keep going with empty images (CI)
         logger.warning(
             f"page_renderer unavailable ({type(render_import_error).__name__}); "
             "using empty images for --dry-run / test — install pipeline-core for real OCR"

--- a/janasunani/evaluation/sarvam_evaluate.py
+++ b/janasunani/evaluation/sarvam_evaluate.py
@@ -94,11 +94,14 @@ def _load_metadata_join(
 ) -> dict[str, dict[str, Any]]:
     """Load redacted metadata for ``--join-metadata``.
 
-    Returns mapping ticket -> {gold_category, handwritten, language,
-    pipeline_category, pipeline_summary}. Only gold_category is attempted from
-    the lake today; other fields degrade to None when not available. An empty
-    dict is returned when the lake is missing or unreadable (the runner
-    continues — the category arm simply becomes “not measured”).
+    Returns mapping ``ticket -> {gold_category, pipeline_category,
+    pipeline_summary, ...}`` plus per-page overrides keyed as
+    ``"{ticket}:{page_number}"`` for ``handwritten``/``language`` so that
+    multi-page tickets with differing page metadata are not collapsed (ticket-
+    keyed overwrites corrupt the handwritten/printed splits).
+
+    When the lake is missing or unreadable an empty dict is returned and the
+    runner continues with category arm marked not measured.
     """
     if lake_dir is None:
         # Try default interim location; if missing, return empty.
@@ -145,22 +148,62 @@ def _load_metadata_join(
             continue
         except Exception:  # noqa: BLE001
             continue
-    # Pages: handwritten, language if present
-    for col in ("handwritten", "language", "district"):
-        try:
-            # Need ticket_number column
-            if col == "handwritten":
-                sql = "SELECT ticket_number, handwritten FROM pages WHERE ticket_number IS NOT NULL"
-            elif col == "language":
-                sql = "SELECT ticket_number, language FROM pages WHERE ticket_number IS NOT NULL"
-            else:
+    # Documents: pipeline outputs for paired accuracy (grievance_category + summary)
+    # This fixes fabricated zero pipeline accuracy when gold is present but
+    # documents.parquet is ignored.
+    try:
+        sql = "SELECT ticket_number, grievance_category, summary FROM documents WHERE ticket_number IS NOT NULL"
+        frame = lake_mod.query(sql, lake_dir, tables=("documents",))
+        for row in frame.iter_rows(named=True):
+            ticket = row.get("ticket_number")
+            if not ticket:
                 continue
+            ticket_s = str(ticket)
+            cat = row.get("grievance_category") or row.get("category")
+            summ = row.get("summary")
+            if cat:
+                mapping.setdefault(ticket_s, {})["pipeline_category"] = str(cat)
+            if summ:
+                mapping.setdefault(ticket_s, {})["pipeline_summary"] = str(summ)
+    except FileNotFoundError:
+        pass
+    except Exception:  # noqa: BLE001
+        pass
+    # Pages: handwritten, language — preserve page identity via (ticket, page_number)
+    # Ticket-keyed overwrites corrupt splits for multi-page tickets, so store
+    # per-page overrides under composite key "{ticket}:{page_number}" and keep
+    # ticket-level fallback for single-page or when page_number missing.
+    for col in ("handwritten", "language"):
+        try:
+            # Select per-page identity; page_number may be NULL for legacy rows
+            sql = (
+                "SELECT ticket_number, page_number, page_id, "
+                f"{col} FROM pages WHERE ticket_number IS NOT NULL AND {col} IS NOT NULL"
+            )
             frame = lake_mod.query(sql, lake_dir, tables=("pages",))
             for row in frame.iter_rows(named=True):
                 ticket = row.get("ticket_number")
                 val = row.get(col)
-                if ticket and val:
-                    mapping.setdefault(str(ticket), {})[col] = str(val)
+                if not ticket or not val:
+                    continue
+                ticket_s = str(ticket)
+                val_s = str(val)
+                page_number = row.get("page_number")
+                # Always keep ticket-level fallback (first wins for backwards compat)
+                mapping.setdefault(ticket_s, {}).setdefault(col, val_s)
+                # Per-page override when page_number available
+                if page_number is not None:
+                    try:
+                        pn = int(page_number)
+                        key = f"{ticket_s}:{pn}"
+                        mapping.setdefault(key, {})[col] = val_s
+                    except (ValueError, TypeError):
+                        pass
+                else:
+                    # page_id fallback if page_number absent
+                    page_id = row.get("page_id")
+                    if page_id:
+                        mapping.setdefault(f"{ticket_s}#{page_id}", {})[col] = val_s
         except FileNotFoundError:
             continue
         except Exception:  # noqa: BLE001
@@ -270,10 +313,24 @@ def main(argv: list[str] | None = None) -> int:
     else:
         from janasunani.egress.sarvam import SarvamAuditContext as _Ctx  # noqa: F401  # ensure import works
 
-    # Lazy pytesseract + renderer — only needed when actually processing
+    # Lazy pytesseract + renderer — require pipeline-core when processing pages
+    # Under `uv run --extra serving` this import fails; the original code
+    # swallowed it and later skipped every Sarvam call with image=None while
+    # still exiting 0 with full cost metadata, producing an empty benchmark.
+    # Fail explicitly so the operator installs the correct extra.
     try:
         from janasunani.pipeline.stages.ocr_extraction.page_renderer import render_page
-    except Exception:  # noqa: BLE001  — allow dry-run tests without pipeline-core
+    except Exception as exc:  # noqa: BLE001
+        # If we have real pages to process (not just --help/--dry-run stub),
+        # the renderer is required. Dry-run still needs it for local OCR
+        # comparison, so fail in the same way.
+        logger.error(
+            "page_renderer not available — install pipeline-core extra: "
+            f"uv run --extra pipeline-core janasunani-evaluate-sarvam ({type(exc).__name__}: {exc})"
+        )
+        # Only fail when pages exist; allows --help without renderer
+        if pages:
+            return 1
         render_page = None  # type: ignore[assignment]
 
     # pylint: disable=import-error
@@ -310,6 +367,7 @@ def main(argv: list[str] | None = None) -> int:
         sarvam_markdown = ""
         sarvam_category: str | None = None
         sarvam_summary: str | None = None
+        page_failed = False
 
         if adapter is not None and image is not None:
             from io import BytesIO
@@ -331,26 +389,74 @@ def main(argv: list[str] | None = None) -> int:
                     failures.append({"page_id": page_id, "error": type(exc).__name__, "arm": "digitise"})
                     logger.error(f"{page_id} digitise: {type(exc).__name__}: {exc}")
                     sarvam_markdown = ""
+                    page_failed = True
             if args.arm in ("extract", "both"):
                 try:
                     raw = adapter.extract(doc_bytes, f"{page_id}.png", args.language, context, schema=schema)
                     payload = _unwrap_extract_result(raw)
                     sarvam_category = payload.get("grievance_category") or payload.get("category") or payload.get("grievanceCategory")
                     sarvam_summary = payload.get("summary") or payload.get("sarvam_summary")
-                    # If extract also returns markdown-like text, keep it as fallback
-                    if not sarvam_markdown and isinstance(payload.get("grievance_text"), str):
-                        sarvam_markdown = payload.get("grievance_text", "") if args.arm == "extract" else sarvam_markdown
+                    # Do not copy grievance_text into sarvam_markdown for extract-only:
+                    # that would publish Extract structured text as Digitise OCR and
+                    # conflate separately billed arms. OCR is not measured for
+                    # extract-only (handled in scorecard).
                 except Exception as exc:  # noqa: BLE001
                     failures.append({"page_id": page_id, "error": type(exc).__name__, "arm": "extract"})
                     logger.error(f"{page_id} extract: {type(exc).__name__}: {exc}")
+                    page_failed = True
+        elif adapter is not None and image is None:
+            # Renderer missing but Sarvam still requested — image is None
+            # implies render failure; treat as per-page failure rather than
+            # scoring empty text as divergence/incorrect.
+            failures.append({"page_id": page_id, "error": "RenderUnavailable", "arm": args.arm})
+            logger.error(f"{page_id}: cannot render page — image is None, skipping Sarvam call")
+            page_failed = True
 
-        # Metadata join overrides
-        meta = metadata.get(ticket, {})
-        gold_category = meta.get("gold_category")
-        handwritten = meta.get("handwritten")
-        language = meta.get("language") or args.language
-        pipeline_category = meta.get("pipeline_category")
-        pipeline_summary = meta.get("pipeline_summary")
+        # Metadata join overrides — page identity preserved for handwritten/language
+        # Ticket-level fields: gold_category, pipeline_*
+        ticket_meta = metadata.get(ticket, {})
+        page_key = f"{ticket}:{number}"
+        page_meta = metadata.get(page_key, {})
+        # gold_category only scored for extract/both (digitise-only would fabricate 0% Sarvam)
+        if args.arm in ("extract", "both"):
+            gold_category = ticket_meta.get("gold_category")
+            pipeline_category = ticket_meta.get("pipeline_category")
+            pipeline_summary = ticket_meta.get("pipeline_summary")
+        else:
+            gold_category = None
+            pipeline_category = None
+            pipeline_summary = None
+        # handwritten/language are page-level; prefer per-page override then ticket fallback
+        handwritten = page_meta.get("handwritten") or ticket_meta.get("handwritten")
+        language = page_meta.get("language") or ticket_meta.get("language") or args.language
+        # For extract-only, OCR is not measured — clear sarvam_markdown even if fallback would set it
+        if args.arm == "extract":
+            sarvam_markdown = ""
+
+        # Exclude failed Sarvam calls from paired scorecard rather than scoring
+        # timeout/rate-limit as divergence or incorrect category (bias).
+        if page_failed:
+            logger.warning(f"{page_id}: Sarvam call failed — excluding page from scorecard (not scored as divergence/incorrect)")
+            # still record lengths for observability but skip PageRecord
+            try:
+                from janasunani.evaluation.sarvam_scorecard import normalize_text
+
+                local_n = len(normalize_text(local_text))
+                remote_n = len(normalize_text(sarvam_markdown))
+            except Exception:  # noqa: BLE001
+                local_n = len(local_text)
+                remote_n = len(sarvam_markdown)
+            page_lengths.append({"page_id": page_id, "pytesseract_chars": local_n, "sarvam_chars": remote_n, "sarvam_raw_chars": len(sarvam_markdown), "failed": True})
+            logger.info(f"{page_id}: pytesseract {local_n} chars, sarvam {remote_n} chars (raw {len(sarvam_markdown)}) — FAILED, excluded")
+            if args.dump_text:
+                print("---- pytesseract ----")
+                print(local_text)
+                print("---- sarvam ----")
+                print(sarvam_markdown)
+                if sarvam_summary:
+                    print("---- sarvam_summary ----")
+                    print(sarvam_summary)
+            continue
 
         records.append(
             PageRecord(
@@ -390,7 +496,9 @@ def main(argv: list[str] | None = None) -> int:
                 print(sarvam_summary)
 
     out_dir.mkdir(parents=True, exist_ok=True)
-    report = build_scorecard(records)
+    # Pass arm + slice so scorecard correctly hides non-measured arms (digitise vs extract)
+    # and renders the selected slice (not demo constant).
+    report = build_scorecard(records, slice_label=args.slice, arm=args.arm)
 
     # Write markdown + base scorecard first, then overwrite JSON with enriched payload
     try:
@@ -419,7 +527,12 @@ def main(argv: list[str] | None = None) -> int:
     print(render_markdown(report))
 
     if failures:
-        logger.warning(f"{len(failures)} page(s) failed; they score as empty remote text")
+        # Failed pages are excluded from paired metrics (not scored as divergence/incorrect)
+        # but kept in failures + pages_submitted for audit; report.n_pages is scored count.
+        logger.warning(f"{len(failures)} page(s) failed; excluded from scorecard (pages_submitted={len(pages)}, scored={report.n_pages})")
+    # Surface scored vs submitted for verification
+    if report.n_pages != len(pages):
+        logger.info(f"Scored {report.n_pages}/{len(pages)} pages; {len(pages)-report.n_pages} excluded (failures or arm filter)")
     return 0
 
 

--- a/janasunani/evaluation/sarvam_evaluate.py
+++ b/janasunani/evaluation/sarvam_evaluate.py
@@ -1,0 +1,427 @@
+"""Sarvam benchmark runner — digitise / extract / both arms.
+
+This is the ``janasunani-evaluate-sarvam`` CLI (Unit E). It reuses the
+same-pixels-to-both-engines invariant from ``scripts/analysis/sarvam_sample.py``
+but promotes it to a proper evaluation module with:
+
+* ``--arm {digitise,extract,both}``  (digitise = OCR markdown vs pytesseract,
+  extract = structured fields vs gold category + BART summary, both = ₹1.50/page)
+* ``--join-metadata``  (lake/OLTP slice for gold_category, pipeline_category,
+  pipeline_summary, handwritten, language — redacted metadata only)
+* ``--schema-version v1``  (pins :mod:`sarvam_grievance_schema` before any
+  output is read, per #127)
+
+Live Sarvam calls are identical to the sample runner: one async job per page
+via :class:`SarvamVisionAdapter`, audit-logged with ticket/stage/provider/
+bytes and resilient to the kill switch (falls back to ``pytesseract``). CI /
+recorded-transport tests use ``--dry-run`` or inject a fake transport; no live
+network call is made in tests.
+
+Cost model (ROADMAP §5.5): digitise ₹0.50/page, extract ₹1.00/page,
+both ₹1.50/page. The scorecard JSON records pages, arm, cost and schema
+version so ``benchmark_report`` can compare runs without re-reading pages.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from janasunani.config import DEMO_SLICE_LABEL
+from janasunani.evaluation.sarvam_grievance_schema import (
+    SCHEMA_VERSION,
+    SUPPORTED_SCHEMA_VERSIONS,
+    get_schema,
+)
+from janasunani.evaluation.sarvam_scorecard import (
+    PageRecord,
+    build_scorecard,
+    render_markdown,
+    write_outputs,
+)
+
+
+PRICE_DIGITISE = 0.50
+PRICE_EXTRACT = 1.00
+PRICE_BOTH = 1.50
+IMAGE_SUFFIXES = {".png", ".jpg", ".jpeg", ".tiff", ".tif", ".bmp", ".gif"}
+
+
+def _price_for_arm(arm: str, n_pages: int) -> float:
+    if arm == "digitise":
+        return n_pages * PRICE_DIGITISE
+    if arm == "extract":
+        return n_pages * PRICE_EXTRACT
+    if arm == "both":
+        return n_pages * PRICE_BOTH
+    return 0.0
+
+
+def _page_count(path: Path) -> int:
+    if path.suffix.lower() == ".pdf":
+        from pdf2image import pdfinfo_from_path
+
+        return int(pdfinfo_from_path(str(path))["Pages"])
+    return 1
+
+
+def _ticket_of(path: Path) -> str:
+    return path.stem.split("_", 1)[0]
+
+
+def discover_pages(input_dir: Path, limit: int | None) -> list[tuple[Path, int]]:
+    pages: list[tuple[Path, int]] = []
+    for path in sorted(input_dir.iterdir()):
+        if not path.is_file():
+            continue
+        if path.suffix.lower() not in IMAGE_SUFFIXES and path.suffix.lower() != ".pdf":
+            continue
+        for number in range(1, _page_count(path) + 1):
+            pages.append((path, number))
+            if limit is not None and len(pages) >= limit:
+                return pages
+    return pages
+
+
+def _load_metadata_join(
+    lake_dir: Path | None,
+    slice_label: str | None,
+) -> dict[str, dict[str, Any]]:
+    """Load redacted metadata for ``--join-metadata``.
+
+    Returns mapping ticket -> {gold_category, handwritten, language,
+    pipeline_category, pipeline_summary}. Only gold_category is attempted from
+    the lake today; other fields degrade to None when not available. An empty
+    dict is returned when the lake is missing or unreadable (the runner
+    continues — the category arm simply becomes “not measured”).
+    """
+    if lake_dir is None:
+        # Try default interim location; if missing, return empty.
+        from janasunani.config import directories
+
+        default = Path(directories.INTERIM)
+        if default.is_dir():
+            lake_dir = default
+        else:
+            return {}
+    lake_dir = Path(lake_dir)
+    if not lake_dir.is_dir():
+        return {}
+    mapping: dict[str, dict[str, Any]] = {}
+    # Lazy import so the module remains importable with --extra serving only.
+    try:
+        from janasunani.olap import lake as lake_mod
+    except Exception:  # noqa: BLE001
+        return {}
+    # Complaints: try grievance_category then category
+    for col in ("grievance_category", "category"):
+        try:
+            # Slice filter if provided
+            where = f"WHERE {col} IS NOT NULL"
+            if slice_label and "/" in slice_label:
+                district, year_s = slice_label.split("/", 1)
+                try:
+                    year = int(year_s.strip())
+                    # Filter by district/year when available
+                    district_esc = district.replace("'", "''")
+                    where += f" AND lower(district) = lower('{district_esc}') AND created_year = {year}"
+                except ValueError:
+                    pass
+            sql = f"SELECT ticket_no, {col} AS gold_category FROM complaints {where}"
+            frame = lake_mod.query(sql, lake_dir, tables=("complaints",))
+            for row in frame.iter_rows(named=True):
+                ticket = row.get("ticket_no") or row.get("ticketNo")
+                gold = row.get("gold_category")
+                if ticket and gold:
+                    mapping.setdefault(str(ticket), {})["gold_category"] = str(gold)
+            if mapping:
+                break
+        except FileNotFoundError:
+            continue
+        except Exception:  # noqa: BLE001
+            continue
+    # Pages: handwritten, language if present
+    for col in ("handwritten", "language", "district"):
+        try:
+            # Need ticket_number column
+            if col == "handwritten":
+                sql = "SELECT ticket_number, handwritten FROM pages WHERE ticket_number IS NOT NULL"
+            elif col == "language":
+                sql = "SELECT ticket_number, language FROM pages WHERE ticket_number IS NOT NULL"
+            else:
+                continue
+            frame = lake_mod.query(sql, lake_dir, tables=("pages",))
+            for row in frame.iter_rows(named=True):
+                ticket = row.get("ticket_number")
+                val = row.get(col)
+                if ticket and val:
+                    mapping.setdefault(str(ticket), {})[col] = str(val)
+        except FileNotFoundError:
+            continue
+        except Exception:  # noqa: BLE001
+            continue
+    return mapping
+
+
+def _unwrap_extract_result(payload: Any) -> dict[str, Any]:
+    """Unwrap the various shapes ``adapter.extract`` may return."""
+    if isinstance(payload, dict):
+        if "results" in payload and isinstance(payload["results"], list) and payload["results"]:
+            first = payload["results"][0]
+            if isinstance(first, dict):
+                return first
+        if "data" in payload and isinstance(payload["data"], dict):
+            return payload["data"]
+        # Direct field dict
+        return payload
+    if isinstance(payload, list) and payload and isinstance(payload[0], dict):
+        return payload[0]
+    return {}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Sarvam benchmark — digitise / extract / both (Unit E).",
+        prog="janasunani-evaluate-sarvam",
+    )
+    parser.add_argument("--input", "--input-dir", type=Path, dest="input_dir", required=True, help="Directory of documents.")
+    parser.add_argument("--out", "--output", "--output-dir", type=Path, dest="out", required=True, help="Where to write aggregates.")
+    parser.add_argument(
+        "--arm",
+        choices=["digitise", "extract", "both"],
+        default="digitise",
+        help="Benchmark arm: digitise (OCR markdown vs pytesseract), extract (structured fields vs gold), or both (digitise+extract).",
+    )
+    parser.add_argument(
+        "--schema-version",
+        default=SCHEMA_VERSION,
+        choices=sorted(SUPPORTED_SCHEMA_VERSIONS.keys()),
+        help="Pinned Extract schema version (frozen before output is read).",
+    )
+    parser.add_argument(
+        "--join-metadata",
+        action="store_true",
+        default=False,
+        help="Join redacted lake/OLTP metadata (gold_category, handwritten, language, pipeline fields).",
+    )
+    parser.add_argument("--lake-dir", type=Path, default=None, help="Lake dir for --join-metadata (default: data/interim).")
+    parser.add_argument("--slice", type=str, default=DEMO_SLICE_LABEL, help="Slice label DISTRICT/YEAR for metadata join (default: Sambalpur/2024).")
+    parser.add_argument("--limit", type=int, default=None, help="Cap pages (cost control).")
+    parser.add_argument("--language", default="en-IN", help="Language hint passed to Sarvam.")
+    parser.add_argument("--audit-db", type=Path, default=None, help="Sarvam egress audit log (default: <out>/sarvam_audit.sqlite).")
+    parser.add_argument("--dry-run", action="store_true", help="Render and run pytesseract only. No Sarvam call, no spend.")
+    parser.add_argument("--dump-text", action="store_true", help="Print both transcripts. Debugging only; refuses more than one page.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    input_dir: Path = args.input_dir  # type: ignore[attr-defined]
+    out_dir: Path = args.out  # type: ignore[attr-defined]
+
+    if not input_dir.is_dir():
+        logger.error(f"input dir not found: {input_dir}")
+        return 1
+
+    try:
+        schema = get_schema(args.schema_version)
+    except ValueError as exc:
+        parser.error(str(exc))
+        return 2  # unreachable (parser.error exits)
+
+    pages = discover_pages(input_dir, args.limit)
+    if not pages:
+        logger.error(f"no documents found under {input_dir}")
+        return 1
+
+    cost = _price_for_arm(args.arm, len(pages))
+    logger.info(f"{len(pages)} page(s) across {len({p for p, _ in pages})} document(s) — arm={args.arm} schema={args.schema_version}")
+    logger.info(f"Sarvam cost if run: Rs {cost:.2f} ({args.arm} @ {cost / len(pages) if pages else 0:.2f}/page)")
+
+    if args.dump_text and len(pages) > 1:
+        logger.error("--dump-text prints real grievance text and is limited to one page; narrow the sample with --limit 1")
+        return 1
+
+    metadata: dict[str, dict[str, Any]] = {}
+    if args.join_metadata:
+        metadata = _load_metadata_join(args.lake_dir, args.slice)
+        logger.info(f"metadata join: {len(metadata)} ticket(s) with lake metadata (slice={args.slice})")
+
+    adapter = None
+    if not args.dry_run:
+        # Lazy import so tests with --extra serving can run without pipeline-core
+        from janasunani.egress.sarvam import PROVIDER_REGISTRY, SarvamAuditContext, SarvamVisionAdapter, SqliteAuditLog
+
+        route = PROVIDER_REGISTRY["sarvam-vision"]
+        if not route.egress_permitted:
+            logger.error(f"Sarvam egress is not permitted: unverified controls {route.unverified_controls} and no accepted risk")
+            return 1
+        logger.warning(f"LIVE RUN: sending {len(pages)} page(s) of real grievance documents to {route.provider} on basis '{route.egress_basis}' (arm={args.arm})")
+        out_dir.mkdir(parents=True, exist_ok=True)
+        audit_db = args.audit_db or (out_dir / "sarvam_audit.sqlite")
+        adapter = SarvamVisionAdapter(enabled=True, audit_log=SqliteAuditLog(audit_db))
+    else:
+        from janasunani.egress.sarvam import SarvamAuditContext as _Ctx  # noqa: F401  # ensure import works
+
+    # Lazy pytesseract + renderer — only needed when actually processing
+    try:
+        from janasunani.pipeline.stages.ocr_extraction.page_renderer import render_page
+    except Exception:  # noqa: BLE001  — allow dry-run tests without pipeline-core
+        render_page = None  # type: ignore[assignment]
+
+    # pylint: disable=import-error
+    records: list[PageRecord] = []
+    failures: list[dict[str, str]] = []
+    page_lengths: list[dict[str, object]] = []
+
+    for path, number in pages:
+        page_id = f"{path.stem}:p{number}"
+        ticket = _ticket_of(path)
+
+        # Render + local OCR (or stub when renderer unavailable)
+        image = None
+        if render_page is not None:
+            try:
+                image = render_page(path, number)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(f"{page_id}: render failed ({type(exc).__name__}), using empty image")
+                image = None
+
+        local_text = ""
+        if image is not None:
+            try:
+                from janasunani.pipeline.stages.ocr_extraction.pytesseract_backend import extract_text
+
+                local_text = extract_text(image)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(f"{page_id}: pytesseract failed ({type(exc).__name__}), using empty text")
+                local_text = ""
+        else:
+            # No renderer (test env) — use empty local text so divergence is still computable
+            local_text = ""
+
+        sarvam_markdown = ""
+        sarvam_category: str | None = None
+        sarvam_summary: str | None = None
+
+        if adapter is not None and image is not None:
+            from io import BytesIO
+
+            from janasunani.egress.sarvam import SarvamAuditContext
+
+            buffer = BytesIO()
+            try:
+                image.save(buffer, format="PNG")
+                doc_bytes = buffer.getvalue()
+            except Exception:  # noqa: BLE001
+                doc_bytes = b""
+            context = SarvamAuditContext(ticket=ticket, stage="ocr_extraction", document_id=f"{path.name}:{number}")
+
+            if args.arm in ("digitise", "both"):
+                try:
+                    sarvam_markdown = adapter.digitise(doc_bytes, f"{page_id}.png", args.language, context)
+                except Exception as exc:  # noqa: BLE001
+                    failures.append({"page_id": page_id, "error": type(exc).__name__, "arm": "digitise"})
+                    logger.error(f"{page_id} digitise: {type(exc).__name__}: {exc}")
+                    sarvam_markdown = ""
+            if args.arm in ("extract", "both"):
+                try:
+                    raw = adapter.extract(doc_bytes, f"{page_id}.png", args.language, context, schema=schema)
+                    payload = _unwrap_extract_result(raw)
+                    sarvam_category = payload.get("grievance_category") or payload.get("category") or payload.get("grievanceCategory")
+                    sarvam_summary = payload.get("summary") or payload.get("sarvam_summary")
+                    # If extract also returns markdown-like text, keep it as fallback
+                    if not sarvam_markdown and isinstance(payload.get("grievance_text"), str):
+                        sarvam_markdown = payload.get("grievance_text", "") if args.arm == "extract" else sarvam_markdown
+                except Exception as exc:  # noqa: BLE001
+                    failures.append({"page_id": page_id, "error": type(exc).__name__, "arm": "extract"})
+                    logger.error(f"{page_id} extract: {type(exc).__name__}: {exc}")
+
+        # Metadata join overrides
+        meta = metadata.get(ticket, {})
+        gold_category = meta.get("gold_category")
+        handwritten = meta.get("handwritten")
+        language = meta.get("language") or args.language
+        pipeline_category = meta.get("pipeline_category")
+        pipeline_summary = meta.get("pipeline_summary")
+
+        records.append(
+            PageRecord(
+                ticket=ticket,
+                page_id=page_id,
+                handwritten=handwritten,
+                language=language,
+                pytesseract_text=local_text,
+                sarvam_markdown=sarvam_markdown,
+                pipeline_category=pipeline_category,
+                sarvam_category=sarvam_category,
+                gold_category=gold_category,
+                sarvam_summary=sarvam_summary,
+                pipeline_summary=pipeline_summary,
+            )
+        )
+
+        # Length reporting — normalised lengths are what the scorecard compares
+        try:
+            from janasunani.evaluation.sarvam_scorecard import normalize_text
+
+            local_n = len(normalize_text(local_text))
+            remote_n = len(normalize_text(sarvam_markdown))
+        except Exception:  # noqa: BLE001
+            local_n = len(local_text)
+            remote_n = len(sarvam_markdown)
+        page_lengths.append({"page_id": page_id, "pytesseract_chars": local_n, "sarvam_chars": remote_n, "sarvam_raw_chars": len(sarvam_markdown)})
+        logger.info(f"{page_id}: pytesseract {local_n} chars, sarvam {remote_n} chars (raw {len(sarvam_markdown)})")
+
+        if args.dump_text:
+            print("---- pytesseract ----")
+            print(local_text)
+            print("---- sarvam ----")
+            print(sarvam_markdown)
+            if sarvam_summary:
+                print("---- sarvam_summary ----")
+                print(sarvam_summary)
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    report = build_scorecard(records)
+
+    # Write markdown + base scorecard first, then overwrite JSON with enriched payload
+    try:
+        outputs = write_outputs(report, out_dir)
+        logger.success(f"markdown -> {outputs['markdown']}")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(f"write_outputs failed: {exc}")
+
+    payload = report.to_dict()
+    # Enrich payload with run metadata (feeds benchmark_report)
+    payload["failures"] = failures
+    payload["pages_submitted"] = len(pages)
+    payload["cost_rupees"] = 0.0 if args.dry_run else cost
+    payload["arm"] = args.arm
+    payload["schema_version"] = args.schema_version
+    payload["slice"] = args.slice
+    payload["page_lengths"] = page_lengths
+    # also record schema itself for audit
+    payload["schema"] = schema
+
+    destination = out_dir / "sarvam_scorecard.json"
+    destination.write_text(json.dumps(payload, indent=2, default=str))
+    logger.success(f"scorecard -> {destination}")
+
+    # Also print markdown to stdout for pipeline visibility
+    print(render_markdown(report))
+
+    if failures:
+        logger.warning(f"{len(failures)} page(s) failed; they score as empty remote text")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/janasunani/evaluation/sarvam_evaluate.py
+++ b/janasunani/evaluation/sarvam_evaluate.py
@@ -319,12 +319,25 @@ def main(argv: list[str] | None = None) -> int:
     # image=None while still exiting 0 with full cost, producing an empty
     # benchmark. For live runs we must fail explicitly; for --dry-run (CI)
     # we allow empty rendering so `uv run --extra serving pytest` stays green.
+    # Preserve already-patched render_page for tests (monkeypatch sets eval_mod.render_page)
+    # so the test's FakeAdapter + fake image is used even when pdf2image is missing on CI
+    _pre_patched = globals().get("render_page", None)
     render_import_error: Exception | None = None
     try:
-        from janasunani.pipeline.stages.ocr_extraction.page_renderer import render_page
+        from janasunani.pipeline.stages.ocr_extraction.page_renderer import render_page as _real_render  # type: ignore[assignment]
+
+        if _pre_patched is not None and callable(_pre_patched):
+            render_page = _pre_patched  # type: ignore[assignment]
+        else:
+            render_page = _real_render  # type: ignore[assignment]
+        render_import_error = None
     except Exception as exc:  # noqa: BLE001
-        render_page = None  # type: ignore[assignment]
-        render_import_error = exc
+        if _pre_patched is not None and callable(_pre_patched):
+            render_page = _pre_patched  # type: ignore[assignment]
+            render_import_error = None
+        else:
+            render_page = None  # type: ignore[assignment]
+            render_import_error = exc
 
     # Fail fast for live runs where renderer is required (would otherwise
     # silently skip every Sarvam call and report pages_submitted with no work).

--- a/janasunani/evaluation/sarvam_evaluate.py
+++ b/janasunani/evaluation/sarvam_evaluate.py
@@ -313,25 +313,33 @@ def main(argv: list[str] | None = None) -> int:
     else:
         from janasunani.egress.sarvam import SarvamAuditContext as _Ctx  # noqa: F401  # ensure import works
 
-    # Lazy pytesseract + renderer — require pipeline-core when processing pages
-    # Under `uv run --extra serving` this import fails; the original code
-    # swallowed it and later skipped every Sarvam call with image=None while
-    # still exiting 0 with full cost metadata, producing an empty benchmark.
-    # Fail explicitly so the operator installs the correct extra.
+    # Lazy pytesseract + renderer — only needed when actually processing
+    # Under `uv run --extra serving` Pillow/pdf2image are absent; the old code
+    # swallowed the ImportError and later skipped every Sarvam call with
+    # image=None while still exiting 0 with full cost, producing an empty
+    # benchmark. For live runs we must fail explicitly; for --dry-run (CI)
+    # we allow empty rendering so `uv run --extra serving pytest` stays green.
+    render_import_error: Exception | None = None
     try:
         from janasunani.pipeline.stages.ocr_extraction.page_renderer import render_page
     except Exception as exc:  # noqa: BLE001
-        # If we have real pages to process (not just --help/--dry-run stub),
-        # the renderer is required. Dry-run still needs it for local OCR
-        # comparison, so fail in the same way.
+        render_page = None  # type: ignore[assignment]
+        render_import_error = exc
+
+    # Fail fast for live runs where renderer is required (would otherwise
+    # silently skip every Sarvam call and report pages_submitted with no work)
+    if render_page is None and adapter is not None:
         logger.error(
             "page_renderer not available — install pipeline-core extra: "
-            f"uv run --extra pipeline-core janasunani-evaluate-sarvam ({type(exc).__name__}: {exc})"
+            f"uv run --extra pipeline-core janasunani-evaluate-sarvam ({type(render_import_error).__name__}: {render_import_error})"
         )
-        # Only fail when pages exist; allows --help without renderer
-        if pages:
-            return 1
-        render_page = None  # type: ignore[assignment]
+        return 1
+    if render_page is None and render_import_error is not None:
+        # Dry-run without renderer: keep going with empty images (CI)
+        logger.warning(
+            f"page_renderer unavailable ({type(render_import_error).__name__}); "
+            "using empty images for --dry-run / test — install pipeline-core for real OCR"
+        )
 
     # pylint: disable=import-error
     records: list[PageRecord] = []

--- a/janasunani/evaluation/sarvam_grievance_schema.py
+++ b/janasunani/evaluation/sarvam_grievance_schema.py
@@ -1,0 +1,57 @@
+"""Pinned Sarvam Extract schema — frozen before any benchmark output is read.
+
+This module is the single source for the JSON schema passed to
+``SarvamVisionAdapter.extract(schema=...)`` in the benchmark. The schema is
+versioned so a later change cannot silently shift the headline category
+accuracy number; callers pin ``--schema-version v1`` and the scorecard
+records the version.
+
+The illustrative schema in the rehearsal plan (Part 5) is reproduced
+verbatim here as ``GRIEVANCE_EXTRACT_SCHEMA_V1``. Field names are aligned
+to the OLTP ``complaints`` taxonomy (``category`` / ``grievance_category``)
+and to the pipeline ``documents`` table so the benchmark's category
+comparison has a stable referee.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+SCHEMA_VERSION = "v1"
+SCHEMA_VERSION_V1 = "v1"
+
+GRIEVANCE_EXTRACT_SCHEMA_V1: dict[str, dict[str, str]] = {
+    "grievance_category": {
+        "type": "string",
+        "description": "ROS grievance category label (taxonomy of complaints.grievance_category / complaints.category)",
+    },
+    "summary": {
+        "type": "string",
+        "description": "One-paragraph grievance summary",
+    },
+    "district": {
+        "type": "string",
+        "description": "District name",
+    },
+    "grievance_text": {
+        "type": "string",
+        "description": "Full grievance text (redacted prose)",
+    },
+}
+
+SUPPORTED_SCHEMA_VERSIONS: dict[str, dict[str, Any]] = {
+    "v1": GRIEVANCE_EXTRACT_SCHEMA_V1,
+}
+
+
+def get_schema(version: str = SCHEMA_VERSION) -> dict[str, Any]:
+    """Return the pinned schema for *version*.
+
+    Raises ``ValueError`` for an unknown version so a typo cannot silently
+    fall back to a different schema.
+    """
+    try:
+        return SUPPORTED_SCHEMA_VERSIONS[version]
+    except KeyError as exc:
+        supported = ", ".join(sorted(SUPPORTED_SCHEMA_VERSIONS))
+        raise ValueError(f"unknown schema version {version!r}; supported: {supported}") from exc

--- a/janasunani/evaluation/sarvam_scorecard.py
+++ b/janasunani/evaluation/sarvam_scorecard.py
@@ -36,12 +36,14 @@ recorded Sarvam markdown fixtures; no live network call is made.
 
 from __future__ import annotations
 
+import json
 import math
 import random
 import re
 import unicodedata
 from collections import defaultdict
 from dataclasses import asdict, dataclass
+from pathlib import Path
 from statistics import NormalDist
 from typing import Any
 
@@ -132,6 +134,9 @@ class PageRecord:
     ``pipeline_category`` / ``sarvam_category`` / ``gold_category`` are for
     the category arm (issue #127) at ticket level; they may be repeated per
     page for convenience and are de-duplicated by ticket when scored.
+    ``sarvam_summary`` / ``pipeline_summary`` are the exploratory summary arm
+    (Extract ``summary`` field vs BART output); no gold referee, divergence
+    only, clustered by ticket like the OCR arm.
     """
 
     ticket: str
@@ -144,6 +149,8 @@ class PageRecord:
     pipeline_category: str | None = None
     sarvam_category: str | None = None
     gold_category: str | None = None
+    sarvam_summary: str | None = None
+    pipeline_summary: str | None = None
 
     def handwritten_bucket(self) -> str:
         if self.handwritten == "yes":
@@ -266,6 +273,35 @@ def divergence_rate(
     rate = sum(disagreements) / n
     # SE for a proportion with clustering: treat disagreements as 1/0 and
     # apply clustered SE for the mean.
+    se = _clustered_se([float(x) for x in disagreements], clusters)
+    z = 1.96
+    return {"rate": rate, "se": se, "ci_low": rate - z * se, "ci_high": rate + z * se, "n": n, "n_clusters": len(set(clusters))}
+
+
+def summary_divergence(
+    sarvam_summaries: list[str | None],
+    pipeline_summaries: list[str | None],
+    clusters: list[str],
+) -> dict[str, float]:
+    """Divergence rate for summaries — exploratory, no gold referee.
+
+    Compares Sarvam Extract ``summary`` vs pipeline BART ``summary`` after the
+    same ``normalize_text`` applied to OCR. Cluster-robust SE by ticket, like
+    ``divergence_rate``. ``None`` is treated as empty string so a missing
+    summary on one side counts as divergence; callers that want to omit
+    missing pairs should filter before calling.
+    """
+    if not (len(sarvam_summaries) == len(pipeline_summaries) == len(clusters)):
+        raise ValueError("inputs must have equal length")
+    n = len(sarvam_summaries)
+    if n == 0:
+        return {"rate": 0.0, "se": 0.0, "ci_low": 0.0, "ci_high": 0.0, "n": 0, "n_clusters": 0}
+    disagreements: list[int] = []
+    for a, b in zip(sarvam_summaries, pipeline_summaries):
+        a_norm = normalize_text(a or "")
+        b_norm = normalize_text(b or "")
+        disagreements.append(0 if a_norm == b_norm else 1)
+    rate = sum(disagreements) / n
     se = _clustered_se([float(x) for x in disagreements], clusters)
     z = 1.96
     return {"rate": rate, "se": se, "ci_low": rate - z * se, "ci_high": rate + z * se, "n": n, "n_clusters": len(set(clusters))}
@@ -553,6 +589,8 @@ class ScorecardReport:
     per_category: dict[str, Any] | None = None
     transliteration_probe_result: dict[str, Any] | None = None
     sample_info: dict[str, Any] | None = None
+    # Unit E — summary divergence exploratory (Sarvam Extract summary vs BART)
+    summary_divergence: dict[str, Any] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -703,6 +741,23 @@ def build_scorecard(pages: list[PageRecord]) -> ScorecardReport:
             "Transcription cannot be produced by an agent because it is the ground truth "
             "an agent would be measured against."
         )
+    # Summary divergence — exploratory, no gold referee
+    pages_with_summaries = [p for p in pages if p.sarvam_summary is not None and p.pipeline_summary is not None]
+    if pages_with_summaries:
+        summ_div = summary_divergence(
+            [p.sarvam_summary for p in pages_with_summaries],
+            [p.pipeline_summary for p in pages_with_summaries],
+            [p.ticket for p in pages_with_summaries],
+        )
+    else:
+        summ_div = None
+    if summ_div is not None:
+        notes_parts.append(
+            f"Summary divergence (exploratory, Sarvam Extract vs BART): "
+            f"{summ_div['rate']:.3f} (n={summ_div['n']}, clusters={summ_div['n_clusters']}) — "
+            "no gold referee; normalised text diff, ticket-clustered CI."
+        )
+
     # Phase 17 extensions
     per_cat = per_category_table(pages)
     trans_probe = transliteration_probe(pages)
@@ -759,4 +814,138 @@ def build_scorecard(pages: list[PageRecord]) -> ScorecardReport:
         per_category=per_cat if per_cat else None,
         transliteration_probe_result=trans_probe,
         sample_info=samp_info,
+        summary_divergence=summ_div,
     )
+
+
+# ---------------------------------------------------------------------------
+# Rendering — markdown + outputs (Unit E)
+# ---------------------------------------------------------------------------
+
+def render_markdown(report: ScorecardReport) -> str:
+    """Render a human-readable markdown summary of *report*.
+
+    Mirrors the ``render_markdown`` pattern in
+    ``janasunani.evaluation.spam_scorecard`` so the benchmark report can
+    inline the Sarvam section verbatim. All numeric fields are formatted
+    with three decimals; missing arms are labelled ``not measured`` rather
+    than omitted so a stale ``DELIVERY.md`` Table 2 row is visible.
+    """
+    lines: list[str] = [
+        f"# Sarvam benchmark — {DEMO_SLICE_LABEL}",
+        "",
+        f"Normalizer: `{report.normalizer_version}` · paired={report.paired_design} · n_pages={report.n_pages} · n_tickets={report.n_tickets}",
+        "",
+        f"**Primary outcome:** {report.primary_outcome}",
+        "",
+    ]
+    # Category headline
+    if report.category is not None:
+        c = report.category
+        lines += [
+            "## Category accuracy (headline — paired, ticket-clustered 95% CI)",
+            "",
+            f"- Pipeline accuracy: **{c['pipeline_accuracy']:.3f}**",
+            f"- Sarvam Extract accuracy: **{c['sarvam_accuracy']:.3f}**",
+            f"- Difference (Sarvam − pipeline): **{c['difference']:.3f}** 95% CI [{c['ci_low']:.3f}, {c['ci_high']:.3f}] (se={c['se']:.3f}, n_tickets={c['n_tickets']}, clusters={c['n_clusters']})",
+            f"- Interpretation: {c.get('interpretation', '')}",
+            "",
+        ]
+    else:
+        lines += [
+            "## Category accuracy",
+            "",
+            "Not measured — no gold labels (``gold_category``) in sample; run with ``--join-metadata`` from the lake slice.",
+            "",
+        ]
+    # Transcription
+    if report.transcription_available and report.transcription_accuracy is not None:
+        t = report.transcription_accuracy
+        lines += [
+            "## Transcription accuracy (ground-truth available)",
+            "",
+            f"- Pipeline: {t['pipeline_accuracy']:.3f} · Sarvam: {t['sarvam_accuracy']:.3f} · diff {t['difference']:.3f} 95% CI [{t['ci_low']:.3f}, {t['ci_high']:.3f}] (n={t['n_pages']}, clusters={t['n_clusters']})",
+            "",
+        ]
+    else:
+        lines += [
+            "## Transcription",
+            "",
+            f"Divergence only (no hand-transcribed ground truth): **{report.transcription_divergence['rate']:.3f}** 95% CI [{report.transcription_divergence['ci_low']:.3f}, {report.transcription_divergence['ci_high']:.3f}] (n={report.transcription_divergence['n']}, clusters={report.transcription_divergence['n_clusters']})",
+            "",
+            "No accuracy verdict — commission a hand-transcribed sample for an accuracy comparison (per DELIVERY.md fallback).",
+            "",
+        ]
+    # Divergence splits
+    def _div_block(title: str, data: dict[str, dict[str, Any]]) -> None:
+        lines.append(f"## {title}")
+        lines.append("")
+        lines.append("| Bucket | n_pages | divergence rate | 95% CI |")
+        lines.append("|---|---:|---:|---|")
+        for bucket, entry in sorted(data.items()):
+            d = entry["divergence"]
+            lines.append(f"| {bucket} | {d['n']} | {d['rate']:.3f} | [{d['ci_low']:.3f}, {d['ci_high']:.3f}] |")
+        lines.append("")
+
+    _div_block("By handwritten", report.by_handwritten)
+    _div_block("By language", report.by_language)
+
+    # Summary divergence exploratory
+    lines.append("## Summary divergence (exploratory — Sarvam Extract vs BART, no gold referee)")
+    lines.append("")
+    if report.summary_divergence is not None:
+        s = report.summary_divergence
+        lines.append(f"- Rate: **{s['rate']:.3f}** 95% CI [{s['ci_low']:.3f}, {s['ci_high']:.3f}] (se={s['se']:.3f}, n={s['n']}, clusters={s['n_clusters']})")
+        lines.append("- Normalised text diff with ticket-clustered SE; exploratory — no accuracy verdict unless a DSI usefulness re-run is commissioned.")
+    else:
+        lines.append("Not measured — no paired ``sarvam_summary`` / ``pipeline_summary`` in sample.")
+    lines.append("")
+
+    # Per-category spread
+    if report.per_category:
+        lines.append("## Per-category accuracy spread")
+        lines.append("")
+        lines.append("| Category | n_tickets | pipeline | Sarvam | diff |")
+        lines.append("|---|---:|---:|---:|---:|")
+        for cat, row in sorted(report.per_category.items()):
+            lines.append(f"| {cat} | {row['n_tickets']} | {row['pipeline_accuracy']:.3f} | {row['sarvam_accuracy']:.3f} | {row['difference']:.3f} |")
+        lines.append("")
+
+    # Transliteration probe
+    if report.transliteration_probe_result is not None:
+        probe = report.transliteration_probe_result
+        lines.append("## Transliteration probe (romanized Odia)")
+        lines.append("")
+        lines.append(f"- Candidates: {probe['n_romanized_candidates']}/{probe['n_total']} — applicable={probe['probe_applicable']}")
+        lines.append(f"- Note: {probe.get('note', '')}")
+        lines.append("")
+
+    # Sample compliance
+    if report.sample_info is not None:
+        si = report.sample_info
+        lines.append("## Sample")
+        lines.append("")
+        lines.append(f"- n_pages={si['n_pages']} · few-hundred={si['is_few_hundred']} · slice={si['slice']} (recommended {si['recommended']}, range {si['min']}–{si['max']})")
+        lines.append("")
+
+    lines.append("## Notes")
+    lines.append("")
+    lines.append(report.notes)
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_outputs(report: ScorecardReport, out_dir: Path | str) -> dict[str, Path]:
+    """Write ``report`` as JSON and markdown under *out_dir*.
+
+    Returns mapping ``{"json": Path, "markdown": Path}``. The JSON is the
+    machine-readable artifact that feeds ``benchmark_report`` Table 2; the
+    markdown is the human-readable fragment inline in the rehearsal slide.
+    """
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    json_path = out / "sarvam_scorecard.json"
+    md_path = out / "sarvam_scorecard.md"
+    json_path.write_text(json.dumps(report.to_dict(), indent=2, default=str))
+    md_path.write_text(render_markdown(report))
+    return {"json": json_path, "markdown": md_path}

--- a/janasunani/evaluation/sarvam_scorecard.py
+++ b/janasunani/evaluation/sarvam_scorecard.py
@@ -437,17 +437,30 @@ def stratified_sample(
     return sampled
 
 
-def sample_compliance(n_pages: int) -> dict[str, Any]:
+def sample_compliance(n_pages: int, slice_label: str | None = None) -> dict[str, Any]:
     """Whether the sample size is the intended few hundred (200–400)."""
+    sl = slice_label or DEMO_SLICE_LABEL
+    # Derive district/year from slice label when possible
+    if "/" in sl:
+        try:
+            d, y_s = sl.split("/", 1)
+            sd = d.strip()
+            sy = int(y_s.strip())
+        except Exception:  # noqa: BLE001
+            sd = DEMO_SLICE_DISTRICT
+            sy = DEMO_SLICE_YEAR
+    else:
+        sd = DEMO_SLICE_DISTRICT
+        sy = DEMO_SLICE_YEAR
     return {
         "n_pages": n_pages,
         "is_few_hundred": BENCHMARK_MIN_SAMPLE <= n_pages <= BENCHMARK_MAX_SAMPLE,
         "recommended": BENCHMARK_SAMPLE_SIZE,
         "min": BENCHMARK_MIN_SAMPLE,
         "max": BENCHMARK_MAX_SAMPLE,
-        "slice": DEMO_SLICE_LABEL,
-        "slice_district": DEMO_SLICE_DISTRICT,
-        "slice_year": DEMO_SLICE_YEAR,
+        "slice": sl,
+        "slice_district": sd,
+        "slice_year": sy,
     }
 
 
@@ -591,6 +604,9 @@ class ScorecardReport:
     sample_info: dict[str, Any] | None = None
     # Unit E — summary divergence exploratory (Sarvam Extract summary vs BART)
     summary_divergence: dict[str, Any] | None = None
+    # Slice + arm for correct rendering (P2 slice label, P1 arm-aware OCR/category)
+    slice_label: str = DEMO_SLICE_LABEL
+    arm: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -603,14 +619,23 @@ PRIMARY_OUTCOME_LABEL = (
 )
 
 
-def build_scorecard(pages: list[PageRecord]) -> ScorecardReport:
+def build_scorecard(
+    pages: list[PageRecord],
+    slice_label: str | None = None,
+    arm: str | None = None,
+) -> ScorecardReport:
     """Build the full scorecard from a frozen sample.
 
     * Every page must have been processed by **both** engines (paired).
     * ``handwritten`` and ``language`` splits are always reported.
     * If no page carries ``transcription``, accuracy is not computable and
       ``transcription_divergence`` is the only transcription result.
+    * ``arm`` controls which headline metrics are measured: ``digitise`` hides
+      category, ``extract`` hides OCR divergence, ``both`` measures both.
+    * ``slice_label`` is the selected slice (e.g. Ganjam/2024) for sample_info
+      and rendering; defaults to DEMO_SLICE_LABEL.
     """
+    resolved_slice = slice_label or DEMO_SLICE_LABEL
     n_pages = len(pages)
     n_tickets = len({p.ticket for p in pages})
 
@@ -636,36 +661,54 @@ def build_scorecard(pages: list[PageRecord]) -> ScorecardReport:
                 pass
 
     # Only tickets with a gold label contribute to paired accuracy
-    cat_tickets = [t for t in ticket_gold if ticket_gold[t] is not None]
-    cat_clusters = cat_tickets  # one per ticket
-    if cat_tickets:
-        pipe_correct = [1 if ticket_pipe.get(t) == ticket_gold[t] else 0 for t in cat_tickets]
-        sarvam_correct = [1 if ticket_sarvam.get(t) == ticket_gold[t] else 0 for t in cat_tickets]
-        pipe_rate = sum(pipe_correct) / len(pipe_correct) if pipe_correct else 0.0
-        sarvam_rate = sum(sarvam_correct) / len(sarvam_correct) if sarvam_correct else 0.0
-        diff = paired_difference(sarvam_correct, pipe_correct, cat_clusters)
-        category_result: dict[str, Any] | None = {
-            "n_tickets": len(cat_tickets),
-            "pipeline_accuracy": pipe_rate,
-            "sarvam_accuracy": sarvam_rate,
-            "difference": diff["diff"],  # sarvam - pipeline, positive favours sarvam
-            "se": diff["se"],
-            "ci_low": diff["ci_low"],
-            "ci_high": diff["ci_high"],
-            "n_clusters": diff["n_clusters"],
-            "interpretation": "difference + CI is the result; marginal rates are description (#127)",
+    # Arm-aware: digitise-only does not score category (gold Category requires Extract)
+    if arm == "digitise":
+        category_result = None
+        cat_tickets = []
+    else:
+        cat_tickets = [t for t in ticket_gold if ticket_gold[t] is not None]
+        cat_clusters = cat_tickets  # one per ticket
+        if cat_tickets:
+            pipe_correct = [1 if ticket_pipe.get(t) == ticket_gold[t] else 0 for t in cat_tickets]
+            sarvam_correct = [1 if ticket_sarvam.get(t) == ticket_gold[t] else 0 for t in cat_tickets]
+            pipe_rate = sum(pipe_correct) / len(pipe_correct) if pipe_correct else 0.0
+            sarvam_rate = sum(sarvam_correct) / len(sarvam_correct) if sarvam_correct else 0.0
+            diff = paired_difference(sarvam_correct, pipe_correct, cat_clusters)
+            category_result: dict[str, Any] | None = {
+                "n_tickets": len(cat_tickets),
+                "pipeline_accuracy": pipe_rate,
+                "sarvam_accuracy": sarvam_rate,
+                "difference": diff["diff"],  # sarvam - pipeline, positive favours sarvam
+                "se": diff["se"],
+                "ci_low": diff["ci_low"],
+                "ci_high": diff["ci_high"],
+                "n_clusters": diff["n_clusters"],
+                "interpretation": "difference + CI is the result; marginal rates are description (#127)",
+            }
+        else:
+            category_result = None
+            cat_tickets = []
+
+    # Transcription arm — arm-aware: extract-only does not measure OCR
+    transcription_available = any(p.transcription is not None for p in pages)
+    if arm == "extract":
+        div: dict[str, Any] = {
+            "rate": 0.0,
+            "se": 0.0,
+            "ci_low": 0.0,
+            "ci_high": 0.0,
+            "n": 0,
+            "n_clusters": 0,
+            "not_measured": True,
+            "reason": "Extract-only arm — Digitise not run; OCR divergence not measured (run with --arm digitise or both).",
         }
     else:
-        category_result = None
-
-    # Transcription arm
-    transcription_available = any(p.transcription is not None for p in pages)
-    # divergence always computable
-    div = divergence_rate(
-        [p.pytesseract_text for p in pages],
-        [p.sarvam_markdown for p in pages],
-        [p.ticket for p in pages],
-    )
+        # divergence always computable when OCR arm is active
+        div = divergence_rate(
+            [p.pytesseract_text for p in pages],
+            [p.sarvam_markdown for p in pages],
+            [p.ticket for p in pages],
+        )
     # accuracy only if ground truth exists
     if transcription_available:
         # For pages without transcription, exclude from accuracy comparison
@@ -692,17 +735,30 @@ def build_scorecard(pages: list[PageRecord]) -> ScorecardReport:
         transcription_accuracy = None
 
     # Splits — divergence split always; accuracy split only if available
+    # When arm == extract, OCR splits are not measured (Digitise not run)
     def _split_metrics(key_fn) -> dict[str, dict[str, Any]]:
         buckets: dict[str, list[PageRecord]] = defaultdict(list)
         for p in pages:
             buckets[key_fn(p)].append(p)
         out: dict[str, dict[str, Any]] = {}
         for bucket, bucket_pages in sorted(buckets.items()):
-            b_div = divergence_rate(
-                [x.pytesseract_text for x in bucket_pages],
-                [x.sarvam_markdown for x in bucket_pages],
-                [x.ticket for x in bucket_pages],
-            )
+            if arm == "extract":
+                b_div: dict[str, Any] = {
+                    "rate": 0.0,
+                    "se": 0.0,
+                    "ci_low": 0.0,
+                    "ci_high": 0.0,
+                    "n": 0,
+                    "n_clusters": 0,
+                    "not_measured": True,
+                    "reason": "Extract-only arm",
+                }
+            else:
+                b_div = divergence_rate(
+                    [x.pytesseract_text for x in bucket_pages],
+                    [x.sarvam_markdown for x in bucket_pages],
+                    [x.ticket for x in bucket_pages],
+                )
             entry: dict[str, Any] = {"n_pages": len(bucket_pages), "divergence": b_div}
             if transcription_available:
                 gt_pages = [x for x in bucket_pages if x.transcription is not None]
@@ -758,10 +814,17 @@ def build_scorecard(pages: list[PageRecord]) -> ScorecardReport:
             "no gold referee; normalised text diff, ticket-clustered CI."
         )
 
+    # Arm-aware summary divergence: only when Extract contributed
+    if arm == "digitise":
+        summ_div = None
+        # Add note that summary not measured for digitise-only
+        notes_parts.append(
+            "Summary divergence not measured — Extract arm not run (digitise-only); run with --arm extract or both."
+        )
     # Phase 17 extensions
     per_cat = per_category_table(pages)
     trans_probe = transliteration_probe(pages)
-    samp_info = sample_compliance(n_pages)
+    samp_info = sample_compliance(n_pages, slice_label=resolved_slice)
     # augment notes with per-category spread headline if available
     if per_cat:
         # headline spread like Police 0.85 vs Welfare 0.51 — report in notes for discoverability
@@ -779,23 +842,35 @@ def build_scorecard(pages: list[PageRecord]) -> ScorecardReport:
             "Sarvam transliteration (od-IN, 1000 chars/chunk) via "
             "janasunani/egress/sarvam.py is the next step before hashing/embedding."
         )
-    # few-hundred compliance note
+    # few-hundred compliance note — use resolved slice, not demo constant
     if not samp_info["is_few_hundred"]:
         notes_parts.append(
             f"Sample size {n_pages} is outside the intended few-hundred "
             f"({BENCHMARK_MIN_SAMPLE}–{BENCHMARK_MAX_SAMPLE}) window for the "
-            f"{DEMO_SLICE_LABEL} stratified benchmark; "
+            f"{resolved_slice} stratified benchmark; "
             "cost and power are calibrated for 200–400 at 10 req/min Vision."
         )
     else:
         notes_parts.append(
             f"Sample size {n_pages} is within the few-hundred "
             f"({BENCHMARK_MIN_SAMPLE}–{BENCHMARK_MAX_SAMPLE}) benchmark window for "
-            f"{DEMO_SLICE_LABEL} (stratified handwritten/printed); "
+            f"{resolved_slice} (stratified handwritten/printed); "
             "Vision divergence reported per-surface with no accuracy verdict "
             "(no transcription ground truth)."
         )
     notes = " ".join(notes_parts)
+
+    # Arm-aware notes for P1 digitise/extract
+    if arm == "digitise" and category_result is None:
+        notes_parts.append(
+            "Category accuracy not measured — digitise-only arm (Extract not run); run with --arm extract or both."
+        )
+        notes = " ".join(notes_parts)
+    if arm == "extract" and div.get("not_measured"):
+        notes_parts.append(
+            "Transcription divergence not measured — extract-only arm (Digitise not run); run with --arm digitise or both."
+        )
+        notes = " ".join(notes_parts)
 
     return ScorecardReport(
         normalizer_version=NORMALIZER_VERSION,
@@ -815,6 +890,8 @@ def build_scorecard(pages: list[PageRecord]) -> ScorecardReport:
         transliteration_probe_result=trans_probe,
         sample_info=samp_info,
         summary_divergence=summ_div,
+        slice_label=resolved_slice,
+        arm=arm,
     )
 
 
@@ -831,8 +908,12 @@ def render_markdown(report: ScorecardReport) -> str:
     with three decimals; missing arms are labelled ``not measured`` rather
     than omitted so a stale ``DELIVERY.md`` Table 2 row is visible.
     """
+    # Use report slice when available (P2), else demo constant
+    slice_for_header = getattr(report, "slice_label", None) or report.sample_info.get("slice") if report.sample_info else DEMO_SLICE_LABEL
+    if not slice_for_header:
+        slice_for_header = DEMO_SLICE_LABEL
     lines: list[str] = [
-        f"# Sarvam benchmark — {DEMO_SLICE_LABEL}",
+        f"# Sarvam benchmark — {slice_for_header}",
         "",
         f"Normalizer: `{report.normalizer_version}` · paired={report.paired_design} · n_pages={report.n_pages} · n_tickets={report.n_tickets}",
         "",
@@ -858,13 +939,21 @@ def render_markdown(report: ScorecardReport) -> str:
             "Not measured — no gold labels (``gold_category``) in sample; run with ``--join-metadata`` from the lake slice.",
             "",
         ]
-    # Transcription
+    # Transcription — arm-aware: extract-only hides OCR
     if report.transcription_available and report.transcription_accuracy is not None:
         t = report.transcription_accuracy
         lines += [
             "## Transcription accuracy (ground-truth available)",
             "",
             f"- Pipeline: {t['pipeline_accuracy']:.3f} · Sarvam: {t['sarvam_accuracy']:.3f} · diff {t['difference']:.3f} 95% CI [{t['ci_low']:.3f}, {t['ci_high']:.3f}] (n={t['n_pages']}, clusters={t['n_clusters']})",
+            "",
+        ]
+    elif report.transcription_divergence.get("not_measured"):
+        reason = report.transcription_divergence.get("reason", "OCR not measured for this arm.")
+        lines += [
+            "## Transcription",
+            "",
+            f"Not measured — {reason}",
             "",
         ]
     else:
@@ -876,10 +965,15 @@ def render_markdown(report: ScorecardReport) -> str:
             "No accuracy verdict — commission a hand-transcribed sample for an accuracy comparison (per DELIVERY.md fallback).",
             "",
         ]
-    # Divergence splits
+    # Divergence splits — arm-aware
     def _div_block(title: str, data: dict[str, dict[str, Any]]) -> None:
         lines.append(f"## {title}")
         lines.append("")
+        # check if arm hides OCR: if any entry has not_measured divergence, show not measured notice
+        if data and any(e.get("divergence", {}).get("not_measured") for e in data.values()):
+            lines.append("Not measured — Extract-only arm (Digitise not run).")
+            lines.append("")
+            return
         lines.append("| Bucket | n_pages | divergence rate | 95% CI |")
         lines.append("|---|---:|---:|---|")
         for bucket, entry in sorted(data.items()):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,6 +156,7 @@ janasunani-demo-preflight = "janasunani.inference.serve:preflight_main"
 janasunani-spam-score = "janasunani.pipeline.spam:main"
 janasunani-spam-scorecard = "janasunani.evaluation.spam_scorecard:main"
 janasunani-evaluate-benchmark = "janasunani.evaluation.benchmark_report:main"
+janasunani-evaluate-sarvam = "janasunani.evaluation.sarvam_evaluate:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/scripts/analysis/sarvam_sample.py
+++ b/scripts/analysis/sarvam_sample.py
@@ -1,217 +1,34 @@
-"""Run a paired Sarvam Vision vs pytesseract sample (#84, #127).
+"""Thin wrapper around janasunani-evaluate-sarvam (digitise-only legacy).
 
-Renders each page of every document once, sends the same rendered page to both
-engines, and scores the pair with ``janasunani.evaluation.sarvam_scorecard``.
-
-Two rules this script exists to enforce:
-
-* **Same pixels to both engines.** Re-rendering, or letting Sarvam read the
-  source PDF while pytesseract reads a raster, would measure the renderer as
-  much as the OCR. Both read exactly one ``render_page`` output.
-* **No page text is ever written to disk.** The inputs are real grievance
-  documents. Only aggregate metrics leave this process; the transcripts stay
-  in memory and are dropped when it exits. ``--dump-text`` exists for
-  debugging a single page and refuses to run over more than one.
-
-Live Sarvam calls cost money (Rs 0.5/page) and send citizen PII to an external
-provider under the recorded acceptance on the route. ``--dry-run`` renders and
-runs pytesseract only, so the sample and the cost can be checked first.
+This script is retained for backward compatibility. New code should invoke
+``janasunani-evaluate-sarvam`` directly (Unit E) with ``--arm digitise``,
+``--arm extract`` or ``--arm both``. The wrapper delegates to
+``janasunani.evaluation.sarvam_evaluate`` so the same-pixels-to-both-engines
+invariant stays in one place.
 """
 
 from __future__ import annotations
 
-import argparse
-import json
 import sys
-from dataclasses import asdict
-from pathlib import Path
 
 from loguru import logger
 
-from janasunani.egress.sarvam import (
-    PROVIDER_REGISTRY,
-    SarvamAuditContext,
-    SarvamVisionAdapter,
-    SqliteAuditLog,
-)
-from janasunani.evaluation.sarvam_scorecard import (
-    PageRecord,
-    build_scorecard,
-    normalize_text,
-)
-from janasunani.pipeline.stages.ocr_extraction.page_renderer import render_page
-
-PRICE_PER_PAGE_RUPEES = 0.5
-IMAGE_SUFFIXES = {".png", ".jpg", ".jpeg", ".tiff", ".tif", ".bmp", ".gif"}
-
-
-def _page_count(path: Path) -> int:
-    if path.suffix.lower() == ".pdf":
-        from pdf2image import pdfinfo_from_path
-
-        return int(pdfinfo_from_path(str(path))["Pages"])
-    return 1
-
-
-def _ticket_of(path: Path) -> str:
-    """Ticket id from the filename prefix, e.g. CMO20251190995_complaint_x.pdf."""
-    return path.stem.split("_", 1)[0]
-
-
-def discover_pages(input_dir: Path, limit: int | None) -> list[tuple[Path, int]]:
-    pages: list[tuple[Path, int]] = []
-    for path in sorted(input_dir.iterdir()):
-        if not path.is_file():
-            continue
-        if path.suffix.lower() not in IMAGE_SUFFIXES and path.suffix.lower() != ".pdf":
-            continue
-        for number in range(1, _page_count(path) + 1):
-            pages.append((path, number))
-            if limit is not None and len(pages) >= limit:
-                return pages
-    return pages
-
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--input", type=Path, required=True, help="Directory of documents.")
-    parser.add_argument("--out", type=Path, required=True, help="Where to write aggregates.")
-    parser.add_argument("--limit", type=int, default=None, help="Cap pages (cost control).")
-    parser.add_argument(
-        "--language", default="en-IN", help="Language hint passed to Sarvam."
-    )
-    parser.add_argument(
-        "--audit-db",
-        type=Path,
-        default=None,
-        help="Sarvam egress audit log (default: <out>/sarvam_audit.sqlite).",
-    )
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Render and run pytesseract only. No Sarvam call, no spend.",
-    )
-    parser.add_argument(
-        "--dump-text",
-        action="store_true",
-        help="Print both transcripts. Debugging only; refuses more than one page.",
-    )
-    args = parser.parse_args(argv)
+    logger.warning("scripts/analysis/sarvam_sample.py is deprecated — use janasunani-evaluate-sarvam --arm digitise")
+    from janasunani.evaluation.sarvam_evaluate import main as evaluate_main
 
-    pages = discover_pages(args.input, args.limit)
-    if not pages:
-        logger.error(f"no documents found under {args.input}")
-        return 1
-
-    cost = len(pages) * PRICE_PER_PAGE_RUPEES
-    logger.info(f"{len(pages)} page(s) across {len({p for p, _ in pages})} document(s)")
-    logger.info(f"Sarvam cost if run: Rs {cost:.2f} at Rs {PRICE_PER_PAGE_RUPEES}/page")
-
-    if args.dump_text and len(pages) > 1:
-        logger.error(
-            "--dump-text prints real grievance text and is limited to one page; "
-            "narrow the sample with --limit 1"
-        )
-        return 1
-
-    adapter = None
-    if not args.dry_run:
-        route = PROVIDER_REGISTRY["sarvam-vision"]
-        if not route.egress_permitted:
-            logger.error(
-                "Sarvam egress is not permitted: "
-                f"unverified controls {route.unverified_controls} and no accepted risk"
-            )
-            return 1
-        logger.warning(
-            f"LIVE RUN: sending {len(pages)} page(s) of real grievance documents to "
-            f"{route.provider} on basis '{route.egress_basis}'"
-        )
-        args.out.mkdir(parents=True, exist_ok=True)
-        audit_db = args.audit_db or (args.out / "sarvam_audit.sqlite")
-        adapter = SarvamVisionAdapter(enabled=True, audit_log=SqliteAuditLog(audit_db))
-
-    from janasunani.pipeline.stages.ocr_extraction.pytesseract_backend import extract_text
-
-    records: list[PageRecord] = []
-    failures: list[dict[str, str]] = []
-    page_lengths: list[dict[str, object]] = []
-    for path, number in pages:
-        page_id = f"{path.stem}:p{number}"
-        image = render_page(path, number)
-
-        local = extract_text(image)
-
-        remote = ""
-        if adapter is not None:
-            from io import BytesIO
-
-            buffer = BytesIO()
-            image.save(buffer, format="PNG")
-            context = SarvamAuditContext(
-                ticket=_ticket_of(path),
-                stage="ocr_extraction",
-                document_id=f"{path.name}:{number}",
-            )
-            try:
-                remote = adapter.digitise(
-                    buffer.getvalue(), f"{page_id}.png", args.language, context
-                )
-            except Exception as exc:  # noqa: BLE001 - recorded, run continues
-                failures.append({"page_id": page_id, "error": type(exc).__name__})
-                logger.error(f"{page_id}: {type(exc).__name__}: {exc}")
-
-        records.append(
-            PageRecord(
-                ticket=_ticket_of(path),
-                page_id=page_id,
-                pytesseract_text=local,
-                sarvam_markdown=remote,
-            )
-        )
-        # Report normalized lengths, because those are what the scorecard
-        # compares. Raw counts are wildly misleading here: Sarvam embeds figure
-        # crops as base64 data URIs, so a page whose text is ~700 characters
-        # arrives as ~36,000 and reads like a 100x blow-up. normalize_text
-        # strips them, and the raw number is kept only to show how much of the
-        # payload was never text.
-        local_n = len(normalize_text(local))
-        remote_n = len(normalize_text(remote))
-        page_lengths.append(
-            {
-                "page_id": page_id,
-                "pytesseract_chars": local_n,
-                "sarvam_chars": remote_n,
-                "sarvam_raw_chars": len(remote),
-            }
-        )
-        logger.info(
-            f"{page_id}: pytesseract {local_n} chars, sarvam {remote_n} chars "
-            f"(sarvam raw {len(remote)}, {100 * (1 - remote_n / len(remote)) if remote else 0:.0f}% non-text)"
-        )
-
-        if args.dump_text:
-            print("---- pytesseract ----")
-            print(local)
-            print("---- sarvam ----")
-            print(remote)
-
-    args.out.mkdir(parents=True, exist_ok=True)
-    report = build_scorecard(records)
-    payload = asdict(report)
-    payload["failures"] = failures
-    payload["pages_submitted"] = len(pages)
-    payload["cost_rupees"] = 0.0 if args.dry_run else cost
-    # Lengths only. Never the text: these documents are real citizen grievances.
-    payload["page_lengths"] = page_lengths
-
-    destination = args.out / "sarvam_scorecard.json"
-    destination.write_text(json.dumps(payload, indent=2, default=str))
-    logger.success(f"scorecard -> {destination}")
-
-    if failures:
-        logger.warning(f"{len(failures)} page(s) failed; they score as empty remote text")
-    return 0
+    # Legacy default: digitise arm.  If caller already passes --arm, honour it.
+    if argv is not None:
+        has_arm = any(a == "--arm" or a.startswith("--arm=") for a in argv)
+        if not has_arm:
+            argv = ["--arm", "digitise", *argv]
+    else:
+        # argv=None -> evaluate_main reads sys.argv; inject default arm if missing
+        has_arm = any(a == "--arm" or a.startswith("--arm=") for a in sys.argv[1:])
+        if not has_arm:
+            sys.argv = [sys.argv[0], "--arm", "digitise", *sys.argv[1:]]
+    return evaluate_main(argv)
 
 
 if __name__ == "__main__":

--- a/tests/test_sarvam_evaluate.py
+++ b/tests/test_sarvam_evaluate.py
@@ -1,0 +1,245 @@
+"""Unit E — janasunani-evaluate-sarvam CLI (arm / schema / metadata join).
+
+Recorded / dry-run only; no live Sarvam call.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def test_grievance_schema_is_pinned_and_versioned():
+    from janasunani.evaluation.sarvam_grievance_schema import (
+        GRIEVANCE_EXTRACT_SCHEMA_V1,
+        SCHEMA_VERSION,
+        SUPPORTED_SCHEMA_VERSIONS,
+        get_schema,
+    )
+
+    assert SCHEMA_VERSION == "v1"
+    assert "v1" in SUPPORTED_SCHEMA_VERSIONS
+    assert SUPPORTED_SCHEMA_VERSIONS["v1"] is GRIEVANCE_EXTRACT_SCHEMA_V1
+    schema = get_schema("v1")
+    assert schema is GRIEVANCE_EXTRACT_SCHEMA_V1
+    # illustrative fields from plan
+    for field in ("grievance_category", "summary", "district", "grievance_text"):
+        assert field in schema
+        assert schema[field]["type"] == "string"
+        assert "description" in schema[field]
+    with pytest.raises(ValueError, match="unknown schema"):
+        get_schema("v9")
+    with pytest.raises(ValueError, match="unknown schema"):
+        get_schema("")
+
+
+def _make_dummy_input(tmp_path: Path, n: int = 2) -> Path:
+    """Create *n* dummy document files (PNG) under a temp input dir."""
+    inp = tmp_path / "input"
+    inp.mkdir(parents=True, exist_ok=True)
+    # Create minimal PNGs via PIL if available, else empty files.
+    try:
+        from PIL import Image
+
+        for i in range(n):
+            img = Image.new("RGB", (10, 10), color="white")
+            img.save(inp / f"TICK{i:03d}_doc.png", format="PNG")
+        return inp
+    except Exception:
+        for i in range(n):
+            (inp / f"TICK{i:03d}_doc.png").write_bytes(b"\x89PNG\r\n\x1a\nfake")
+        return inp
+
+
+def test_evaluate_dry_run_digitise_arm(tmp_path: Path):
+    from janasunani.evaluation.sarvam_evaluate import main
+
+    inp = _make_dummy_input(tmp_path, n=2)
+    out = tmp_path / "out"
+    rc = main(["--input", str(inp), "--out", str(out), "--arm", "digitise", "--dry-run"])
+    assert rc == 0
+    # outputs exist
+    json_path = out / "sarvam_scorecard.json"
+    md_path = out / "sarvam_scorecard.md"
+    assert json_path.is_file()
+    assert md_path.is_file()
+    data = json.loads(json_path.read_text())
+    assert data["n_pages"] == 2
+    assert data["arm"] == "digitise"
+    assert data["schema_version"] == "v1"
+    assert data["cost_rupees"] == 0.0  # dry-run
+    assert "summary_divergence" in data
+    # markdown mentions arm/slice
+    md = md_path.read_text()
+    assert "Sarvam" in md
+    assert "Sambalpur" in md
+
+
+def test_evaluate_arm_choices_and_schema_version(tmp_path: Path):
+    from janasunani.evaluation.sarvam_evaluate import build_parser
+
+    parser = build_parser()
+    # valid
+    args = parser.parse_args(["--input", "a", "--out", "b", "--arm", "extract", "--schema-version", "v1"])
+    assert args.arm == "extract"
+    assert args.schema_version == "v1"
+    args2 = parser.parse_args(["--input", "a", "--out", "b", "--arm", "both"])
+    assert args2.arm == "both"
+    # invalid arm
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--input", "a", "--out", "b", "--arm", "invalid"])
+    # invalid schema version
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--input", "a", "--out", "b", "--schema-version", "v9"])
+
+
+def test_evaluate_both_arm_cost(tmp_path: Path):
+    from janasunani.evaluation.sarvam_evaluate import main
+
+    inp = _make_dummy_input(tmp_path, n=3)
+    out = tmp_path / "out2"
+    # dry-run cost is 0, but payload records arm
+    rc = main(["--input", str(inp), "--out", str(out), "--arm", "both", "--dry-run"])
+    assert rc == 0
+    data = json.loads((out / "sarvam_scorecard.json").read_text())
+    assert data["arm"] == "both"
+    # When not dry-run, cost would be 1.50/page; verify helper
+    from janasunani.evaluation.sarvam_evaluate import _price_for_arm
+
+    assert _price_for_arm("digitise", 10) == pytest.approx(5.0)
+    assert _price_for_arm("extract", 10) == pytest.approx(10.0)
+    assert _price_for_arm("both", 10) == pytest.approx(15.0)
+
+
+def test_evaluate_join_metadata_from_lake(tmp_path: Path):
+    """--join-metadata should populate gold_category from lake complaints parquet."""
+    import polars as pl
+
+    inp = _make_dummy_input(tmp_path, n=2)
+    # Align ticket ids with input files: TICK000, TICK001
+    lake_dir = tmp_path / "lake"
+    lake_dir.mkdir()
+    complaints = pl.DataFrame(
+        {
+            "ticket_no": ["TICK000", "TICK001"],
+            "district": ["Sambalpur", "Sambalpur"],
+            "created_year": [2024, 2024],
+            "category": ["Police", "Revenue"],
+        }
+    )
+    complaints.write_parquet(lake_dir / "complaints.parquet")
+
+    out = tmp_path / "out3"
+    from janasunani.evaluation.sarvam_evaluate import main
+
+    rc = main(
+        [
+            "--input",
+            str(inp),
+            "--out",
+            str(out),
+            "--arm",
+            "digitise",
+            "--dry-run",
+            "--join-metadata",
+            "--lake-dir",
+            str(lake_dir),
+            "--slice",
+            "Sambalpur/2024",
+        ]
+    )
+    assert rc == 0
+    data = json.loads((out / "sarvam_scorecard.json").read_text())
+    # With gold present, category headline should be computed (not None)
+    assert data["category"] is not None
+    assert data["category"]["n_tickets"] == 2
+
+
+def test_evaluate_extract_arm_with_mocked_adapter(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """--arm extract should call adapter.extract(schema=...) and map to PageRecord."""
+    inp = _make_dummy_input(tmp_path, n=1)
+    out = tmp_path / "out4"
+
+    # Fake adapter that returns a known extract payload
+    class FakeAdapter:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def digitise(self, *args, **kwargs):
+            return "fake markdown"
+
+        def extract(self, doc_bytes, filename, language, context, schema=None, config_id=None):
+            assert schema is not None
+            assert "grievance_category" in schema
+            return {"grievance_category": "Police", "summary": "Sarvam summary text", "district": "Sambalpur"}
+
+    # Patch the class used by evaluate
+    import janasunani.evaluation.sarvam_evaluate as eval_mod
+
+    monkeypatch.setattr(eval_mod, "SarvamVisionAdapter", FakeAdapter, raising=False)
+    # Also need to patch the import inside main (it does `from janasunani.egress.sarvam import ...`)
+    # So patch the egress module's class as well
+    import janasunani.egress.sarvam as egress_mod
+
+    monkeypatch.setattr(egress_mod, "SarvamVisionAdapter", FakeAdapter, raising=False)
+    # Patch SqliteAuditLog to avoid creating real DB
+    class FakeLog:
+        def __init__(self, *a, **kw):
+            pass
+
+    monkeypatch.setattr(egress_mod, "SqliteAuditLog", FakeLog, raising=False)
+    # Need a fake PROVIDER_REGISTRY that permits egress
+    from dataclasses import replace
+
+    from janasunani.egress.sarvam import GovernanceControl, PROVIDER_REGISTRY
+
+    verified = GovernanceControl(statement="test", verified=True)
+    fake_route = replace(PROVIDER_REGISTRY["sarvam-vision"], retention_terms=verified, encryption_in_transit=verified, encryption_at_rest=verified)
+    monkeypatch.setattr(egress_mod, "PROVIDER_REGISTRY", {"sarvam-vision": fake_route}, raising=False)
+    # Patch render_page to return a real PIL image so digitise/extract paths are exercised
+    try:
+        from PIL import Image
+
+        fake_image = Image.new("RGB", (5, 5))
+        monkeypatch.setattr(eval_mod, "render_page", lambda p, n: fake_image, raising=False)
+        # Also patch the lazy import path if evaluate imports render_page inside function via import statement;
+        # monkeypatch the module where it's imported: janasunani.pipeline.stages.ocr_extraction.page_renderer
+        import janasunani.pipeline.stages.ocr_extraction.page_renderer as renderer_mod  # type: ignore
+
+        monkeypatch.setattr(renderer_mod, "render_page", lambda p, n: fake_image, raising=False)
+    except Exception:
+        pass
+
+    # Run without --dry-run so adapter is used; mock will prevent network
+    from janasunani.evaluation.sarvam_evaluate import main
+
+    # We need to ensure the adapter mock is used — the evaluate code does
+    # `from janasunani.egress.sarvam import SarvamVisionAdapter` inside main,
+    # which after our patch will pick up FakeAdapter.
+    rc = main(["--input", str(inp), "--out", str(out), "--arm", "extract"])
+    assert rc == 0
+    data = json.loads((out / "sarvam_scorecard.json").read_text())
+    assert data["arm"] == "extract"
+    # The sarvam category/summary should have been mapped from fake payload
+    # Scorecard will have at least one ticket with sarvam_category
+    assert data["n_pages"] == 1
+
+
+def test_wrapper_script_delegates(tmp_path: Path):
+    """scripts/analysis/sarvam_sample.py thin wrapper should still run dry-run."""
+    import subprocess
+
+    inp = _make_dummy_input(tmp_path, n=1)
+    out = tmp_path / "out_wrap"
+    # Invoke wrapper as module
+    result = subprocess.run(
+        [sys.executable, "scripts/analysis/sarvam_sample.py", "--input", str(inp), "--out", str(out), "--dry-run"],
+        capture_output=True,
+        text=True,
+    )
+    # Should exit 0 and produce outputs (wrapper injects --arm digitise)
+    assert result.returncode == 0, f"wrapper failed: {result.stderr}\n{result.stdout}"
+    assert (out / "sarvam_scorecard.json").is_file()

--- a/tests/test_sarvam_evaluate.py
+++ b/tests/test_sarvam_evaluate.py
@@ -135,6 +135,7 @@ def test_evaluate_join_metadata_from_lake(tmp_path: Path):
     out = tmp_path / "out3"
     from janasunani.evaluation.sarvam_evaluate import main
 
+    # Category is only scored for extract/both (digitise-only would fabricate 0% Sarvam)
     rc = main(
         [
             "--input",
@@ -142,7 +143,7 @@ def test_evaluate_join_metadata_from_lake(tmp_path: Path):
             "--out",
             str(out),
             "--arm",
-            "digitise",
+            "extract",
             "--dry-run",
             "--join-metadata",
             "--lake-dir",
@@ -156,6 +157,27 @@ def test_evaluate_join_metadata_from_lake(tmp_path: Path):
     # With gold present, category headline should be computed (not None)
     assert data["category"] is not None
     assert data["category"]["n_tickets"] == 2
+    # Digitise-only with same gold should NOT score category (avoids fabricated zero)
+    out2 = tmp_path / "out3_digitise"
+    rc2 = main(
+        [
+            "--input",
+            str(inp),
+            "--out",
+            str(out2),
+            "--arm",
+            "digitise",
+            "--dry-run",
+            "--join-metadata",
+            "--lake-dir",
+            str(lake_dir),
+            "--slice",
+            "Sambalpur/2024",
+        ]
+    )
+    assert rc2 == 0
+    data2 = json.loads((out2 / "sarvam_scorecard.json").read_text())
+    assert data2["category"] is None
 
 
 def test_evaluate_extract_arm_with_mocked_adapter(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_sarvam_scorecard.py
+++ b/tests/test_sarvam_scorecard.py
@@ -402,3 +402,90 @@ def test_few_hundred_sample_compliance_flagged_in_report():
     assert report_big.sample_info["is_few_hundred"] is True
     assert report_big.sample_info["n_pages"] == 250
     assert "within the few-hundred" in report_big.notes
+
+
+# ---------------------------------------------------------------------------
+# Unit E extensions — PageRecord summary fields, summary_divergence,
+# render_markdown, write_outputs
+# ---------------------------------------------------------------------------
+
+
+def test_pagerecord_summary_fields_exist():
+    """PageRecord must carry sarvam_summary / pipeline_summary (Unit E)."""
+    from janasunani.evaluation.sarvam_scorecard import PageRecord
+
+    rec = PageRecord(ticket="T1", page_id="P1", sarvam_summary="sarvam one-paragraph", pipeline_summary="bart summary")
+    assert rec.sarvam_summary == "sarvam one-paragraph"
+    assert rec.pipeline_summary == "bart summary"
+    # defaults are None
+    rec2 = PageRecord(ticket="T2", page_id="P2")
+    assert rec2.sarvam_summary is None
+    assert rec2.pipeline_summary is None
+
+
+def test_summary_divergence_clustered():
+    """summary_divergence is the exploratory counterpart of divergence_rate."""
+    from janasunani.evaluation.sarvam_scorecard import summary_divergence
+
+    sarvam = ["same summary", "same summary", "different A", "different A"]
+    pipe = ["same summary", "same summary", "different B", "different B"]
+    clusters = ["T1", "T1", "T2", "T2"]
+    res = summary_divergence(sarvam, pipe, clusters)
+    assert res["rate"] == 0.5
+    assert res["n"] == 4
+    assert res["n_clusters"] == 2
+    assert res["ci_low"] < 0.5 < res["ci_high"]
+    # markdown normalisation: same after normalise -> not divergent
+    res2 = summary_divergence(["**bold** text", "a | b"], ["bold text", "a b"], ["T1", "T2"])
+    assert res2["rate"] == 0.0
+
+
+def test_build_scorecard_computes_summary_divergence_when_present():
+    from janasunani.evaluation.sarvam_scorecard import PageRecord, build_scorecard
+
+    pages = [
+        PageRecord(ticket="T1", page_id="P1", sarvam_summary="same", pipeline_summary="same", pytesseract_text="a", sarvam_markdown="a"),
+        PageRecord(ticket="T2", page_id="P2", sarvam_summary="sarvam diff", pipeline_summary="bart diff", pytesseract_text="a", sarvam_markdown="a"),
+    ]
+    report = build_scorecard(pages)
+    assert report.summary_divergence is not None
+    assert report.summary_divergence["rate"] == 0.5
+    assert report.summary_divergence["n"] == 2
+    assert "Summary divergence" in report.notes
+
+    # No summaries -> None and not in notes as measured
+    pages2 = [PageRecord(ticket="T1", page_id="P1", pytesseract_text="a", sarvam_markdown="a")]
+    report2 = build_scorecard(pages2)
+    assert report2.summary_divergence is None
+
+
+def test_render_markdown_and_write_outputs():
+    """render_markdown must mention headline, divergence, summary; write_outputs writes files."""
+    import json
+    import tempfile
+    from pathlib import Path
+
+    from janasunani.evaluation.sarvam_scorecard import PageRecord, build_scorecard, render_markdown, write_outputs
+
+    pages = [
+        PageRecord(ticket="T1", page_id="P1", gold_category="Police", pipeline_category="Police", sarvam_category="Police", sarvam_summary="same", pipeline_summary="same", pytesseract_text="a", sarvam_markdown="a"),
+        PageRecord(ticket="T2", page_id="P2", gold_category="Revenue", pipeline_category="Police", sarvam_category="Revenue", sarvam_summary="x", pipeline_summary="y", pytesseract_text="a", sarvam_markdown="b"),
+    ]
+    report = build_scorecard(pages)
+    md = render_markdown(report)
+    assert "Sarvam" in md
+    assert "Category accuracy" in md
+    assert "Divergence" in md or "divergence" in md
+    assert "Summary divergence" in md
+    assert "Sambalpur/2024" in md or "Sambalpur" in md
+
+    with tempfile.TemporaryDirectory() as tmp:
+        out = Path(tmp) / "out"
+        paths = write_outputs(report, out)
+        assert paths["json"].is_file()
+        assert paths["markdown"].is_file()
+        data = json.loads(paths["json"].read_text())
+        assert data["n_pages"] == 2
+        assert "summary_divergence" in data
+        md2 = paths["markdown"].read_text()
+        assert md2 == md


### PR DESCRIPTION
Unit E — Three Sarvam arms (digitise / extract / both) per 2026-08-08-demo-integration-rehearsal.md Part 5.

**Owns** (file-disjoint, do-not-touch respected):
- `janasunani/evaluation/sarvam_grievance_schema.py` — pinned `GRIEVANCE_EXTRACT_SCHEMA_V1` (v1, frozen before any output read)
- `janasunani/evaluation/sarvam_scorecard.py` extensions — `PageRecord.sarvam_summary/pipeline_summary`, `summary_divergence` (normalised, ticket-clustered SE), `ScorecardReport.summary_divergence`, `render_markdown`, `write_outputs`
- `janasunani/evaluation/sarvam_evaluate.py` — new `janasunani-evaluate-sarvam` CLI with `--arm digitise|extract|both` (₹0.50/1.00/1.50 per page), `--join-metadata` (lake/OLTP redacted metadata → gold_category/handwritten/language), `--schema-version v1`, cost + arm recorded in scorecard JSON
- `pyproject.toml` — `janasunani-evaluate-sarvam` entry
- `scripts/analysis/sarvam_sample.py` — thin wrapper delegating to evaluate (default arm digitise, deprecation warning)
- `tests/test_sarvam_scorecard.py` extensions + `tests/test_sarvam_evaluate.py` new

**Do-not-touch**: `janasunani/egress/sarvam.py`, `janasunani/evaluation/benchmark_report.py`, `scripts/benchmark_pipeline.py`, `janasunani/inference/**`, `janasunani/serving/**`

**Verify**:
```
uv run ruff check janasunani/evaluation/sarvam_grievance_schema.py janasunani/evaluation/sarvam_scorecard.py
# All checks passed
uv run --extra serving pytest tests/test_sarvam_scorecard.py tests/test_sarvam_egress.py tests/test_sarvam_evaluate.py -v
# 63 passed, 6 skipped
uv run janasunani-evaluate-sarvam --help  # arm / schema-version / join-metadata visible
```

Live Sarvam requires egress permission; CI uses recorded transports / --dry-run only (per plan).

Refs #126