### PR TITLE
fix(sarvam): send Extract a JSON Schema root, not a bare field map

### DIFF
--- a/janasunani/egress/sarvam.py
+++ b/janasunani/egress/sarvam.py
@@ -228,6 +228,18 @@ class SarvamGovernanceError(SarvamError):
 #: Sarvam Extract caps schema nesting at this depth.
 MAX_EXTRACT_SCHEMA_DEPTH = 4
 
+#: The field types Sarvam Extract's inline schema actually accepts. Anything
+#: outside this set is answered with HTTP 400 invalid_request_error.
+#: https://docs.sarvam.ai/api/api-guides-tutorials/document-intelligence/overview
+#:
+#: This is an allowlist on purpose, not a check for known-bad values. A
+#: denylist has to be updated every time the provider's rejection surface is
+#: discovered by a 400 in production; an allowlist can only ever be too
+#: strict, never silently permissive of a type nobody has tested.
+SUPPORTED_EXTRACT_FIELD_TYPES = frozenset(
+    {"string", "number", "integer", "boolean", "object", "array"}
+)
+
 
 def _validate_extract_schema(schema: dict[str, Any]) -> None:
     """Reject a schema Sarvam would answer with HTTP 400.
@@ -308,6 +320,11 @@ def _validate_object(node: dict[str, Any], *, path: str, level: int) -> None:
         field_type = field.get("type")
         if not field_type:
             raise ValueError(f"Extract schema field {where!r} needs a 'type'.")
+        if field_type not in SUPPORTED_EXTRACT_FIELD_TYPES:
+            raise ValueError(
+                f"Extract schema field {where!r} has unsupported type {field_type!r}; "
+                f"Sarvam only accepts {sorted(SUPPORTED_EXTRACT_FIELD_TYPES)}."
+            )
         if not str(field.get("description") or "").strip():
             raise ValueError(
                 f"Extract schema field {where!r} needs a non-empty 'description'. "

--- a/janasunani/egress/sarvam.py
+++ b/janasunani/egress/sarvam.py
@@ -294,9 +294,31 @@ def _validate_properties(node: dict[str, Any], *, path: str, level: int) -> None
         if field_type == "object":
             _validate_properties(field, path=where, level=level + 1)
         elif field_type == "array":
-            items = field.get("items")
-            if isinstance(items, dict) and items.get("type") == "object":
-                _validate_properties(items, path=f"{where}[]", level=level + 1)
+            _validate_array_items(field, path=where, level=level + 1)
+
+
+def _validate_array_items(field: dict[str, Any], *, path: str, level: int) -> None:
+    """Walk down through nested arrays to whatever they finally contain.
+
+    An array of arrays of objects would otherwise stop traversal at the first
+    ``items`` whose type is not ``object``, so an inner field with no
+    description, or arbitrarily deeper nesting, would pass the guard and reach
+    the provider as an HTTP 400. Each array level counts toward the depth cap,
+    because each is a level the provider has to descend too.
+    """
+    items = field.get("items")
+    here = f"{path}[]"
+    while isinstance(items, dict) and items.get("type") == "array":
+        if level > MAX_EXTRACT_SCHEMA_DEPTH:
+            raise ValueError(
+                f"Extract schema nests deeper than {MAX_EXTRACT_SCHEMA_DEPTH} "
+                f"levels at {here}; Sarvam rejects it."
+            )
+        items = items.get("items")
+        here = f"{here}[]"
+        level += 1
+    if isinstance(items, dict) and items.get("type") == "object":
+        _validate_properties(items, path=here, level=level)
 
 
 @dataclass(frozen=True)

--- a/janasunani/egress/sarvam.py
+++ b/janasunani/egress/sarvam.py
@@ -248,11 +248,39 @@ def _validate_extract_schema(schema: dict[str, Any]) -> None:
             f"type={schema.get('type')!r}. A bare field map is rejected with "
             "HTTP 400 — wrap it as {'type': 'object', 'properties': {...}}."
         )
-    _validate_properties(schema, path="", level=1)
+    _validate_object(schema, path="", level=1)
 
 
-def _validate_properties(node: dict[str, Any], *, path: str, level: int) -> None:
-    """Validate one ``properties`` map and recurse into nested objects.
+# --- Depth accounting -------------------------------------------------------
+#
+# "Level" means: the number of schema nodes the provider walks through to
+# reach this node, counting the root object itself as level 1. Every one of
+# the following is one more node, and so one more level, with no exceptions:
+#   - the root schema object                                   -> level 1
+#   - a `properties` entry whose type is `object`               -> parent + 1
+#   - an array field's `items` (the array itself is the field)  -> parent + 1
+#   - a further `items` inside an array-of-array                -> parent + 1
+#   - the object an array (or chain of arrays) finally contains -> parent + 1
+# A field whose type is a primitive (string, number, ...) is a leaf: it does
+# not itself occupy a level, because the provider does not descend past it.
+#
+# `_check_depth` is the single place that enforces the cap. `_validate_object`
+# and `_validate_array` are the only two places that assign a level to a
+# node, and each does it exactly once, at the point where it received that
+# node from its caller — so no node is ever validated at two different levels
+# and no descent (object property, array items, array-of-array, or the
+# object an array chain bottoms out in) can slip past uncounted.
+def _check_depth(level: int, path: str) -> None:
+    if level > MAX_EXTRACT_SCHEMA_DEPTH:
+        where = path or "root"
+        raise ValueError(
+            f"Extract schema nests deeper than {MAX_EXTRACT_SCHEMA_DEPTH} levels "
+            f"at {where}; Sarvam rejects it."
+        )
+
+
+def _validate_object(node: dict[str, Any], *, path: str, level: int) -> None:
+    """Validate one object node's ``properties`` map, recursing into nested containers.
 
     Recursion is the point. The provider's field rules apply at every depth,
     so validating only the top level lets a nested field with no description
@@ -263,12 +291,7 @@ def _validate_properties(node: dict[str, Any], *, path: str, level: int) -> None
     schema that is both too deep and malformed reports the malformation it
     hits first instead of a depth error that hides it.
     """
-    if level > MAX_EXTRACT_SCHEMA_DEPTH:
-        where = path or "root"
-        raise ValueError(
-            f"Extract schema nests deeper than {MAX_EXTRACT_SCHEMA_DEPTH} levels "
-            f"at {where}; Sarvam rejects it."
-        )
+    _check_depth(level, path)
 
     properties = node.get("properties")
     if not isinstance(properties, dict) or not properties:
@@ -292,44 +315,34 @@ def _validate_properties(node: dict[str, Any], *, path: str, level: int) -> None
                 "silently degrades extraction quality."
             )
         if field_type == "object":
-            _validate_properties(field, path=where, level=level + 1)
+            _validate_object(field, path=where, level=level + 1)
         elif field_type == "array":
-            _validate_array_items(field, path=where, level=level + 1)
+            _validate_array(field, path=where, level=level + 1)
 
 
-def _validate_array_items(field: dict[str, Any], *, path: str, level: int) -> None:
-    """Walk down through nested arrays to whatever they finally contain.
+def _validate_array(field: dict[str, Any], *, path: str, level: int) -> None:
+    """Validate one array node, recursing through array-of-array to whatever it finally contains.
 
-    An array of arrays of objects would otherwise stop traversal at the first
-    ``items`` whose type is not ``object``, so an inner field with no
-    description, or arbitrarily deeper nesting, would pass the guard and reach
-    the provider as an HTTP 400. Each array level counts toward the depth cap,
-    because each is a level the provider has to descend too.
+    ``level`` is this array's own level, already assigned by the caller (the
+    array field itself is one level deeper than the object it is a property
+    of). Every further descent through ``items`` — into another array or into
+    the terminal object — is one more level and gets one more depth check,
+    via the same recursive calls that assign it: an array-of-array recurses
+    into ``_validate_array`` at ``level + 1``, and an array whose items are an
+    object recurses into ``_validate_object`` at ``level + 1``. There is no
+    separate walk and no third place that re-derives the level, which is what
+    let three different off-by-ones through before.
     """
+    _check_depth(level, path)
+
     items = field.get("items")
-    here = f"{path}[]"
-    while isinstance(items, dict) and items.get("type") == "array":
-        if level > MAX_EXTRACT_SCHEMA_DEPTH:
-            raise ValueError(
-                f"Extract schema nests deeper than {MAX_EXTRACT_SCHEMA_DEPTH} "
-                f"levels at {here}; Sarvam rejects it."
-            )
-        items = items.get("items")
-        here = f"{here}[]"
-        level += 1
-    # The loop only checks depth before each *further* array descent, so the
-    # level reached by the final descent — the one that just happened, into
-    # whatever the last array actually contains — is never checked here. A
-    # chain ending in a primitive would otherwise skip depth checking
-    # entirely, since only the isinstance(..., object) branch below checks
-    # it (via the recursive call), and a primitive never takes that branch.
-    if level > MAX_EXTRACT_SCHEMA_DEPTH:
-        raise ValueError(
-            f"Extract schema nests deeper than {MAX_EXTRACT_SCHEMA_DEPTH} "
-            f"levels at {here}; Sarvam rejects it."
-        )
-    if isinstance(items, dict) and items.get("type") == "object":
-        _validate_properties(items, path=here, level=level)
+    where = f"{path}[]"
+    if isinstance(items, dict) and items.get("type") == "array":
+        _validate_array(items, path=where, level=level + 1)
+    elif isinstance(items, dict) and items.get("type") == "object":
+        _validate_object(items, path=where, level=level + 1)
+    # A primitive (or absent/malformed) `items` is a leaf: nothing further to
+    # descend into, so nothing further to validate.
 
 
 @dataclass(frozen=True)

--- a/janasunani/egress/sarvam.py
+++ b/janasunani/egress/sarvam.py
@@ -225,6 +225,63 @@ class SarvamGovernanceError(SarvamError):
     """The external route lacks verified provider-held-data controls."""
 
 
+#: Sarvam Extract caps schema nesting at this depth.
+MAX_EXTRACT_SCHEMA_DEPTH = 4
+
+
+def _validate_extract_schema(schema: dict[str, Any]) -> None:
+    """Reject a schema Sarvam would answer with HTTP 400.
+
+    The provider requires a whole JSON Schema document, not the bare field
+    map. Handing it the field map fails at submission on every page, and the
+    audit row records only ``SarvamError``, so the cause is invisible in the
+    log. Every test injects a fake transport and cannot see a 400 either.
+    This guard is what turns that silent, uniform failure into an error that
+    names the problem before any bytes leave the box.
+
+    Raises ``ValueError`` (a caller bug, not a remote failure), so it is not
+    swallowed by the fallback-to-pytesseract path.
+    """
+    if schema.get("type") != "object":
+        raise ValueError(
+            "Sarvam Extract schema root must be {'type': 'object', ...}; got "
+            f"type={schema.get('type')!r}. A bare field map is rejected with "
+            "HTTP 400 — wrap it as {'type': 'object', 'properties': {...}}."
+        )
+    properties = schema.get("properties")
+    if not isinstance(properties, dict) or not properties:
+        raise ValueError(
+            "Sarvam Extract schema needs a non-empty 'properties' map; got "
+            f"{properties!r}."
+        )
+    for name, field in properties.items():
+        if not isinstance(field, dict):
+            raise ValueError(f"Extract schema field {name!r} must be an object.")
+        if not field.get("type"):
+            raise ValueError(f"Extract schema field {name!r} needs a 'type'.")
+        if not str(field.get("description") or "").strip():
+            raise ValueError(
+                f"Extract schema field {name!r} needs a non-empty 'description'. "
+                "The description is what steers the model, so an empty one "
+                "silently degrades extraction quality."
+            )
+
+    def depth(node: object, level: int = 1) -> int:
+        if not isinstance(node, dict):
+            return level
+        nested = node.get("properties")
+        if not isinstance(nested, dict) or not nested:
+            return level
+        return max(depth(child, level + 1) for child in nested.values())
+
+    found = depth(schema)
+    if found > MAX_EXTRACT_SCHEMA_DEPTH:
+        raise ValueError(
+            f"Extract schema nests {found} levels; Sarvam caps it at "
+            f"{MAX_EXTRACT_SCHEMA_DEPTH}."
+        )
+
+
 @dataclass(frozen=True)
 class SarvamAuditContext:
     """Identity required to make a document egress call auditable."""
@@ -515,6 +572,7 @@ class SarvamVisionAdapter:
             raise ValueError("provide exactly one of schema or config_id for Sarvam Extract")
         form: dict[str, Any] = {"language": language, "output_format": "json"}
         if schema is not None:
+            _validate_extract_schema(schema)
             form["schema"] = json.dumps(
                 schema,
                 sort_keys=True,

--- a/janasunani/egress/sarvam.py
+++ b/janasunani/egress/sarvam.py
@@ -317,6 +317,17 @@ def _validate_array_items(field: dict[str, Any], *, path: str, level: int) -> No
         items = items.get("items")
         here = f"{here}[]"
         level += 1
+    # The loop only checks depth before each *further* array descent, so the
+    # level reached by the final descent — the one that just happened, into
+    # whatever the last array actually contains — is never checked here. A
+    # chain ending in a primitive would otherwise skip depth checking
+    # entirely, since only the isinstance(..., object) branch below checks
+    # it (via the recursive call), and a primitive never takes that branch.
+    if level > MAX_EXTRACT_SCHEMA_DEPTH:
+        raise ValueError(
+            f"Extract schema nests deeper than {MAX_EXTRACT_SCHEMA_DEPTH} "
+            f"levels at {here}; Sarvam rejects it."
+        )
     if isinstance(items, dict) and items.get("type") == "object":
         _validate_properties(items, path=here, level=level)
 

--- a/janasunani/egress/sarvam.py
+++ b/janasunani/egress/sarvam.py
@@ -248,38 +248,55 @@ def _validate_extract_schema(schema: dict[str, Any]) -> None:
             f"type={schema.get('type')!r}. A bare field map is rejected with "
             "HTTP 400 — wrap it as {'type': 'object', 'properties': {...}}."
         )
-    properties = schema.get("properties")
-    if not isinstance(properties, dict) or not properties:
+    _validate_properties(schema, path="", level=1)
+
+
+def _validate_properties(node: dict[str, Any], *, path: str, level: int) -> None:
+    """Validate one ``properties`` map and recurse into nested objects.
+
+    Recursion is the point. The provider's field rules apply at every depth,
+    so validating only the top level lets a nested field with no description
+    through this guard and straight into an HTTP 400 — the exact failure this
+    guard exists to convert into a legible error.
+
+    Depth is checked on the way down rather than by a separate walk, so a
+    schema that is both too deep and malformed reports the malformation it
+    hits first instead of a depth error that hides it.
+    """
+    if level > MAX_EXTRACT_SCHEMA_DEPTH:
+        where = path or "root"
         raise ValueError(
-            "Sarvam Extract schema needs a non-empty 'properties' map; got "
-            f"{properties!r}."
+            f"Extract schema nests deeper than {MAX_EXTRACT_SCHEMA_DEPTH} levels "
+            f"at {where}; Sarvam rejects it."
         )
+
+    properties = node.get("properties")
+    if not isinstance(properties, dict) or not properties:
+        where = f" at {path}" if path else ""
+        raise ValueError(
+            f"Sarvam Extract schema needs a non-empty 'properties' map{where}; "
+            f"got {properties!r}."
+        )
+
     for name, field in properties.items():
+        where = f"{path}.{name}" if path else str(name)
         if not isinstance(field, dict):
-            raise ValueError(f"Extract schema field {name!r} must be an object.")
-        if not field.get("type"):
-            raise ValueError(f"Extract schema field {name!r} needs a 'type'.")
+            raise ValueError(f"Extract schema field {where!r} must be an object.")
+        field_type = field.get("type")
+        if not field_type:
+            raise ValueError(f"Extract schema field {where!r} needs a 'type'.")
         if not str(field.get("description") or "").strip():
             raise ValueError(
-                f"Extract schema field {name!r} needs a non-empty 'description'. "
+                f"Extract schema field {where!r} needs a non-empty 'description'. "
                 "The description is what steers the model, so an empty one "
                 "silently degrades extraction quality."
             )
-
-    def depth(node: object, level: int = 1) -> int:
-        if not isinstance(node, dict):
-            return level
-        nested = node.get("properties")
-        if not isinstance(nested, dict) or not nested:
-            return level
-        return max(depth(child, level + 1) for child in nested.values())
-
-    found = depth(schema)
-    if found > MAX_EXTRACT_SCHEMA_DEPTH:
-        raise ValueError(
-            f"Extract schema nests {found} levels; Sarvam caps it at "
-            f"{MAX_EXTRACT_SCHEMA_DEPTH}."
-        )
+        if field_type == "object":
+            _validate_properties(field, path=where, level=level + 1)
+        elif field_type == "array":
+            items = field.get("items")
+            if isinstance(items, dict) and items.get("type") == "object":
+                _validate_properties(items, path=f"{where}[]", level=level + 1)
 
 
 @dataclass(frozen=True)

--- a/janasunani/evaluation/sarvam_grievance_schema.py
+++ b/janasunani/evaluation/sarvam_grievance_schema.py
@@ -7,10 +7,20 @@ accuracy number; callers pin ``--schema-version v1`` and the scorecard
 records the version.
 
 The illustrative schema in the rehearsal plan (Part 5) is reproduced
-verbatim here as ``GRIEVANCE_EXTRACT_SCHEMA_V1``. Field names are aligned
+verbatim here as ``GRIEVANCE_EXTRACT_FIELDS_V1``. Field names are aligned
 to the OLTP ``complaints`` taxonomy (``category`` / ``grievance_category``)
 and to the pipeline ``documents`` table so the benchmark's category
 comparison has a stable referee.
+
+⚠️ The value handed to ``extract(schema=...)`` must be a **whole JSON Schema
+document**, not the bare field map. Sarvam requires a root of
+``{"type": "object", "properties": {...}}`` and rejects anything else with
+HTTP 400. Sending the bare map is what broke every Extract submission until
+2026-08-09: digitise succeeded on the same pages while extract failed 5 of 5,
+so the arm carrying the only real ground truth (recorded category) produced
+nothing. Every test mocked the transport, so no test could see the 400.
+``GRIEVANCE_EXTRACT_SCHEMA_V1`` is therefore the wrapped document, and the
+field map is exported separately for readability.
 """
 
 from __future__ import annotations
@@ -20,7 +30,8 @@ from typing import Any
 SCHEMA_VERSION = "v1"
 SCHEMA_VERSION_V1 = "v1"
 
-GRIEVANCE_EXTRACT_SCHEMA_V1: dict[str, dict[str, str]] = {
+#: The field map. Not sendable on its own — see ``GRIEVANCE_EXTRACT_SCHEMA_V1``.
+GRIEVANCE_EXTRACT_FIELDS_V1: dict[str, dict[str, str]] = {
     "grievance_category": {
         "type": "string",
         "description": "ROS grievance category label (taxonomy of complaints.grievance_category / complaints.category)",
@@ -37,6 +48,12 @@ GRIEVANCE_EXTRACT_SCHEMA_V1: dict[str, dict[str, str]] = {
         "type": "string",
         "description": "Full grievance text (redacted prose)",
     },
+}
+
+#: The document actually sent to Sarvam Extract.
+GRIEVANCE_EXTRACT_SCHEMA_V1: dict[str, Any] = {
+    "type": "object",
+    "properties": GRIEVANCE_EXTRACT_FIELDS_V1,
 }
 
 SUPPORTED_SCHEMA_VERSIONS: dict[str, dict[str, Any]] = {

--- a/tests/test_sarvam_egress.py
+++ b/tests/test_sarvam_egress.py
@@ -67,6 +67,16 @@ class FakeClock:
         self.now += seconds
 
 
+def _wrap(fields: dict[str, Any]) -> dict[str, Any]:
+    """Wrap a field map as the JSON Schema document Sarvam Extract requires.
+
+    The provider rejects a bare field map with HTTP 400, so fixtures that pass
+    one are testing a request that could never succeed. See
+    ``_validate_extract_schema``.
+    """
+    return {"type": "object", "properties": fields}
+
+
 def _context() -> SarvamAuditContext:
     return SarvamAuditContext(ticket="T-42", stage="ocr_extraction", document_id="doc:1")
 
@@ -478,7 +488,7 @@ def test_extract_resume_key_is_stable_across_schema_dict_order(tmp_path):
             "page.png",
             "en-IN",
             _context(),
-            schema={"z_field": {"type": "string"}, "a_field": {"type": "number"}},
+            schema=_wrap({"z_field": {"type": "string", "description": "z"}, "a_field": {"type": "number", "description": "a"}}),
         )
 
     resumed_transport = RecordedTransport(
@@ -502,7 +512,7 @@ def test_extract_resume_key_is_stable_across_schema_dict_order(tmp_path):
         "page.png",
         "en-IN",
         _context(),
-        schema={"a_field": {"type": "number"}, "z_field": {"type": "string"}},
+        schema=_wrap({"a_field": {"type": "number", "description": "a"}, "z_field": {"type": "string", "description": "z"}}),
     )
 
     assert result == {"results": [{"a_field": 1, "z_field": "ok"}]}
@@ -531,7 +541,7 @@ def test_changed_result_defining_parameter_does_not_resume_recorded_job(
                 "page.png",
                 "en-IN",
                 _context(),
-                schema={"field": "number" if changed else "string"},
+                schema=_wrap({"field": {"type": "number" if changed else "string", "description": "f"}}),
             )
         return adapter.extract(
             b"fixture-png",
@@ -1072,7 +1082,7 @@ def test_extract_submission_omits_an_unsupported_model_field(tmp_path):
         "page.png",
         "en-IN",
         _context(),
-        schema={"complainant_name": "string"},
+        schema=_wrap({"complainant_name": {"type": "string", "description": "name"}}),
     )
 
     assert result == {"results": [{"complainant_name": "Example"}]}
@@ -1080,7 +1090,7 @@ def test_extract_submission_omits_an_unsupported_model_field(tmp_path):
     assert submission_data == {
         "language": "en-IN",
         "output_format": "json",
-        "schema": '{"complainant_name":"string"}',
+        "schema": '{"properties":{"complainant_name":{"description":"name","type":"string"}},"type":"object"}',
     }
     assert "model" not in submission_data
 

--- a/tests/test_sarvam_evaluate.py
+++ b/tests/test_sarvam_evaluate.py
@@ -71,6 +71,10 @@ def test_extract_rejects_a_bare_field_map_before_any_egress():
         ({"type": "object"}, "non-empty 'properties'"),
         ({"type": "object", "properties": {}}, "non-empty 'properties'"),
         ({"type": "object", "properties": {"a": {"description": "x"}}}, "needs a 'type'"),
+        (
+            {"type": "object", "properties": {"a": {"type": "nonsense", "description": "x"}}},
+            "unsupported type",
+        ),
         ({"type": "object", "properties": {"a": {"type": "string"}}}, "non-empty 'description'"),
         (
             {"type": "object", "properties": {"a": {"type": "string", "description": "  "}}},
@@ -662,3 +666,63 @@ def test_codex_232_repro_root_three_arrays_terminal_object_is_rejected():
 
     with pytest.raises(ValueError, match="nests deeper than"):
         _validate_extract_schema(_array_chain_object(3))
+
+
+# --- Field type allowlist ----------------------------------------------------
+#
+# Codex finding on #232: the field-level check only asked whether ``type`` was
+# present (``if not field_type``), not whether it was one of the types Sarvam
+# actually supports. A truthy-but-invalid value like ``"nonsense"`` therefore
+# passed local validation and would have reached the provider as the exact
+# HTTP 400 this guard exists to prevent. This had already been patched three
+# times over for depth-accounting bugs in this same function, each patch
+# adding one more special case on top of the last, so the fix here is an
+# allowlist (``SUPPORTED_EXTRACT_FIELD_TYPES``) rather than a fourth patch: a
+# denylist of known-bad values can always miss a new one, an allowlist cannot.
+
+
+def test_extract_schema_guard_rejects_an_unsupported_field_type():
+    """Reproduces the finding's exact example against the pre-fix code.
+
+    Direct reproduction against the unpatched guard: ``_validate_extract_schema``
+    on ``{"type": "object", "properties": {"field": {"type": "nonsense",
+    "description": "x"}}}`` printed "unknown root field type ACCEPTED" --
+    confirming a caller-supplied schema with an invalid type sailed through
+    the guard meant to catch exactly this before any bytes leave the box.
+    """
+    from janasunani.egress.sarvam import _validate_extract_schema
+
+    schema = {
+        "type": "object",
+        "properties": {"field": {"type": "nonsense", "description": "x"}},
+    }
+    with pytest.raises(ValueError, match="unsupported type"):
+        _validate_extract_schema(schema)
+
+
+def test_every_supported_extract_field_type_is_accepted():
+    """The allowlist's positive half: every type Sarvam's docs list must still pass.
+
+    Types confirmed against https://docs.sarvam.ai/api/api-guides-tutorials/
+    document-intelligence/overview: string, number, integer, boolean, object,
+    array. An allowlist that silently drifted narrower than what the provider
+    actually accepts would be its own outage, so this is asserted rather than
+    left implicit in the constant alone.
+    """
+    from janasunani.egress.sarvam import SUPPORTED_EXTRACT_FIELD_TYPES, _validate_extract_schema
+
+    assert SUPPORTED_EXTRACT_FIELD_TYPES == {
+        "string",
+        "number",
+        "integer",
+        "boolean",
+        "object",
+        "array",
+    }
+    for field_type in sorted(SUPPORTED_EXTRACT_FIELD_TYPES):
+        field: dict = {"type": field_type, "description": f"a {field_type} field"}
+        if field_type == "object":
+            # An object field must itself carry a non-empty properties map --
+            # a separate, already-covered rule, not part of this guard.
+            field["properties"] = {"child": {"type": "string", "description": "child field"}}
+        _validate_extract_schema({"type": "object", "properties": {"field": field}})

--- a/tests/test_sarvam_evaluate.py
+++ b/tests/test_sarvam_evaluate.py
@@ -405,3 +405,67 @@ def test_wrapper_script_delegates(tmp_path: Path):
     # Should exit 0 and produce outputs (wrapper injects --arm digitise)
     assert result.returncode == 0, f"wrapper failed: {result.stderr}\n{result.stdout}"
     assert (out / "sarvam_scorecard.json").is_file()
+
+
+def test_objects_inside_nested_arrays_are_validated():
+    """Codex follow-up on #232: an array of arrays stopped the traversal.
+
+    The first `items` had type "array", not "object", so the walk gave up and
+    everything below it bypassed both field validation and the depth cap.
+    """
+    from janasunani.egress.sarvam import _validate_extract_schema
+
+    schema = {
+        "type": "object",
+        "properties": {
+            "pages": {
+                "type": "array",
+                "description": "pages, each holding a list of line items",
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {"line": {"type": "string"}},  # no description
+                    },
+                },
+            }
+        },
+    }
+    with pytest.raises(ValueError, match=r"pages\[\]\[\].line"):
+        _validate_extract_schema(schema)
+
+
+def test_arrays_count_toward_the_depth_cap():
+    """Each array level is one the provider descends too."""
+    from janasunani.egress.sarvam import _validate_extract_schema
+
+    items: dict = {"type": "object", "properties": {"leaf": {"type": "string", "description": "x"}}}
+    for _ in range(6):
+        items = {"type": "array", "items": items}
+
+    schema = {
+        "type": "object",
+        "properties": {"deep": {"type": "array", "description": "d", "items": items}},
+    }
+    with pytest.raises(ValueError, match="nests deeper than"):
+        _validate_extract_schema(schema)
+
+
+def test_a_well_formed_array_of_objects_is_accepted():
+    from janasunani.egress.sarvam import _validate_extract_schema
+
+    _validate_extract_schema(
+        {
+            "type": "object",
+            "properties": {
+                "attachments": {
+                    "type": "array",
+                    "description": "documents attached",
+                    "items": {
+                        "type": "object",
+                        "properties": {"kind": {"type": "string", "description": "kind"}},
+                    },
+                }
+            },
+        }
+    )

--- a/tests/test_sarvam_evaluate.py
+++ b/tests/test_sarvam_evaluate.py
@@ -85,15 +85,89 @@ def test_extract_schema_guard_rejects_malformed_schemas(schema, expected):
         _validate_extract_schema(schema)
 
 
+def _nested_schema(object_levels: int) -> dict:
+    """A schema whose root is an object nested *object_levels* deep."""
+    node: dict = {"type": "string", "description": "leaf"}
+    for _ in range(object_levels):
+        node = {"type": "object", "description": "nested", "properties": {"child": node}}
+    return node
+
+
+def test_a_schema_exactly_at_the_depth_cap_is_accepted():
+    """Pin the boundary rather than leave the off-by-one implicit."""
+    from janasunani.egress.sarvam import MAX_EXTRACT_SCHEMA_DEPTH, _validate_extract_schema
+
+    _validate_extract_schema(_nested_schema(MAX_EXTRACT_SCHEMA_DEPTH))
+
+
 def test_extract_schema_guard_enforces_the_provider_depth_cap():
     from janasunani.egress.sarvam import MAX_EXTRACT_SCHEMA_DEPTH, _validate_extract_schema
 
-    node: dict = {"type": "string", "description": "leaf"}
-    for _ in range(MAX_EXTRACT_SCHEMA_DEPTH):
-        node = {"type": "object", "description": "nested", "properties": {"child": node}}
+    with pytest.raises(ValueError, match="nests deeper than"):
+        _validate_extract_schema(_nested_schema(MAX_EXTRACT_SCHEMA_DEPTH + 1))
 
-    with pytest.raises(ValueError, match="caps it at"):
-        _validate_extract_schema(node)
+
+def test_a_malformed_nested_field_is_caught_not_just_the_top_level():
+    """Codex finding on #232: the provider's field rules apply at every depth.
+
+    Validating only the root lets a nested field with no description through
+    the guard and into the HTTP 400 the guard exists to prevent.
+    """
+    from janasunani.egress.sarvam import _validate_extract_schema
+
+    schema = {
+        "type": "object",
+        "properties": {
+            "petitioner": {
+                "type": "object",
+                "description": "who filed it",
+                "properties": {
+                    "name": {"type": "string"},  # no description
+                },
+            }
+        },
+    }
+    with pytest.raises(ValueError, match="petitioner.name"):
+        _validate_extract_schema(schema)
+
+
+def test_nested_objects_inside_arrays_are_validated_too():
+    from janasunani.egress.sarvam import _validate_extract_schema
+
+    schema = {
+        "type": "object",
+        "properties": {
+            "attachments": {
+                "type": "array",
+                "description": "documents attached to the grievance",
+                "items": {
+                    "type": "object",
+                    "properties": {"kind": {"type": "string"}},  # no description
+                },
+            }
+        },
+    }
+    with pytest.raises(ValueError, match=r"attachments\[\].kind"):
+        _validate_extract_schema(schema)
+
+
+def test_a_well_formed_nested_schema_is_accepted():
+    from janasunani.egress.sarvam import _validate_extract_schema
+
+    _validate_extract_schema(
+        {
+            "type": "object",
+            "properties": {
+                "petitioner": {
+                    "type": "object",
+                    "description": "who filed it",
+                    "properties": {
+                        "district": {"type": "string", "description": "district name"},
+                    },
+                }
+            },
+        }
+    )
 
 
 def _make_dummy_input(tmp_path: Path, n: int = 2) -> Path:

--- a/tests/test_sarvam_evaluate.py
+++ b/tests/test_sarvam_evaluate.py
@@ -469,3 +469,38 @@ def test_a_well_formed_array_of_objects_is_accepted():
             },
         }
     )
+
+
+def _array_chain_schema(array_levels: int) -> dict:
+    """A schema whose root field is *array_levels* deep in arrays, ending in a primitive.
+
+    Unlike ``_nested_schema``, the chain never bottoms out in an object, so
+    only the depth check reachable from a primitive terminal can catch an
+    over-depth schema built this way.
+    """
+    node: dict = {"type": "string", "description": "leaf"}
+    for _ in range(array_levels):
+        node = {"type": "array", "description": "list", "items": node}
+    return {"type": "object", "properties": {"root": node}}
+
+
+def test_an_array_chain_exactly_at_the_depth_cap_ending_in_a_primitive_is_accepted():
+    """Pin the boundary for the array-only path, same as the object path."""
+    from janasunani.egress.sarvam import MAX_EXTRACT_SCHEMA_DEPTH, _validate_extract_schema
+
+    _validate_extract_schema(_array_chain_schema(MAX_EXTRACT_SCHEMA_DEPTH - 1))
+
+
+def test_extract_schema_guard_catches_an_over_depth_array_chain_ending_in_a_primitive():
+    """Codex finding on #232: the loop checks depth before each descent, never after.
+
+    A chain of arrays that bottoms out in a primitive (not an object) never
+    takes the ``isinstance(items, dict) and items.get("type") == "object"``
+    branch, so before this fix nothing checked the level reached by the
+    final descent and an over-depth schema like this one reached the
+    provider as an HTTP 400.
+    """
+    from janasunani.egress.sarvam import MAX_EXTRACT_SCHEMA_DEPTH, _validate_extract_schema
+
+    with pytest.raises(ValueError, match="nests deeper than"):
+        _validate_extract_schema(_array_chain_schema(MAX_EXTRACT_SCHEMA_DEPTH))

--- a/tests/test_sarvam_evaluate.py
+++ b/tests/test_sarvam_evaluate.py
@@ -14,6 +14,7 @@ import pytest
 
 def test_grievance_schema_is_pinned_and_versioned():
     from janasunani.evaluation.sarvam_grievance_schema import (
+        GRIEVANCE_EXTRACT_FIELDS_V1,
         GRIEVANCE_EXTRACT_SCHEMA_V1,
         SCHEMA_VERSION,
         SUPPORTED_SCHEMA_VERSIONS,
@@ -25,15 +26,74 @@ def test_grievance_schema_is_pinned_and_versioned():
     assert SUPPORTED_SCHEMA_VERSIONS["v1"] is GRIEVANCE_EXTRACT_SCHEMA_V1
     schema = get_schema("v1")
     assert schema is GRIEVANCE_EXTRACT_SCHEMA_V1
-    # illustrative fields from plan
+    # illustrative fields from plan, now under the JSON Schema root
     for field in ("grievance_category", "summary", "district", "grievance_text"):
-        assert field in schema
-        assert schema[field]["type"] == "string"
-        assert "description" in schema[field]
+        assert field in GRIEVANCE_EXTRACT_FIELDS_V1
+        assert GRIEVANCE_EXTRACT_FIELDS_V1[field]["type"] == "string"
+        assert GRIEVANCE_EXTRACT_FIELDS_V1[field]["description"].strip()
     with pytest.raises(ValueError, match="unknown schema"):
         get_schema("v9")
     with pytest.raises(ValueError, match="unknown schema"):
         get_schema("")
+
+
+def test_pinned_schema_satisfies_the_provider_contract():
+    """The pinned schema must be a whole JSON Schema document.
+
+    Sarvam answers a bare field map with HTTP 400. Verified live on
+    2026-08-09: bare map -> 400 on every page, wrapped -> job completed.
+    The old assertions checked ``schema["summary"]["type"]``, which only
+    passes for the shape the provider rejects, so the test agreed with the
+    bug. This asserts the shape that actually submits.
+    """
+    from janasunani.egress.sarvam import _validate_extract_schema
+    from janasunani.evaluation.sarvam_grievance_schema import get_schema
+
+    schema = get_schema("v1")
+    assert schema["type"] == "object"
+    assert schema["properties"]
+    _validate_extract_schema(schema)  # must not raise
+
+
+def test_extract_rejects_a_bare_field_map_before_any_egress():
+    """The exact payload that failed 5 of 5 pages must now fail loudly."""
+    from janasunani.egress.sarvam import _validate_extract_schema
+    from janasunani.evaluation.sarvam_grievance_schema import GRIEVANCE_EXTRACT_FIELDS_V1
+
+    with pytest.raises(ValueError, match="must be"):
+        _validate_extract_schema(GRIEVANCE_EXTRACT_FIELDS_V1)
+
+
+@pytest.mark.parametrize(
+    "schema, expected",
+    [
+        ({"type": "array", "properties": {"a": {"type": "string", "description": "x"}}}, "must be"),
+        ({"type": "object"}, "non-empty 'properties'"),
+        ({"type": "object", "properties": {}}, "non-empty 'properties'"),
+        ({"type": "object", "properties": {"a": {"description": "x"}}}, "needs a 'type'"),
+        ({"type": "object", "properties": {"a": {"type": "string"}}}, "non-empty 'description'"),
+        (
+            {"type": "object", "properties": {"a": {"type": "string", "description": "  "}}},
+            "non-empty 'description'",
+        ),
+    ],
+)
+def test_extract_schema_guard_rejects_malformed_schemas(schema, expected):
+    from janasunani.egress.sarvam import _validate_extract_schema
+
+    with pytest.raises(ValueError, match=expected):
+        _validate_extract_schema(schema)
+
+
+def test_extract_schema_guard_enforces_the_provider_depth_cap():
+    from janasunani.egress.sarvam import MAX_EXTRACT_SCHEMA_DEPTH, _validate_extract_schema
+
+    node: dict = {"type": "string", "description": "leaf"}
+    for _ in range(MAX_EXTRACT_SCHEMA_DEPTH):
+        node = {"type": "object", "description": "nested", "properties": {"child": node}}
+
+    with pytest.raises(ValueError, match="caps it at"):
+        _validate_extract_schema(node)
 
 
 def _make_dummy_input(tmp_path: Path, n: int = 2) -> Path:
@@ -195,7 +255,13 @@ def test_evaluate_extract_arm_with_mocked_adapter(tmp_path: Path, monkeypatch: p
 
         def extract(self, doc_bytes, filename, language, context, schema=None, config_id=None):
             assert schema is not None
-            assert "grievance_category" in schema
+            # Assert the shape the provider actually accepts. The fake stands
+            # in for the transport, so it must hold the same contract the real
+            # endpoint does or the mock re-hides the HTTP 400.
+            from janasunani.egress.sarvam import _validate_extract_schema
+
+            _validate_extract_schema(schema)
+            assert "grievance_category" in schema["properties"]
             return {"grievance_category": "Police", "summary": "Sarvam summary text", "district": "Sambalpur"}
 
     # Patch the class used by evaluate

--- a/tests/test_sarvam_evaluate.py
+++ b/tests/test_sarvam_evaluate.py
@@ -504,3 +504,161 @@ def test_extract_schema_guard_catches_an_over_depth_array_chain_ending_in_a_prim
 
     with pytest.raises(ValueError, match="nests deeper than"):
         _validate_extract_schema(_array_chain_schema(MAX_EXTRACT_SCHEMA_DEPTH))
+
+
+# --- Table-driven depth accounting ------------------------------------------
+#
+# Three off-by-ones in the depth accounting have now reached review in a row,
+# each "fixed" by adding another check on top of the last. The accounting was
+# rewritten instead (see the module comment above `_validate_object` in
+# `janasunani/egress/sarvam.py`), and this table is what pins it down: every
+# shape below states the level its deepest node reaches, so the boundary is
+# asserted, not inferred from a single accept/reject pair.
+#
+# Level, per that module comment: the root schema object is level 1; every
+# object property, every array `items` step (including array-of-array), and
+# the object a chain of arrays finally bottoms out in each add one level. A
+# primitive field is a leaf and does not itself occupy a level.
+
+
+def _object_chain(levels: int) -> dict:
+    """root + nested objects, deepest level == *levels*."""
+    return _nested_schema(levels)
+
+
+def _array_chain_primitive(levels: int) -> dict:
+    """root + nested arrays ending in a primitive, deepest level == *levels*."""
+    return _array_chain_schema(levels - 1)
+
+
+def _array_chain_object(array_levels: int) -> dict:
+    """root -> *array_levels* nested arrays -> a terminal well-formed object.
+
+    Deepest level == *array_levels* + 2: one for the root, one per array, and
+    one more for the terminal object the innermost array's ``items``
+    descends into -- the exact descent Codex's finding on #232 showed was
+    not being counted (the walk reached this object with the innermost
+    array's level, unchanged).
+    """
+    node: dict = {
+        "type": "object",
+        "properties": {"leaf": {"type": "string", "description": "x"}},
+    }
+    for _ in range(array_levels):
+        node = {"type": "array", "description": "list", "items": node}
+    return {"type": "object", "properties": {"root": node}}
+
+
+def _mixed_chain_object_array_object() -> dict:
+    """root -> object -> array -> terminal object. Deepest level 4."""
+    return {
+        "type": "object",
+        "properties": {
+            "petitioner": {
+                "type": "object",
+                "description": "who filed it",
+                "properties": {
+                    "attachments": {
+                        "type": "array",
+                        "description": "documents",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "kind": {"type": "string", "description": "kind"},
+                            },
+                        },
+                    }
+                },
+            }
+        },
+    }
+
+
+def _mixed_chain_array_object_array_array_primitive() -> dict:
+    """root -> array -> object -> array -> array -> primitive. Deepest level 5."""
+    return {
+        "type": "object",
+        "properties": {
+            "pages": {
+                "type": "array",
+                "description": "pages, each an object with a grid of line segments",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "lines": {
+                            "type": "array",
+                            "description": "rows of line segments on the page",
+                            "items": {
+                                "type": "array",
+                                "description": "line segments in a row",
+                                "items": {"type": "string", "description": "segment text"},
+                            },
+                        }
+                    },
+                },
+            }
+        },
+    }
+
+
+DEPTH_ACCOUNTING_CASES = [
+    # (label, schema, deepest_level, accepted)
+    ("root + 4 nested objects", _object_chain(4), 4, True),
+    ("root + 5 nested objects", _object_chain(5), 5, False),
+    ("root + 3 nested arrays -> primitive", _array_chain_primitive(4), 4, True),
+    ("root + 4 nested arrays -> primitive", _array_chain_primitive(5), 5, False),
+    ("root + 2 nested arrays -> terminal object", _array_chain_object(2), 4, True),
+    (
+        "root + 3 nested arrays -> terminal object (Codex #232 repro)",
+        _array_chain_object(3),
+        5,
+        False,
+    ),
+    ("mixed: root -> object -> array -> object", _mixed_chain_object_array_object(), 4, True),
+    (
+        "mixed: root -> array -> object -> array -> array -> primitive",
+        _mixed_chain_array_object_array_array_primitive(),
+        5,
+        False,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "label, schema, deepest_level, accepted",
+    DEPTH_ACCOUNTING_CASES,
+    ids=[case[0] for case in DEPTH_ACCOUNTING_CASES],
+)
+def test_depth_accounting_table(label, schema, deepest_level, accepted):
+    """Pin the level each schema shape reaches, not just accept/reject.
+
+    ``deepest_level`` is asserted against ``MAX_EXTRACT_SCHEMA_DEPTH`` here so
+    that a future change to the cap makes the boundary this table encodes
+    explicit, rather than the table quietly agreeing with whatever the code
+    now does -- which is how the previous three off-by-ones went unnoticed.
+    """
+    from janasunani.egress.sarvam import MAX_EXTRACT_SCHEMA_DEPTH, _validate_extract_schema
+
+    assert (deepest_level <= MAX_EXTRACT_SCHEMA_DEPTH) == accepted, label
+    if accepted:
+        _validate_extract_schema(schema)
+    else:
+        with pytest.raises(ValueError, match="nests deeper than"):
+            _validate_extract_schema(schema)
+
+
+def test_codex_232_repro_root_three_arrays_terminal_object_is_rejected():
+    """Exact reproduction from the review finding: must be REJECTED at cap 4.
+
+    Before this fix, the array walk reached the terminal object passing
+    ``level`` unchanged from the innermost array's level (4), so this
+    schema -- whose terminal object is actually the fifth schema level --
+    was wrongly accepted; a direct reproduction printed
+    ``ACCEPTED root + 3 arrays + terminal object``. Fixed by having
+    ``_validate_array`` recurse into ``_validate_object`` at ``level + 1``,
+    the same rule it already used for array-of-array.
+    """
+    from janasunani.egress.sarvam import _validate_extract_schema
+
+    with pytest.raises(ValueError, match="nests deeper than"):
+        _validate_extract_schema(_array_chain_object(3))


### PR DESCRIPTION
## The bug

The pinned Extract schema was a bare field map. Sarvam requires a whole JSON Schema document and rejects anything else with **HTTP 400**, so **every Extract submission failed**.

Found by the first live Sarvam run (9 Aug, 5 pages, `--arm both`). The audit log splits cleanly:

| operation | event | rows |
|---|---|---:|
| digitise | submission / poll / result_lookup / download | 5 each |
| extract | **submission_error** | **5** |

Scored 0 of 5 pages.

## Why it matters more than 5 pages suggests

Extract is the arm carrying the only real ground truth we hold: the recorded category on the ticket. #127 names category accuracy the **headline outcome** of the benchmark, and #126 is built on the same reference. That arm was 100% broken and nothing reported it as such — the run just produced an empty scorecard.

## Confirmed live, same page, same key

    bare field map                  -> HTTP 400
    {"type":"object","properties":…} -> job completed, result returned

## Why no test caught it

Every test injects a recorded transport, so **no test can observe a 400**. The assertions then encoded the broken shape:

    assert schema["summary"]["type"] == "string"

which only holds for the payload the provider rejects. Four more fixtures in `test_sarvam_egress.py` passed bare field maps. The suite agreed with the bug.

## The fix

- `GRIEVANCE_EXTRACT_SCHEMA_V1` is now the wrapped document; the field map stays exported as `GRIEVANCE_EXTRACT_FIELDS_V1`.
- `_validate_extract_schema` rejects a bad root, empty `properties`, a field missing `type`, a field with an empty `description` (it steers the model, so an empty one silently degrades quality), and nesting past the provider cap of 4.
- It raises `ValueError`, not `SarvamError`, so a caller bug is **not** swallowed by the fallback-to-pytesseract path, and it fires before any bytes leave the box.
- Tests now assert the shape that actually submits; the mocked adapter holds the same contract as the real endpoint.

## Judgment call worth reviewing

**Schema version stays `v1`.** Versioning exists so a change cannot silently shift the headline number. There is no number to shift: v1 never completed a single submission. Bumping to v2 would imply v1 produced something comparable. Say so if you would rather bump.

## Verification after the fix

Same 5 pages, live: **zero** `submission_error` rows, digitise and extract both 5/5, 2 tickets, ₹7.50.

    uv run ruff check .   -> All checks passed!
    uv run --extra serving --extra pipeline-core pytest -> 1285 passed, 8 skipped

Refs #53, #127, #126
---

## Merge note — Codex review round skipped

Merged without a further Codex round at the repository owner's explicit direction: *"the codex reviews keep returning issues each time without converging ... please then merge it idc"*.

Recording this plainly rather than implying a policy basis: `CONTRIBUTING.md` scopes the `codex-review-not-required` label to config-only branches and to Codex being out of review credits. **Neither applies here.** This is a deliberate override by the repository owner, labelled so the exception is visible in the record.

All findings raised on this PR were replied to in-thread and resolved. Any finding not fixed here is filed as a tracked issue rather than dropped.
