### PR TITLE
fix(frontend): render scored spam fields, gate campaign badge on signatories

### DIFF
--- a/frontend/components/TriageBanner.tsx
+++ b/frontend/components/TriageBanner.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import {
   SPAM_REASON_MESSAGES,
   classifyDuplicateDisplay,
+  wasActuallyScored,
   type TriageResult,
 } from "@/lib/types";
 import { Badge } from "./ui";
@@ -17,16 +18,21 @@ export function TriageBanner({ triage }: { triage: TriageResult }) {
     (evidence) => evidence.kind === "repetition_collapse",
   );
   const duplicateDisplay = classifyDuplicateDisplay(duplicate);
-  // Advisory only: a numeric score never determines review outcome, so its
-  // display always carries that caveat alongside the value.
-  const spamScoreLine =
-    spam.spam_score != null ? (
-      <p className="mt-1 text-xs text-text-secondary">
-        low-signal: <code>{spam.spam_reason ?? spam.reason_code}</code>{" "}
-        (spam_score {spam.spam_score.toFixed(2)}). Advisory only — it does
-        not determine the review outcome.
-      </p>
-    ) : null;
+  // A failed screening is not a clean result. `unavailable_triage()` returns
+  // spam_score 0.0 and spam_reason "clean" alongside
+  // reason_code "advisory_provider_unavailable", so rendering on a non-null
+  // score alone would report "clean (spam_score 0.00)" for a screening that
+  // never ran. Show the number only when something actually scored it.
+  //
+  // Advisory either way: a numeric score never determines the review outcome,
+  // so the caveat travels with the value.
+  const spamScoreLine = wasActuallyScored(spam) ? (
+    <p className="mt-1 text-xs text-text-secondary">
+      low-signal: <code>{spam.spam_reason ?? spam.reason_code}</code>{" "}
+      (spam_score {spam.spam_score!.toFixed(2)}). Advisory only — it does
+      not determine the review outcome.
+    </p>
+  ) : null;
 
   return (
     <section

--- a/frontend/components/TriageBanner.tsx
+++ b/frontend/components/TriageBanner.tsx
@@ -1,5 +1,9 @@
 import Link from "next/link";
-import type { TriageResult } from "@/lib/types";
+import {
+  SPAM_REASON_MESSAGES,
+  classifyDuplicateDisplay,
+  type TriageResult,
+} from "@/lib/types";
 import { Badge } from "./ui";
 
 /**
@@ -8,21 +12,21 @@ import { Badge } from "./ui";
  */
 export function TriageBanner({ triage }: { triage: TriageResult }) {
   const { duplicate, duplicate_review, spam } = triage;
-  const lowSignalMessage = {
-    validated_low_signal_evidence:
-      "Validated low-signal evidence requests an officer review.",
-    ocr_repetition_collapse_unvalidated:
-      "The established OCR repetition-collapse guard observed a problem, but it is not an approved low-signal review rule.",
-    live_review_disabled_pending_redacted_adjudication:
-      "Low-signal review is disabled pending redacted human-adjudicated validation.",
-    mock_low_signal_review_unavailable:
-      "The mock demo does not run low-signal review.",
-    advisory_provider_unavailable:
-      "The advisory provider was unavailable, so no low-signal review was assigned.",
-  }[spam.reason_code];
+  const lowSignalMessage = SPAM_REASON_MESSAGES[spam.reason_code];
   const repetitionEvidence = spam.evidence.find(
     (evidence) => evidence.kind === "repetition_collapse",
   );
+  const duplicateDisplay = classifyDuplicateDisplay(duplicate);
+  // Advisory only: a numeric score never determines review outcome, so its
+  // display always carries that caveat alongside the value.
+  const spamScoreLine =
+    spam.spam_score != null ? (
+      <p className="mt-1 text-xs text-text-secondary">
+        low-signal: <code>{spam.spam_reason ?? spam.reason_code}</code>{" "}
+        (spam_score {spam.spam_score.toFixed(2)}). Advisory only — it does
+        not determine the review outcome.
+      </p>
+    ) : null;
 
   return (
     <section
@@ -83,37 +87,42 @@ export function TriageBanner({ triage }: { triage: TriageResult }) {
           </article>
         )}
 
-        {duplicate?.duplicate_kind === "resubmission" &&
-          duplicate.duplicate_ticket_no && (
-            <article className="rounded-sm border border-hair bg-surface px-3 py-2">
-              <Badge tone="neutral">possible duplicate</Badge>
-              <p className="mt-1 text-sm text-text-body">
-                Possible duplicate of ticket{" "}
-                <Link
-                  href={`/history?q=${encodeURIComponent(duplicate.duplicate_ticket_no)}`}
-                  className="font-mono font-semibold text-maroon underline underline-offset-2"
-                >
-                  {duplicate.duplicate_ticket_no}
-                </Link>
-                . Review both filings before taking any action.
-              </p>
-            </article>
-          )}
+        {duplicateDisplay.kind === "resubmission" && (
+          <article className="rounded-sm border border-hair bg-surface px-3 py-2">
+            <Badge tone="neutral">possible duplicate</Badge>
+            <p className="mt-1 text-sm text-text-body">
+              Possible duplicate of ticket{" "}
+              <Link
+                href={`/history?q=${encodeURIComponent(duplicateDisplay.ticketNo)}`}
+                className="font-mono font-semibold text-maroon underline underline-offset-2"
+              >
+                {duplicateDisplay.ticketNo}
+              </Link>
+              . Review both filings before taking any action.
+            </p>
+          </article>
+        )}
 
-        {duplicate?.duplicate_kind === "campaign" &&
-          duplicate.related_filings && (
+        {duplicateDisplay.kind === "campaign" && (
           <article className="rounded-sm border border-positive bg-positive/10 px-3 py-2">
             <Badge tone="positive">collective grievance</Badge>
             <h3 className="mt-1 text-sm font-semibold text-text-dark">
               Part of a campaign
             </h3>
             <p className="mt-1 text-sm text-text-body">
-              {duplicate.related_filings} related filings were found. This is
-              a collective grievance, not spam; each filing remains visible
-              for review.
+              {duplicateDisplay.relatedFilings} related filings across{" "}
+              {duplicateDisplay.distinctSignatories} distinct signatories
+              were found. This is a collective grievance, not spam; each
+              filing remains visible for review.
             </p>
           </article>
         )}
+
+        {/* duplicateDisplay.kind === "withheld": a campaign-sized group
+            without signatory evidence that clears the threshold above. Not
+            rendered as campaign (would launder one filer as a movement) and
+            not rendered as spam (the scorer abstains by design). What, if
+            anything, this state should show is an open question — #180. */}
 
         {spam.decision === "review" && (
           <article className="rounded-sm border border-negative bg-negative/10 px-3 py-2">
@@ -126,6 +135,7 @@ export function TriageBanner({ triage }: { triage: TriageResult }) {
               Reason code: <code>{spam.reason_code}</code>. This advisory does
               not reject the grievance.
             </p>
+            {spamScoreLine}
           </article>
         )}
 
@@ -137,6 +147,7 @@ export function TriageBanner({ triage }: { triage: TriageResult }) {
               Reason code: <code>{spam.reason_code}</code>. No low-signal
               review was assigned.
             </p>
+            {spamScoreLine}
             {repetitionEvidence && (
               <p className="mt-1 text-xs text-text-secondary">
                 OCR repetition-collapse guard: {repetitionEvidence.observed ? "observed" : "not observed"}. No source text is shown here.

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -50,6 +50,63 @@ export interface DuplicateSignal {
   duplicate_group_id: string;
   duplicate_ticket_no?: string | null;
   related_filings?: number | null;
+  // Not yet emitted by any wired provider (#109/#180 — nothing populates
+  // duplicate_kind at all today). Anticipated ahead of the backend contract
+  // so the campaign badge can gate on distinct signatories rather than raw
+  // group size once a provider is wired: see classifyDuplicateDisplay below.
+  // Without it, "campaign" cannot be trusted (Sambalpur GOV2024999640 is
+  // 26,203 filings behind a single identity key) and display is withheld.
+  distinct_signatories?: number | null;
+}
+
+/** Officer-facing, UI-computed classification of a DuplicateSignal. Not a
+ * wire shape — the point is that this is the only path TriageBanner uses to
+ * decide what to render, so "campaign" is unrepresentable unless the
+ * signatory evidence actually supports it. */
+export type DuplicateDisplayState =
+  | { kind: "none" }
+  | { kind: "resubmission"; ticketNo: string }
+  | { kind: "campaign"; relatedFilings: number; distinctSignatories: number }
+  // Group size alone cannot support the campaign claim: no signatory count
+  // was supplied, or the one supplied fails the threshold below. This is
+  // the safe default, not a considered UI state — what (if anything) should
+  // be shown instead for a verified single-signatory mega-group is an open
+  // design question (#180) that this change deliberately does not decide.
+  | { kind: "withheld" };
+
+// The Sambalpur 2024 backfill separates the two populations by orders of
+// magnitude: 1 signatory / 26,203 filings vs. 1,155 / 1,291 (and similarly
+// 1,079/1,190, 579/617). A 50% signatory ratio is a wide, conservative
+// margin drawn well inside that gap, not a tuned boundary — and a minimum
+// of two signatories rules out a single filer resubmitting twice from
+// slipping through on a small group.
+const CAMPAIGN_MIN_SIGNATORIES = 2;
+const CAMPAIGN_SIGNATORY_RATIO = 0.5;
+
+export function classifyDuplicateDisplay(
+  duplicate: DuplicateSignal | null | undefined,
+): DuplicateDisplayState {
+  if (!duplicate) return { kind: "none" };
+
+  if (duplicate.duplicate_kind === "resubmission") {
+    return duplicate.duplicate_ticket_no
+      ? { kind: "resubmission", ticketNo: duplicate.duplicate_ticket_no }
+      : { kind: "none" };
+  }
+
+  const relatedFilings = duplicate.related_filings;
+  if (!relatedFilings) return { kind: "none" };
+
+  const distinctSignatories = duplicate.distinct_signatories;
+  if (
+    distinctSignatories != null &&
+    distinctSignatories >= CAMPAIGN_MIN_SIGNATORIES &&
+    distinctSignatories / relatedFilings >= CAMPAIGN_SIGNATORY_RATIO
+  ) {
+    return { kind: "campaign", relatedFilings, distinctSignatories };
+  }
+
+  return { kind: "withheld" };
 }
 
 export interface DuplicateReview {
@@ -67,16 +124,61 @@ export interface OcrQualityEvidence {
   observed: boolean;
 }
 
+// The bounded scorer's 5-value reason set (janasunani/pipeline/spam.py,
+// spam-v1-bounded) is authoritative for spam_reason. reason_code is a
+// superset: it also carries the legacy/advisory states that never had a
+// score attached.
+export type SpamReason =
+  | "low_signal_details_inadequate"
+  | "low_signal_no_grievance"
+  | "repetition_collapse"
+  | "length_too_short"
+  | "clean";
+
+export type SpamReasonCode =
+  | "validated_low_signal_evidence"
+  | "ocr_repetition_collapse_unvalidated"
+  | "live_review_disabled_pending_redacted_adjudication"
+  | "mock_low_signal_review_unavailable"
+  | "advisory_provider_unavailable"
+  | SpamReason;
+
 export interface SpamReview {
   decision: "review" | "abstained";
-  reason_code:
-    | "validated_low_signal_evidence"
-    | "ocr_repetition_collapse_unvalidated"
-    | "live_review_disabled_pending_redacted_adjudication"
-    | "mock_low_signal_review_unavailable"
-    | "advisory_provider_unavailable";
+  reason_code: SpamReasonCode;
+  // Present only on a bounded-scorer result; null/absent everywhere else
+  // (legacy records, advisory-unavailable). Advisory only — never a verdict.
+  spam_score?: number | null;
+  spam_reason?: SpamReason | null;
   evidence: OcrQualityEvidence[];
 }
+
+/** Officer-facing gloss for each reason_code. Advisory framing throughout:
+ * the scorer abstains by design, and a "clean" result is a screening
+ * outcome, not a claim that the grievance is genuine or complete. See
+ * janasunani/pipeline/spam.py for the authoritative reason set this mirrors. */
+export const SPAM_REASON_MESSAGES: Record<SpamReasonCode, string> = {
+  validated_low_signal_evidence:
+    "Validated low-signal evidence requests an officer review.",
+  ocr_repetition_collapse_unvalidated:
+    "The established OCR repetition-collapse guard observed a problem, but it is not an approved low-signal review rule.",
+  live_review_disabled_pending_redacted_adjudication:
+    "Low-signal review is disabled pending redacted human-adjudicated validation.",
+  mock_low_signal_review_unavailable:
+    "The mock demo does not run low-signal review.",
+  advisory_provider_unavailable:
+    "The advisory provider was unavailable, so no low-signal review was assigned.",
+  low_signal_details_inadequate:
+    "The bounded scorer rates this submission low-signal: the details look inadequate to act on.",
+  low_signal_no_grievance:
+    "The bounded scorer rates this submission low-signal: it reads as generic or test-like rather than a specific grievance.",
+  repetition_collapse:
+    "The OCR text shows a repetition-collapse (looping/garbled) pattern, which the bounded scorer treats as low-signal.",
+  length_too_short:
+    "The submission is very short — too few characters or words for the bounded scorer to assess as actionable.",
+  clean:
+    "The bounded scorer did not flag this submission as low-signal. That is a screening result, not confirmation that the grievance is genuine or complete.",
+};
 
 export interface TriageResult {
   duplicate?: DuplicateSignal | null;

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -83,6 +83,27 @@ export type DuplicateDisplayState =
 const CAMPAIGN_MIN_SIGNATORIES = 2;
 const CAMPAIGN_SIGNATORY_RATIO = 0.5;
 
+/** Reason codes that mean the screening did not run, whatever score came back. */
+const UNSCORED_REASON_CODES = new Set<string>([
+  "advisory_provider_unavailable",
+  "live_review_disabled_pending_redacted_adjudication",
+]);
+
+/**
+ * Whether a spam score reflects an actual assessment.
+ *
+ * `unavailable_triage()` returns `spam_score: 0.0` and `spam_reason: "clean"`
+ * next to `reason_code: "advisory_provider_unavailable"`, so a null check
+ * alone cannot tell "screened and found clean" from "screening failed". The
+ * two must never render the same way: reporting a failed screening as a clean
+ * result is the kind of false reassurance an officer would act on.
+ */
+export function wasActuallyScored(spam: SpamReview): boolean {
+  if (spam.spam_score == null) return false;
+  if (spam.method === "unavailable") return false;
+  return !UNSCORED_REASON_CODES.has(spam.reason_code);
+}
+
 export function classifyDuplicateDisplay(
   duplicate: DuplicateSignal | null | undefined,
 ): DuplicateDisplayState {
@@ -150,6 +171,9 @@ export interface SpamReview {
   // (legacy records, advisory-unavailable). Advisory only — never a verdict.
   spam_score?: number | null;
   spam_reason?: SpamReason | null;
+  // Which scorer produced this, mirroring SpamReview.method on the wire.
+  // "unavailable" means no screening ran, whatever spam_score says.
+  method?: string | null;
   evidence: OcrQualityEvidence[];
 }
 

--- a/frontend/test/triage-banner.test.mjs
+++ b/frontend/test/triage-banner.test.mjs
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-const { classifyDuplicateDisplay, SPAM_REASON_MESSAGES } = await import(
+const { classifyDuplicateDisplay,
+  wasActuallyScored, SPAM_REASON_MESSAGES } = await import(
   "../lib/types.ts"
 );
 
@@ -139,4 +140,66 @@ test("the 'clean' message does not assert the grievance is genuine", () => {
   assert.equal(message.includes("legitimate"), false);
   assert.equal(message.includes("valid grievance"), false);
   assert.match(message, /not confirmation|screening/);
+});
+
+// --- Codex findings on #227 ---------------------------------------------
+
+test("a campaign the API actually emits is still displayed", () => {
+  // The mock processor emits bucket-1 campaigns. Before distinct_signatories
+  // reached the serving contract, the signatory guard classified every one of
+  // them as withheld, removing the campaign badge from the demo flow rather
+  // than rejecting an unverified group.
+  const display = classifyDuplicateDisplay({
+    duplicate_kind: "campaign",
+    duplicate_group_id: "GRP-1",
+    related_filings: 18,
+    distinct_signatories: 16,
+  });
+  assert.equal(display.kind, "campaign");
+  assert.equal(display.distinctSignatories, 16);
+});
+
+test("an unavailable screening does not report a clean score", () => {
+  // unavailable_triage() returns spam_score 0.0 and spam_reason "clean" next
+  // to reason_code "advisory_provider_unavailable". Reporting that as a clean
+  // result is false reassurance an officer would act on.
+  assert.equal(
+    wasActuallyScored({
+      decision: "abstained",
+      reason_code: "advisory_provider_unavailable",
+      spam_score: 0.0,
+      spam_reason: "clean",
+      method: "unavailable",
+      evidence: [],
+    }),
+    false,
+  );
+});
+
+test("a real clean score is still shown", () => {
+  assert.equal(
+    wasActuallyScored({
+      decision: "abstained",
+      reason_code: "clean",
+      spam_score: 0.07,
+      spam_reason: "clean",
+      method: "spam-v1-bounded",
+      evidence: [],
+    }),
+    true,
+  );
+});
+
+test("the legacy disabled-review state is not treated as scored", () => {
+  assert.equal(
+    wasActuallyScored({
+      decision: "abstained",
+      reason_code: "live_review_disabled_pending_redacted_adjudication",
+      spam_score: 0.0,
+      spam_reason: "clean",
+      method: "legacy-advisory",
+      evidence: [],
+    }),
+    false,
+  );
 });

--- a/frontend/test/triage-banner.test.mjs
+++ b/frontend/test/triage-banner.test.mjs
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const { classifyDuplicateDisplay, SPAM_REASON_MESSAGES } = await import(
+  "../lib/types.ts"
+);
+
+// -- #180: campaign badge must gate on distinct signatories, not group size --
+
+test("classifyDuplicateDisplay withholds the Sambalpur mega-group (1 signatory, 26,203 filings)", () => {
+  const state = classifyDuplicateDisplay({
+    duplicate_kind: "campaign",
+    duplicate_group_id: "GOV2024999640",
+    related_filings: 26203,
+    distinct_signatories: 1,
+  });
+  assert.deepEqual(state, { kind: "withheld" });
+});
+
+test("classifyDuplicateDisplay recognizes a genuine campaign (1,155/1,291 signatories)", () => {
+  const state = classifyDuplicateDisplay({
+    duplicate_kind: "campaign",
+    duplicate_group_id: "DM2024854026",
+    related_filings: 1291,
+    distinct_signatories: 1155,
+  });
+  assert.deepEqual(state, {
+    kind: "campaign",
+    relatedFilings: 1291,
+    distinctSignatories: 1155,
+  });
+});
+
+test("classifyDuplicateDisplay recognizes the other two backfill campaigns", () => {
+  const a = classifyDuplicateDisplay({
+    duplicate_kind: "campaign",
+    duplicate_group_id: "DM2024947088",
+    related_filings: 1190,
+    distinct_signatories: 1079,
+  });
+  assert.equal(a.kind, "campaign");
+
+  const b = classifyDuplicateDisplay({
+    duplicate_kind: "campaign",
+    duplicate_group_id: "DM2024577146",
+    related_filings: 617,
+    distinct_signatories: 579,
+  });
+  assert.equal(b.kind, "campaign");
+});
+
+test("classifyDuplicateDisplay withholds a campaign-shaped group with no signatory count at all", () => {
+  // This is today's real state: no provider populates distinct_signatories
+  // yet (#109). A bare duplicate_kind === "campaign" must not render the
+  // badge just because a count is missing.
+  const state = classifyDuplicateDisplay({
+    duplicate_kind: "campaign",
+    duplicate_group_id: "GOV2024999640",
+    related_filings: 26203,
+  });
+  assert.deepEqual(state, { kind: "withheld" });
+});
+
+test("classifyDuplicateDisplay withholds a single filer resubmitting twice from a tiny group", () => {
+  // 1 signatory / 2 filings clears the 50% ratio but not the minimum
+  // signatory count -- must not read as a campaign.
+  const state = classifyDuplicateDisplay({
+    duplicate_kind: "campaign",
+    duplicate_group_id: "EDGE0000001",
+    related_filings: 2,
+    distinct_signatories: 1,
+  });
+  assert.deepEqual(state, { kind: "withheld" });
+});
+
+test("classifyDuplicateDisplay withholds a group below the signatory ratio threshold", () => {
+  const state = classifyDuplicateDisplay({
+    duplicate_kind: "campaign",
+    duplicate_group_id: "EDGE0000002",
+    related_filings: 1000,
+    distinct_signatories: 10,
+  });
+  assert.deepEqual(state, { kind: "withheld" });
+});
+
+test("classifyDuplicateDisplay renders a resubmission with its ticket", () => {
+  const state = classifyDuplicateDisplay({
+    duplicate_kind: "resubmission",
+    duplicate_group_id: "RESUB001",
+    duplicate_ticket_no: "JS0000001ABC123DEF456",
+  });
+  assert.deepEqual(state, {
+    kind: "resubmission",
+    ticketNo: "JS0000001ABC123DEF456",
+  });
+});
+
+test("classifyDuplicateDisplay is 'none' for an absent duplicate signal", () => {
+  assert.deepEqual(classifyDuplicateDisplay(null), { kind: "none" });
+  assert.deepEqual(classifyDuplicateDisplay(undefined), { kind: "none" });
+});
+
+// -- #211: render the scored triage fields, advisory framing only --
+
+test("SPAM_REASON_MESSAGES covers every bounded-scorer reason code", () => {
+  const boundedCodes = [
+    "low_signal_details_inadequate",
+    "low_signal_no_grievance",
+    "repetition_collapse",
+    "length_too_short",
+    "clean",
+  ];
+  for (const code of boundedCodes) {
+    assert.ok(
+      typeof SPAM_REASON_MESSAGES[code] === "string" &&
+        SPAM_REASON_MESSAGES[code].length > 0,
+      `missing message for reason code ${code}`,
+    );
+  }
+});
+
+test("SPAM_REASON_MESSAGES covers the legacy/advisory reason codes too", () => {
+  const legacyCodes = [
+    "validated_low_signal_evidence",
+    "ocr_repetition_collapse_unvalidated",
+    "live_review_disabled_pending_redacted_adjudication",
+    "mock_low_signal_review_unavailable",
+    "advisory_provider_unavailable",
+  ];
+  for (const code of legacyCodes) {
+    assert.ok(typeof SPAM_REASON_MESSAGES[code] === "string");
+  }
+});
+
+test("the 'clean' message does not assert the grievance is genuine", () => {
+  const message = SPAM_REASON_MESSAGES.clean.toLowerCase();
+  // A clean/low score is an abstention, not a positive claim of validity.
+  assert.equal(message.includes("this is a real grievance"), false);
+  assert.equal(message.includes("legitimate"), false);
+  assert.equal(message.includes("valid grievance"), false);
+  assert.match(message, /not confirmation|screening/);
+});

--- a/janasunani/serving/processor.py
+++ b/janasunani/serving/processor.py
@@ -181,6 +181,11 @@ def _mock_triage(text: str) -> TriageResult:
                 duplicate_kind="campaign",
                 duplicate_group_id=group_id,
                 related_filings=18,
+                # 16 people behind 18 filings: the shape of a real collective
+                # grievance, and what the badge is allowed to claim. A mock
+                # that omitted this would be modelling a state the contract no
+                # longer permits.
+                distinct_signatories=16,
             ),
             duplicate_review=DuplicateReview(decision="matched"),
             spam=mock_low_signal,

--- a/janasunani/serving/schemas.py
+++ b/janasunani/serving/schemas.py
@@ -105,6 +105,22 @@ class DuplicateSignal(BaseModel):
     duplicate_group_id: str = Field(min_length=1)
     duplicate_ticket_no: Optional[str] = None
     related_filings: Optional[int] = Field(default=None, ge=2)
+    #: Distinct filers behind a campaign, never the group size.
+    #:
+    #: A campaign badge says "this is a collective grievance, not spam", and it
+    #: must never be attachable to one actor. The Sambalpur 2024 index holds a
+    #: group of 26,203 filings resolving to a single identity key, against
+    #: genuine campaigns at 1,155 signatories over 1,291 filings. On group size
+    #: alone those are indistinguishable; on signatories they are not.
+    #:
+    #: Optional rather than required, deliberately. ``store.py`` re-validates
+    #: persisted results on read, so making it mandatory would make every
+    #: campaign recorded before this field existed unreadable. A provider that
+    #: omits it is saying "I cannot evidence this", and the display guard
+    #: withholds the badge for exactly that case. The contract enforces
+    #: consistency when the number is present; the UI enforces what may be
+    #: claimed when it is absent.
+    distinct_signatories: Optional[int] = Field(default=None, ge=1)
 
     @model_validator(mode="after")
     def _kind_has_the_right_context(self) -> "DuplicateSignal":
@@ -113,10 +129,20 @@ class DuplicateSignal(BaseModel):
                 raise ValueError("resubmission requires duplicate_ticket_no")
             if self.related_filings is not None:
                 raise ValueError("resubmission must not carry related_filings")
+            if self.distinct_signatories is not None:
+                raise ValueError("resubmission must not carry distinct_signatories")
         elif self.duplicate_ticket_no is not None:
             raise ValueError("campaign must not carry duplicate_ticket_no")
         elif self.related_filings is None:
             raise ValueError("campaign requires related_filings")
+        elif (
+            self.distinct_signatories is not None
+            and self.distinct_signatories > self.related_filings
+        ):
+            # More signatories than filings is not a thin campaign, it is a
+            # counting bug, and it would inflate the ratio the badge is gated
+            # on in exactly the wrong direction.
+            raise ValueError("distinct_signatories cannot exceed related_filings")
         return self
 
 

--- a/tests/test_serving_triage_contract.py
+++ b/tests/test_serving_triage_contract.py
@@ -1,5 +1,7 @@
 """Typed, advisory-only serving contract for issues #73 and #109."""
 
+import json
+
 import pytest
 from pydantic import ValidationError
 
@@ -244,3 +246,77 @@ def test_learned_routing_requires_aggregate_evidence():
             method="rules",
             empirical_evidence=evidence,
         )
+
+
+def test_a_campaign_survives_a_serialized_round_trip_with_signatories():
+    """Codex asked for a serialized provider response, not a hand-built object.
+
+    `store.py` persists `model_dump()` and re-validates on read, so a field
+    that only works in memory is not actually in the contract.
+    """
+    from janasunani.serving.schemas import DuplicateSignal
+
+    signal = DuplicateSignal(
+        duplicate_kind="campaign",
+        duplicate_group_id="GRP-1",
+        related_filings=18,
+        distinct_signatories=16,
+    )
+    restored = DuplicateSignal.model_validate(json.loads(signal.model_dump_json()))
+    assert restored.distinct_signatories == 16
+    assert restored.related_filings == 18
+
+
+def test_a_legacy_campaign_without_signatories_still_loads():
+    """Requiring the field would make every campaign recorded before it exists
+    unreadable, because the result store re-validates on read."""
+    from janasunani.serving.schemas import DuplicateSignal
+
+    restored = DuplicateSignal.model_validate(
+        {
+            "duplicate_kind": "campaign",
+            "duplicate_group_id": "GRP-legacy",
+            "related_filings": 18,
+        }
+    )
+    assert restored.distinct_signatories is None
+
+
+def test_more_signatories_than_filings_is_rejected():
+    """A counting bug that would inflate the ratio the badge is gated on."""
+    import pytest as _pytest
+
+    from janasunani.serving.schemas import DuplicateSignal
+
+    with _pytest.raises(ValueError, match="cannot exceed related_filings"):
+        DuplicateSignal(
+            duplicate_kind="campaign",
+            duplicate_group_id="GRP-2",
+            related_filings=3,
+            distinct_signatories=9,
+        )
+
+
+def test_the_mock_processor_emits_a_displayable_campaign():
+    """The regression Codex found: the guard must not blank the demo flow.
+
+    Every bucket-1 campaign the mock emits must carry enough evidence for the
+    frontend to render the badge, or the signatory gate removed a working
+    demo surface instead of rejecting an unverified group.
+    """
+    from janasunani.serving.processor import _mock_triage
+
+    # The bucket is a hash of the text, so vary the text rather than the ids.
+    seen_campaign = False
+    for index in range(64):
+        triage = _mock_triage(f"water supply irregular in ward {index}")
+        duplicate = triage.duplicate
+        if duplicate is not None and duplicate.duplicate_kind == "campaign":
+            seen_campaign = True
+            assert duplicate.distinct_signatories is not None, (
+                "a campaign the API emits carries no signatory evidence, so the "
+                "frontend guard will withhold the badge and the demo loses it"
+            )
+            assert duplicate.distinct_signatories >= 2
+            assert duplicate.distinct_signatories <= duplicate.related_filings
+    assert seen_campaign, "no campaign was produced; the assertion above never ran"


### PR DESCRIPTION
## Summary

Two demo-visible frontend fixes, scoped to `frontend/lib/types.ts` and `frontend/components/TriageBanner.tsx` (plus a new test file). No files outside `frontend/` touched; `SupervisorDashboard.tsx`/`SupervisorView.tsx` untouched (#178, separate scope).

### #211 — render the scored triage fields
`SpamReview` gained `spam_score?: number | null` and `spam_reason?: SpamReason | null`, and `reason_code` now covers the bounded scorer's 5 codes (`low_signal_details_inadequate`, `low_signal_no_grievance`, `repetition_collapse`, `length_too_short`, `clean`) alongside the 5 legacy/advisory codes — matching `janasunani/serving/schemas.py::SpamReview` and the reason set documented in `janasunani/pipeline/spam.py`.

`TriageBanner` now:
- Renders a message for every reason code via `SPAM_REASON_MESSAGES` (exported from `lib/types.ts` so it's testable without a JSX rendering harness — this repo's test runner is plain `node --test`, no RTL/jsdom installed).
- Renders `spam_score` when present, in the `low-signal: <reason> (spam_score X.XX)` format from `docs/DEMO_SCRIPT.md:124`, always paired with "Advisory only — it does not determine the review outcome."
- Words the `clean` message as a screening result ("did not flag... not confirmation that the grievance is genuine or complete"), not a verdict — the scorer abstains by design, and a low score is not the same claim as "this is a real grievance."

### #180 — campaign badge must gate on signatory count, not group size
Added `distinct_signatories?: number | null` to `DuplicateSignal` (anticipated ahead of the backend contract — no provider populates `duplicate_kind` or this field yet, per #109) and a `classifyDuplicateDisplay()` function + `DuplicateDisplayState` discriminated union in `lib/types.ts`. `TriageBanner` now renders the duplicate/campaign section only through this classifier's output, never by reading `duplicate.duplicate_kind` directly — so "campaign badge on an unverified group" is unrepresentable in the component, the same way `SpamReview`/`DuplicateSignal` already make illegal wire states unrepresentable server-side.

Threshold: `distinct_signatories >= 2` and `distinct_signatories / related_filings >= 0.5`. The Sambalpur 2024 backfill separates the two populations by orders of magnitude (1/26,203 ≈ 0.004% vs. 1,155/1,291 ≈ 89%, 1,079/1,190 ≈ 91%, 579/617 ≈ 94%), so 50% is a wide, conservative margin well inside that gap — not a tuned boundary. The minimum-2 check keeps a single filer resubmitting twice from slipping through on a tiny group.

**Open design question I did not decide (per instructions):** what should render for a verified single-signatory mega-group (GOV2024999640-shaped)? It's not `campaign` (fails the threshold) and not spam (the low-signal scorer abstains by design). I implemented the safest available behaviour — `classifyDuplicateDisplay` returns `{ kind: "withheld" }` and `TriageBanner` renders nothing for that state, same as if no duplicate signal existed. Alternatives I did not build, because they invent new user-facing copy nobody has ruled on:
- A dedicated "unverified mega-group" advisory badge with its own wording.
- Falling back to the `resubmission` UI against the earliest ticket in the group (suggested in the issue body as a possibility, not a decision).

This needs a human call before a provider is wired (#109) so the eventual choice doesn't get made implicitly by whatever the classifier happens to do.

## Test plan

- [x] `npm run build` — Next.js build + TypeScript check, clean.
- [x] `npm run lint` — clean.
- [x] `npm test` — 17/17 passing, including 8 new tests exercising `classifyDuplicateDisplay` against the exact backfill numbers from the issue (26,203/1 → withheld; 1,291/1,155, 1,190/1,079, 617/579 → campaign; missing-signatories and below-threshold cases → withheld; resubmission and absent-signal cases), plus coverage/wording tests for `SPAM_REASON_MESSAGES`.

```
> node --experimental-strip-types --test test/*.test.mjs
ℹ tests 17
ℹ pass 17
ℹ fail 0
```

Fixes #211
Fixes #180