### PR TITLE
docs: correct stale routing, Sarvam and PII-scorecard claims

### DIFF
--- a/docs/DELIVERY.md
+++ b/docs/DELIVERY.md
@@ -14,7 +14,7 @@ The full grievance history is loaded and verified: 1,371,288 complaints and 6,55
 
 All six pipeline stages are implemented: page classification, text extraction, removal of personal information, page-type filtering, summarisation, categorisation. End-to-end integration is unverified, since it has not yet been run start to finish in one pass.
 
-Live processing works. A grievance submitted through the web interface comes back with its redacted text, category, summary and routing. The interface is built; wiring it to the live models rather than to test responses is still in progress. Routing uses fixed rules; the learned version is later work.
+Live processing works. A grievance submitted through the web interface comes back with its redacted text, category, summary and routing. The interface is built; wiring it to the live models rather than to test responses is still in progress. Routing now runs on the empirical crosswalk learned from case history (issue #33, closed 7 August). Argmax accuracy: 60.9% on category alone, 67.5% with subcategory, 72.8% with subcategory and district. It learns where cases were historically sent, not where they resolved best. A learned outcome-based scorer on disposal time and citizen benefit (issue #106) is a separate, harder problem and stays later work.
 
 Deployment automation is written and reviewed but not yet run. The system is not switched on at our AWS server.
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -98,12 +98,18 @@ Legacy reference for comparison: the DSI report records **80.56% any-overlap,
 are synthetic and are not a substitute for the gold set. What they establish
 is a floor on a known failure mode, not a coverage claim.
 
-### What is not measured
+### The scorecard, now wired
 
-`janasunani.evaluation.pii_scorecard` cannot yet report a missed-PII rate. It
-passes empty predictions to the scorer, so every entity reads
-`overlap_recall=0.000`, `missed_rate=1.000` by construction. See #67. Its
-slicing, language split and thin-slice guard do work.
+`janasunani.evaluation.pii_scorecard` no longer passes empty predictions by
+construction. `score_per_language` calls `score_examples`, which wires the
+live Presidio recognizers (`detect_pii_spans`) by default; it falls back to
+empty predictions only if the analyzer cannot be imported, e.g. an
+environment without the `pii` extra (#67, closed). Its slicing, language
+split and thin-slice guard run against real predictions.
+
+The measured result is in DELIVERY.md: **49.6% overlap recall** on the
+corrected 89-page, 529-label gold set (PHONE 0.83, AADHAAR 0.86, EMAIL 0.75,
+NAME 0.44). English only — no Odia labelled set exists.
 
 ## 3. Models
 
@@ -138,6 +144,12 @@ against production Postgres.
 
 Provenance is complete: `source_name = oltp:complaints+grievance_redactions`,
 snapshot `sha256:a7a01cde…`. Zero legacy NULLs.
+
+Backfill confirmed complete on the CPU box, verified directly against
+production Postgres (read-only counts): `grievance_redactions` = 55,544 rows,
+`dedup_signatures` = 55,544 rows, `dedup_groups` populated, for
+Sambalpur/2024. The 7 Aug re-run logged `55544 redacted complaints, 55544
+already indexed`.
 
 ### Decomposition, and why the third number exists
 
@@ -200,11 +212,28 @@ issue's own baseline: top-10 strings are 36.7% of rows, top-500 pairs 60.3%.
 
 ## 6. Sarvam
 
-Not called. All three provider-held-data controls (`retention_terms`,
-`encryption_in_transit`, `encryption_at_rest`) are `verified=False`, so
-`route.live_use_ready is False`. With `enabled=True` and a real key the
-adapter falls back to pytesseract **without making a network call** and
-audits `reason="SarvamGovernanceError"`.
+Not called. Not because governance blocks it — because nobody has supplied
+`SARVAM_API_KEY` and run it.
+
+All three provider-held-data controls (`retention_terms`,
+`encryption_in_transit`, `encryption_at_rest`) are `verified=False`. That does
+not gate a live call. Evaluated directly against the registered route
+(`janasunani/egress/sarvam.py`):
+
+| | |
+|---|---|
+| `live_use_ready` | False |
+| `egress_permitted` | **True** |
+| `egress_basis` | `accepted_risk` |
+| Unverified controls | `retention_terms`, `encryption_in_transit`, `encryption_at_rest` |
+
+A `RiskAcceptance` is recorded on the route (authority: Additional Chief
+Secretary, Electronics & IT Department, Government of Odisha), so
+`egress_permitted` is true on `accepted_risk` even though `live_use_ready`
+stays false. The gate the adapter actually checks before a live call
+(`janasunani/egress/sarvam.py:625`, `:825`) is `route.egress_permitted`, not
+`live_use_ready`. With `enabled=True` and a real key, it would call Sarvam,
+not fall back to pytesseract.
 
 Sample size for the paired comparison, at 10 points detectable and 25%
 discordance: **194 pages** at 80% power / 5% level, **259** at 90% power,
@@ -222,16 +251,23 @@ discordance: **194 pages** at 80% power / 5% level, **259** at 90% power,
 
 ## 8. Known gaps
 
-Three places where the data now exists and nothing reads it:
+Two places where the data now exists and nothing reads it:
 
 - `spike.sql` hardcodes `NULL::INTEGER AS distinct_clusters` with no join, so
   the mart still reports `pending dedup index` (#78).
-- `RecordedWorkloadPanel` and `RecordedSpikePanel` are constructed nowhere, so
-  those two supervisor panels cannot go `recorded` (#178).
 - `UnwiredTriageProvider` returns spam only, so the duplicate and campaign
   banner branches cannot fire (#109).
 
+Fixed since this file's `ca58f31` baseline, not re-verified end to end:
+
+- `RecordedWorkloadPanel` and `RecordedSpikePanel` were flagged as
+  constructed nowhere (#178, still open). `janasunani/serving/intelligence.py`
+  now builds both from `workload.csv` / `spike.csv` (PR #201, commit
+  `ce0eaea`). Whether the panels reach `recorded` for the demo slice depends
+  on those two artifacts being published, which this file does not confirm.
+- The PII scorecard reported no measurement (#67, closed). It is wired now
+  — see §2.
+
 Plus:
 
-- The PII scorecard reports no measurement (#67).
 - The action-type lookup covers 22.4% against a ~62% target (#75).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -82,7 +82,7 @@ The only place phase status is recorded.
 | 6 | II | Model tracking (DVC is the tracker; MLflow helpers merged, unused) | 🔄 |
 | 7 | II | CI (ruff + pytest on a Postgres service container) | ✅ *(docs pending)* |
 | 8 | II | Real-time inference core (warm processor, live CLI) | ✅ |
-| 9 | II | Routing (rules built; crosswalk built, wiring pending — now `demo` via #33/`#74` bounded) | 🔄 |
+| 9 | II | Routing (rules + empirical crosswalk, wired — `method:"learned"`) | ✅ *(crosswalk landed #33, closed 07 Aug; outcome-based scorer deferred, #106)* |
 | 10 | II | Serving API (default mock + opt-in live wiring) | ✅ |
 | 11 | II | Demo frontend (Next.js, DPIC-branded; first cut) | 🔄 |
 | 12 | II | Demo integration & cloud deployment | 🔄 |
@@ -103,8 +103,12 @@ Anchor facts:
 
 - Verified corpus, local SQLite **and** cloud Postgres, which must match after any
   migration change: **1,371,288 complaints / 6,556,171 action-history rows**.
-- The demo ships with routing on **`method:"fallback"`**. Smarter routing is Part
-  III; the demo does not block on it.
+- The demo ships with routing on **`method:"learned"`**, backed by the empirical
+  crosswalk built from case history (issue #33, closed 7 Aug). Argmax accuracy:
+  60.9% category only, 67.5% + subcategory, 72.8% + subcategory + district. It
+  learns where cases were historically sent, not where they resolved best. A
+  learned outcome-based scorer (disposal time, citizen benefit, issue #106) is a
+  separate, harder problem and stays Part III.
 
 ### Phase renumbering (2026-07-27)
 
@@ -340,10 +344,14 @@ format/OCR under `pipeline-core`, PII under `pii`, page type/summary under
 - **9 Routing.** The deterministic `RuleRouter` / `MappingRouter` are built,
   producing the frozen `RoutingResult`. The master tables carry no
   category→department link (`intCategoryGrp` is NULL on all 62 categories), so the
-  crosswalk has to be learned from history:
+  crosswalk is learned from history:
   `(category, subcategory, district) → argmax(dept, office)`, measured at
-  60.9 / 67.5 / 72.8%. Crosswalk and learned scorer are deferred past the demo
-  (issue #33), which ships on `fallback`.
+  60.9 / 67.5 / 72.8%. The crosswalk is wired and live (issue #33, closed 7 Aug,
+  PR #198): `DEFAULT_ROUTER` tries it first (`method="learned"`), falling back to
+  `MappingRouter` then the generic fallback. This learns where cases were
+  historically sent, not where they resolved best. A learned outcome-based scorer
+  on disposal time and citizen benefit (issue #106) is a separate, harder problem
+  and stays deferred past the demo.
 - **10 Serving.** Three endpoints plus `/health` and CORS behind the frozen
   `serving/schemas.py` contract. The default app is mocked (`janasunani-api`);
   `janasunani-api-live` mounts the real processor. Live submissions persist to a


### PR DESCRIPTION
## Summary

Docs-only truth pass. Three claims no longer matched `main`.

**1. Routing is no longer `fallback`.**
`DELIVERY.md` and `ROADMAP.md` still said routing shipped on fixed rules /
`method:"fallback"`. The empirical crosswalk landed and is wired (#33,
closed 7 Aug, PR #198): `DEFAULT_ROUTER` now tries the crosswalk first
(`method="learned"`) before falling back to `MappingRouter` then rules.

Evidence checked:
- `janasunani/routing/reference/routing_crosswalk.json` exists (`by_category`,
  `by_subcategory`, `by_category_district`, `by_full`)
- `janasunani/routing/rules.py:324` emits `method="learned"`
- `janasunani/serving/schemas.py:89` admits `"learned"` and requires
  `empirical_evidence` with it
- PR #198 (merged 2026-08-08): "Wires MappingRouter(enable_crosswalk=True)
  with ladder: crosswalk method:learned ... -> mappings/rules method:rules
  -> fallback method:fallback"
- Argmax accuracy from the crosswalk module docstring: 60.9% category only,
  67.5% + subcategory, 72.8% + subcategory + district

Kept the distinction the task called out: the crosswalk learns **where
cases were sent** (incidence), not where they resolved well. The
outcome-based scorer (disposal time, citizen benefit — #106) is separate,
open, and still deferred. No wording implies routing optimizes for
outcomes.

**2. Sarvam §6 had the wrong reason for "not called".**
The doc said all three unverified provider controls made
`route.live_use_ready` False and the adapter refuses the call
(`reason="SarvamGovernanceError"`). The gate the adapter actually checks
(`janasunani/egress/sarvam.py:625`, `:825`) is `route.egress_permitted`,
not `live_use_ready`. Evaluated `PROVIDER_REGISTRY["sarvam-vision"]`
directly:

```
live_use_ready    False
egress_permitted  True     (egress_basis: "accepted_risk")
unverified        retention_terms, encryption_in_transit, encryption_at_rest
```

A `RiskAcceptance` recorded at `janasunani/egress/sarvam.py:191` (authority:
Additional Chief Secretary, Electronics & IT Department, GoO) makes egress
permitted. Sarvam is not governance-blocked — it has never been run because
nobody has supplied `SARVAM_API_KEY`. Rewrote §6 accordingly; kept "Not
called", the three unverified controls, and the sample-size numbers.

**3. §8 Known gaps — verified each bullet against current `main`.**
- PII scorecard (#67, closed): stale. `janasunani/evaluation/pii_scorecard.py`
  now wires the live Presidio recognizers by default (`score_examples`,
  landed in PR #196, after this file's stated `ca58f31` baseline). It only
  falls back to empty predictions if the analyzer can't be imported. The
  49.6% overlap-recall measurement already in `DELIVERY.md` is the real
  output of this path. Updated §2 and §8 to say so.
- `RecordedWorkloadPanel`/`RecordedSpikePanel` (#178, still open): stale.
  `janasunani/serving/intelligence.py` now constructs both from
  `workload.csv`/`spike.csv` (PR #201, commit `ce0eaea`, also after
  `ca58f31`). Whether they currently reach `recorded` for the demo slice
  (i.e. whether those artifacts have been published) was not re-verified
  here, so I said that explicitly rather than claim it.
- `spike.sql` NULL `distinct_clusters` (#78): still true — line 56 still
  hardcodes `NULL::INTEGER AS distinct_clusters`. Kept.
- `UnwiredTriageProvider` spam-only (#109): still true —
  `janasunani/serving/triage.py` still has "Duplicate matching remains
  unwired" and only returns `TriageResult(spam=...)`. Kept.
- Action-type lookup 22.4% vs ~62% (#75): still true, matches §5's own
  numbers (74 templates, top-500 target, top-10 36.7%, top-500 60.3%). Kept.

**Also added to §4** (dedup section): the CPU-box backfill confirmation,
since it wasn't already stated precisely — `grievance_redactions` = 55,544
rows, `dedup_signatures` = 55,544 rows, verified read-only against
production Postgres for Sambalpur/2024, plus the 7 Aug re-run log line.

## Test plan
- [x] `uv run ruff check .` — clean
- [x] `uv run --extra serving --extra pipeline-core pytest` — 1172 passed,
      19 skipped
- [x] Self-reviewed the diff against the cited code paths (not just the
      commit message)

Docs-only, under 400 changed lines — should be exempt from the Codex review
gate per CONTRIBUTING.md, but flagging for a human sanity check anyway
since it touches routing/Sarvam/PII framing that other docs quote from.