### PR TITLE
fix: five P2 benchmark-harness tech-debt findings

### DIFF
--- a/janasunani/evaluation/benchmark_report.py
+++ b/janasunani/evaluation/benchmark_report.py
@@ -783,25 +783,47 @@ def main(argv: list[str] | None = None) -> int:
         errors = validate_report(json_path)
         try:
             data = json.loads(json_path.read_text())
-            gen = data.get("generated_at")
-            if gen and not args.allow_stale:
-                try:
-                    ts = _dt.datetime.fromisoformat(gen)
-                    if ts.tzinfo is None:
-                        ts = ts.replace(tzinfo=_dt.timezone.utc)
-                    age_days = (_dt.datetime.now(tz=_dt.timezone.utc) - ts).total_seconds() / 86400.0
-                    if age_days > 7:
+        except Exception as exc:
+            print(f"check failed: unreadable {json_path}: {exc}")
+            return 1
+        gen = data.get("generated_at")
+        if gen:
+            try:
+                ts = _dt.datetime.fromisoformat(gen)
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=_dt.timezone.utc)
+                age_days = (_dt.datetime.now(tz=_dt.timezone.utc) - ts).total_seconds() / 86400.0
+                if age_days > 7:
+                    if args.allow_stale:
                         print(f"warning: table2.json is {age_days:.1f} days old (>7d); regenerate before freeze")
-                except Exception:
-                    pass
-        except Exception:
-            pass
+                    else:
+                        errors.append(
+                            f"table2.json is {age_days:.1f} days old (>7d); "
+                            "regenerate or pass --allow-stale"
+                        )
+            except Exception:
+                pass
+        # The rehearsal and demo display the Markdown artifact directly, so
+        # a schema-valid JSON with a stale or corrupt table2.md must still
+        # fail the check — render_markdown is deterministic given the JSON
+        # payload, so any mismatch means the Markdown is out of date.
+        try:
+            expected_md = render_markdown(data)
+            actual_md = md_path.read_text()
+        except Exception as exc:
+            errors.append(f"unreadable {md_path}: {exc}")
+        else:
+            if actual_md != expected_md:
+                errors.append(
+                    f"{md_path} does not match render_markdown(table2.json) "
+                    "— stale or corrupt Markdown artifact; regenerate"
+                )
         if errors:
             print("check failed — schema errors:")
             for e in errors:
                 print(f"  - {e}")
             return 1
-        print(f"check ok: {json_path} and {md_path} are valid (reference_only=True, {len(json.loads(json_path.read_text()).get('rows', []))} rows)")
+        print(f"check ok: {json_path} and {md_path} are valid (reference_only=True, {len(data.get('rows', []))} rows)")
         return 0
     if args.latency:
         latency_result = _try_load_json(args.latency)

--- a/janasunani/evaluation/benchmark_report.py
+++ b/janasunani/evaluation/benchmark_report.py
@@ -42,6 +42,10 @@ DEFAULT_SPAM_ALT_PATH: Path = DEFAULT_OUT_DIR / "spam.json"
 DEFAULT_DEDUP_PATH: Path = DEFAULT_OUT_DIR / "dedup.json"
 NOT_MEASURED: str = "not_measured"
 
+#: A report older than this fails ``--check`` unless ``--allow-stale``.
+#: Kept in step with the mtime warning in ``scripts/demo_rehearsal.sh``.
+STALE_REPORT_DAYS: int = 7
+
 
 def _try_load_json(path: Path | None) -> dict[str, Any] | None:
     if path is None:
@@ -786,23 +790,48 @@ def main(argv: list[str] | None = None) -> int:
         except Exception as exc:
             print(f"check failed: unreadable {json_path}: {exc}")
             return 1
+        # A missing or unparseable timestamp is a failure, not a skip. The
+        # freshness gate is only enforceable if the field it reads is
+        # required: otherwise a stale artifact passes --check by deleting or
+        # corrupting `generated_at` and regenerating the Markdown around it,
+        # which is the one way an out-of-date table reaches a demo unnoticed.
         gen = data.get("generated_at")
-        if gen:
+        ts: _dt.datetime | None = None
+        if not gen:
+            if args.allow_stale:
+                print("warning: table2.json has no generated_at; freshness not checked")
+            else:
+                errors.append(
+                    "table2.json has no generated_at; the freshness gate cannot be "
+                    "enforced without it (regenerate, or pass --allow-stale)"
+                )
+        else:
             try:
                 ts = _dt.datetime.fromisoformat(gen)
-                if ts.tzinfo is None:
-                    ts = ts.replace(tzinfo=_dt.timezone.utc)
-                age_days = (_dt.datetime.now(tz=_dt.timezone.utc) - ts).total_seconds() / 86400.0
-                if age_days > 7:
-                    if args.allow_stale:
-                        print(f"warning: table2.json is {age_days:.1f} days old (>7d); regenerate before freeze")
-                    else:
-                        errors.append(
-                            f"table2.json is {age_days:.1f} days old (>7d); "
-                            "regenerate or pass --allow-stale"
-                        )
-            except Exception:
-                pass
+            except (TypeError, ValueError) as exc:
+                if args.allow_stale:
+                    print(f"warning: table2.json generated_at is unparseable ({exc})")
+                else:
+                    errors.append(
+                        f"table2.json generated_at is not a parseable ISO timestamp "
+                        f"({gen!r}); regenerate or pass --allow-stale"
+                    )
+
+        if ts is not None:
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=_dt.timezone.utc)
+            age_days = (_dt.datetime.now(tz=_dt.timezone.utc) - ts).total_seconds() / 86400.0
+            if age_days > STALE_REPORT_DAYS:
+                if args.allow_stale:
+                    print(
+                        f"warning: table2.json is {age_days:.1f} days old "
+                        f"(>{STALE_REPORT_DAYS}d); regenerate before freeze"
+                    )
+                else:
+                    errors.append(
+                        f"table2.json is {age_days:.1f} days old "
+                        f"(>{STALE_REPORT_DAYS}d); regenerate or pass --allow-stale"
+                    )
         # The rehearsal and demo display the Markdown artifact directly, so
         # a schema-valid JSON with a stale or corrupt table2.md must still
         # fail the check — render_markdown is deterministic given the JSON

--- a/scripts/benchmark_pipeline.py
+++ b/scripts/benchmark_pipeline.py
@@ -31,6 +31,7 @@ available; this harness reports wall-clock only.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import math
 import random
@@ -322,8 +323,15 @@ def _fake_process(
     statistics path deterministically. When callers want real sleep, set
     ``BENCHMARK_FAKE_SLEEP=1``.
     """
-    # Seed per ticket+repeat for deterministic per-doc variation
-    rng_seed = hash((seed, ticket, repeat_idx, variant)) & 0xFFFFFFFF
+    # Seed per ticket+repeat for deterministic per-doc variation. Python's
+    # hash() is salted per-interpreter via PYTHONHASHSEED, so it must not
+    # feed the RNG here — the same --seed would silently produce different
+    # fake latency means/SEs across machines and runs. A stable digest keeps
+    # outputs/benchmark/latency.json reproducible for a given seed+docs.
+    digest = hashlib.sha256(
+        f"{seed}:{ticket}:{repeat_idx}:{variant}".encode()
+    ).digest()
+    rng_seed = int.from_bytes(digest[:8], "big") & 0xFFFFFFFF
     rng = random.Random(rng_seed)
     return _fake_timings_for_variant(variant, ticket, repeat_idx, rng)
 
@@ -672,6 +680,14 @@ def main(argv: list[str] | None = None) -> int:
         parser.error("at least one of --n-docs or --n-image-docs must be > 0")
 
     discard_warm = not args.no_warm_discard
+    if args.repeats == 1 and discard_warm:
+        # With repeats=1 and warmup discard on, every observation is the
+        # discarded warm one — the harness would silently write an
+        # all-zero latency report (mean 0, se 0, n=0) with exit 0.
+        parser.error(
+            "--repeats must be >= 2 when discarding warmup, "
+            "or pass --no-warm-discard"
+        )
 
     # Fake mode is explicit and non-publishable; real mode wires processor.
     # For backward compat with existing tests that call main() without --fake,

--- a/tests/test_benchmark_pipeline.py
+++ b/tests/test_benchmark_pipeline.py
@@ -8,6 +8,10 @@ for the four variants standard / sarvam_digitise / sarvam_extract / sarvam_both.
 from __future__ import annotations
 
 import json
+import os
+import subprocess
+import sys
+from pathlib import Path
 
 import pytest
 
@@ -18,6 +22,7 @@ from scripts.benchmark_pipeline import (
     STAGES,
     VALID_VARIANTS,
     _clustered_se,
+    _fake_process,
     _percentile,
     compute_stage_stats,
     latency_json_payload,
@@ -28,6 +33,8 @@ from scripts.benchmark_pipeline import (
 
 # Also import the script as module for CLI tests
 import scripts.benchmark_pipeline as bench_mod
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 def test_valid_variants_are_exactly_four_expected():
@@ -305,6 +312,88 @@ def test_cli_no_warm_discard(tmp_path):
     data = json.loads(out.read_text())
     assert data["warm_discarded"] is False
     assert data["stages"]["e2e"]["n"] == 4  # 2 docs * 2 repeats
+
+
+def test_fake_process_same_call_is_deterministic():
+    # Same inputs, same process: must be bit-identical (sanity before the
+    # cross-process PYTHONHASHSEED check below).
+    t1 = _fake_process("standard", "SYN-TXT-0001", 1, seed=42)
+    t2 = _fake_process("standard", "SYN-TXT-0001", 1, seed=42)
+    assert t1.e2e == t2.e2e
+    assert t1.per_stage == t2.per_stage
+
+
+def test_fake_process_timings_stable_across_pythonhashseed():
+    """Regression for #208: rng_seed must not be derived from hash().
+
+    Python salts hash() per-interpreter via PYTHONHASHSEED, so seeding the
+    RNG from hash((seed, ticket, repeat_idx, variant)) made identical
+    --seed + docs produce different fake latency means/SEs across
+    machines/runs. The fix (hashlib.sha256 digest) must give the same
+    fake timings for the same inputs regardless of PYTHONHASHSEED.
+    """
+    script = (
+        "import json, sys; "
+        "from scripts.benchmark_pipeline import _fake_process; "
+        "t = _fake_process('sarvam_extract', 'SYN-TXT-0007', 2, seed=42); "
+        "print(json.dumps({'e2e': t.e2e, 'per_stage': t.per_stage}))"
+    )
+    outputs = []
+    for hashseed in ("0", "1", "1337"):
+        env = dict(os.environ)
+        env["PYTHONHASHSEED"] = hashseed
+        proc = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=str(REPO_ROOT),
+            check=True,
+        )
+        outputs.append(json.loads(proc.stdout.strip()))
+    assert outputs[0] == outputs[1] == outputs[2], (
+        f"fake timings differ across PYTHONHASHSEED: {outputs}"
+    )
+
+
+def test_cli_repeats_one_with_warm_discard_rejected(tmp_path, capsys):
+    # #209: --repeats 1 with default warmup discard means every observation
+    # is the discarded warm one — the harness must reject this instead of
+    # silently writing an all-zero latency report with exit 0.
+    out = tmp_path / "latency.json"
+    with pytest.raises(SystemExit) as exc:
+        bench_mod.main(
+            ["--repeats", "1", "--output", str(out), "--fake", "--n-docs", "2", "--n-image-docs", "0"]
+        )
+    assert exc.value.code == 2
+    assert not out.exists()
+    err = capsys.readouterr().err
+    assert "--repeats" in err
+    assert "--no-warm-discard" in err
+
+
+def test_cli_repeats_one_with_no_warm_discard_is_allowed(tmp_path):
+    # The sole observation is retained (not discarded) when warmup discard
+    # is explicitly turned off, so repeats=1 is legitimate there.
+    out = tmp_path / "latency.json"
+    rc = bench_mod.main(
+        [
+            "--repeats",
+            "1",
+            "--no-warm-discard",
+            "--output",
+            str(out),
+            "--fake",
+            "--n-docs",
+            "2",
+            "--n-image-docs",
+            "0",
+        ]
+    )
+    assert rc == 0
+    data = json.loads(out.read_text())
+    assert data["stages"]["e2e"]["n"] == 2
+    assert data["stages"]["e2e"]["mean_seconds"] > 0
 
 
 def test_benchmark_end_to_end_structure_matches_output_spec(tmp_path):

--- a/tests/test_benchmark_report.py
+++ b/tests/test_benchmark_report.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime as dt
 import json
 from pathlib import Path
 
@@ -225,6 +226,48 @@ def test_cli_check_detects_corrupt_json(tmp_path: Path):
     p.write_text(json.dumps(data))
     rc = benchmark_report.main(["--out", str(tmp_path), "--check"])
     assert rc == 1
+
+
+def test_cli_check_detects_corrupt_markdown(tmp_path: Path):
+    # #212: --check must validate the Markdown artifact too, not just
+    # confirm table2.md exists. A corrupt/stale Markdown must fail --check
+    # even though table2.json is untouched and schema-valid.
+    rc = benchmark_report.main(["--out", str(tmp_path)])
+    assert rc == 0
+    md_path = tmp_path / "table2.md"
+    md_path.write_text("CORRUPT")
+    rc = benchmark_report.main(["--out", str(tmp_path), "--check"])
+    assert rc == 1
+
+
+def test_cli_check_passes_when_markdown_matches_json(tmp_path: Path):
+    rc = benchmark_report.main(["--out", str(tmp_path)])
+    assert rc == 0
+    rc = benchmark_report.main(["--out", str(tmp_path), "--check"])
+    assert rc == 0
+
+
+def test_cli_check_fails_on_stale_report_without_allow_stale(tmp_path: Path):
+    # #214: --check must fail (nonzero) on a >7d-old generated_at unless
+    # --allow-stale is passed — a warning-only check cannot enforce the
+    # rehearsal freeze window.
+    rc = benchmark_report.main(["--out", str(tmp_path)])
+    assert rc == 0
+    json_path = tmp_path / "table2.json"
+    md_path = tmp_path / "table2.md"
+    data = json.loads(json_path.read_text())
+    stale_ts = (dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=8)).isoformat()
+    data["generated_at"] = stale_ts
+    json_path.write_text(json.dumps(data, indent=2, sort_keys=True, default=str))
+    # Regenerate the Markdown from the same stale data so only the
+    # staleness check (not the #212 Markdown check) is under test here.
+    md_path.write_text(benchmark_report.render_markdown(data))
+
+    rc = benchmark_report.main(["--out", str(tmp_path), "--check"])
+    assert rc == 1
+
+    rc = benchmark_report.main(["--out", str(tmp_path), "--check", "--allow-stale"])
+    assert rc == 0
 
 
 def test_cli_latency_path(tmp_path: Path):

--- a/tests/test_benchmark_report.py
+++ b/tests/test_benchmark_report.py
@@ -270,6 +270,45 @@ def test_cli_check_fails_on_stale_report_without_allow_stale(tmp_path: Path):
     assert rc == 0
 
 
+def _regenerate_with(tmp_path: Path, mutate) -> None:
+    """Write table2.json through *mutate*, keeping the Markdown consistent."""
+    json_path = tmp_path / "table2.json"
+    data = json.loads(json_path.read_text())
+    mutate(data)
+    json_path.write_text(json.dumps(data, indent=2, sort_keys=True, default=str))
+    (tmp_path / "table2.md").write_text(benchmark_report.render_markdown(data))
+
+
+def test_check_fails_when_generated_at_is_missing(tmp_path: Path):
+    """Codex finding on #226: the freshness gate must not be skippable.
+
+    A stale artifact could otherwise pass --check by deleting the field the
+    gate reads and regenerating the Markdown around it, which is exactly how
+    an out-of-date table reaches a demo unnoticed.
+    """
+    assert benchmark_report.main(["--out", str(tmp_path)]) == 0
+    _regenerate_with(tmp_path, lambda d: d.pop("generated_at", None))
+
+    assert benchmark_report.main(["--out", str(tmp_path), "--check"]) == 1
+    # The escape hatch still works, and says what it is not checking.
+    assert benchmark_report.main(["--out", str(tmp_path), "--check", "--allow-stale"]) == 0
+
+
+@pytest.mark.parametrize("bad", ["", "not-a-timestamp", "2026-13-45T99:99:99", 12345])
+def test_check_fails_when_generated_at_is_unparseable(tmp_path: Path, bad):
+    assert benchmark_report.main(["--out", str(tmp_path)]) == 0
+    _regenerate_with(tmp_path, lambda d: d.__setitem__("generated_at", bad))
+
+    assert benchmark_report.main(["--out", str(tmp_path), "--check"]) == 1
+    assert benchmark_report.main(["--out", str(tmp_path), "--check", "--allow-stale"]) == 0
+
+
+def test_a_fresh_report_still_passes_check(tmp_path: Path):
+    """The guard must not turn a good report red."""
+    assert benchmark_report.main(["--out", str(tmp_path)]) == 0
+    assert benchmark_report.main(["--out", str(tmp_path), "--check"]) == 0
+
+
 def test_cli_latency_path(tmp_path: Path):
     latency = {
         "stages": {


### PR DESCRIPTION
## Summary

Fixes four of the five P2 tech-debt findings from the #204 and #206 Codex
reviews, scoped strictly to `scripts/benchmark_pipeline.py` and
`janasunani/evaluation/benchmark_report.py`:

- **#208** — `_fake_process` seeded its RNG from `hash(...)`, which Python
  salts per-interpreter via `PYTHONHASHSEED`. Same `--seed` + docs could
  yield different fake latency numbers across machines/runs. Now uses a
  `hashlib.sha256` digest of the same key.
- **#209** — `--repeats 1` with the default warmup discard silently wrote
  an all-zero latency report (`mean 0, se 0, n=0`) with exit 0. `main()`
  now rejects `--repeats 1` unless `--no-warm-discard` is also passed.
- **#212** — `--check` only confirmed `table2.md` existed; a corrupt or
  stale Markdown file passed silently. `--check` now re-renders Markdown
  from the validated JSON via `render_markdown()` and fails on mismatch.
- **#214** — a `>7d`-old `generated_at` only printed a warning under
  `--check`; it now fails (exit 1) unless `--allow-stale` is passed,
  matching the CLI's own help text and the 7-day threshold already used
  by `scripts/demo_rehearsal.sh`'s mtime check.

**#213 skipped** — it lives entirely in `scripts/e2e_pipeline.sh`, which is
outside this branch's file scope (another agent owns it in parallel). Not
touched here; still open.

## Follow-up needed (not in this PR)

`scripts/demo_rehearsal.sh` line 472 calls
`janasunani-evaluate-benchmark --check` without `--allow-stale`. After
this lands, a stale `table2.md` will also fail that schema-check call —
on top of the script's own separate mtime warning at lines 466-468. Both
paths already resolve to `warn`, not a hard failure, in the rehearsal
script's own handling, so this isn't a regression, just slightly
redundant. Worth deduping in a follow-up; out of scope here since another
agent owns that file.

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run --extra serving --extra pipeline-core pytest` — 1179 passed,
      19 skipped, 0 failed
- [x] Every new/changed-behavior test verified to fail against the
      pre-fix code (`git stash` of just the two source files) and pass
      after — pasted below.

```
FAILED tests/test_benchmark_pipeline.py::test_fake_process_timings_stable_across_pythonhashseed
FAILED tests/test_benchmark_pipeline.py::test_cli_repeats_one_with_warm_discard_rejected
FAILED tests/test_benchmark_report.py::test_cli_check_detects_corrupt_markdown
FAILED tests/test_benchmark_report.py::test_cli_check_fails_on_stale_report_without_allow_stale
4 failed, 1 passed in 0.57s   (pre-fix)
```

Fixes #208
Fixes #209
Fixes #212
Fixes #214