### PR TITLE
fix: harden demo rehearsal and e2e pipeline scripts (P2 tech debt)

### DIFF
--- a/scripts/demo_rehearsal.sh
+++ b/scripts/demo_rehearsal.sh
@@ -430,35 +430,56 @@ phase_c_artifacts() {
   elif [ "$closure_count" -eq 0 ]; then
     check_artifact "outputs/findings/closure_finding_summary.csv" "closure findings (neither closure_finding_summary.csv nor closure_recording_no_action.csv present)" 0
   else
-    check_artifact "outputs/findings/closure_finding_summary.csv" "closure findings ($closure_count candidates present; the provider requires exactly one and reports unavailable otherwise)" 0
+    # Both candidate names exist on disk, so routing this through
+    # check_artifact (existence-based) would always report OK -- exactly the
+    # unavailable-but-passing state the provider hits (len(candidates) != 1).
+    # Emit the failure directly instead of through a helper that cannot see
+    # the count.
+    fail "closure findings ($closure_count candidates present; the provider requires exactly one and reports unavailable otherwise)"
   fi
 
-  # 3. Aggregates — explicit JANASUNANI_SUPERVISOR_AGGREGATES_DIR, falling
-  #    back to JANASUNANI_SUPERVISOR_FINDINGS_DIR (mirrors
-  #    ArtifactSupervisorProvider's own fallback in intelligence.py); data/
-  #    probe requires opt-in per AGENTS.md
-  # ArtifactSupervisorProvider searches BOTH (aggregates_dir, findings_dir),
-  # so an aggregates dir that is set but absent or empty does not make its
-  # panels unavailable when the findings dir still holds the artifacts. The
-  # rehearsal must inspect the same fallback or it fails a strict run over a
-  # demo that would have worked.
-  AGG_FOUND=""
-  AGG_COUNT=0
+  # 3. Aggregates — workload.csv and spike.csv are each searched
+  #    independently, in (JANASUNANI_SUPERVISOR_AGGREGATES_DIR,
+  #    JANASUNANI_SUPERVISOR_FINDINGS_DIR) order. This mirrors
+  #    ArtifactSupervisorProvider._load_workload() / _load_spike() exactly:
+  #    each walks that same two-directory fallback looking for its own named
+  #    file, not "any csv in the directory". Counting any *.csv let a
+  #    directory holding only workload.csv, or an unrelated csv, report
+  #    available while the provider's spike panel (or both panels) stayed
+  #    unavailable. A directory that is configured but incomplete is a known,
+  #    deterministic break -- not a "not published yet" state -- so it fails
+  #    outright rather than following the warn-unless-strict pattern used
+  #    below for "nothing configured at all".
+  WORKLOAD_DIR=""
   for candidate in "${JANASUNANI_SUPERVISOR_AGGREGATES_DIR:-}" "${JANASUNANI_SUPERVISOR_FINDINGS_DIR:-}"; do
     [ -n "$candidate" ] || continue
-    [ -d "$candidate" ] || continue
-    candidate_count="$(find "$candidate" -type f -name "*.csv" | wc -l | tr -d ' ')"
-    if [ "$candidate_count" -gt 0 ]; then
-      AGG_FOUND="$candidate"
-      AGG_COUNT="$candidate_count"
+    if [ -f "$candidate/workload.csv" ]; then
+      WORKLOAD_DIR="$candidate"
+      break
+    fi
+  done
+  SPIKE_DIR=""
+  for candidate in "${JANASUNANI_SUPERVISOR_AGGREGATES_DIR:-}" "${JANASUNANI_SUPERVISOR_FINDINGS_DIR:-}"; do
+    [ -n "$candidate" ] || continue
+    if [ -f "$candidate/spike.csv" ]; then
+      SPIKE_DIR="$candidate"
       break
     fi
   done
   AGG_DIR="${JANASUNANI_SUPERVISOR_AGGREGATES_DIR:-${JANASUNANI_SUPERVISOR_FINDINGS_DIR:-}}"
-  if [ -n "$AGG_FOUND" ]; then
-    ok "aggregates: $AGG_FOUND ($AGG_COUNT csv(s))"
+  if [ -n "$WORKLOAD_DIR" ] && [ -n "$SPIKE_DIR" ]; then
+    if [ "$WORKLOAD_DIR" = "$SPIKE_DIR" ]; then
+      ok "aggregates: $WORKLOAD_DIR (workload.csv, spike.csv)"
+    else
+      ok "aggregates: workload.csv in $WORKLOAD_DIR, spike.csv in $SPIKE_DIR"
+    fi
   elif [ -n "$AGG_DIR" ]; then
-    check_artifact "$AGG_DIR/*.csv" "aggregates in JANASUNANI_SUPERVISOR_AGGREGATES_DIR/JANASUNANI_SUPERVISOR_FINDINGS_DIR (neither directory holds a csv)" 0
+    missing="workload.csv"
+    [ -n "$WORKLOAD_DIR" ] && missing=""
+    if [ -z "$SPIKE_DIR" ]; then
+      if [ -n "$missing" ]; then missing="$missing, spike.csv"; else missing="spike.csv"; fi
+    fi
+    fail "aggregates in JANASUNANI_SUPERVISOR_AGGREGATES_DIR/JANASUNANI_SUPERVISOR_FINDINGS_DIR missing: $missing (checked both directories individually per artifact; the provider requires each by name)"
   else
     if [ "${REHEARSAL_ALLOW_DATA:-0}" = "1" ]; then
       if [ -d "data/aggregates" ] && [ "$(find data/aggregates -type f -name "*.csv" 2>/dev/null | wc -l | tr -d ' ')" -gt 0 ]; then

--- a/scripts/demo_rehearsal.sh
+++ b/scripts/demo_rehearsal.sh
@@ -412,30 +412,53 @@ phase_c_artifacts() {
   if [ -d "outputs/findings" ]; then
     ls -1 outputs/findings | head -20 | sed 's/^/    /'
   fi
-  closure_ok=""
+  # ArtifactSupervisorProvider._load_closure() reports unavailable unless
+  # EXACTLY ONE candidate exists (len(candidates) != 1), so stopping at the
+  # first match let a strict rehearsal pass while the live closure panel was
+  # unavailable -- precisely the transition state between the two filenames.
+  # Count them instead of short-circuiting.
+  closure_found=""
+  closure_count=0
   for name in closure_finding_summary.csv closure_recording_no_action.csv; do
     if [ -f "outputs/findings/$name" ]; then
-      ok "closure: outputs/findings/$name"
-      closure_ok=1
-      break
+      closure_count=$((closure_count + 1))
+      closure_found="$name"
     fi
   done
-  if [ -z "$closure_ok" ]; then
+  if [ "$closure_count" -eq 1 ]; then
+    ok "closure: outputs/findings/$closure_found"
+  elif [ "$closure_count" -eq 0 ]; then
     check_artifact "outputs/findings/closure_finding_summary.csv" "closure findings (neither closure_finding_summary.csv nor closure_recording_no_action.csv present)" 0
+  else
+    check_artifact "outputs/findings/closure_finding_summary.csv" "closure findings ($closure_count candidates present; the provider requires exactly one and reports unavailable otherwise)" 0
   fi
 
   # 3. Aggregates — explicit JANASUNANI_SUPERVISOR_AGGREGATES_DIR, falling
   #    back to JANASUNANI_SUPERVISOR_FINDINGS_DIR (mirrors
   #    ArtifactSupervisorProvider's own fallback in intelligence.py); data/
   #    probe requires opt-in per AGENTS.md
-  AGG_DIR="${JANASUNANI_SUPERVISOR_AGGREGATES_DIR:-${JANASUNANI_SUPERVISOR_FINDINGS_DIR:-}}"
-  if [ -n "$AGG_DIR" ] && [ -d "$AGG_DIR" ]; then
-    AGG_COUNT="$(find "$AGG_DIR" -type f -name "*.csv" | wc -l | tr -d ' ')"
-    if [ "$AGG_COUNT" -gt 0 ]; then
-      ok "aggregates: $AGG_DIR ($AGG_COUNT csv(s))"
-    else
-      check_artifact "$AGG_DIR/*.csv" "aggregates in JANASUNANI_SUPERVISOR_AGGREGATES_DIR/JANASUNANI_SUPERVISOR_FINDINGS_DIR" 0
+  # ArtifactSupervisorProvider searches BOTH (aggregates_dir, findings_dir),
+  # so an aggregates dir that is set but absent or empty does not make its
+  # panels unavailable when the findings dir still holds the artifacts. The
+  # rehearsal must inspect the same fallback or it fails a strict run over a
+  # demo that would have worked.
+  AGG_FOUND=""
+  AGG_COUNT=0
+  for candidate in "${JANASUNANI_SUPERVISOR_AGGREGATES_DIR:-}" "${JANASUNANI_SUPERVISOR_FINDINGS_DIR:-}"; do
+    [ -n "$candidate" ] || continue
+    [ -d "$candidate" ] || continue
+    candidate_count="$(find "$candidate" -type f -name "*.csv" | wc -l | tr -d ' ')"
+    if [ "$candidate_count" -gt 0 ]; then
+      AGG_FOUND="$candidate"
+      AGG_COUNT="$candidate_count"
+      break
     fi
+  done
+  AGG_DIR="${JANASUNANI_SUPERVISOR_AGGREGATES_DIR:-${JANASUNANI_SUPERVISOR_FINDINGS_DIR:-}}"
+  if [ -n "$AGG_FOUND" ]; then
+    ok "aggregates: $AGG_FOUND ($AGG_COUNT csv(s))"
+  elif [ -n "$AGG_DIR" ]; then
+    check_artifact "$AGG_DIR/*.csv" "aggregates in JANASUNANI_SUPERVISOR_AGGREGATES_DIR/JANASUNANI_SUPERVISOR_FINDINGS_DIR (neither directory holds a csv)" 0
   else
     if [ "${REHEARSAL_ALLOW_DATA:-0}" = "1" ]; then
       if [ -d "data/aggregates" ] && [ "$(find data/aggregates -type f -name "*.csv" 2>/dev/null | wc -l | tr -d ' ')" -gt 0 ]; then

--- a/scripts/demo_rehearsal.sh
+++ b/scripts/demo_rehearsal.sh
@@ -403,38 +403,49 @@ phase_c_artifacts() {
     info "  hint: run 'uv run janasunani-build-crosswalk' and commit the artifact to restore method:learned"
   fi
 
-  # 2. Closure summary in outputs/findings/ (Unit 4a)
+  # 2. Closure summary in outputs/findings/ (Unit 4a) — must be one of the
+  #    two filenames janasunani/serving/intelligence.py's closure reader
+  #    (_CLOSURE_ARTIFACT_NAMES) actually accepts. Any other file present in
+  #    the directory (a PII/discard finding, say) does not make the
+  #    supervisor closure panel available, so the gate must not report
+  #    success on that alone.
   if [ -d "outputs/findings" ]; then
-    FINDINGS_COUNT="$(find outputs/findings -type f | wc -l | tr -d ' ')"
-    if [ "$FINDINGS_COUNT" -gt 0 ]; then
-      ok "findings: outputs/findings/ ($FINDINGS_COUNT file(s))"
-      ls -1 outputs/findings | head -20 | sed 's/^/    /'
-    else
-      check_artifact "outputs/findings/closure_finding_summary.csv" "closure findings (outputs/findings/ empty)" 0
+    ls -1 outputs/findings | head -20 | sed 's/^/    /'
+  fi
+  closure_ok=""
+  for name in closure_finding_summary.csv closure_recording_no_action.csv; do
+    if [ -f "outputs/findings/$name" ]; then
+      ok "closure: outputs/findings/$name"
+      closure_ok=1
+      break
     fi
-  else
-    check_artifact "outputs/findings" "closure findings" 0
+  done
+  if [ -z "$closure_ok" ]; then
+    check_artifact "outputs/findings/closure_finding_summary.csv" "closure findings (neither closure_finding_summary.csv nor closure_recording_no_action.csv present)" 0
   fi
 
-  # 3. Aggregates — explicit JANASUNANI_SUPERVISOR_FINDINGS_DIR only; data/ probe requires opt-in per AGENTS.md
-  AGG_DIR="${JANASUNANI_SUPERVISOR_FINDINGS_DIR:-}"
+  # 3. Aggregates — explicit JANASUNANI_SUPERVISOR_AGGREGATES_DIR, falling
+  #    back to JANASUNANI_SUPERVISOR_FINDINGS_DIR (mirrors
+  #    ArtifactSupervisorProvider's own fallback in intelligence.py); data/
+  #    probe requires opt-in per AGENTS.md
+  AGG_DIR="${JANASUNANI_SUPERVISOR_AGGREGATES_DIR:-${JANASUNANI_SUPERVISOR_FINDINGS_DIR:-}}"
   if [ -n "$AGG_DIR" ] && [ -d "$AGG_DIR" ]; then
     AGG_COUNT="$(find "$AGG_DIR" -type f -name "*.csv" | wc -l | tr -d ' ')"
     if [ "$AGG_COUNT" -gt 0 ]; then
       ok "aggregates: $AGG_DIR ($AGG_COUNT csv(s))"
     else
-      check_artifact "$AGG_DIR/*.csv" "aggregates in JANASUNANI_SUPERVISOR_FINDINGS_DIR" 0
+      check_artifact "$AGG_DIR/*.csv" "aggregates in JANASUNANI_SUPERVISOR_AGGREGATES_DIR/JANASUNANI_SUPERVISOR_FINDINGS_DIR" 0
     fi
   else
     if [ "${REHEARSAL_ALLOW_DATA:-0}" = "1" ]; then
       if [ -d "data/aggregates" ] && [ "$(find data/aggregates -type f -name "*.csv" 2>/dev/null | wc -l | tr -d ' ')" -gt 0 ]; then
         ok "aggregates: data/aggregates/"
       else
-        check_artifact "data/aggregates/*.csv" "workload/spike aggregates (data/aggregates/ or JANASUNANI_SUPERVISOR_FINDINGS_DIR)" 0
+        check_artifact "data/aggregates/*.csv" "workload/spike aggregates (data/aggregates/ or JANASUNANI_SUPERVISOR_AGGREGATES_DIR/JANASUNANI_SUPERVISOR_FINDINGS_DIR)" 0
         info "  hint: run 'uv run janasunani-publish-workload' / 'janasunani-publish-intelligence --publish-aggregates' to publish"
       fi
     else
-      warn "aggregates: no JANASUNANI_SUPERVISOR_FINDINGS_DIR configured — skipping data/ probe per AGENTS.md (set REHEARSAL_ALLOW_DATA=1 to inspect data/ or configure JANASUNANI_SUPERVISOR_FINDINGS_DIR outside data/)"
+      warn "aggregates: no JANASUNANI_SUPERVISOR_AGGREGATES_DIR/JANASUNANI_SUPERVISOR_FINDINGS_DIR configured — skipping data/ probe per AGENTS.md (set REHEARSAL_ALLOW_DATA=1 to inspect data/ or configure one of them outside data/)"
     fi
   fi
 

--- a/scripts/demo_rehearsal.sh
+++ b/scripts/demo_rehearsal.sh
@@ -450,6 +450,18 @@ phase_c_artifacts() {
   #    deterministic break -- not a "not published yet" state -- so it fails
   #    outright rather than following the warn-unless-strict pattern used
   #    below for "nothing configured at all".
+  # supervisor_provider_from_env() (janasunani/serving/intelligence.py) gates
+  # the whole aggregate seam on JANASUNANI_SUPERVISOR_FINDINGS_DIR alone: if
+  # that variable is unset it returns UnavailableSupervisorProvider
+  # immediately, before ArtifactSupervisorProvider is ever constructed --
+  # JANASUNANI_SUPERVISOR_AGGREGATES_DIR is not consulted at all in that
+  # path, so workload.csv/spike.csv sitting there are never read live. Mirror
+  # that on/off gate before doing any per-file lookup below, so an
+  # aggregates-only configuration cannot report success for a provider that
+  # will never come up.
+  if [ -z "${JANASUNANI_SUPERVISOR_FINDINGS_DIR:-}" ] && [ -n "${JANASUNANI_SUPERVISOR_AGGREGATES_DIR:-}" ]; then
+    fail "JANASUNANI_SUPERVISOR_AGGREGATES_DIR is set but JANASUNANI_SUPERVISOR_FINDINGS_DIR is not; supervisor_provider_from_env() requires FINDINGS_DIR to enable the aggregate seam at all, so these aggregates would never be served"
+  else
   WORKLOAD_DIR=""
   for candidate in "${JANASUNANI_SUPERVISOR_AGGREGATES_DIR:-}" "${JANASUNANI_SUPERVISOR_FINDINGS_DIR:-}"; do
     [ -n "$candidate" ] || continue
@@ -491,6 +503,7 @@ phase_c_artifacts() {
     else
       warn "aggregates: no JANASUNANI_SUPERVISOR_AGGREGATES_DIR/JANASUNANI_SUPERVISOR_FINDINGS_DIR configured — skipping data/ probe per AGENTS.md (set REHEARSAL_ALLOW_DATA=1 to inspect data/ or configure one of them outside data/)"
     fi
+  fi
   fi
 
   # 4. Sarvam scorecard (if Unit 5 landed) — warn only

--- a/scripts/e2e_pipeline.sh
+++ b/scripts/e2e_pipeline.sh
@@ -14,6 +14,12 @@
 # Usage:
 #   bash scripts/e2e_pipeline.sh [fixture] [pipeline_db]
 #   FIXTURE=tests/fixtures/demo_letter.png PIPELINE_DB=data/output/pipeline-e2e.sqlite bash scripts/e2e_pipeline.sh
+#
+# PIPELINE_DB is reset fresh on every run so the rehearsal stays isolated
+# (see the DB-reset guard below): the default scratch path is deleted and
+# reinitialized automatically; a non-default PIPELINE_DB needs
+# E2E_ALLOW_DB_RESET=1 to confirm it is disposable, or E2E_ALLOW_REUSE_DB=1
+# to keep it as-is.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -59,6 +65,31 @@ fi
 # 3. Run the pipeline (Tier 3, real weights when available).
 #    Use --workers 1 for determinism in rehearsal.
 mkdir -p "$(dirname "$PIPELINE_DB")"
+
+# Guard: refuse to silently reuse a stale artifact DB. A leftover PIPELINE_DB
+# from a prior run makes every stage skip already-processed rows and the
+# exporter re-upsert old ones into OLTP -- the run silently stops being
+# isolated (#215). But `rm -f` on an arbitrary PIPELINE_DB is its own
+# data-loss footgun if this script is ever pointed at a real artifact DB --
+# e.g. the pipeline CLI's own default, data/output/pipeline.sqlite, which a
+# real ingestion run may have populated. Only this script's own throwaway
+# scratch path is ever deleted automatically; anything else needs an
+# explicit opt-in, so the destructive branch can never fire against a DB
+# this script did not itself choose as disposable.
+DEFAULT_PIPELINE_DB="data/output/pipeline-e2e.sqlite"
+if [ -e "$PIPELINE_DB" ]; then
+  if [ "${E2E_ALLOW_REUSE_DB:-0}" = "1" ]; then
+    info "reusing existing pipeline DB (E2E_ALLOW_REUSE_DB=1): $PIPELINE_DB"
+  elif [ "$PIPELINE_DB" = "$DEFAULT_PIPELINE_DB" ] || [ "${E2E_ALLOW_DB_RESET:-0}" = "1" ]; then
+    info "removing stale pipeline DB for a fresh run: $PIPELINE_DB"
+    rm -f "$PIPELINE_DB"
+  else
+    fail "refusing to remove existing pipeline DB at a non-default path ($PIPELINE_DB) without confirmation -- this script only auto-resets its own default scratch DB ($DEFAULT_PIPELINE_DB); set E2E_ALLOW_DB_RESET=1 to confirm $PIPELINE_DB is a throwaway e2e artifact DB, E2E_ALLOW_REUSE_DB=1 to reuse it as-is, or remove it manually"
+  fi
+fi
+uv run --extra pipeline-core janasunani-pipeline init-db --db "$PIPELINE_DB"
+ok "pipeline DB ready: $PIPELINE_DB"
+
 info "janasunani-pipeline run --input $FIXTURE_DIR --db $PIPELINE_DB --models $MODELS_DIR"
 # If fixture is a single file, pass --file-list via a temp list so the
 # pipeline's directory walk does not ingest sibling fixtures unintentionally.

--- a/tests/test_deploy_stack.py
+++ b/tests/test_deploy_stack.py
@@ -1462,14 +1462,27 @@ def _run_phase_c(tmp_path, *, env_extra=None, findings=()):
     (workdir / "outputs" / "findings").mkdir(parents=True)
     for name in findings:
         (workdir / "outputs" / "findings" / name).write_text("a,b\n1,2\n")
+    # Item 1 (routing crosswalk) always fails when the file is absent,
+    # regardless of strict mode. Stub it present so these tests measure only
+    # the closure/aggregates behaviour under test, not an unrelated failure.
+    crosswalk = workdir / "janasunani" / "routing" / "reference" / "routing_crosswalk.json"
+    crosswalk.parent.mkdir(parents=True)
+    crosswalk.write_text("{}\n")
 
     script = REHEARSAL_SH_PATH.read_text()
-    # Take the helpers and the phase C function verbatim, so the test runs the
-    # shipped logic rather than a paraphrase of it.
+    # Take the helpers, check_artifact, and the phase C function verbatim, so
+    # the test runs the shipped logic rather than a paraphrase of it. In
+    # particular, check_artifact must be the real existence-based helper, not
+    # a mock -- one of the bugs under test here is exactly that helper
+    # reporting OK for a path that exists but should not count as success.
     helpers = "\n".join(
         line for line in script.splitlines()
         if line.startswith(("info()", "ok()", "warn()", "log()", "fail()"))
     )
+    ca_start = script.index("check_artifact() {")
+    ca_end = script.index("\n}\n", ca_start) + 3
+    check_artifact_fn = script[ca_start:ca_end]
+
     start = script.index("phase_c_artifacts() {")
     end = script.index("\n}\n", start) + 3
     body = script[start:end]
@@ -1480,11 +1493,9 @@ WARNINGS=0
 FAILURES=0
 REHEARSAL_SKIP_ARTIFACTS="${{REHEARSAL_SKIP_ARTIFACTS:-0}}"
 REHEARSAL_ALLOW_DATA="${{REHEARSAL_ALLOW_DATA:-0}}"
-STRICT="${{STRICT:-0}}"
-log() {{ echo "$1 $2"; }}
+REHEARSAL_STRICT="${{REHEARSAL_STRICT:-0}}"
 {helpers}
-fail() {{ log "FAIL" "$1"; FAILURES=$((FAILURES+1)); }}
-check_artifact() {{ fail "missing: $2"; }}
+{check_artifact_fn}
 {body}
 phase_c_artifacts || true
 echo "WARNINGS=$WARNINGS FAILURES=$FAILURES"
@@ -1505,6 +1516,7 @@ echo "WARNINGS=$WARNINGS FAILURES=$FAILURES"
 def test_phase_c_accepts_exactly_one_closure_artifact(tmp_path):
     result = _run_phase_c(tmp_path, findings=["closure_finding_summary.csv"])
     assert "closure: outputs/findings/closure_finding_summary.csv" in result.stdout
+    assert "FAILURES=0" in result.stdout
 
 
 def test_phase_c_rejects_two_closure_artifacts(tmp_path):
@@ -1512,21 +1524,24 @@ def test_phase_c_rejects_two_closure_artifacts(tmp_path):
 
     Stopping at the first match let a strict rehearsal pass while the live
     closure panel was unavailable, which is the transition state between the
-    two filenames.
+    two filenames. A duplicate is a deterministic break (the provider will
+    unconditionally refuse to serve it), not a "not published yet" state, so
+    this must fail the run outright rather than only when --strict is set --
+    the failure count must actually move, not just the logged message.
     """
     result = _run_phase_c(
         tmp_path,
         findings=["closure_finding_summary.csv", "closure_recording_no_action.csv"],
     )
     assert "2 candidates present" in result.stdout
-    assert "FAILURES=0" not in result.stdout
+    assert "FAILURES=1" in result.stdout
 
 
 def test_phase_c_falls_back_to_findings_when_aggregates_is_empty(tmp_path):
     """ArtifactSupervisorProvider searches both dirs, so the gate must too.
 
     An aggregates dir that is set but empty does not make the panels
-    unavailable when the findings dir still holds the artifacts.
+    unavailable when the findings dir still holds both named artifacts.
     """
     empty = tmp_path / "aggregates-empty"
     empty.mkdir()
@@ -1543,10 +1558,16 @@ def test_phase_c_falls_back_to_findings_when_aggregates_is_empty(tmp_path):
         },
         findings=["closure_finding_summary.csv"],
     )
-    assert f"aggregates: {findings}" in result.stdout
+    assert f"aggregates: {findings} (workload.csv, spike.csv)" in result.stdout
+    assert "FAILURES=0" in result.stdout
 
 
-def test_phase_c_prefers_aggregates_when_it_has_content(tmp_path):
+def test_phase_c_workload_in_aggregates_spike_in_findings_passes(tmp_path):
+    """Each artifact falls back independently, per
+    ArtifactSupervisorProvider._load_workload() / _load_spike(): workload.csv
+    found in the aggregates dir and spike.csv found only in the findings dir
+    must still pass, because the provider would serve both panels.
+    """
     aggregates = tmp_path / "aggregates"
     aggregates.mkdir()
     (aggregates / "workload.csv").write_text("a\n1\n")
@@ -1562,4 +1583,43 @@ def test_phase_c_prefers_aggregates_when_it_has_content(tmp_path):
         },
         findings=["closure_finding_summary.csv"],
     )
-    assert f"aggregates: {aggregates}" in result.stdout
+    assert f"aggregates: workload.csv in {aggregates}, spike.csv in {findings}" in result.stdout
+    assert "FAILURES=0" in result.stdout
+
+
+def test_phase_c_fails_when_aggregates_has_only_workload_csv(tmp_path):
+    """ArtifactSupervisorProvider._load_spike() looks for spike.csv by name;
+    a directory holding only workload.csv (with no spike.csv anywhere in the
+    fallback chain) does not make the spike panel available. Counting "any
+    csv present" let this pass; the gate must check workload.csv and
+    spike.csv individually.
+    """
+    aggregates = tmp_path / "aggregates"
+    aggregates.mkdir()
+    (aggregates / "workload.csv").write_text("a\n1\n")
+
+    result = _run_phase_c(
+        tmp_path,
+        env_extra={"JANASUNANI_SUPERVISOR_AGGREGATES_DIR": str(aggregates)},
+        findings=["closure_finding_summary.csv"],
+    )
+    assert "missing: spike.csv" in result.stdout
+    assert "FAILURES=1" in result.stdout
+
+
+def test_phase_c_fails_on_unrelated_csv_in_aggregates_dir(tmp_path):
+    """A directory holding some unrelated csv is not the same as holding
+    workload.csv and spike.csv; the provider looks for those two names
+    specifically, so an unrelated file must not report available.
+    """
+    aggregates = tmp_path / "aggregates"
+    aggregates.mkdir()
+    (aggregates / "unrelated.csv").write_text("a\n1\n")
+
+    result = _run_phase_c(
+        tmp_path,
+        env_extra={"JANASUNANI_SUPERVISOR_AGGREGATES_DIR": str(aggregates)},
+        findings=["closure_finding_summary.csv"],
+    )
+    assert "missing: workload.csv, spike.csv" in result.stdout
+    assert "FAILURES=1" in result.stdout

--- a/tests/test_deploy_stack.py
+++ b/tests/test_deploy_stack.py
@@ -1446,3 +1446,120 @@ def test_makefile_has_rehearsal_target():
     # Must be .PHONY so make treats it as a command even if a file named
     # rehearsal exists
     assert re.search(r"\.PHONY:.*rehearsal", text), "rehearsal must be .PHONY"
+
+
+# --- Phase C behaviour, run against real directories -----------------------
+#
+# Codex findings on #231. Both were cases where the rehearsal's verdict and
+# ArtifactSupervisorProvider's behaviour disagreed, which is the one thing a
+# rehearsal gate must not do: it either passes a demo that will not work, or
+# fails a demo that would have.
+
+
+def _run_phase_c(tmp_path, *, env_extra=None, findings=()):
+    """Execute the real phase_c_artifacts body against a scratch tree."""
+    workdir = tmp_path / "repo"
+    (workdir / "outputs" / "findings").mkdir(parents=True)
+    for name in findings:
+        (workdir / "outputs" / "findings" / name).write_text("a,b\n1,2\n")
+
+    script = REHEARSAL_SH_PATH.read_text()
+    # Take the helpers and the phase C function verbatim, so the test runs the
+    # shipped logic rather than a paraphrase of it.
+    helpers = "\n".join(
+        line for line in script.splitlines()
+        if line.startswith(("info()", "ok()", "warn()", "log()", "fail()"))
+    )
+    start = script.index("phase_c_artifacts() {")
+    end = script.index("\n}\n", start) + 3
+    body = script[start:end]
+
+    harness = f"""
+set -u
+WARNINGS=0
+FAILURES=0
+REHEARSAL_SKIP_ARTIFACTS="${{REHEARSAL_SKIP_ARTIFACTS:-0}}"
+REHEARSAL_ALLOW_DATA="${{REHEARSAL_ALLOW_DATA:-0}}"
+STRICT="${{STRICT:-0}}"
+log() {{ echo "$1 $2"; }}
+{helpers}
+fail() {{ log "FAIL" "$1"; FAILURES=$((FAILURES+1)); }}
+check_artifact() {{ fail "missing: $2"; }}
+{body}
+phase_c_artifacts || true
+echo "WARNINGS=$WARNINGS FAILURES=$FAILURES"
+"""
+    env = dict(os.environ)
+    env.pop("JANASUNANI_SUPERVISOR_AGGREGATES_DIR", None)
+    env.pop("JANASUNANI_SUPERVISOR_FINDINGS_DIR", None)
+    env.update(env_extra or {})
+    return subprocess.run(
+        ["bash", "-c", harness],
+        cwd=workdir,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_phase_c_accepts_exactly_one_closure_artifact(tmp_path):
+    result = _run_phase_c(tmp_path, findings=["closure_finding_summary.csv"])
+    assert "closure: outputs/findings/closure_finding_summary.csv" in result.stdout
+
+
+def test_phase_c_rejects_two_closure_artifacts(tmp_path):
+    """The provider reports unavailable unless exactly one candidate exists.
+
+    Stopping at the first match let a strict rehearsal pass while the live
+    closure panel was unavailable, which is the transition state between the
+    two filenames.
+    """
+    result = _run_phase_c(
+        tmp_path,
+        findings=["closure_finding_summary.csv", "closure_recording_no_action.csv"],
+    )
+    assert "2 candidates present" in result.stdout
+    assert "FAILURES=0" not in result.stdout
+
+
+def test_phase_c_falls_back_to_findings_when_aggregates_is_empty(tmp_path):
+    """ArtifactSupervisorProvider searches both dirs, so the gate must too.
+
+    An aggregates dir that is set but empty does not make the panels
+    unavailable when the findings dir still holds the artifacts.
+    """
+    empty = tmp_path / "aggregates-empty"
+    empty.mkdir()
+    findings = tmp_path / "findings"
+    findings.mkdir()
+    (findings / "workload.csv").write_text("a\n1\n")
+    (findings / "spike.csv").write_text("a\n1\n")
+
+    result = _run_phase_c(
+        tmp_path,
+        env_extra={
+            "JANASUNANI_SUPERVISOR_AGGREGATES_DIR": str(empty),
+            "JANASUNANI_SUPERVISOR_FINDINGS_DIR": str(findings),
+        },
+        findings=["closure_finding_summary.csv"],
+    )
+    assert f"aggregates: {findings}" in result.stdout
+
+
+def test_phase_c_prefers_aggregates_when_it_has_content(tmp_path):
+    aggregates = tmp_path / "aggregates"
+    aggregates.mkdir()
+    (aggregates / "workload.csv").write_text("a\n1\n")
+    findings = tmp_path / "findings"
+    findings.mkdir()
+    (findings / "spike.csv").write_text("a\n1\n")
+
+    result = _run_phase_c(
+        tmp_path,
+        env_extra={
+            "JANASUNANI_SUPERVISOR_AGGREGATES_DIR": str(aggregates),
+            "JANASUNANI_SUPERVISOR_FINDINGS_DIR": str(findings),
+        },
+        findings=["closure_finding_summary.csv"],
+    )
+    assert f"aggregates: {aggregates}" in result.stdout

--- a/tests/test_deploy_stack.py
+++ b/tests/test_deploy_stack.py
@@ -1593,14 +1593,23 @@ def test_phase_c_fails_when_aggregates_has_only_workload_csv(tmp_path):
     fallback chain) does not make the spike panel available. Counting "any
     csv present" let this pass; the gate must check workload.csv and
     spike.csv individually.
+
+    JANASUNANI_SUPERVISOR_FINDINGS_DIR is set (empty) so this test exercises
+    the per-file naming check under test, not the separate
+    findings-dir-must-be-set gate covered below.
     """
     aggregates = tmp_path / "aggregates"
     aggregates.mkdir()
     (aggregates / "workload.csv").write_text("a\n1\n")
+    findings = tmp_path / "findings-empty"
+    findings.mkdir()
 
     result = _run_phase_c(
         tmp_path,
-        env_extra={"JANASUNANI_SUPERVISOR_AGGREGATES_DIR": str(aggregates)},
+        env_extra={
+            "JANASUNANI_SUPERVISOR_AGGREGATES_DIR": str(aggregates),
+            "JANASUNANI_SUPERVISOR_FINDINGS_DIR": str(findings),
+        },
         findings=["closure_finding_summary.csv"],
     )
     assert "missing: spike.csv" in result.stdout
@@ -1611,15 +1620,51 @@ def test_phase_c_fails_on_unrelated_csv_in_aggregates_dir(tmp_path):
     """A directory holding some unrelated csv is not the same as holding
     workload.csv and spike.csv; the provider looks for those two names
     specifically, so an unrelated file must not report available.
+
+    JANASUNANI_SUPERVISOR_FINDINGS_DIR is set (empty) so this test exercises
+    the per-file naming check under test, not the separate
+    findings-dir-must-be-set gate covered below.
     """
     aggregates = tmp_path / "aggregates"
     aggregates.mkdir()
     (aggregates / "unrelated.csv").write_text("a\n1\n")
+    findings = tmp_path / "findings-empty"
+    findings.mkdir()
+
+    result = _run_phase_c(
+        tmp_path,
+        env_extra={
+            "JANASUNANI_SUPERVISOR_AGGREGATES_DIR": str(aggregates),
+            "JANASUNANI_SUPERVISOR_FINDINGS_DIR": str(findings),
+        },
+        findings=["closure_finding_summary.csv"],
+    )
+    assert "missing: workload.csv, spike.csv" in result.stdout
+    assert "FAILURES=1" in result.stdout
+
+
+def test_phase_c_fails_when_findings_dir_unset_even_with_complete_aggregates(tmp_path):
+    """Codex finding on #231: supervisor_provider_from_env() gates the whole
+    aggregate seam on JANASUNANI_SUPERVISOR_FINDINGS_DIR alone -- unset it
+    and the function returns UnavailableSupervisorProvider before
+    ArtifactSupervisorProvider (and therefore workload.csv/spike.csv in
+    JANASUNANI_SUPERVISOR_AGGREGATES_DIR) is ever consulted. Previously the
+    rehearsal reported "ok" here because it searched the aggregates dir
+    directly instead of mirroring that on/off switch -- a vacuous pass: the
+    gate said available while the live provider would never come up. An
+    aggregates-only configuration, even a complete one, must fail.
+    """
+    aggregates = tmp_path / "aggregates"
+    aggregates.mkdir()
+    (aggregates / "workload.csv").write_text("a\n1\n")
+    (aggregates / "spike.csv").write_text("a\n1\n")
 
     result = _run_phase_c(
         tmp_path,
         env_extra={"JANASUNANI_SUPERVISOR_AGGREGATES_DIR": str(aggregates)},
         findings=["closure_finding_summary.csv"],
     )
-    assert "missing: workload.csv, spike.csv" in result.stdout
+    assert "JANASUNANI_SUPERVISOR_FINDINGS_DIR" in result.stdout
     assert "FAILURES=1" in result.stdout
+    # The old vacuous-pass line must not appear.
+    assert "aggregates: " + str(aggregates) not in result.stdout

--- a/tests/test_deploy_stack.py
+++ b/tests/test_deploy_stack.py
@@ -1304,6 +1304,136 @@ def test_e2e_pipeline_script_covers_required_steps():
     assert "set -e" in text or "set -euo pipefail" in text
 
 
+def test_e2e_pipeline_script_resets_the_default_scratch_db_before_running():
+    """#215: a stale PIPELINE_DB from a prior run must not silently make the
+    rehearsal non-isolated (every stage skips already-processed rows, the
+    exporter re-upserts old ones into OLTP). Static check that the reset
+    guard and the `init-db` call are both present; the guard's actual
+    refuse/reset behavior is exercised for real below."""
+    text = E2E_PIPELINE_SH_PATH.read_text()
+    assert "init-db" in text
+    assert 'DEFAULT_PIPELINE_DB="data/output/pipeline-e2e.sqlite"' in text
+    assert "E2E_ALLOW_DB_RESET" in text
+    assert 'rm -f "$PIPELINE_DB"' in text
+
+
+def test_e2e_pipeline_script_refuses_to_delete_a_non_default_pipeline_db(tmp_path):
+    """#215 regression test: the destructive `rm -f "$PIPELINE_DB"` path must
+    never fire against a database this script did not itself pick as
+    disposable -- e.g. the pipeline CLI's OWN default artifact DB
+    (data/output/pipeline.sqlite), which a real ingestion run may have
+    populated. Runs the real script (copied verbatim, like the deploy.sh
+    stub tests above) against a stale non-default PIPELINE_DB and confirms
+    it refuses and exits non-zero *before* touching the file -- not a grep
+    over the script text."""
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    script_copy = scripts_dir / "e2e_pipeline.sh"
+    shutil.copy(E2E_PIPELINE_SH_PATH, script_copy)
+    script_copy.chmod(0o755)
+
+    stale_db = tmp_path / "pipeline.sqlite"  # NOT the script's own default name
+    marker = b"stale artifact db -- must not be touched by the guard"
+    stale_db.write_bytes(marker)
+
+    fixture = ROOT_DIR / "tests" / "fixtures" / "demo_letter.png"
+    assert fixture.exists(), "test fixture missing"
+
+    env = dict(os.environ)
+    env["FIXTURE"] = str(fixture)
+    env["PIPELINE_DB"] = str(stale_db)
+    env.pop("E2E_ALLOW_DB_RESET", None)
+    env.pop("E2E_ALLOW_REUSE_DB", None)
+
+    result = subprocess.run(
+        ["bash", str(script_copy)],
+        cwd=scripts_dir,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    combined = result.stdout + result.stderr
+
+    assert result.returncode != 0, combined
+    assert "refusing to remove" in combined, combined
+    assert "E2E_ALLOW_DB_RESET" in combined
+    # The guard must fire before anything destructive happens -- the stale
+    # file must survive completely untouched.
+    assert stale_db.read_bytes() == marker
+
+
+def test_e2e_pipeline_script_allows_reuse_with_explicit_opt_in(tmp_path):
+    """The companion positive case: E2E_ALLOW_REUSE_DB=1 must let a
+    non-default, pre-existing PIPELINE_DB through without deleting it."""
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    script_copy = scripts_dir / "e2e_pipeline.sh"
+    shutil.copy(E2E_PIPELINE_SH_PATH, script_copy)
+    script_copy.chmod(0o755)
+
+    stale_db = tmp_path / "pipeline.sqlite"
+    marker = b"stale artifact db -- reuse must not touch this"
+    stale_db.write_bytes(marker)
+
+    fixture = ROOT_DIR / "tests" / "fixtures" / "demo_letter.png"
+
+    env = dict(os.environ)
+    env["FIXTURE"] = str(fixture)
+    env["PIPELINE_DB"] = str(stale_db)
+    env["E2E_ALLOW_REUSE_DB"] = "1"
+    # Point MODELS_DIR at a location with no models -- the script only warns
+    # on a missing models dir, and we don't need the run to actually
+    # succeed; we only need to observe the DB guard's own decision before
+    # the (heavy, model-dependent) pipeline run step runs.
+    env["MODELS_DIR"] = str(tmp_path / "no-models")
+
+    result = subprocess.run(
+        ["bash", str(script_copy)],
+        cwd=scripts_dir,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    combined = result.stdout + result.stderr
+
+    # The guard itself must not refuse or delete -- whatever happens
+    # downstream (the real pipeline run needs models this environment may
+    # not have) is out of scope for this test.
+    assert "refusing to remove" not in combined, combined
+    assert "reusing existing pipeline DB" in combined, combined
+    assert stale_db.read_bytes() == marker
+
+
+def test_demo_rehearsal_script_checks_specific_closure_artifact_names():
+    """#216: the closure gate must check for the exact filenames
+    janasunani/serving/intelligence.py's closure reader accepts
+    (_CLOSURE_ARTIFACT_NAMES), not "any file present in outputs/findings/".
+    A PII/discard finding sitting in that directory must not make the gate
+    report closure artifacts as available."""
+    text = REHEARSAL_SH_PATH.read_text()
+    assert "closure_finding_summary.csv" in text
+    assert "closure_recording_no_action.csv" in text
+    # The old bug: gating success on "any file in outputs/findings/ exists"
+    # rather than one of the two specific names above.
+    assert 'find outputs/findings -type f | wc -l' not in text
+
+
+def test_demo_rehearsal_script_honors_the_aggregates_dir_env_var():
+    """#218: JANASUNANI_SUPERVISOR_AGGREGATES_DIR (workload/spike) must not
+    be silently overwritten with JANASUNANI_SUPERVISOR_FINDINGS_DIR
+    (closure) -- the two are configured separately in
+    janasunani/serving/intelligence.py's supervisor_provider_from_env /
+    ArtifactSupervisorProvider, and the rehearsal's AGG_DIR must mirror that
+    same fallback (aggregates dir first, findings dir only as a fallback)."""
+    text = REHEARSAL_SH_PATH.read_text()
+    assert (
+        'AGG_DIR="${JANASUNANI_SUPERVISOR_AGGREGATES_DIR:-${JANASUNANI_SUPERVISOR_FINDINGS_DIR:-}}"'
+        in text
+    )
+
+
 def test_makefile_has_rehearsal_target():
     """`make rehearsal` must exist and delegate to scripts/demo_rehearsal.sh."""
     text = MAKEFILE_PATH.read_text()

--- a/tests/test_pipeline_e2e.py
+++ b/tests/test_pipeline_e2e.py
@@ -397,50 +397,62 @@ def test_stage_order_is_six_and_no_spam_stage():
     assert len(STAGE_ORDER) == 6
 
 
-def _try_run_spam_sidecar(config: PipelineConfig, sidecar_path: Path) -> bool:
-    """Score redacted_text as a sidecar after PII — never gates page-type.
+def _try_run_spam_sidecar(config: PipelineConfig, sidecar_path: Path) -> None:
+    """Score redacted_text via the production live-triage path, then write a
+    JSON probe for the downstream count-reconciliation assertions below.
 
-    Uses the bounded scorer (pipeline/spam) over redacted_text only; writes
-    a JSON sidecar with spam_score in [0,1] and spam_reason. Returns True if
-    the real scorer ran, False if simulated (still writes a valid sidecar so
-    downstream hops can be verified and counts reconcile).
+    ``spam.json`` here is a **test probe file, not a production artifact**
+    (issue #219): no production batch writer emits a per-page spam sidecar —
+    batch spam scores the lake slice instead (``janasunani.pipeline.spam:main``,
+    ``janasunani-spam-score``), and live submissions score through exactly
+    the path exercised here: ``janasunani.serving.triage.UnwiredTriageProvider``,
+    which wraps the bounded ``spam-v1-bounded`` scorer via
+    ``score_spam_review``. Going through the provider — rather than calling
+    ``score_spam`` directly, as this helper used to — means a break anywhere
+    in that live wiring (the provider, ``score_spam_review``, or the scorer
+    itself) fails this test loudly. The prior version's ``except ImportError``
+    branch fabricated a deterministic score whenever the import failed for
+    any reason, so the gate stayed green even with the real path broken —
+    there is no such fallback here.
     """
     import json
+    from datetime import UTC, datetime
 
-    try:
-        from janasunani.pipeline.spam import score_spam  # noqa: F401
-    except ImportError:
-        # Simulate: read redacted_text and write a deterministic sidecar
-        with connect(config.db_path) as con:
-            rows = con.execute("SELECT page_id, redacted_text FROM pages").fetchall()
-            redacted = " ".join(r["redacted_text"] or "" for r in rows)
-        # simple bounded score for simulation
-        spam_score = 0.07 if len(redacted.split()) > 8 else 0.68
-        spam_reason = "clean" if spam_score < 0.5 else "low_signal_details_inadequate"
-        sidecar_path.parent.mkdir(parents=True, exist_ok=True)
-        sidecar_path.write_text(json.dumps({"spam_score": spam_score, "spam_reason": spam_reason}), encoding="utf-8")
-        return False
-    from janasunani.pipeline.spam import score_spam
+    from janasunani.serving.triage import UnwiredTriageProvider
 
     with connect(config.db_path) as con:
         rows = con.execute("SELECT page_id, redacted_text, extracted_text FROM pages").fetchall()
     # Score over redacted_text; fallback to extracted if redacted missing
     texts = [r["redacted_text"] or r["extracted_text"] or "" for r in rows]
     combined = " ".join(texts)
-    # Real scorer is CI-safe (import-light). If import succeeded, a failure
-    # on valid redacted input must fail the test — no fabricated fallback.
-    scored = score_spam(combined)
-    import json as _json
+
+    result = UnwiredTriageProvider().assess(
+        redacted_text=combined, district=None, submitted_on=datetime.now(UTC)
+    )
+    spam = result.spam
+    assert spam.reason_code != "advisory_provider_unavailable", (
+        "production spam scorer unavailable via UnwiredTriageProvider.assess "
+        "— refusing to fabricate a score to keep this test green"
+    )
+    assert spam.spam_score is not None
+    assert 0.0 <= spam.spam_score <= 1.0
+    assert spam.spam_reason in ("low_signal_details_inadequate", "low_signal_no_grievance", "repetition_collapse", "length_too_short", "clean")
 
     sidecar_path.parent.mkdir(parents=True, exist_ok=True)
-    sidecar_path.write_text(_json.dumps({"spam_score": scored.spam_score, "spam_reason": scored.spam_reason}), encoding="utf-8")
-    assert 0.0 <= scored.spam_score <= 1.0
-    assert scored.spam_reason in ("low_signal_details_inadequate", "low_signal_no_grievance", "repetition_collapse", "length_too_short", "clean")
-    return True
+    sidecar_path.write_text(
+        json.dumps({"spam_score": spam.spam_score, "spam_reason": spam.spam_reason}),
+        encoding="utf-8",
+    )
 
 
 def test_spam_sidecar_after_pii_before_page_type_writes_bounded_score(tmp_path):
-    """Spam signal is a sidecar after PII, before page-type — not a pipeline gate."""
+    """Spam signal is a sidecar after PII, before page-type — not a pipeline gate.
+
+    Exercises the production live-triage path (``UnwiredTriageProvider`` ->
+    ``score_spam_review`` -> ``score_spam``), the same wiring
+    ``scripts/demo_rehearsal.sh`` Phase B checks via a live ``POST
+    /grievance``'s ``triage.spam.spam_score`` — see issue #219.
+    """
     input_dir = tmp_path / "input"
     db = tmp_path / "pipeline.sqlite"
     sidecar = tmp_path / "sidecar" / "spam.json"


### PR DESCRIPTION
## Summary

Four P2 tech-debt findings against the 14 Aug demo rehearsal gate (Codex review on #203/#205), all in `scripts/demo_rehearsal.sh` / `scripts/e2e_pipeline.sh` and their covering tests:

- **#215** — `e2e_pipeline.sh` reused a stale `PIPELINE_DB` across runs (every stage skipped already-processed rows, the exporter re-upserted old rows into OLTP). Added a guard that only auto-deletes the script's own default scratch path; anything else needs `E2E_ALLOW_DB_RESET=1` (or `E2E_ALLOW_REUSE_DB=1` to keep it as-is), then calls `janasunani-pipeline init-db`.
- **#216** — `demo_rehearsal.sh`'s closure-artifact check passed on *any* file under `outputs/findings/`, even ones `janasunani/serving/intelligence.py`'s closure reader would never accept. Now checks specifically for `closure_finding_summary.csv` / `closure_recording_no_action.csv` (`_CLOSURE_ARTIFACT_NAMES`).
- **#218** — `demo_rehearsal.sh` read `JANASUNANI_SUPERVISOR_FINDINGS_DIR` for the aggregates (workload/spike) check, ignoring `JANASUNANI_SUPERVISOR_AGGREGATES_DIR` entirely. `AGG_DIR` now prefers `AGGREGATES_DIR`, falling back to `FINDINGS_DIR`, mirroring `ArtifactSupervisorProvider`'s own fallback.
- **#219** — `tests/test_pipeline_e2e.py`'s spam-sidecar test fabricated `spam.json` in-test (called `score_spam()` directly, wrote the file, asserted on the file it just wrote) — the gate stayed green even if the live triage wiring were broken. Rewrote the helper to route through `janasunani.serving.triage.UnwiredTriageProvider` (the same path live submissions and `demo_rehearsal.sh`'s own `triage.spam.spam_score` check use), failing loudly on `advisory_provider_unavailable` instead of a fabricated fallback.

Combined into one PR: all four findings sit in the same two scripts (plus their covering tests) and are small enough individually that splitting would mean four near-empty PRs touching files the others also touch.

## Safety verification

- `#215`'s destructive path (`rm -f "$PIPELINE_DB"`) can never target a Postgres DSN — the pipeline CLI's `--db` is always a `Path` (sqlite file), never a connection string. The guard was verified by running the real script (subprocess, copied into a scratch dir) against a non-default stale DB: it refuses and exits non-zero, and the file is left byte-for-byte untouched. The default-path/opt-in reset path was verified by calling the real `uv run --extra pipeline-core janasunani-pipeline init-db` against a throwaway sqlite file.
- `#219`'s fix was verified by deliberately breaking the production import in `janasunani/serving/triage.py` (forced an exception before the `score_spam` import): the test went red with the new assertion (`production spam scorer unavailable via UnwiredTriageProvider.assess`). Reverted and confirmed green again.
- `#216`/`#218` were verified by extracting the real `phase_c_artifacts` function body from the script and running it against real scratch directories (an unrelated file only → warns; a real `closure_finding_summary.csv` → ok; `JANASUNANI_SUPERVISOR_AGGREGATES_DIR` set alongside a different `JANASUNANI_SUPERVISOR_FINDINGS_DIR` → the aggregates dir wins).
- No test in this PR touches the production Postgres or `data/`; the `#215` functional tests never resolve OLTP at all, and fail before any `uv run --extra pipeline-core janasunani-pipeline run` invocation.

## Test plan

- [x] `uv run ruff check .` — all checks passed
- [x] `uv run --extra serving --extra pipeline-core pytest` — 1177 passed, 19 skipped (pre-existing skips), 0 failed
- [x] `bash -n scripts/demo_rehearsal.sh` / `bash -n scripts/e2e_pipeline.sh` — both valid
- [x] Manual real-code-path verification of each fix (see Safety verification above)

Fixes #215
Fixes #216
Fixes #218
Fixes #219
---

## Merge note — Codex review round skipped

Merged without a further Codex round at the repository owner's explicit direction: *"the codex reviews keep returning issues each time without converging ... please then merge it idc"*.

Recording this plainly rather than implying a policy basis: `CONTRIBUTING.md` scopes the `codex-review-not-required` label to config-only branches and to Codex being out of review credits. **Neither applies here.** This is a deliberate override by the repository owner, labelled so the exception is visible in the record.

All findings raised on this PR were replied to in-thread and resolved. Any finding not fixed here is filed as a tracked issue rather than dropped.
