### PR TITLE
build: gate pull requests on the Codex review

### DIFF
--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -93,6 +93,14 @@ jobs:
         run: |
           set -euo pipefail
 
+          # The trusted copy is the base branch, so until this lands there the
+          # gate has nothing to run. Stay quiet rather than failing every open
+          # pull request on a workflow that is not deployed yet.
+          if [ ! -f scripts/check_codex_review.py ]; then
+            echo "::notice::Gate not yet on the base branch; nothing to enforce."
+            exit 0
+          fi
+
           for pr in $NUMBERS; do
             echo "::group::PR #$pr"
             python3 scripts/check_codex_review.py \

--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -6,23 +6,29 @@ name: Codex Review Gate
 #
 # Two GitHub constraints explain the shape of this file:
 #
-#   1. Reactions emit no webhook, so the clean :+1: cannot trigger a workflow.
-#      The schedule sweeps open pull requests to catch it.
+#   1. Reactions emit no webhook, and neither does resolving a review thread,
+#      so a clean :+1: and the last resolve of a round cannot trigger a run.
+#      The schedule sweeps open pull requests to catch both.
 #   2. Runs from `issue_comment` and `pull_request_review` attach to the default
 #      branch, not the pull request head. The check run is therefore created
 #      against `head_sha` through the API rather than reported by the job.
 #
-# Branch protection should require the check named below, not this job.
+# Branch protection should require the check named `codex-review`, which this
+# job creates through the API. The job itself is deliberately named something
+# else: a job called `codex-review` would produce a second, always-green check
+# run under the same name, and protection would accept that one instead.
 
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
   pull_request_review:
     types: [submitted, dismissed]
+  pull_request_review_comment:
+    types: [created, deleted]
   issue_comment:
     types: [created]
   schedule:
-    - cron: "*/10 * * * *"
+    - cron: "*/5 * * * *"
   workflow_dispatch:
     inputs:
       pr:
@@ -39,15 +45,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  codex-review:
+  evaluate:
     runs-on: ubuntu-latest
     # issue_comment fires on plain issues too; only pull requests have a head.
     if: >-
       github.event_name != 'issue_comment' ||
       github.event.issue.pull_request != null
     steps:
-      - name: Check out repository
+      # Never the pull request's own code. On `pull_request` the default
+      # checkout is `refs/pull/N/merge`, which would run a contributor-edited
+      # gate script with this job's `checks: write` token -- a branch could
+      # post its own passing `codex-review` check. The script reads only the
+      # API, so the base copy is all it needs. The consequence is that edits
+      # to the gate are not exercised here; `tests/test_check_codex_review.py`
+      # covers them on the normal test job instead.
+      - name: Check out trusted base copy of the gate
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch || 'main' }}
+          persist-credentials: false
 
       - name: Resolve pull requests to gate
         id: targets

--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -13,10 +13,11 @@ name: Codex Review Gate
 #      branch, not the pull request head. The check run is therefore created
 #      against `head_sha` through the API rather than reported by the job.
 #
-# Branch protection should require the check named `codex-review`, which this
-# job creates through the API. The job itself is deliberately named something
-# else: a job called `codex-review` would produce a second, always-green check
-# run under the same name, and protection would accept that one instead.
+# The `no-push-only-pr` ruleset on `main` should require the check named
+# `codex-review`, which this job creates through the API. The job itself is
+# deliberately named something else: a job called `codex-review` would produce
+# a second, always-green check run under the same name, and the ruleset would
+# accept that one instead.
 
 on:
   pull_request:

--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -1,0 +1,88 @@
+name: Codex Review Gate
+
+# Codex in GitHub publishes no check run and no commit status, so this job
+# turns its two signals -- a review naming the commit it read, or a bare :+1:
+# when it found nothing -- into one required check.
+#
+# Two GitHub constraints explain the shape of this file:
+#
+#   1. Reactions emit no webhook, so the clean :+1: cannot trigger a workflow.
+#      The schedule sweeps open pull requests to catch it.
+#   2. Runs from `issue_comment` and `pull_request_review` attach to the default
+#      branch, not the pull request head. The check run is therefore created
+#      against `head_sha` through the API rather than reported by the job.
+#
+# Branch protection should require the check named below, not this job.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+  pull_request_review:
+    types: [submitted, dismissed]
+  issue_comment:
+    types: [created]
+  schedule:
+    - cron: "*/10 * * * *"
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: Pull request number
+        required: true
+
+permissions:
+  checks: write
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: codex-review-gate-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  codex-review:
+    runs-on: ubuntu-latest
+    # issue_comment fires on plain issues too; only pull requests have a head.
+    if: >-
+      github.event_name != 'issue_comment' ||
+      github.event.issue.pull_request != null
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Resolve pull requests to gate
+        id: targets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_PR: ${{ github.event.pull_request.number || github.event.issue.number || inputs.pr }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "schedule" ]; then
+            numbers="$(gh pr list --repo "$GITHUB_REPOSITORY" --state open \
+              --limit 100 --json number --jq '.[].number' | tr '\n' ' ')"
+          else
+            numbers="$EVENT_PR"
+          fi
+
+          echo "numbers=$numbers" >> "$GITHUB_OUTPUT"
+          echo "Gating: ${numbers:-none}"
+
+      - name: Evaluate Codex review signal
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          NUMBERS: ${{ steps.targets.outputs.numbers }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          for pr in $NUMBERS; do
+            echo "::group::PR #$pr"
+            python3 scripts/check_codex_review.py \
+              --repo "$GITHUB_REPOSITORY" \
+              --pr "$pr" \
+              --check-name codex-review \
+              --post-check-run
+            echo "::endgroup::"
+          done

--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -55,11 +55,18 @@ jobs:
     steps:
       # Never the pull request's own code. On `pull_request` the default
       # checkout is `refs/pull/N/merge`, which would run a contributor-edited
-      # gate script with this job's `checks: write` token -- a branch could
-      # post its own passing `codex-review` check. The script reads only the
-      # API, so the base copy is all it needs. The consequence is that edits
-      # to the gate are not exercised here; `tests/test_check_codex_review.py`
-      # covers them on the normal test job instead.
+      # gate script with this job's `checks: write` token. The script reads
+      # only the API, so the base copy is all it needs. The consequence is
+      # that edits to the gate are not exercised here;
+      # `tests/test_check_codex_review.py` covers them on the normal test job.
+      #
+      # This raises the cost of self-bypass; it does not close it, and an
+      # earlier version of this comment wrongly claimed it did. On a same-repo
+      # `pull_request` the *workflow definition* also comes from the merge ref,
+      # so a branch can delete this step and keep the token. Closing that needs
+      # the decision to run from a base-controlled event -- see #223. Fork PRs
+      # are not a way in: their `GITHUB_TOKEN` is read-only, so `checks: write`
+      # is never granted.
       - name: Check out trusted base copy of the gate
         uses: actions/checkout@v4
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,8 +35,22 @@ change:
 uv lock --upgrade-package dpic && uv sync && uv run dpic-sync-standards
 ```
 
-CI runs Lint, Pipeline, and Data Check on every pull request. It does not run
-the heavy ML extras, and it never executes a data stage.
+CI runs Lint, Pipeline, Data Check, and the Codex Review Gate on every pull
+request. It does not run the heavy ML extras, and it never executes a data
+stage.
+
+`main` is governed by the `no-push-only-pr` ruleset: no force-push, no
+deletion, and changes land only through a pull request. Its required status
+checks are `ruff`, `test-and-validate-pipeline`, and `no-raw-data-in-git`, and
+**every review thread must be resolved** before the merge button unlocks. No
+approving review is required, and nobody can bypass the ruleset.
+
+The Codex Review Gate publishes a check run named `codex-review` that turns
+that protocol into a pass/fail signal
+([.github/workflows/codex-review-gate.yml](.github/workflows/codex-review-gate.yml)).
+`codex-review` is **not yet in the ruleset's required checks**, so today it
+reports without blocking a merge. Making it binding means adding that context
+to the ruleset: add the check name, not the job that creates it.
 
 Every feature ships with pytest tests that exercise the real code path. Green
 before "done", not after review.
@@ -116,8 +130,10 @@ restating the description.
    path, and confirm the tests would fail without the fix.
 2. **Request a Codex review** by commenting `@codex review` on the pull
    request. Do this for anything touching the pipeline, serving, deploy, PII,
-   or data paths, and re-request after pushing a material change. Small
-   docs-only or config-only branches do not need one.
+   or data paths. Codex names the commit it read, and the gate binds its
+   verdict to that sha, so **re-request after every push**, not only after a
+   material change. A clean run leaves no review at all, only a :+1: reaction;
+   the gate accepts that when the reaction is newer than the head commit.
 3. **Handle the findings under the protocol** in
    [.dpic/standards/agent-conventions.md](.dpic/standards/agent-conventions.md).
    Findings are claims to verify, not instructions to execute. Reproduce before
@@ -132,4 +148,20 @@ restating the description.
 
 Do not merge with review comments left unanswered. Every finding ends in one of
 three states: fixed in the branch, filed as an issue, or rejected in a reply
-that shows the evidence.
+that shows the evidence — and then **the thread is resolved**. Resolving is what
+both the ruleset and the gate count, so a finding answered in a reply but left
+open blocks the merge outright.
+
+### When the review is not required
+
+The gate decides this itself; it is not a judgement call at merge time.
+
+- **Docs-only branches** are exempt automatically, up to 400 changed lines.
+  Past that the branch goes through the normal review: a docs change large
+  enough to restate a policy is worth reading.
+- **Config-only branches** cannot be told apart from a diff, so they need the
+  `codex-review-not-required` label. Say in the pull request why.
+
+If Codex answers `@codex review` with a plain comment about usage limits, the
+account is out of review credits and read nothing. The check stays red and
+re-commenting cannot clear it; wait for the quota, or use the label and say so.

--- a/scripts/check_codex_review.py
+++ b/scripts/check_codex_review.py
@@ -14,8 +14,13 @@ is what the protocol already tracks -- fixed, filed as an issue, or rejected
 with evidence, then resolved.
 
 The clean signal carries no commit sha, so freshness for that path is decided
-on time: the reaction must be newer than the head commit. A force-push of an
-older commit can therefore keep a stale :+1: valid; pushing new work cannot.
+on time: the reaction must be newer than the head commit. That commit date is
+written by the committing client, not by GitHub, so anyone able to push can
+defeat this rung by backdating -- with `GIT_COMMITTER_DATE`, or by force-pushing
+older history. An earlier version of this docstring claimed pushing new work
+could not keep a stale :+1: valid. It can, and #224 tracks moving the
+comparison onto the server-assigned push time in the pull request timeline.
+The reviewed-a-named-sha path is unaffected.
 
 There is a third thing Codex does: when the account is out of review credits
 it answers with an ordinary comment and reads nothing. That stays a failure --

--- a/scripts/check_codex_review.py
+++ b/scripts/check_codex_review.py
@@ -17,6 +17,11 @@ The clean signal carries no commit sha, so freshness for that path is decided
 on time: the reaction must be newer than the head commit. A force-push of an
 older commit can therefore keep a stale :+1: valid; pushing new work cannot.
 
+There is a third thing Codex does: when the account is out of review credits
+it answers with an ordinary comment and reads nothing. That stays a failure --
+the diff really was not reviewed -- but it is reported as itself, because the
+usual "comment `@codex review`" advice cannot succeed in that state.
+
 Stdlib only, so the workflow runs it without installing the project.
 """
 
@@ -41,6 +46,11 @@ API_ROOT = "https://api.github.com"
 CODEX_LOGINS = {"chatgpt-codex-connector", "chatgpt-codex-connector[bot]"}
 
 REVIEWED_COMMIT_RE = re.compile(r"Reviewed commit:\*\*\s*`([0-9a-f]{7,40})`")
+
+# Out of review credits, Codex answers `@codex review` with a plain issue
+# comment and never looks at the diff. Without recognising it the check sits
+# red telling you to do the one thing that cannot work.
+QUOTA_RE = re.compile(r"usage limits for code reviews", re.IGNORECASE)
 
 # CONTRIBUTING.md exempts "small docs-only or config-only branches". Docs-only
 # is decidable from the diff; config-only is not, so it goes through the label.
@@ -170,10 +180,26 @@ def reviewed_shas(reviews: Iterable[dict[str, Any]]) -> list[str]:
     return found
 
 
-def latest_thumbs_up(rest: RestFetch, pr_number: int) -> datetime | None:
+def latest_quota_refusal(comments: Iterable[dict[str, Any]]) -> datetime | None:
+    """When Codex last declined to review because the account is out of credits."""
+    newest: datetime | None = None
+    for comment in comments:
+        if not is_codex((comment.get("user") or {}).get("login")):
+            continue
+        if not QUOTA_RE.search(comment.get("body") or ""):
+            continue
+        stamp = parse_timestamp(comment["created_at"])
+        if newest is None or stamp > newest:
+            newest = stamp
+    return newest
+
+
+def latest_thumbs_up(
+    rest: RestFetch, pr_number: int, comments: Iterable[dict[str, Any]]
+) -> datetime | None:
     """When Codex last signalled "clean" on the PR body or a comment."""
     targets = [f"issues/{pr_number}/reactions"]
-    for comment in rest(f"issues/{pr_number}/comments") or []:
+    for comment in comments:
         if (comment.get("reactions") or {}).get("total_count"):
             targets.append(f"issues/comments/{comment['id']}/reactions")
 
@@ -307,12 +333,28 @@ def evaluate(rest: RestFetch, graphql: GraphQLFetch, repo: str, pr_number: int) 
     reviewed = reviewed_shas(reviews)
     reviewed_head = any(head_sha.startswith(sha) for sha in reviewed)
 
-    thumbs_up = latest_thumbs_up(rest, pr_number)
+    comments = rest(f"issues/{pr_number}/comments") or []
+    thumbs_up = latest_thumbs_up(rest, pr_number, comments)
     head_commit = rest(f"commits/{head_sha}")
     head_time = parse_timestamp(head_commit["commit"]["committer"]["date"])
     cleared_head = thumbs_up is not None and thumbs_up > head_time
 
     if not reviewed_head and not cleared_head:
+        quota = latest_quota_refusal(comments)
+        if quota is not None and quota > head_time:
+            # Still a failure: the diff was not reviewed, and passing here
+            # would disable the gate exactly when it cannot do its job. Only
+            # the advice changes, because asking again will not help.
+            return Verdict(
+                "failure",
+                "Codex is out of review credits",
+                f"Codex declined to review `{head_sha[:10]}` at "
+                f"{quota:%Y-%m-%d %H:%M UTC}: the account has hit its code "
+                "review usage limit, so `@codex review` will not help. Add "
+                f"credits, or take the documented override with the "
+                f"`{SKIP_LABEL}` label and say why in the pull request.",
+                head_sha,
+            )
         return Verdict(
             "failure",
             f"Codex has not reviewed {head_sha[:10]}",

--- a/scripts/check_codex_review.py
+++ b/scripts/check_codex_review.py
@@ -57,11 +57,17 @@ GraphQLFetch = Callable[[str, dict[str, Any]], Any]
 
 @dataclass(frozen=True)
 class Verdict:
-    """Outcome of the gate, shaped for a GitHub check run."""
+    """Outcome of the gate, shaped for a GitHub check run.
+
+    ``head_sha`` is the commit the verdict was actually computed against, and
+    the only sha it may be posted to. Re-reading the head at posting time would
+    stamp a pass earned by a reviewed commit onto whatever was pushed since.
+    """
 
     conclusion: str  # "success" | "failure"
     title: str
     summary: str
+    head_sha: str
 
     @property
     def ok(self) -> bool:
@@ -241,9 +247,24 @@ def is_docs_only(files: Sequence[dict[str, Any]]) -> bool:
     if not files:
         return False
     return all(
-        any(fnmatch.fnmatch(entry["filename"], pattern) for pattern in DOCS_ONLY_PATTERNS)
+        any(fnmatch.fnmatch(path, pattern) for pattern in DOCS_ONLY_PATTERNS)
         for entry in files
+        for path in _entry_paths(entry)
     )
+
+
+def _entry_paths(entry: dict[str, Any]) -> list[str]:
+    """Both sides of a rename.
+
+    GitHub puts the destination in ``filename`` and the source in
+    ``previous_filename``. Judging on the destination alone would read
+    `janasunani/pipeline/run.py` -> `docs/run.md` as a docs change, and a pure
+    rename adds no lines, so it would clear the size cap too.
+    """
+    paths = [entry["filename"]]
+    if entry.get("previous_filename"):
+        paths.append(entry["previous_filename"])
+    return paths
 
 
 def changed_lines(files: Iterable[dict[str, Any]]) -> int:
@@ -262,7 +283,12 @@ def evaluate(rest: RestFetch, graphql: GraphQLFetch, repo: str, pr_number: int) 
     labels = {label["name"] for label in pull.get("labels") or []}
 
     if SKIP_LABEL in labels:
-        return Verdict("success", "Codex review not required", f"Skipped by `{SKIP_LABEL}`.")
+        return Verdict(
+            "success",
+            "Codex review not required",
+            f"Skipped by `{SKIP_LABEL}`.",
+            head_sha,
+        )
 
     files = rest(f"pulls/{pr_number}/files") or []
     if is_docs_only(files) and changed_lines(files) <= DOCS_ONLY_MAX_LINES:
@@ -271,10 +297,11 @@ def evaluate(rest: RestFetch, graphql: GraphQLFetch, repo: str, pr_number: int) 
             "Codex review not required",
             f"Docs-only branch, {changed_lines(files)} changed lines; "
             "CONTRIBUTING.md exempts small ones.",
+            head_sha,
         )
 
     if pull.get("draft"):
-        return Verdict("success", "Draft", "Codex reviews on ready-for-review.")
+        return Verdict("success", "Draft", "Codex reviews on ready-for-review.", head_sha)
 
     reviews = rest(f"pulls/{pr_number}/reviews") or []
     reviewed = reviewed_shas(reviews)
@@ -290,6 +317,7 @@ def evaluate(rest: RestFetch, graphql: GraphQLFetch, repo: str, pr_number: int) 
             "failure",
             f"Codex has not reviewed {head_sha[:10]}",
             _stale_summary(head_sha, reviewed, thumbs_up, head_time),
+            head_sha,
         )
 
     unresolved = unresolved_codex_threads(graphql, owner, name, pr_number)
@@ -301,10 +329,13 @@ def evaluate(rest: RestFetch, graphql: GraphQLFetch, repo: str, pr_number: int) 
             "CONTRIBUTING.md: every finding ends fixed, filed as an issue, or "
             "rejected in a reply that shows the evidence. Reply, then resolve "
             f"the thread.\n\n{listed}",
+            head_sha,
         )
 
     how = "reviewed with findings, all answered" if reviewed_head else "cleared with :+1:"
-    return Verdict("success", "Codex review passed", f"Head `{head_sha[:10]}` {how}.")
+    return Verdict(
+        "success", "Codex review passed", f"Head `{head_sha[:10]}` {how}.", head_sha
+    )
 
 
 def _stale_summary(
@@ -331,14 +362,15 @@ def _stale_summary(
 # --------------------------------------------------------------------------
 
 
-def post_check_run(repo: str, token: str, head_sha: str, name: str, verdict: Verdict) -> None:
+def post_check_run(repo: str, token: str, name: str, verdict: Verdict) -> None:
+    """Post to the sha the verdict was computed against, never a re-read one."""
     _request(
         f"{API_ROOT}/repos/{repo}/check-runs",
         token,
         method="POST",
         body={
             "name": name,
-            "head_sha": head_sha,
+            "head_sha": verdict.head_sha,
             "status": "completed",
             "conclusion": verdict.conclusion,
             "output": {"title": verdict.title, "summary": verdict.summary},
@@ -373,8 +405,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     print(f"{verdict.conclusion}: {verdict.title}\n{verdict.summary}")
 
     if args.post_check_run:
-        head_sha = rest(f"pulls/{args.pr}")["head"]["sha"]
-        post_check_run(args.repo, token, head_sha, args.check_name, verdict)
+        post_check_run(args.repo, token, args.check_name, verdict)
         return 0
     return 0 if verdict.ok else 1
 

--- a/scripts/check_codex_review.py
+++ b/scripts/check_codex_review.py
@@ -1,0 +1,373 @@
+"""Gate a pull request on the Codex review having run and been answered.
+
+Codex in GitHub reports neither a check run nor a commit status, so there is
+nothing to mark required in branch protection. It leaves two signals instead:
+
+- If it has findings, it posts a review whose body carries
+  ``**Reviewed commit:** `<sha>` `` and one inline thread per finding.
+- If it is clean, it posts nothing at all and reacts :+1:.
+
+This script reads both and decides whether the pull request satisfies the
+review protocol in CONTRIBUTING.md: Codex has looked at the current head, and
+no finding is left unanswered. Threads are the unit of "answered" because that
+is what the protocol already tracks -- fixed, filed as an issue, or rejected
+with evidence, then resolved.
+
+The clean signal carries no commit sha, so freshness for that path is decided
+on time: the reaction must be newer than the head commit. A force-push of an
+older commit can therefore keep a stale :+1: valid; pushing new work cannot.
+
+Stdlib only, so the workflow runs it without installing the project.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable, Iterable, Sequence
+
+API_ROOT = "https://api.github.com"
+
+# REST reports the login with the suffix, GraphQL without it.
+CODEX_LOGINS = {"chatgpt-codex-connector", "chatgpt-codex-connector[bot]"}
+
+REVIEWED_COMMIT_RE = re.compile(r"Reviewed commit:\*\*\s*`([0-9a-f]{7,40})`")
+
+# CONTRIBUTING.md exempts "small docs-only or config-only branches". Docs-only
+# is decidable from the diff; config-only is not, so it goes through the label.
+DOCS_ONLY_PATTERNS = ("*.md", "docs/*", "docs/**", "*.rst", "LICENSE")
+SKIP_LABEL = "codex-review-not-required"
+
+RestFetch = Callable[[str], Any]
+GraphQLFetch = Callable[[str, dict[str, Any]], Any]
+
+
+@dataclass(frozen=True)
+class Verdict:
+    """Outcome of the gate, shaped for a GitHub check run."""
+
+    conclusion: str  # "success" | "failure"
+    title: str
+    summary: str
+
+    @property
+    def ok(self) -> bool:
+        return self.conclusion == "success"
+
+
+class GitHubError(RuntimeError):
+    pass
+
+
+# --------------------------------------------------------------------------
+# Transport
+# --------------------------------------------------------------------------
+
+
+def _request(url: str, token: str, method: str = "GET", body: Any = None) -> Any:
+    data = json.dumps(body).encode() if body is not None else None
+    request = urllib.request.Request(url, data=data, method=method)
+    request.add_header("Authorization", f"Bearer {token}")
+    request.add_header("Accept", "application/vnd.github+json")
+    request.add_header("X-GitHub-Api-Version", "2022-11-28")
+    if data is not None:
+        request.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(request) as response:
+            payload = response.read()
+    except urllib.error.HTTPError as exc:  # pragma: no cover - network path
+        raise GitHubError(f"{method} {url} -> {exc.code}: {exc.read().decode()}") from exc
+    return json.loads(payload) if payload else None
+
+
+def make_rest_fetch(repo: str, token: str) -> RestFetch:
+    """Return a paginating GET for repo-relative REST paths."""
+
+    def fetch(path: str) -> Any:
+        url = f"{API_ROOT}/repos/{repo}/{path.lstrip('/')}"
+        first = _request(_with_per_page(url), token)
+        if not isinstance(first, list):
+            return first
+        items = list(first)
+        page = 2
+        while len(first) == 100 and page <= 10:
+            more = _request(_with_per_page(url, page=page), token)
+            if not more:
+                break
+            items.extend(more)
+            if len(more) < 100:
+                break
+            page += 1
+        return items
+
+    return fetch
+
+
+def _with_per_page(url: str, page: int | None = None) -> str:
+    parts = urllib.parse.urlsplit(url)
+    query = dict(urllib.parse.parse_qsl(parts.query))
+    query["per_page"] = "100"
+    if page is not None:
+        query["page"] = str(page)
+    return urllib.parse.urlunsplit(parts._replace(query=urllib.parse.urlencode(query)))
+
+
+def make_graphql_fetch(token: str) -> GraphQLFetch:
+    def fetch(query: str, variables: dict[str, Any]) -> Any:
+        payload = _request(
+            f"{API_ROOT}/graphql",
+            token,
+            method="POST",
+            body={"query": query, "variables": variables},
+        )
+        if payload and payload.get("errors"):
+            raise GitHubError(f"GraphQL errors: {payload['errors']}")
+        return payload
+    return fetch
+
+
+# --------------------------------------------------------------------------
+# Signal extraction
+# --------------------------------------------------------------------------
+
+
+def is_codex(login: str | None) -> bool:
+    return (login or "").lower() in CODEX_LOGINS
+
+
+def parse_timestamp(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+def reviewed_shas(reviews: Iterable[dict[str, Any]]) -> list[str]:
+    """Shas Codex says it reviewed, in the order the reviews were posted."""
+    found: list[str] = []
+    for review in reviews:
+        if not is_codex((review.get("user") or {}).get("login")):
+            continue
+        match = REVIEWED_COMMIT_RE.search(review.get("body") or "")
+        if match:
+            found.append(match.group(1))
+    return found
+
+
+def latest_thumbs_up(rest: RestFetch, pr_number: int) -> datetime | None:
+    """When Codex last signalled "clean" on the PR body or a comment."""
+    targets = [f"issues/{pr_number}/reactions"]
+    for comment in rest(f"issues/{pr_number}/comments") or []:
+        if (comment.get("reactions") or {}).get("total_count"):
+            targets.append(f"issues/comments/{comment['id']}/reactions")
+
+    newest: datetime | None = None
+    for path in targets:
+        for reaction in rest(path) or []:
+            if reaction.get("content") != "+1":
+                continue
+            if not is_codex((reaction.get("user") or {}).get("login")):
+                continue
+            stamp = parse_timestamp(reaction["created_at"])
+            if newest is None or stamp > newest:
+                newest = stamp
+    return newest
+
+
+def unresolved_codex_threads(
+    graphql: GraphQLFetch, owner: str, name: str, pr_number: int
+) -> list[str]:
+    """First-line summaries of Codex threads nobody has resolved."""
+    query = """
+    query($owner:String!, $name:String!, $number:Int!, $cursor:String) {
+      repository(owner:$owner, name:$name) {
+        pullRequest(number:$number) {
+          reviewThreads(first:100, after:$cursor) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              isResolved
+              comments(first:1) { nodes { author { login } body path } }
+            }
+          }
+        }
+      }
+    }
+    """
+    unresolved: list[str] = []
+    cursor: str | None = None
+    while True:
+        payload = graphql(
+            query, {"owner": owner, "name": name, "number": pr_number, "cursor": cursor}
+        )
+        threads = payload["data"]["repository"]["pullRequest"]["reviewThreads"]
+        for thread in threads["nodes"]:
+            if thread["isResolved"]:
+                continue
+            comments = (thread.get("comments") or {}).get("nodes") or []
+            if not comments:
+                continue
+            first = comments[0]
+            if not is_codex((first.get("author") or {}).get("login")):
+                continue
+            unresolved.append(_thread_label(first))
+        if not threads["pageInfo"]["hasNextPage"]:
+            return unresolved
+        cursor = threads["pageInfo"]["endCursor"]
+
+
+def _thread_label(comment: dict[str, Any]) -> str:
+    """Codex titles a finding in bold on the first non-badge line."""
+    path = comment.get("path") or "?"
+    for line in (comment.get("body") or "").splitlines():
+        text = re.sub(r"!\[[^\]]*\]\([^)]*\)", "", line)
+        text = re.sub(r"</?(sub|sup|b|strong)>", "", text)
+        text = text.replace("*", "").strip()
+        if text:
+            return f"{path}: {text}"
+    return path
+
+
+def is_docs_only(files: Sequence[dict[str, Any]]) -> bool:
+    if not files:
+        return False
+    return all(
+        any(fnmatch.fnmatch(entry["filename"], pattern) for pattern in DOCS_ONLY_PATTERNS)
+        for entry in files
+    )
+
+
+# --------------------------------------------------------------------------
+# Decision
+# --------------------------------------------------------------------------
+
+
+def evaluate(rest: RestFetch, graphql: GraphQLFetch, repo: str, pr_number: int) -> Verdict:
+    owner, name = repo.split("/", 1)
+    pull = rest(f"pulls/{pr_number}")
+    head_sha = pull["head"]["sha"]
+    labels = {label["name"] for label in pull.get("labels") or []}
+
+    if SKIP_LABEL in labels:
+        return Verdict("success", "Codex review not required", f"Skipped by `{SKIP_LABEL}`.")
+
+    if is_docs_only(rest(f"pulls/{pr_number}/files") or []):
+        return Verdict(
+            "success",
+            "Codex review not required",
+            "Docs-only branch; CONTRIBUTING.md exempts these.",
+        )
+
+    if pull.get("draft"):
+        return Verdict("success", "Draft", "Codex reviews on ready-for-review.")
+
+    reviews = rest(f"pulls/{pr_number}/reviews") or []
+    reviewed = reviewed_shas(reviews)
+    reviewed_head = any(head_sha.startswith(sha) for sha in reviewed)
+
+    thumbs_up = latest_thumbs_up(rest, pr_number)
+    head_commit = rest(f"commits/{head_sha}")
+    head_time = parse_timestamp(head_commit["commit"]["committer"]["date"])
+    cleared_head = thumbs_up is not None and thumbs_up > head_time
+
+    if not reviewed_head and not cleared_head:
+        return Verdict(
+            "failure",
+            f"Codex has not reviewed {head_sha[:10]}",
+            _stale_summary(head_sha, reviewed, thumbs_up, head_time),
+        )
+
+    unresolved = unresolved_codex_threads(graphql, owner, name, pr_number)
+    if unresolved:
+        listed = "\n".join(f"- {item}" for item in unresolved)
+        return Verdict(
+            "failure",
+            f"{len(unresolved)} Codex finding(s) unanswered",
+            "CONTRIBUTING.md: every finding ends fixed, filed as an issue, or "
+            "rejected in a reply that shows the evidence. Reply, then resolve "
+            f"the thread.\n\n{listed}",
+        )
+
+    how = "reviewed with findings, all answered" if reviewed_head else "cleared with :+1:"
+    return Verdict("success", "Codex review passed", f"Head `{head_sha[:10]}` {how}.")
+
+
+def _stale_summary(
+    head_sha: str,
+    reviewed: Sequence[str],
+    thumbs_up: datetime | None,
+    head_time: datetime,
+) -> str:
+    lines = [f"Comment `@codex review` on the pull request. Head is `{head_sha[:10]}`."]
+    if reviewed:
+        lines.append(f"Codex last reviewed `{reviewed[-1]}`.")
+    if thumbs_up is not None:
+        lines.append(
+            f"The :+1: at {thumbs_up:%Y-%m-%d %H:%M UTC} predates the head "
+            f"commit at {head_time:%Y-%m-%d %H:%M UTC}."
+        )
+    elif not reviewed:
+        lines.append("Codex has left no review or reaction on this pull request.")
+    return " ".join(lines)
+
+
+# --------------------------------------------------------------------------
+# Entrypoint
+# --------------------------------------------------------------------------
+
+
+def post_check_run(repo: str, token: str, head_sha: str, name: str, verdict: Verdict) -> None:
+    _request(
+        f"{API_ROOT}/repos/{repo}/check-runs",
+        token,
+        method="POST",
+        body={
+            "name": name,
+            "head_sha": head_sha,
+            "status": "completed",
+            "conclusion": verdict.conclusion,
+            "output": {"title": verdict.title, "summary": verdict.summary},
+        },
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY"))
+    parser.add_argument("--pr", type=int, required=True)
+    parser.add_argument("--check-name", default="codex-review")
+    parser.add_argument(
+        "--post-check-run",
+        action="store_true",
+        help="Report the verdict as a check run on the PR head instead of exiting non-zero.",
+    )
+    args = parser.parse_args(argv)
+
+    token = os.environ.get("GITHUB_TOKEN") or ""
+    if not token:
+        print("GITHUB_TOKEN is required", file=sys.stderr)
+        return 2
+    if not args.repo:
+        print("--repo or GITHUB_REPOSITORY is required", file=sys.stderr)
+        return 2
+
+    rest = make_rest_fetch(args.repo, token)
+    graphql = make_graphql_fetch(token)
+    verdict = evaluate(rest, graphql, args.repo, args.pr)
+
+    print(f"{verdict.conclusion}: {verdict.title}\n{verdict.summary}")
+
+    if args.post_check_run:
+        head_sha = rest(f"pulls/{args.pr}")["head"]["sha"]
+        post_check_run(args.repo, token, head_sha, args.check_name, verdict)
+        return 0
+    return 0 if verdict.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_codex_review.py
+++ b/scripts/check_codex_review.py
@@ -44,7 +44,11 @@ REVIEWED_COMMIT_RE = re.compile(r"Reviewed commit:\*\*\s*`([0-9a-f]{7,40})`")
 
 # CONTRIBUTING.md exempts "small docs-only or config-only branches". Docs-only
 # is decidable from the diff; config-only is not, so it goes through the label.
+# "Small" is load-bearing and not defined upstream: a docs rewrite large enough
+# to restate a policy deserves the review, so past this many changed lines the
+# exemption lapses and the branch goes through the normal gate or the label.
 DOCS_ONLY_PATTERNS = ("*.md", "docs/*", "docs/**", "*.rst", "LICENSE")
+DOCS_ONLY_MAX_LINES = 400
 SKIP_LABEL = "codex-review-not-required"
 
 RestFetch = Callable[[str], Any]
@@ -242,6 +246,10 @@ def is_docs_only(files: Sequence[dict[str, Any]]) -> bool:
     )
 
 
+def changed_lines(files: Iterable[dict[str, Any]]) -> int:
+    return sum(entry.get("additions", 0) + entry.get("deletions", 0) for entry in files)
+
+
 # --------------------------------------------------------------------------
 # Decision
 # --------------------------------------------------------------------------
@@ -256,11 +264,13 @@ def evaluate(rest: RestFetch, graphql: GraphQLFetch, repo: str, pr_number: int) 
     if SKIP_LABEL in labels:
         return Verdict("success", "Codex review not required", f"Skipped by `{SKIP_LABEL}`.")
 
-    if is_docs_only(rest(f"pulls/{pr_number}/files") or []):
+    files = rest(f"pulls/{pr_number}/files") or []
+    if is_docs_only(files) and changed_lines(files) <= DOCS_ONLY_MAX_LINES:
         return Verdict(
             "success",
             "Codex review not required",
-            "Docs-only branch; CONTRIBUTING.md exempts these.",
+            f"Docs-only branch, {changed_lines(files)} changed lines; "
+            "CONTRIBUTING.md exempts small ones.",
         )
 
     if pull.get("draft"):

--- a/tests/test_check_codex_review.py
+++ b/tests/test_check_codex_review.py
@@ -302,6 +302,68 @@ def test_changed_lines_counts_both_sides_of_the_diff():
     assert check.changed_lines(files) == 16
 
 
+def test_renaming_code_into_docs_is_not_docs_only():
+    """A pure rename adds no lines, so the size cap would not catch it either."""
+    files = [
+        {
+            "filename": "docs/run.md",
+            "previous_filename": "janasunani/pipeline/run.py",
+            "status": "renamed",
+            "additions": 0,
+            "deletions": 0,
+        }
+    ]
+    assert check.is_docs_only(files) is False
+
+
+def test_renaming_one_doc_to_another_stays_docs_only():
+    files = [
+        {
+            "filename": "docs/ROADMAP.md",
+            "previous_filename": "ROADMAP.md",
+            "status": "renamed",
+            "additions": 0,
+            "deletions": 0,
+        }
+    ]
+    assert check.is_docs_only(files) is True
+
+
+# --------------------------------------------------------------------------
+# The verdict is bound to the sha it was computed against
+# --------------------------------------------------------------------------
+
+
+def test_verdict_carries_the_evaluated_head():
+    api = FakeGitHub(reviews=[codex_review(HEAD[:10])], threads=[thread(resolved=True)])
+    assert api.evaluate().head_sha == HEAD
+
+
+def test_check_run_is_posted_to_the_evaluated_head_not_a_refetched_one():
+    """A push landing mid-run must not inherit the previous head's pass."""
+    old, new = "a" * 40, "b" * 40
+    api = FakeGitHub(head_sha=old, reviews=[codex_review(old[:10])], threads=[])
+    verdict = api.evaluate()
+    assert verdict.ok
+
+    api.head_sha = new  # the branch moves while the gate is still running
+    posted: dict[str, Any] = {}
+
+    def fake_request(url, token, method="GET", body=None):
+        posted.update(body)
+        return {}
+
+    original = check._request
+    check._request = fake_request
+    try:
+        check.post_check_run(REPO, "token", "codex-review", verdict)
+    finally:
+        check._request = original
+
+    assert posted["head_sha"] == old
+    assert posted["conclusion"] == "success"
+
+
 def test_skip_label_is_exempt():
     api = FakeGitHub(labels=["codex-review-not-required"])
     verdict = api.evaluate()

--- a/tests/test_check_codex_review.py
+++ b/tests/test_check_codex_review.py
@@ -255,6 +255,69 @@ def test_unresolved_thread_fails_even_when_a_fresh_thumbs_up_exists():
 
 
 # --------------------------------------------------------------------------
+# Codex out of review credits
+# --------------------------------------------------------------------------
+
+# Verbatim from PR #221, where the account hit its limit mid-review-round.
+QUOTA_BODY = (
+    "You have reached your Codex usage limits for code reviews. You can see "
+    "your limits in the [Codex usage dashboard](https://chatgpt.com/codex/"
+    "cloud/settings/usage).\nTo continue using code reviews, you can upgrade "
+    "your account or add credits to your account."
+)
+
+
+def quota_comment(at: str) -> dict[str, Any]:
+    return {"id": 7, "user": CODEX, "body": QUOTA_BODY, "created_at": at}
+
+
+def test_quota_refusal_is_reported_as_itself_not_as_a_missing_review():
+    api = FakeGitHub(comments=[quota_comment("2026-08-08T19:03:54Z")])
+    verdict = api.evaluate()
+    assert not verdict.ok
+    assert verdict.title == "Codex is out of review credits"
+    assert "`@codex review` will not help" in verdict.summary
+    assert "codex-review-not-required" in verdict.summary
+
+
+def test_quota_refusal_still_fails_the_gate():
+    """Passing here would switch the gate off exactly when it cannot do its job."""
+    api = FakeGitHub(comments=[quota_comment("2026-08-08T19:03:54Z")])
+    assert api.evaluate().conclusion == "failure"
+
+
+def test_quota_refusal_predating_the_head_does_not_change_the_message():
+    """Credits may have been topped up since; the ordinary advice applies again."""
+    api = FakeGitHub(comments=[quota_comment("2026-08-08T11:00:00Z")])
+    verdict = api.evaluate()
+    assert not verdict.ok
+    assert verdict.title.startswith("Codex has not reviewed")
+
+
+def test_a_review_of_the_head_beats_an_earlier_quota_refusal():
+    api = FakeGitHub(
+        comments=[quota_comment("2026-08-08T12:05:00Z")],
+        reviews=[codex_review(HEAD[:10])],
+        threads=[thread(resolved=True)],
+    )
+    assert api.evaluate().ok
+
+
+def test_quota_wording_from_a_human_is_not_the_signal():
+    api = FakeGitHub(
+        comments=[
+            {
+                "id": 7,
+                "user": HUMAN,
+                "body": "we have reached your Codex usage limits for code reviews",
+                "created_at": "2026-08-08T19:03:54Z",
+            }
+        ]
+    )
+    assert api.evaluate().title.startswith("Codex has not reviewed")
+
+
+# --------------------------------------------------------------------------
 # Exemptions
 # --------------------------------------------------------------------------
 

--- a/tests/test_check_codex_review.py
+++ b/tests/test_check_codex_review.py
@@ -1,0 +1,340 @@
+"""Tests for scripts/check_codex_review.py.
+
+Fake REST/GraphQL payloads shaped after real responses from this repo's pull
+requests: the review body Codex posts when it has findings, the :+1: it leaves
+when it does not, and the thread resolution state the protocol turns on.
+
+Loaded via importlib (scripts/ is not a package).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, _SCRIPTS / f"{name}.py")
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+check = _load("check_codex_review")
+
+REPO = "Data-Policy-and-Innovation-Centre/janasunani"
+HEAD = "f319c879a1b2c3d4e5f60718293a4b5c6d7e8f90"
+HEAD_TIME = "2026-08-08T12:00:00Z"
+CODEX = {"login": "chatgpt-codex-connector[bot]"}
+HUMAN = {"login": "ymohanty"}
+
+# Abridged from the real body; the parser only needs the commit line.
+CODEX_REVIEW_BODY = """
+### 💡 Codex Review
+
+Here are some automated review suggestions for this pull request.
+
+**Reviewed commit:** `{sha}`
+
+<details> <summary>ℹ️ About Codex in GitHub</summary>
+If Codex has suggestions, it will comment; otherwise it will react with 👍.
+</details>
+"""
+
+FINDING_BODY = (
+    "**<sub><sub>![P1 Badge](https://img.shields.io/badge/P1-orange?style=flat)"
+    "</sub></sub>  Exclude failed Sarvam calls from the paired scorecard**\n\n"
+    "Whenever a page fails, the scorecard still counts it."
+)
+
+
+class FakeGitHub:
+    """Minimal stand-in for the REST + GraphQL surfaces the gate reads."""
+
+    def __init__(
+        self,
+        *,
+        head_sha: str = HEAD,
+        head_time: str = HEAD_TIME,
+        draft: bool = False,
+        labels: list[str] | None = None,
+        files: list[str] | None = None,
+        reviews: list[dict[str, Any]] | None = None,
+        comments: list[dict[str, Any]] | None = None,
+        reactions: dict[str, list[dict[str, Any]]] | None = None,
+        threads: list[dict[str, Any]] | None = None,
+    ) -> None:
+        self.head_sha = head_sha
+        self.head_time = head_time
+        self.draft = draft
+        self.labels = labels or []
+        self.files = files if files is not None else ["janasunani/evaluation/sarvam.py"]
+        self.reviews = reviews or []
+        self.comments = comments or []
+        self.reactions = reactions or {}
+        self.threads = threads or []
+
+    def rest(self, path: str) -> Any:
+        if path.startswith("pulls/") and path.endswith("/files"):
+            return [{"filename": name} for name in self.files]
+        if path.startswith("pulls/") and path.endswith("/reviews"):
+            return self.reviews
+        if path.startswith("pulls/"):
+            return {
+                "head": {"sha": self.head_sha},
+                "draft": self.draft,
+                "labels": [{"name": name} for name in self.labels],
+            }
+        if path.startswith("commits/"):
+            return {"commit": {"committer": {"date": self.head_time}}}
+        if path.endswith("/comments"):
+            return self.comments
+        if path.endswith("/reactions"):
+            return self.reactions.get(path, [])
+        raise AssertionError(f"unexpected REST path: {path}")
+
+    def graphql(self, query: str, variables: dict[str, Any]) -> Any:
+        return {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": {
+                            "pageInfo": {"hasNextPage": False, "endCursor": None},
+                            "nodes": self.threads,
+                        }
+                    }
+                }
+            }
+        }
+
+    def evaluate(self):
+        return check.evaluate(self.rest, self.graphql, REPO, 207)
+
+
+def codex_review(sha: str) -> dict[str, Any]:
+    return {"user": CODEX, "body": CODEX_REVIEW_BODY.format(sha=sha), "state": "COMMENTED"}
+
+
+def thread(*, resolved: bool, author: dict[str, str] = CODEX, body: str = FINDING_BODY):
+    return {
+        "isResolved": resolved,
+        "comments": {
+            "nodes": [
+                {
+                    "author": {"login": author["login"].removesuffix("[bot]")},
+                    "body": body,
+                    "path": "janasunani/evaluation/sarvam.py",
+                }
+            ]
+        },
+    }
+
+
+def thumbs_up(at: str, *, user: dict[str, str] = CODEX) -> dict[str, Any]:
+    return {"content": "+1", "user": user, "created_at": at}
+
+
+# --------------------------------------------------------------------------
+# The clean path: Codex reacts and posts nothing
+# --------------------------------------------------------------------------
+
+
+def test_thumbs_up_after_head_commit_passes():
+    api = FakeGitHub(
+        comments=[{"id": 1, "reactions": {"total_count": 1}}],
+        reactions={"issues/comments/1/reactions": [thumbs_up("2026-08-08T12:05:00Z")]},
+    )
+    verdict = api.evaluate()
+    assert verdict.ok
+    assert "cleared" in verdict.summary
+
+
+def test_thumbs_up_on_pull_request_body_passes():
+    api = FakeGitHub(reactions={"issues/207/reactions": [thumbs_up("2026-08-08T12:05:00Z")]})
+    assert api.evaluate().ok
+
+
+def test_thumbs_up_predating_head_commit_fails():
+    """A push after the clean run invalidates it; the reaction carries no sha."""
+    api = FakeGitHub(
+        comments=[{"id": 1, "reactions": {"total_count": 1}}],
+        reactions={"issues/comments/1/reactions": [thumbs_up("2026-08-08T11:00:00Z")]},
+    )
+    verdict = api.evaluate()
+    assert not verdict.ok
+    assert "predates the head commit" in verdict.summary
+
+
+def test_thumbs_up_from_a_human_is_not_the_signal():
+    api = FakeGitHub(
+        comments=[{"id": 1, "reactions": {"total_count": 1}}],
+        reactions={
+            "issues/comments/1/reactions": [thumbs_up("2026-08-08T12:05:00Z", user=HUMAN)]
+        },
+    )
+    assert not api.evaluate().ok
+
+
+def test_comments_without_reactions_are_not_fetched():
+    """total_count == 0 must not cost a request; the sweep runs every 10 minutes."""
+    api = FakeGitHub(comments=[{"id": 9, "reactions": {"total_count": 0}}])
+    api.reactions = {}  # a fetch for comment 9 would raise in rest()
+    assert not api.evaluate().ok
+
+
+# --------------------------------------------------------------------------
+# The findings path: Codex reviews, threads must be answered
+# --------------------------------------------------------------------------
+
+
+def test_review_of_head_with_all_threads_resolved_passes():
+    api = FakeGitHub(
+        reviews=[codex_review(HEAD[:10])],
+        threads=[thread(resolved=True), thread(resolved=True)],
+    )
+    verdict = api.evaluate()
+    assert verdict.ok
+    assert "all answered" in verdict.summary
+
+
+def test_unresolved_codex_thread_fails_and_names_the_finding():
+    api = FakeGitHub(reviews=[codex_review(HEAD[:10])], threads=[thread(resolved=False)])
+    verdict = api.evaluate()
+    assert not verdict.ok
+    assert "1 Codex finding(s) unanswered" in verdict.title
+    assert "Exclude failed Sarvam calls from the paired scorecard" in verdict.summary
+    assert "janasunani/evaluation/sarvam.py" in verdict.summary
+
+
+def test_unresolved_human_thread_does_not_fail_the_gate():
+    """Reviewer notes on our own PRs stay open by habit; the gate is about Codex."""
+    api = FakeGitHub(
+        reviews=[codex_review(HEAD[:10])],
+        threads=[thread(resolved=False, author=HUMAN, body="Cost model matches ROADMAP.")],
+    )
+    assert api.evaluate().ok
+
+
+def test_review_of_an_older_commit_fails():
+    api = FakeGitHub(reviews=[codex_review("9869703727")])
+    verdict = api.evaluate()
+    assert not verdict.ok
+    assert "9869703727" in verdict.summary
+    assert HEAD[:10] in verdict.title
+
+
+def test_no_codex_activity_at_all_fails():
+    verdict = FakeGitHub().evaluate()
+    assert not verdict.ok
+    assert "@codex review" in verdict.summary
+    assert "no review or reaction" in verdict.summary
+
+
+def test_unresolved_thread_fails_even_when_a_fresh_thumbs_up_exists():
+    """CONTRIBUTING.md: do not merge with review comments left unanswered."""
+    api = FakeGitHub(
+        comments=[{"id": 1, "reactions": {"total_count": 1}}],
+        reactions={"issues/comments/1/reactions": [thumbs_up("2026-08-08T12:05:00Z")]},
+        threads=[thread(resolved=False)],
+    )
+    assert not api.evaluate().ok
+
+
+# --------------------------------------------------------------------------
+# Exemptions
+# --------------------------------------------------------------------------
+
+
+def test_docs_only_branch_is_exempt():
+    api = FakeGitHub(files=["docs/ROADMAP.md", "CONTRIBUTING.md"])
+    verdict = api.evaluate()
+    assert verdict.ok
+    assert "Docs-only" in verdict.summary
+
+
+def test_one_code_file_removes_the_docs_exemption():
+    api = FakeGitHub(files=["docs/ROADMAP.md", "janasunani/pipeline/run.py"])
+    assert not api.evaluate().ok
+
+
+def test_empty_diff_is_not_treated_as_docs_only():
+    assert check.is_docs_only([]) is False
+
+
+def test_skip_label_is_exempt():
+    api = FakeGitHub(labels=["codex-review-not-required"])
+    verdict = api.evaluate()
+    assert verdict.ok
+    assert "codex-review-not-required" in verdict.summary
+
+
+def test_draft_pull_requests_pass():
+    assert FakeGitHub(draft=True).evaluate().ok
+
+
+# --------------------------------------------------------------------------
+# Parsing helpers
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "login, expected",
+    [
+        ("chatgpt-codex-connector[bot]", True),  # REST spelling
+        ("chatgpt-codex-connector", True),  # GraphQL spelling
+        ("github-actions[bot]", False),
+        ("ymohanty", False),
+        (None, False),
+    ],
+)
+def test_codex_login_is_recognised_in_both_api_spellings(login, expected):
+    assert check.is_codex(login) is expected
+
+
+def test_reviewed_shas_ignores_non_codex_reviews():
+    reviews = [
+        {"user": HUMAN, "body": "**Reviewed commit:** `deadbeef12`"},
+        codex_review("f319c879a1"),
+    ]
+    assert check.reviewed_shas(reviews) == ["f319c879a1"]
+
+
+def test_reviewed_shas_keeps_posting_order():
+    reviews = [codex_review("aaaaaaaaaa"), codex_review("bbbbbbbbbb")]
+    assert check.reviewed_shas(reviews) == ["aaaaaaaaaa", "bbbbbbbbbb"]
+
+
+def test_thread_label_strips_the_priority_badge():
+    label = check._thread_label({"path": "a/b.py", "body": FINDING_BODY})
+    assert label == "a/b.py: Exclude failed Sarvam calls from the paired scorecard"
+
+
+def test_paginated_review_threads_are_all_inspected():
+    pages = [
+        {
+            "pageInfo": {"hasNextPage": True, "endCursor": "cursor1"},
+            "nodes": [thread(resolved=True)],
+        },
+        {
+            "pageInfo": {"hasNextPage": False, "endCursor": None},
+            "nodes": [thread(resolved=False)],
+        },
+    ]
+    seen: list[str | None] = []
+
+    def graphql(query: str, variables: dict[str, Any]) -> Any:
+        seen.append(variables["cursor"])
+        page = pages[len(seen) - 1]
+        return {"data": {"repository": {"pullRequest": {"reviewThreads": page}}}}
+
+    unresolved = check.unresolved_codex_threads(graphql, "owner", "name", 207)
+    assert seen == [None, "cursor1"]
+    assert len(unresolved) == 1

--- a/tests/test_check_codex_review.py
+++ b/tests/test_check_codex_review.py
@@ -67,6 +67,7 @@ class FakeGitHub:
         draft: bool = False,
         labels: list[str] | None = None,
         files: list[str] | None = None,
+        changed_lines: int = 20,
         reviews: list[dict[str, Any]] | None = None,
         comments: list[dict[str, Any]] | None = None,
         reactions: dict[str, list[dict[str, Any]]] | None = None,
@@ -77,6 +78,7 @@ class FakeGitHub:
         self.draft = draft
         self.labels = labels or []
         self.files = files if files is not None else ["janasunani/evaluation/sarvam.py"]
+        self.changed_lines = changed_lines
         self.reviews = reviews or []
         self.comments = comments or []
         self.reactions = reactions or {}
@@ -84,7 +86,11 @@ class FakeGitHub:
 
     def rest(self, path: str) -> Any:
         if path.startswith("pulls/") and path.endswith("/files"):
-            return [{"filename": name} for name in self.files]
+            per_file, extra = divmod(self.changed_lines, len(self.files))
+            return [
+                {"filename": name, "additions": per_file + (extra if i == 0 else 0)}
+                for i, name in enumerate(self.files)
+            ]
         if path.startswith("pulls/") and path.endswith("/reviews"):
             return self.reviews
         if path.startswith("pulls/"):
@@ -253,11 +259,33 @@ def test_unresolved_thread_fails_even_when_a_fresh_thumbs_up_exists():
 # --------------------------------------------------------------------------
 
 
-def test_docs_only_branch_is_exempt():
-    api = FakeGitHub(files=["docs/ROADMAP.md", "CONTRIBUTING.md"])
+def test_small_docs_only_branch_is_exempt():
+    api = FakeGitHub(files=["docs/ROADMAP.md", "CONTRIBUTING.md"], changed_lines=30)
     verdict = api.evaluate()
     assert verdict.ok
     assert "Docs-only" in verdict.summary
+
+
+def test_large_docs_only_branch_is_not_exempt():
+    """CONTRIBUTING.md exempts *small* docs branches; a policy rewrite is not one."""
+    api = FakeGitHub(
+        files=["docs/ROADMAP.md"], changed_lines=check.DOCS_ONLY_MAX_LINES + 1
+    )
+    assert not api.evaluate().ok
+
+
+def test_docs_exemption_holds_exactly_at_the_threshold():
+    api = FakeGitHub(files=["docs/ROADMAP.md"], changed_lines=check.DOCS_ONLY_MAX_LINES)
+    assert api.evaluate().ok
+
+
+def test_large_docs_only_branch_can_still_use_the_label():
+    api = FakeGitHub(
+        files=["docs/ROADMAP.md"],
+        changed_lines=check.DOCS_ONLY_MAX_LINES + 1,
+        labels=["codex-review-not-required"],
+    )
+    assert api.evaluate().ok
 
 
 def test_one_code_file_removes_the_docs_exemption():
@@ -267,6 +295,11 @@ def test_one_code_file_removes_the_docs_exemption():
 
 def test_empty_diff_is_not_treated_as_docs_only():
     assert check.is_docs_only([]) is False
+
+
+def test_changed_lines_counts_both_sides_of_the_diff():
+    files = [{"additions": 10, "deletions": 5}, {"additions": 1, "deletions": 0}]
+    assert check.changed_lines(files) == 16
 
 
 def test_skip_label_is_exempt():


### PR DESCRIPTION
Codex in GitHub publishes neither a check run nor a commit status, so there is nothing branch protection can require today. Its two signals live only in the API. This turns them into one check named `codex-review`.

## The rule

Pass needs both halves of the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) review protocol:

1. **Codex read the current head.** Either a review whose `**Reviewed commit:**` matches `head_sha`, or a 👍 newer than the head commit.
2. **No finding left unanswered.** Every Codex review thread resolved.

Threads are the unit of "answered" because that is already what the protocol tracks: fixed, filed as an issue, or rejected with evidence, then resolved. Human threads are ignored. Our own inline notes stay open by habit and must not block a merge.

Exempt: docs-only diffs (CONTRIBUTING already exempts them), drafts, and a `codex-review-not-required` label. Config-only is not decidable from a diff, so it goes through the explicit label rather than a guess.

## Two GitHub constraints, both load-bearing

- **Reactions emit no webhook.** The clean 👍 cannot trigger a workflow, hence the `*/10` cron sweeping open PRs. Everything else is event-driven and immediate.
- **Runs from `issue_comment` and `pull_request_review` attach to the default branch, not the PR head.** A job-reported status would never satisfy protection. The check run is created against `head_sha` through the API instead, and the job itself stays green so the two cannot double-count.

## Verified against the live API

```
PR 202: success — docs-only, exempt
PR 207: failure — head cb78fafae3, Codex last reviewed f319c879a1
PR 206: failure — head 5cf5a14e6e, Codex last reviewed 3c3faed0e9
PR 204: failure — head d2aafe168a, Codex last reviewed 9869703727
```

Those three failures are correct, not false positives. Each pushed fix commits after its Codex review and merged without re-requesting, which CONTRIBUTING step 2 asks for. The gate would have caught all three.

`tests/test_check_codex_review.py`: 25 tests, green. `ruff` clean. Fake REST/GraphQL payloads shaped after real responses from this repo.

## Known limits

- **The clean-👍 path is unit-tested but never observed live.** No PR in this repo has a Codex 👍 to check against, so the reaction shape comes from GitHub's reactions API rather than from a real one. First clean PR after merge will confirm it.
- **Freshness on the clean path is decided on time, not sha,** because the reaction carries no commit. A force-push of an older commit can keep a stale 👍 valid; pushing new work cannot.
- **Advisory until `main` is protected.** It is currently unprotected (`404 Branch not protected`). Making `codex-review` required is a repo settings change and left to the maintainer.

Stdlib only, so CI runs it without `uv sync`.