### PR TITLE
feat(evaluation): commit the benchmark sample draw with its failure modes

### DIFF
--- a/janasunani/evaluation/sarvam_s3.py
+++ b/janasunani/evaluation/sarvam_s3.py
@@ -25,7 +25,15 @@ from loguru import logger
 
 DEFAULT_BUCKET = "janasunani-documents-main"
 DEFAULT_REGION = "ap-south-1"
-DEFAULT_PROFILE = "Janasunani"
+
+#: No named profile by default: the documented EC2 hosts authenticate to S3
+#: via a shared IAM instance role and have no local AWS profile installed
+#: (docs/DEPLOY.md: "S3 access is via the instance role -- no static keys on
+#: the boxes"). Passing a profile name here forces boto3 past that chain and
+#: onto a local profile lookup, which raises ``ProfileNotFound`` on those
+#: boxes. Leave it unset so ``boto3.Session`` falls through to the instance
+#: role; a local user who wants a named profile can still pass one.
+DEFAULT_PROFILE = None
 
 #: Expedited Glacier retrieval is minutes; Standard is hours. On a deadline,
 #: the difference is a coffee break against a lost day.
@@ -33,6 +41,18 @@ DEFAULT_RESTORE_TIER = "Expedited"
 
 #: Long enough that a sample outlives the thing it was drawn for.
 DEFAULT_RESTORE_DAYS = 21
+
+#: AWS's documented Glacier retrieval windows, padded for headroom, keyed by
+#: restore tier: Expedited is minutes, Standard is 3-5 hours, Bulk is 5-12
+#: hours. A single fixed timeout (the old default was 1,200s) is only long
+#: enough for Expedited; under Standard or Bulk it always expires first and
+#: every archived object -- roughly 90% of this corpus -- is silently
+#: excluded from the manifest.
+DEFAULT_RESTORE_TIMEOUT_SECONDS: dict[str, int] = {
+    "Expedited": 15 * 60,
+    "Standard": 6 * 3600,
+    "Bulk": 13 * 3600,
+}
 
 
 class S3DocumentSource:
@@ -50,7 +70,7 @@ class S3DocumentSource:
         restore_days: int = DEFAULT_RESTORE_DAYS,
         restore_tier: str = DEFAULT_RESTORE_TIER,
         poll_seconds: int = 30,
-        restore_timeout_seconds: int = 1200,
+        restore_timeout_seconds: int | None = None,
         client: Any | None = None,
         sleep: Any | None = None,
     ) -> None:
@@ -58,7 +78,15 @@ class S3DocumentSource:
         self.restore_days = restore_days
         self.restore_tier = restore_tier
         self.poll_seconds = poll_seconds
-        self.restore_timeout_seconds = restore_timeout_seconds
+        # No explicit override: wait as long as the selected tier needs, not
+        # a one-size-fits-all figure that only suits Expedited.
+        self.restore_timeout_seconds = (
+            restore_timeout_seconds
+            if restore_timeout_seconds is not None
+            else DEFAULT_RESTORE_TIMEOUT_SECONDS.get(
+                restore_tier, DEFAULT_RESTORE_TIMEOUT_SECONDS["Bulk"]
+            )
+        )
         self._sleep = sleep or time.sleep
         self._client = client
         self._region = region

--- a/janasunani/evaluation/sarvam_s3.py
+++ b/janasunani/evaluation/sarvam_s3.py
@@ -1,0 +1,154 @@
+"""S3 document source for the benchmark sample draw.
+
+Split from ``sarvam_sample_builder`` so the draw itself has no hard dependency
+on boto3 or on the network, and so the whole selection path can be tested
+against a fake source. This module is the only part that talks to S3.
+
+The operational fact this exists to handle: roughly **90% of the document
+corpus is in GLACIER**, where ``GetObject`` fails outright with
+``InvalidObjectState``. A restore stages a temporary readable copy, and the
+window has to outlast whatever the sample is for. A 3-day window set on
+9 August 2026 expired on the 13th, the day before the demo it was built for,
+which is why ``restore_days`` defaults high rather than low.
+
+Reading is one-directional: this module downloads documents and requests
+restores. It never writes objects, and it never deletes them.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any, Sequence
+
+from loguru import logger
+
+DEFAULT_BUCKET = "janasunani-documents-main"
+DEFAULT_REGION = "ap-south-1"
+DEFAULT_PROFILE = "Janasunani"
+
+#: Expedited Glacier retrieval is minutes; Standard is hours. On a deadline,
+#: the difference is a coffee break against a lost day.
+DEFAULT_RESTORE_TIER = "Expedited"
+
+#: Long enough that a sample outlives the thing it was drawn for.
+DEFAULT_RESTORE_DAYS = 21
+
+
+class S3DocumentSource:
+    """Find, restore and fetch documents for a ticket.
+
+    Satisfies ``sarvam_sample_builder.DocumentSource``.
+    """
+
+    def __init__(
+        self,
+        *,
+        bucket: str = DEFAULT_BUCKET,
+        region: str = DEFAULT_REGION,
+        profile: str | None = DEFAULT_PROFILE,
+        restore_days: int = DEFAULT_RESTORE_DAYS,
+        restore_tier: str = DEFAULT_RESTORE_TIER,
+        poll_seconds: int = 30,
+        restore_timeout_seconds: int = 1200,
+        client: Any | None = None,
+        sleep: Any | None = None,
+    ) -> None:
+        self.bucket = bucket
+        self.restore_days = restore_days
+        self.restore_tier = restore_tier
+        self.poll_seconds = poll_seconds
+        self.restore_timeout_seconds = restore_timeout_seconds
+        self._sleep = sleep or time.sleep
+        self._client = client
+        self._region = region
+        self._profile = profile
+
+    @property
+    def client(self) -> Any:
+        if self._client is None:
+            import boto3
+
+            session = boto3.Session(profile_name=self._profile, region_name=self._region)
+            self._client = session.client("s3")
+        return self._client
+
+    def find(self, ticket: str) -> tuple[str, str] | None:
+        """The first object whose key starts ``{ticket}_``, with its class."""
+        response = self.client.list_objects_v2(
+            Bucket=self.bucket, Prefix=f"{ticket}_", MaxKeys=1
+        )
+        contents = response.get("Contents") or []
+        if not contents:
+            return None
+        return contents[0]["Key"], contents[0].get("StorageClass", "STANDARD")
+
+    def _restore_state(self, key: str) -> str:
+        """``ready``, ``in_progress`` or ``needs_restore``."""
+        head = self.client.head_object(Bucket=self.bucket, Key=key)
+        if head.get("StorageClass", "STANDARD") == "STANDARD":
+            return "ready"
+        restore = head.get("Restore")
+        if restore is None:
+            return "needs_restore"
+        return "in_progress" if 'ongoing-request="true"' in restore else "ready"
+
+    def _request_restore(self, key: str) -> str:
+        import botocore.exceptions
+
+        try:
+            self.client.restore_object(
+                Bucket=self.bucket,
+                Key=key,
+                RestoreRequest={
+                    "Days": self.restore_days,
+                    "GlacierJobParameters": {"Tier": self.restore_tier},
+                },
+            )
+            return "in_progress"
+        except botocore.exceptions.ClientError as exc:
+            code = exc.response["Error"]["Code"]
+            if code == "RestoreAlreadyInProgress":
+                return "in_progress"
+            if code == "InvalidObjectState":
+                # Already restored, or not archived after all.
+                return "ready"
+            raise
+
+    def ensure_readable(self, keys: Sequence[str]) -> set[str]:
+        """Restore archived keys and wait. Returns those still unavailable.
+
+        Returning rather than raising is deliberate: one object stuck in a
+        restore should cost the sample that document, not the whole run.
+        """
+        pending: set[str] = set()
+        for key in keys:
+            state = self._restore_state(key)
+            if state == "needs_restore":
+                state = self._request_restore(key)
+            if state == "in_progress":
+                pending.add(key)
+
+        if not pending:
+            return set()
+
+        logger.info(
+            "restore requested ({}) for {} object(s)", self.restore_tier, len(pending)
+        )
+        waited = 0
+        while pending and waited < self.restore_timeout_seconds:
+            self._sleep(self.poll_seconds)
+            waited += self.poll_seconds
+            pending = {k for k in pending if self._restore_state(k) != "ready"}
+            logger.info("  {}s: {} still staging", waited, len(pending))
+        if pending:
+            logger.warning(
+                "{} object(s) still staging after {}s; excluding them",
+                len(pending),
+                waited,
+            )
+        return pending
+
+    def fetch(self, key: str, destination: Path) -> None:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        self.client.download_file(self.bucket, key, str(destination))

--- a/janasunani/evaluation/sarvam_sample_builder.py
+++ b/janasunani/evaluation/sarvam_sample_builder.py
@@ -1,0 +1,200 @@
+"""Build the category-stratified page sample the Sarvam benchmark runs on.
+
+Selection lives here rather than inside ``sarvam_evaluate`` so the draw is
+reproducible and auditable: every ticket, its recorded category, its S3 key and
+its page count are written to a manifest *before* a page is sent anywhere.
+
+Design, per #126 and #127:
+
+* **Stratify by recorded category.** The label is administrative data we already
+  hold, so the join is exact and costs no annotation.
+* **Floor per category, then proportional.** The floor buys per-class signal;
+  the proportional tail keeps the draw anchored to the slice.
+* **Match on ticket, never on text.**
+* **Seeded**, so a run can be reproduced or extended without repeating spend.
+
+Three failures found by running this for real on 2026-08-09. Each is now a
+named function with a test, because each produced a plausible-looking sample
+that was quietly wrong:
+
+1. **Allocation must be budgeted in documents, not pages.** Documents average
+   2.8 pages and run to 22. Budgeting the draw against a page target let the
+   two largest categories consume the whole cap before a third was reached:
+   301 pages covering 3 of 31 categories.
+2. **Download order must interleave across categories.** Walking the selection
+   in category order and stopping at the page budget truncates the tail rather
+   than thinning every class. Round-robin makes an early stop shrink cells
+   evenly.
+3. **A per-category page cap is not enough on its own.** One 22-page document
+   filled almost the entire COVID-19 cell, a category with 3 tickets in the
+   whole slice. Cap pages per document as well.
+
+Archived storage is the other operational fact worth encoding: roughly 90% of
+this corpus is in GLACIER, where ``GetObject`` fails outright. Restores must be
+requested and waited for, and the restore window has to outlast whatever the
+sample is for. A 3-day window set on 9 August expired on the 13th, the day
+before the demo it was built for.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+from collections import defaultdict
+from itertools import zip_longest
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+DEFAULT_BUCKET = "janasunani-documents-main"
+DEFAULT_REGION = "ap-south-1"
+
+#: Sarvam bills per page; a document is one or more pages.
+PRICE_PER_PAGE_BOTH = 1.50
+
+
+def allocate(counts: Mapping[str, int], budget: int, floor: int) -> dict[str, int]:
+    """Documents to draw per category: a floor, then proportional remainder.
+
+    ``budget`` is a **document** count, not a page count. Passing a page target
+    here is the first of the three failures in the module docstring: the
+    selection loop stops at the document cap, so a page-sized budget lets the
+    largest categories exhaust it before smaller ones are reached.
+    """
+    categories = sorted(counts)
+    alloc = {c: min(floor, counts[c]) for c in categories}
+    remaining = max(0, budget - sum(alloc.values()))
+    headroom = {c: counts[c] - alloc[c] for c in categories}
+    total_headroom = sum(headroom.values())
+    if remaining and total_headroom:
+        for category in categories:
+            extra = round(remaining * headroom[category] / total_headroom)
+            alloc[category] += min(extra, headroom[category])
+    return alloc
+
+
+def interleave(chosen: Sequence[Mapping[str, Any]], counts: Mapping[str, int]) -> list[Mapping[str, Any]]:
+    """Round-robin the selection across categories, largest class first.
+
+    ``chosen`` arrives grouped by category. Downloading it in that order and
+    stopping at a page budget yields only the largest few classes, so the
+    stratification never survives to the sample. Interleaving makes an early
+    stop shrink every cell instead of truncating the tail.
+    """
+    groups: dict[str, list[Mapping[str, Any]]] = defaultdict(list)
+    for document in chosen:
+        groups[document["gold_category"]].append(document)
+    ordered = sorted(groups, key=lambda c: -counts.get(c, 0))
+    return [
+        document
+        for row in zip_longest(*(groups[c] for c in ordered))
+        for document in row
+        if document is not None
+    ]
+
+
+def is_ambiguous_key(key: str) -> bool:
+    """Whether the evaluator would attribute this key to the wrong ticket.
+
+    ``sarvam_evaluate`` derives the ticket from the file stem up to the first
+    underscore, so ``AN063/E/2021/00001_complaint_….pdf`` reads as ticket
+    ``00001``. Rare in this bucket, and silently joins to the wrong record.
+    """
+    return "/" in key
+
+
+def select_within_caps(
+    documents: Iterable[Mapping[str, Any]],
+    *,
+    page_counts: Mapping[str, int],
+    target_pages: int,
+    max_pages_per_category: int,
+    max_pages_per_document: int,
+) -> list[dict[str, Any]]:
+    """Take documents in order until the page budget or a cap is reached.
+
+    Both caps matter and they fail differently. Without the category cap, one
+    class dominates the run. Without the document cap, one long PDF fills a
+    class on its own: a 22-page scan took 22 of the 25 pages allowed to a
+    category holding 3 tickets in a 36,909-ticket slice.
+    """
+    taken: list[dict[str, Any]] = []
+    pages_total = 0
+    per_category: dict[str, int] = defaultdict(int)
+    for document in documents:
+        if pages_total >= target_pages:
+            break
+        category = document["gold_category"]
+        pages = page_counts.get(document["file"], 0)
+        if pages <= 0 or pages > max_pages_per_document:
+            continue
+        if per_category[category] >= max_pages_per_category:
+            continue
+        if per_category[category] + pages > max_pages_per_category and per_category[category] > 0:
+            # Keep the cap meaningful without discarding a category's only doc.
+            continue
+        taken.append({**document, "pages": pages})
+        pages_total += pages
+        per_category[category] += pages
+    return taken
+
+
+def build_manifest(
+    documents: Sequence[Mapping[str, Any]],
+    *,
+    slice_label: str,
+    seed: int,
+    target_pages: int,
+    floor: int,
+    max_pages_per_category: int,
+    max_pages_per_document: int,
+    restore_expiry: str | None = None,
+) -> dict[str, Any]:
+    """The record that makes the draw auditable rather than asserted."""
+    pages_by_category: dict[str, int] = defaultdict(int)
+    for document in documents:
+        pages_by_category[document["gold_category"]] += document.get("pages", 0)
+    pages_total = sum(pages_by_category.values())
+    return {
+        "slice": slice_label,
+        "seed": seed,
+        "target_pages": target_pages,
+        "floor_per_category": floor,
+        "max_pages_per_category": max_pages_per_category,
+        "max_pages_per_document": max_pages_per_document,
+        "pages_staged": pages_total,
+        "tickets": len(documents),
+        "categories": len(pages_by_category),
+        "estimated_cost_rupees_arm_both": round(pages_total * PRICE_PER_PAGE_BOTH, 2),
+        "restore_expiry": restore_expiry,
+        "pages_by_category": dict(sorted(pages_by_category.items(), key=lambda kv: -kv[1])),
+        "documents": list(documents),
+    }
+
+
+def write_manifest(manifest: Mapping[str, Any], path: Path) -> Path:
+    """Write the manifest.
+
+    ⚠️ The manifest carries real ticket numbers and S3 keys, so it is citizen
+    data by reference and must never be committed to Git. `data-check.yml`
+    already refuses tracked files under ``data/`` and ``outputs/``; keep the
+    manifest in one of those or under DVC.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(manifest, indent=2))
+    return path
+
+
+def draw_tickets(
+    rows: Iterable[tuple[str, str]],
+    *,
+    seed: int,
+) -> tuple[dict[str, list[str]], dict[str, int]]:
+    """Shuffle slice tickets per category under a fixed seed."""
+    by_category: dict[str, list[str]] = defaultdict(list)
+    for ticket, category in rows:
+        if category:
+            by_category[category].append(ticket)
+    rng = random.Random(seed)
+    for tickets in by_category.values():
+        rng.shuffle(tickets)
+    return dict(by_category), {c: len(t) for c, t in by_category.items()}

--- a/janasunani/evaluation/sarvam_sample_builder.py
+++ b/janasunani/evaluation/sarvam_sample_builder.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 
 import json
 import random
+import shutil
 from collections import defaultdict
 from itertools import zip_longest
 from pathlib import Path
@@ -339,6 +340,38 @@ def choose_documents(
     return chosen
 
 
+def prepare_out_dir(out_dir: Path, *, clean: bool = False) -> None:
+    """Make *out_dir* ready to stage into: empty, and created if missing.
+
+    A pre-existing non-empty directory is not harmless leftover. The cleanup
+    at the end of ``build_sample`` only removes files it fetched itself, so
+    documents a prior draw left behind survive untouched; `sarvam_evaluate`
+    then enumerates every supported document under the directory without
+    consulting the manifest, so a rerun with a different seed or cap submits
+    stale pages that are absent from the new manifest -- corrupting both the
+    paired sample and its reported cost. Reject a dirty directory by default;
+    only clear it when the caller explicitly asks to.
+    """
+    if not out_dir.exists():
+        out_dir.mkdir(parents=True, exist_ok=True)
+        return
+    leftover = list(out_dir.iterdir())
+    if not leftover:
+        return
+    if not clean:
+        raise FileExistsError(
+            f"{out_dir} already has {len(leftover)} entr{'y' if len(leftover) == 1 else 'ies'} "
+            "in it. A prior draw's documents would be re-submitted alongside this one "
+            "without appearing in its manifest. Pass clean=True (CLI: --clean) to clear "
+            "it first, or point --out at an empty directory."
+        )
+    for entry in leftover:
+        if entry.is_dir():
+            shutil.rmtree(entry)
+        else:
+            entry.unlink()
+
+
 def build_sample(
     rows: Iterable[tuple[str, str]],
     source: DocumentSource,
@@ -353,13 +386,17 @@ def build_sample(
     max_pages_per_document: int,
     page_counter: Callable[[Path], int] | None = None,
     restore_expiry: str | None = None,
+    clean_out_dir: bool = False,
 ) -> dict[str, Any]:
     """Draw, stage and record one reproducible sample. The whole path.
 
     Returns the manifest. Writes the staged documents and the manifest under
     *out_dir*, which must not be inside the repository: the manifest carries
-    real ticket numbers and S3 keys.
+    real ticket numbers and S3 keys. *out_dir* must be empty (or absent); pass
+    ``clean_out_dir=True`` to clear a leftover directory from a prior draw
+    rather than mixing its files into this one's manifest.
     """
+    prepare_out_dir(out_dir, clean=clean_out_dir)
     count_pages = page_counter or page_count
     by_category, counts = draw_tickets(rows, seed=seed)
     chosen = choose_documents(
@@ -445,6 +482,22 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--bucket", default=DEFAULT_BUCKET)
     parser.add_argument("--restore-days", type=int, default=21, help="Must outlast whatever the sample is for.")
     parser.add_argument("--restore-tier", default="Expedited", choices=["Expedited", "Standard", "Bulk"])
+    parser.add_argument(
+        "--restore-timeout-seconds",
+        type=int,
+        default=None,
+        help="Overrides the tier-appropriate default (Expedited minutes, Standard/Bulk hours).",
+    )
+    parser.add_argument(
+        "--profile",
+        default=None,
+        help="Named AWS profile. Leave unset to use the instance-role credential chain.",
+    )
+    parser.add_argument(
+        "--clean",
+        action="store_true",
+        help="Clear a non-empty --out directory left by a prior draw instead of rejecting it.",
+    )
     parser.add_argument("--dry-run", action="store_true", help="Plan only; fetch nothing.")
     args = parser.parse_args(argv)
 
@@ -477,6 +530,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         bucket=args.bucket,
         restore_days=args.restore_days,
         restore_tier=args.restore_tier,
+        restore_timeout_seconds=args.restore_timeout_seconds,
+        profile=args.profile,
     )
     build_sample(
         rows,
@@ -489,6 +544,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         max_documents=args.max_documents,
         max_pages_per_category=args.max_pages_per_category,
         max_pages_per_document=args.max_pages_per_document,
+        clean_out_dir=args.clean,
     )
     return 0
 

--- a/janasunani/evaluation/sarvam_sample_builder.py
+++ b/janasunani/evaluation/sarvam_sample_builder.py
@@ -43,13 +43,35 @@ import random
 from collections import defaultdict
 from itertools import zip_longest
 from pathlib import Path
-from typing import Any, Iterable, Mapping, Sequence
+from typing import Any, Callable, Iterable, Mapping, Protocol, Sequence
+
+from loguru import logger
 
 DEFAULT_BUCKET = "janasunani-documents-main"
 DEFAULT_REGION = "ap-south-1"
 
 #: Sarvam bills per page; a document is one or more pages.
 PRICE_PER_PAGE_BOTH = 1.50
+
+IMAGE_SUFFIXES = frozenset({".png", ".jpg", ".jpeg", ".tiff", ".tif", ".bmp", ".gif"})
+
+
+def page_count(path: Path) -> int:
+    """Pages in a staged document. Images are one page; PDFs are asked.
+
+    Returns 0 for anything unreadable, which ``select_within_caps`` treats as
+    unusable. A document whose page count cannot be determined must not be
+    billed for, since pages are the billed unit.
+    """
+    if path.suffix.lower() in IMAGE_SUFFIXES:
+        return 1
+    try:
+        from pdf2image import pdfinfo_from_path
+
+        return int(pdfinfo_from_path(str(path))["Pages"])
+    except Exception:
+        logger.warning("could not read a page count from {}; excluding it", path.name)
+        return 0
 
 
 def allocate(counts: Mapping[str, int], budget: int, floor: int) -> dict[str, int]:
@@ -59,16 +81,46 @@ def allocate(counts: Mapping[str, int], budget: int, floor: int) -> dict[str, in
     here is the first of the three failures in the module docstring: the
     selection loop stops at the document cap, so a page-sized budget lets the
     largest categories exhaust it before smaller ones are reached.
+
+    The remainder is apportioned by largest remainder (Hamilton), not by
+    rounding each category independently. Independent rounding does not sum to
+    the budget it is meant to enforce: with the real slice,
+    ``allocate(counts, budget=220, floor=3)`` returned 221, and three equal
+    categories on a budget of 5 returned 6. The whole point of this function is
+    to respect a budget, so overshooting it is not a rounding detail.
+
+    Ties break on category name so the result is reproducible rather than
+    dependent on the input's ordering.
     """
     categories = sorted(counts)
     alloc = {c: min(floor, counts[c]) for c in categories}
     remaining = max(0, budget - sum(alloc.values()))
     headroom = {c: counts[c] - alloc[c] for c in categories}
     total_headroom = sum(headroom.values())
-    if remaining and total_headroom:
-        for category in categories:
-            extra = round(remaining * headroom[category] / total_headroom)
-            alloc[category] += min(extra, headroom[category])
+    if not remaining or not total_headroom:
+        return alloc
+
+    # Largest remainder: floor everyone, then hand out what is left over to the
+    # largest fractional parts until the budget is exactly spent.
+    exact = {c: remaining * headroom[c] / total_headroom for c in categories}
+    for category in categories:
+        alloc[category] += min(int(exact[category]), headroom[category])
+
+    spent = sum(alloc.values())
+    leftover = budget - spent
+    if leftover <= 0:
+        return alloc
+
+    order = sorted(
+        categories,
+        key=lambda c: (-(exact[c] - int(exact[c])), c),
+    )
+    for category in order:
+        if leftover <= 0:
+            break
+        if alloc[category] < counts[category]:
+            alloc[category] += 1
+            leftover -= 1
     return alloc
 
 
@@ -189,12 +241,257 @@ def draw_tickets(
     *,
     seed: int,
 ) -> tuple[dict[str, list[str]], dict[str, int]]:
-    """Shuffle slice tickets per category under a fixed seed."""
-    by_category: dict[str, list[str]] = defaultdict(list)
+    """Shuffle slice tickets per category under a fixed seed.
+
+    Rows are canonicalised before the RNG is touched. ``rows`` comes from a
+    lake query with no guaranteed ordering, and both the per-category ticket
+    lists and the category iteration order would otherwise inherit that
+    ordering: the same tickets and the same seed produced a different sample
+    when the query returned them in a different order. The manifest claims the
+    draw is reproducible from the recorded seed and slice, so a result that
+    depends on unspecified row order makes that claim false.
+    """
+    grouped: dict[str, list[str]] = defaultdict(list)
     for ticket, category in rows:
         if category:
-            by_category[category].append(ticket)
+            grouped[category].append(ticket)
+
     rng = random.Random(seed)
-    for tickets in by_category.values():
+    by_category: dict[str, list[str]] = {}
+    for category in sorted(grouped):
+        tickets = sorted(grouped[category])
         rng.shuffle(tickets)
-    return dict(by_category), {c: len(t) for c, t in by_category.items()}
+        by_category[category] = tickets
+    return by_category, {c: len(t) for c, t in by_category.items()}
+
+
+# ---------------------------------------------------------------------------
+# The executable path
+#
+# Everything above is a pure function, and for a while that was all this module
+# had: the operational draw lived in a scratchpad script that was never
+# committed, so the checked-in code could not reproduce the sample it claimed
+# to describe and `is_ambiguous_key` was never actually enforced against a real
+# key. The orchestration below is the part that makes the rest true.
+#
+# Document lookup and archive restore are behind a Protocol so the whole path
+# is testable without S3. That is not ceremony: ~90% of this corpus is in
+# GLACIER, and a test that needed a restore would never run.
+# ---------------------------------------------------------------------------
+
+
+class DocumentSource(Protocol):
+    """Where a ticket's scanned document comes from, and how to fetch it."""
+
+    def find(self, ticket: str) -> tuple[str, str] | None:
+        """Return ``(key, storage_class)`` for *ticket*, or None."""
+        ...
+
+    def ensure_readable(self, keys: Sequence[str]) -> set[str]:
+        """Make *keys* readable, returning those that are not yet available."""
+        ...
+
+    def fetch(self, key: str, destination: Path) -> None:
+        """Download *key* to *destination*."""
+        ...
+
+
+def choose_documents(
+    by_category: Mapping[str, Sequence[str]],
+    counts: Mapping[str, int],
+    source: DocumentSource,
+    *,
+    max_documents: int,
+    floor: int,
+) -> list[dict[str, Any]]:
+    """Pick documents per the allocation, skipping tickets with no usable scan."""
+    alloc = allocate(counts, max_documents, floor)
+    chosen: list[dict[str, Any]] = []
+    for category in sorted(alloc, key=lambda c: (-counts.get(c, 0), c)):
+        if len(chosen) >= max_documents:
+            break
+        drawn = 0
+        for ticket in by_category.get(category, ()):
+            if len(chosen) >= max_documents or drawn >= alloc[category]:
+                break
+            found = source.find(ticket)
+            if found is None:
+                continue
+            key, storage_class = found
+            if is_ambiguous_key(key):
+                # Enforced here, on a real key, rather than only in a unit test.
+                logger.warning(
+                    "skipping {}: key {!r} would be attributed to the wrong ticket",
+                    ticket,
+                    key,
+                )
+                continue
+            drawn += 1
+            chosen.append(
+                {
+                    "ticket": ticket,
+                    "gold_category": category,
+                    "s3_key": key,
+                    "storage_class": storage_class,
+                    "file": Path(key).name,
+                }
+            )
+    return chosen
+
+
+def build_sample(
+    rows: Iterable[tuple[str, str]],
+    source: DocumentSource,
+    *,
+    out_dir: Path,
+    slice_label: str,
+    seed: int,
+    target_pages: int,
+    floor: int,
+    max_documents: int,
+    max_pages_per_category: int,
+    max_pages_per_document: int,
+    page_counter: Callable[[Path], int] | None = None,
+    restore_expiry: str | None = None,
+) -> dict[str, Any]:
+    """Draw, stage and record one reproducible sample. The whole path.
+
+    Returns the manifest. Writes the staged documents and the manifest under
+    *out_dir*, which must not be inside the repository: the manifest carries
+    real ticket numbers and S3 keys.
+    """
+    count_pages = page_counter or page_count
+    by_category, counts = draw_tickets(rows, seed=seed)
+    chosen = choose_documents(
+        by_category,
+        counts,
+        source,
+        max_documents=max_documents,
+        floor=floor,
+    )
+    logger.info("selected {} documents across {} categories", len(chosen), len(counts))
+
+    pending = source.ensure_readable([doc["s3_key"] for doc in chosen])
+    if pending:
+        logger.warning("{} document(s) are still unavailable and will be skipped", len(pending))
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    available = [doc for doc in chosen if doc["s3_key"] not in pending]
+    ordered = interleave(available, counts)
+
+    page_counts: dict[str, int] = {}
+    fetched: list[Mapping[str, Any]] = []
+    for doc in ordered:
+        destination = out_dir / doc["file"]
+        try:
+            source.fetch(doc["s3_key"], destination)
+        except Exception as exc:
+            logger.warning("skipping {}: {}", doc["file"], type(exc).__name__)
+            continue
+        page_counts[doc["file"]] = count_pages(destination)
+        fetched.append(doc)
+
+    selected = select_within_caps(
+        fetched,
+        page_counts=page_counts,
+        target_pages=target_pages,
+        max_pages_per_category=max_pages_per_category,
+        max_pages_per_document=max_pages_per_document,
+    )
+
+    # Anything fetched but not selected is not part of the sample, and leaving
+    # it beside the manifest would let a later run read pages the manifest does
+    # not account for.
+    kept = {doc["file"] for doc in selected}
+    for doc in fetched:
+        if doc["file"] not in kept:
+            (out_dir / doc["file"]).unlink(missing_ok=True)
+
+    manifest = build_manifest(
+        selected,
+        slice_label=slice_label,
+        seed=seed,
+        target_pages=target_pages,
+        floor=floor,
+        max_pages_per_category=max_pages_per_category,
+        max_pages_per_document=max_pages_per_document,
+        restore_expiry=restore_expiry,
+    )
+    write_manifest(manifest, out_dir / "sample_manifest.json")
+    logger.success(
+        "staged {} pages over {} tickets in {} categories",
+        manifest["pages_staged"],
+        manifest["tickets"],
+        manifest["categories"],
+    )
+    return manifest
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """``janasunani-build-sarvam-sample``."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Draw the Sarvam benchmark sample.")
+    parser.add_argument("--out", type=Path, required=True, help="Staging directory (keep outside the repo).")
+    parser.add_argument("--lake-dir", type=Path, default=Path("data/interim"))
+    parser.add_argument("--district", default=None)
+    parser.add_argument("--year", type=int, default=None)
+    parser.add_argument("--target-pages", type=int, default=300)
+    parser.add_argument("--floor", type=int, default=3)
+    parser.add_argument("--max-documents", type=int, default=220)
+    parser.add_argument("--max-pages-per-category", type=int, default=25)
+    parser.add_argument("--max-pages-per-document", type=int, default=8)
+    parser.add_argument("--seed", type=int, default=20260809)
+    parser.add_argument("--bucket", default=DEFAULT_BUCKET)
+    parser.add_argument("--restore-days", type=int, default=21, help="Must outlast whatever the sample is for.")
+    parser.add_argument("--restore-tier", default="Expedited", choices=["Expedited", "Standard", "Bulk"])
+    parser.add_argument("--dry-run", action="store_true", help="Plan only; fetch nothing.")
+    args = parser.parse_args(argv)
+
+    from janasunani.config import DEMO_SLICE_DISTRICT, DEMO_SLICE_YEAR
+    from janasunani.olap import lake
+
+    district = args.district or DEMO_SLICE_DISTRICT
+    year = args.year or DEMO_SLICE_YEAR
+    frame = lake.query(
+        "SELECT ticket_no, category FROM complaints "
+        f"WHERE lower(district) = lower('{district}') AND created_year = {year} "
+        "AND category IS NOT NULL",
+        lake_dir=args.lake_dir,
+        tables=["complaints"],
+    )
+    rows = list(frame.iter_rows())
+    logger.info("slice {}/{}: {} labelled tickets", district, year, len(rows))
+
+    if args.dry_run:
+        by_category, counts = draw_tickets(rows, seed=args.seed)
+        alloc = allocate(counts, args.max_documents, args.floor)
+        for category in sorted(alloc, key=lambda c: -counts[c]):
+            logger.info("  {}: {} of {} available", category, alloc[category], counts[category])
+        logger.info("planned documents: {}", sum(alloc.values()))
+        return 0
+
+    from janasunani.evaluation.sarvam_s3 import S3DocumentSource
+
+    source = S3DocumentSource(
+        bucket=args.bucket,
+        restore_days=args.restore_days,
+        restore_tier=args.restore_tier,
+    )
+    build_sample(
+        rows,
+        source,
+        out_dir=args.out,
+        slice_label=f"{district}/{year}",
+        seed=args.seed,
+        target_pages=args.target_pages,
+        floor=args.floor,
+        max_documents=args.max_documents,
+        max_pages_per_category=args.max_pages_per_category,
+        max_pages_per_document=args.max_pages_per_document,
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/janasunani/evaluation/sarvam_sample_builder.py
+++ b/janasunani/evaluation/sarvam_sample_builder.py
@@ -29,6 +29,24 @@ that was quietly wrong:
    filled almost the entire COVID-19 cell, a category with 3 tickets in the
    whole slice. Cap pages per document as well.
 
+Two more found by review rather than a live run:
+
+4. **A missing page-counting backend must not look like a bad document.** The
+   console script declares no runtime dependency on ``pdf2image`` (it lives
+   only in the ``pipeline-core``/``ocr-deepseek`` extras), so
+   ``uv run janasunani-build-sarvam-sample`` without an extra hit ``ImportError``
+   here. A blanket ``except Exception`` caught it and treated it exactly like
+   an unreadable PDF: page count 0, excluded by ``select_within_caps``. Every
+   fetched PDF would fail the same way, and the CLI would exit 0 having
+   written an empty or truncated manifest. An absent backend must fail loudly.
+5. **A category floor must be checked against the budget before it is handed
+   out.** Independent rounding was fixed to respect the budget (largest
+   remainder, below), but the floor stage that runs before it was not: if the
+   floors alone already exceed the budget, the allocation is infeasible from
+   the start, and ``choose_documents`` was silently resolving that by
+   truncating in largest-category order -- dropping exactly the small
+   categories the floor exists to protect.
+
 Archived storage is the other operational fact worth encoding: roughly 90% of
 this corpus is in GLACIER, where ``GetObject`` fails outright. Restores must be
 requested and waited for, and the restore window has to outlast whatever the
@@ -57,19 +75,51 @@ PRICE_PER_PAGE_BOTH = 1.50
 IMAGE_SUFFIXES = frozenset({".png", ".jpg", ".jpeg", ".tiff", ".tif", ".bmp", ".gif"})
 
 
+class PageCountBackendUnavailable(RuntimeError):
+    """The page-counting backend itself is missing -- not a bad document.
+
+    Must never be swallowed by the generic "unreadable document" path: doing
+    so is how a plain ``uv run janasunani-build-sarvam-sample`` (no extra)
+    used to silently zero out every PDF's page count and ship an empty or
+    truncated manifest while exiting 0.
+    """
+
+
 def page_count(path: Path) -> int:
     """Pages in a staged document. Images are one page; PDFs are asked.
 
-    Returns 0 for anything unreadable, which ``select_within_caps`` treats as
-    unusable. A document whose page count cannot be determined must not be
-    billed for, since pages are the billed unit.
+    Returns 0 for a document that is itself unreadable (corrupt PDF, wrong
+    magic bytes, ...), which ``select_within_caps`` treats as unusable. A
+    document whose page count cannot be determined must not be billed for,
+    since pages are the billed unit.
+
+    Raises :class:`PageCountBackendUnavailable` instead of returning 0 when
+    the *backend* -- ``pdf2image``, or the Poppler binaries it shells out to
+    -- is not installed. That is an environment problem, not a bad document:
+    ``pdf2image`` lives only in the ``pipeline-core``/``ocr-deepseek`` extras
+    (see ``pyproject.toml``), so the bare console script hits this every time
+    unless ``--extra pipeline-core`` was used to run it.
     """
     if path.suffix.lower() in IMAGE_SUFFIXES:
         return 1
     try:
         from pdf2image import pdfinfo_from_path
+        from pdf2image.exceptions import PDFInfoNotInstalledError
+    except ImportError as exc:
+        raise PageCountBackendUnavailable(
+            "pdf2image is not installed, so PDF pages cannot be counted. It is "
+            "not a base dependency of this CLI -- run with "
+            "`uv run --extra pipeline-core janasunani-build-sarvam-sample ...`."
+        ) from exc
 
+    try:
         return int(pdfinfo_from_path(str(path))["Pages"])
+    except PDFInfoNotInstalledError as exc:
+        raise PageCountBackendUnavailable(
+            "pdf2image is installed but Poppler (`pdfinfo`) is not, so PDF "
+            "pages cannot be counted. Install Poppler (`apt-get install "
+            "poppler-utils` / `brew install poppler`)."
+        ) from exc
     except Exception:
         logger.warning("could not read a page count from {}; excluding it", path.name)
         return 0
@@ -90,12 +140,31 @@ def allocate(counts: Mapping[str, int], budget: int, floor: int) -> dict[str, in
     categories on a budget of 5 returned 6. The whole point of this function is
     to respect a budget, so overshooting it is not a rounding detail.
 
-    Ties break on category name so the result is reproducible rather than
-    dependent on the input's ordering.
+    The floor stage is checked against the budget before any remainder is
+    apportioned. If the floors alone (each capped at what the category
+    actually has) already exceed ``budget``, the allocation is infeasible and
+    this raises ``ValueError`` rather than silently returning an
+    over-allocation: three populated categories with ``budget=2, floor=1``
+    used to return 3, and the caller (``choose_documents``) resolved that
+    itself by truncating in largest-category order -- dropping exactly the
+    small categories the floor exists to protect, and doing so differently
+    depending on how the categories happened to sort. Raising forces the
+    caller to pick a coherent floor/budget instead.
+
+    Ties in the remainder break on category name so the result is
+    reproducible rather than dependent on the input's ordering.
     """
     categories = sorted(counts)
     alloc = {c: min(floor, counts[c]) for c in categories}
-    remaining = max(0, budget - sum(alloc.values()))
+    floor_total = sum(alloc.values())
+    if floor_total > budget:
+        raise ValueError(
+            f"the floor alone ({floor_total} documents across {len(categories)} "
+            f"categories at floor={floor}) exceeds the budget ({budget}); this "
+            "allocation cannot be made to fit. Lower --floor, raise "
+            "--max-documents, or narrow the category set."
+        )
+    remaining = budget - floor_total
     headroom = {c: counts[c] - alloc[c] for c in categories}
     total_headroom = sum(headroom.values())
     if not remaining or not total_headroom:
@@ -518,7 +587,11 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if args.dry_run:
         by_category, counts = draw_tickets(rows, seed=args.seed)
-        alloc = allocate(counts, args.max_documents, args.floor)
+        try:
+            alloc = allocate(counts, args.max_documents, args.floor)
+        except ValueError as exc:
+            logger.error(str(exc))
+            return 1
         for category in sorted(alloc, key=lambda c: -counts[c]):
             logger.info("  {}: {} of {} available", category, alloc[category], counts[category])
         logger.info("planned documents: {}", sum(alloc.values()))
@@ -533,19 +606,23 @@ def main(argv: Sequence[str] | None = None) -> int:
         restore_timeout_seconds=args.restore_timeout_seconds,
         profile=args.profile,
     )
-    build_sample(
-        rows,
-        source,
-        out_dir=args.out,
-        slice_label=f"{district}/{year}",
-        seed=args.seed,
-        target_pages=args.target_pages,
-        floor=args.floor,
-        max_documents=args.max_documents,
-        max_pages_per_category=args.max_pages_per_category,
-        max_pages_per_document=args.max_pages_per_document,
-        clean_out_dir=args.clean,
-    )
+    try:
+        build_sample(
+            rows,
+            source,
+            out_dir=args.out,
+            slice_label=f"{district}/{year}",
+            seed=args.seed,
+            target_pages=args.target_pages,
+            floor=args.floor,
+            max_documents=args.max_documents,
+            max_pages_per_category=args.max_pages_per_category,
+            max_pages_per_document=args.max_pages_per_document,
+            clean_out_dir=args.clean,
+        )
+    except (ValueError, PageCountBackendUnavailable) as exc:
+        logger.error(str(exc))
+        return 1
     return 0
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,7 @@ janasunani-spam-score = "janasunani.pipeline.spam:main"
 janasunani-spam-scorecard = "janasunani.evaluation.spam_scorecard:main"
 janasunani-evaluate-benchmark = "janasunani.evaluation.benchmark_report:main"
 janasunani-evaluate-sarvam = "janasunani.evaluation.sarvam_evaluate:main"
+janasunani-build-sarvam-sample = "janasunani.evaluation.sarvam_sample_builder:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/test_sarvam_s3.py
+++ b/tests/test_sarvam_s3.py
@@ -1,0 +1,106 @@
+"""Tests for the S3 document source.
+
+Never makes a live AWS call: ``client`` is always stubbed in, so nothing here
+touches boto3's network path or requires credentials.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from janasunani.evaluation.sarvam_s3 import (
+    DEFAULT_RESTORE_TIMEOUT_SECONDS,
+    S3DocumentSource,
+)
+
+
+def test_default_profile_is_unset_so_the_instance_role_chain_applies():
+    """Codex finding on #233: the deployed boxes have no 'Janasunani' profile.
+
+    docs/DEPLOY.md: "S3 access is via the instance role -- no static keys on
+    the boxes." ``boto3.Session(profile_name=None, ...)`` falls through to
+    the default credential chain, which resolves to that instance role on
+    those hosts. A hardcoded profile name instead forces a local profile
+    lookup that raises ``ProfileNotFound`` there.
+    """
+    source = S3DocumentSource()
+    assert source._profile is None
+
+
+def test_a_local_user_can_still_opt_into_a_named_profile():
+    source = S3DocumentSource(profile="MyLocalProfile")
+    assert source._profile == "MyLocalProfile"
+
+
+@pytest.mark.parametrize(
+    "tier, hours_floor",
+    [("Expedited", 0), ("Standard", 3), ("Bulk", 5)],
+)
+def test_default_timeout_covers_the_documented_retrieval_window(tier, hours_floor):
+    """Codex finding on #233: a fixed 1,200s timeout only suits Expedited.
+
+    Standard Glacier retrieval is documented at 3-5 hours and Bulk at 5-12;
+    the old fixed 20-minute timeout always expired first under those tiers
+    and silently dropped every archived object from the manifest.
+    """
+    source = S3DocumentSource(restore_tier=tier)
+    assert source.restore_timeout_seconds >= hours_floor * 3600
+
+
+def test_standard_and_bulk_wait_longer_than_expedited():
+    expedited = S3DocumentSource(restore_tier="Expedited").restore_timeout_seconds
+    standard = S3DocumentSource(restore_tier="Standard").restore_timeout_seconds
+    bulk = S3DocumentSource(restore_tier="Bulk").restore_timeout_seconds
+    assert expedited < standard < bulk
+
+
+def test_an_explicit_timeout_overrides_the_tier_default():
+    source = S3DocumentSource(restore_tier="Standard", restore_timeout_seconds=60)
+    assert source.restore_timeout_seconds == 60
+
+
+def test_an_unknown_tier_falls_back_to_the_longest_default():
+    """Fail safe rather than fail fast: an unrecognised tier should wait too
+    long rather than too little and silently drop archived objects."""
+    source = S3DocumentSource(restore_tier="SomeNewTier")
+    assert source.restore_timeout_seconds == DEFAULT_RESTORE_TIMEOUT_SECONDS["Bulk"]
+
+
+def test_ensure_readable_waits_out_the_tier_default_before_giving_up():
+    """A restore that never completes should be polled for the whole
+    tier-appropriate window, not the old fixed 1,200s."""
+
+    class _NeverReadyClient:
+        def head_object(self, Bucket, Key):
+            return {"StorageClass": "GLACIER", "Restore": 'ongoing-request="true"'}
+
+    waits: list[int] = []
+    source = S3DocumentSource(
+        restore_tier="Standard",
+        poll_seconds=1800,  # 30 minutes, so the loop is short even over a multi-hour timeout
+        client=_NeverReadyClient(),
+        sleep=lambda s: waits.append(s),
+    )
+    pending = source.ensure_readable(["archived.pdf"])
+    assert pending == {"archived.pdf"}
+    assert sum(waits) >= DEFAULT_RESTORE_TIMEOUT_SECONDS["Standard"]
+
+
+def test_ensure_readable_stops_polling_once_the_object_is_ready():
+    calls = {"n": 0}
+
+    class _EventuallyReadyClient:
+        def head_object(self, Bucket, Key):
+            calls["n"] += 1
+            if calls["n"] < 3:
+                return {"StorageClass": "GLACIER", "Restore": 'ongoing-request="true"'}
+            return {"StorageClass": "GLACIER", "Restore": 'ongoing-request="false"'}
+
+    source = S3DocumentSource(
+        restore_tier="Expedited",
+        poll_seconds=1,
+        client=_EventuallyReadyClient(),
+        sleep=lambda s: None,
+    )
+    pending = source.ensure_readable(["archived.pdf"])
+    assert pending == set()

--- a/tests/test_sarvam_sample_builder.py
+++ b/tests/test_sarvam_sample_builder.py
@@ -15,6 +15,7 @@ import pytest
 from janasunani.evaluation.sarvam_sample_builder import (
     allocate,
     build_manifest,
+    build_sample,
     draw_tickets,
     interleave,
     is_ambiguous_key,
@@ -209,3 +210,217 @@ def test_documents_with_impossible_or_oversized_page_counts_are_skipped(pages):
         max_pages_per_document=8,
     )
     assert taken == []
+
+
+# --- the executable path ----------------------------------------------------
+
+
+class FakeDocumentSource:
+    """A DocumentSource with no S3, so the whole path is testable.
+
+    ~90% of the real corpus is in GLACIER, so a test that needed a restore
+    would never run. This models the parts that matter: some tickets have no
+    document, some keys are ambiguous, and some objects stay archived.
+    """
+
+    def __init__(self, *, keys, archived=(), never_ready=(), pages=None):
+        self.keys = dict(keys)
+        self.archived = set(archived)
+        self.never_ready = set(never_ready)
+        self.pages = pages or {}
+        self.fetched: list[str] = []
+        self.restored: list[str] = []
+
+    def find(self, ticket):
+        key = self.keys.get(ticket)
+        if key is None:
+            return None
+        return key, "GLACIER" if key in self.archived else "STANDARD"
+
+    def ensure_readable(self, keys):
+        for key in keys:
+            if key in self.archived:
+                self.restored.append(key)
+        return {k for k in keys if k in self.never_ready}
+
+    def fetch(self, key, destination):
+        self.fetched.append(key)
+        destination.write_bytes(b"%PDF-1.4 fake")
+
+
+def _rows(per_category):
+    return [
+        (f"T{category[:2]}{index:03d}", category)
+        for category, n in per_category.items()
+        for index in range(n)
+    ]
+
+
+def _source_for(rows, *, pages=1, **kwargs):
+    keys = {ticket: f"{ticket}_complaint.pdf" for ticket, _ in rows}
+    return FakeDocumentSource(
+        keys=keys,
+        pages={f"{ticket}_complaint.pdf": pages for ticket, _ in rows},
+        **kwargs,
+    )
+
+
+def test_build_sample_runs_the_whole_path_and_writes_a_manifest(tmp_path):
+    """Codex finding on #233: the module composed none of its own helpers.
+
+    The operational draw lived in an uncommitted scratchpad, so the checked-in
+    code could not reproduce the sample it described.
+    """
+    rows = _rows({"Housing": 10, "Social Welfare": 10, "Tourism": 2})
+    source = _source_for(rows)
+
+    manifest = build_sample(
+        rows,
+        source,
+        out_dir=tmp_path / "stage",
+        slice_label="Sambalpur/2024",
+        seed=20260809,
+        target_pages=12,
+        floor=2,
+        max_documents=20,
+        max_pages_per_category=5,
+        max_pages_per_document=8,
+        page_counter=lambda p: 1,
+    )
+
+    assert (tmp_path / "stage" / "sample_manifest.json").is_file()
+    assert manifest["pages_staged"] > 0
+    assert manifest["categories"] >= 2
+    assert manifest["slice"] == "Sambalpur/2024"
+    # Every staged file is accounted for by the manifest, and vice versa.
+    staged = {p.name for p in (tmp_path / "stage").iterdir() if p.suffix != ".json"}
+    assert staged == {d["file"] for d in manifest["documents"]}
+
+
+def test_build_sample_enforces_ambiguous_keys_on_a_real_key(tmp_path):
+    """`is_ambiguous_key` was only ever exercised by its own unit test."""
+    rows = [("T1", "Housing"), ("T2", "Housing")]
+    source = FakeDocumentSource(
+        keys={"T1": "AN063/E/2021/00001_complaint.pdf", "T2": "T2_complaint.pdf"}
+    )
+
+    manifest = build_sample(
+        rows,
+        source,
+        out_dir=tmp_path / "stage",
+        slice_label="Sambalpur/2024",
+        seed=1,
+        target_pages=10,
+        floor=2,
+        max_documents=10,
+        max_pages_per_category=10,
+        max_pages_per_document=8,
+        page_counter=lambda p: 1,
+    )
+    tickets = {d["ticket"] for d in manifest["documents"]}
+    assert "T1" not in tickets, "a key that joins to the wrong ticket was staged"
+    assert "T2" in tickets
+
+
+def test_build_sample_skips_objects_that_never_restore(tmp_path):
+    rows = [("T1", "Housing"), ("T2", "Housing")]
+    source = FakeDocumentSource(
+        keys={"T1": "T1_c.pdf", "T2": "T2_c.pdf"},
+        archived=["T1_c.pdf", "T2_c.pdf"],
+        never_ready=["T1_c.pdf"],
+    )
+
+    manifest = build_sample(
+        rows,
+        source,
+        out_dir=tmp_path / "stage",
+        slice_label="Sambalpur/2024",
+        seed=1,
+        target_pages=10,
+        floor=2,
+        max_documents=10,
+        max_pages_per_category=10,
+        max_pages_per_document=8,
+        page_counter=lambda p: 1,
+    )
+    assert {d["ticket"] for d in manifest["documents"]} == {"T2"}
+    assert "T1_c.pdf" not in source.fetched
+
+
+def test_build_sample_leaves_no_unaccounted_files_on_disk(tmp_path):
+    """A fetched-but-unselected file would let a later run read pages the
+    manifest does not account for, and those pages would be billed."""
+    rows = _rows({"Housing": 8})
+    source = _source_for(rows)
+
+    manifest = build_sample(
+        rows,
+        source,
+        out_dir=tmp_path / "stage",
+        slice_label="Sambalpur/2024",
+        seed=1,
+        target_pages=3,
+        floor=1,
+        max_documents=8,
+        max_pages_per_category=10,
+        max_pages_per_document=8,
+        page_counter=lambda p: 1,
+    )
+    on_disk = {p.name for p in (tmp_path / "stage").iterdir() if p.suffix != ".json"}
+    assert on_disk == {d["file"] for d in manifest["documents"]}
+    assert len(on_disk) <= 3
+
+
+def test_the_same_seed_reproduces_the_same_sample(tmp_path):
+    rows = _rows({"Housing": 12, "Social Welfare": 12})
+    first = build_sample(
+        rows, _source_for(rows), out_dir=tmp_path / "a", slice_label="S/2024",
+        seed=99, target_pages=8, floor=2, max_documents=12,
+        max_pages_per_category=10, max_pages_per_document=8, page_counter=lambda p: 1,
+    )
+    second = build_sample(
+        list(reversed(rows)), _source_for(rows), out_dir=tmp_path / "b", slice_label="S/2024",
+        seed=99, target_pages=8, floor=2, max_documents=12,
+        max_pages_per_category=10, max_pages_per_document=8, page_counter=lambda p: 1,
+    )
+    assert [d["ticket"] for d in first["documents"]] == [
+        d["ticket"] for d in second["documents"]
+    ]
+
+
+# --- the two arithmetic guarantees -----------------------------------------
+
+
+@pytest.mark.parametrize(
+    "counts, budget, floor",
+    [
+        (SLICE_COUNTS, 220, 3),
+        ({"A": 100, "B": 100, "C": 100}, 5, 1),
+        ({"A": 10, "B": 10, "C": 10, "D": 10}, 7, 1),
+        (SLICE_COUNTS, 31, 3),
+        ({"A": 1, "B": 1}, 50, 3),
+    ],
+)
+def test_allocation_never_exceeds_the_budget(counts, budget, floor):
+    """Codex finding on #233: independent rounding overshot the budget.
+
+    `allocate(SLICE_COUNTS, budget=220, floor=3)` returned 221, and three
+    equal categories on a budget of 5 returned 6. A function whose purpose is
+    to respect a budget must respect it.
+    """
+    alloc = allocate(counts, budget=budget, floor=floor)
+    total = sum(alloc.values())
+    feasible = min(budget, sum(counts.values()))
+    assert total <= budget, f"allocated {total} against a budget of {budget}"
+    # And it should not leave the budget unspent when capacity exists.
+    assert total == feasible or total >= min(feasible, sum(min(floor, c) for c in counts.values()))
+
+
+def test_the_draw_does_not_depend_on_input_row_order():
+    """The manifest claims reproducibility from the seed; row order broke it."""
+    rows = [("T1", "A"), ("T2", "A"), ("T3", "A"), ("U1", "B"), ("U2", "B")]
+    forward, counts_a = draw_tickets(rows, seed=7)
+    reversed_draw, counts_b = draw_tickets(list(reversed(rows)), seed=7)
+    assert forward == reversed_draw
+    assert counts_a == counts_b
+    assert list(forward) == sorted(forward), "category order must be canonical too"

--- a/tests/test_sarvam_sample_builder.py
+++ b/tests/test_sarvam_sample_builder.py
@@ -9,16 +9,19 @@ asserting on.
 from __future__ import annotations
 
 import json
+import sys
 
 import pytest
 
 from janasunani.evaluation.sarvam_sample_builder import (
+    PageCountBackendUnavailable,
     allocate,
     build_manifest,
     build_sample,
     draw_tickets,
     interleave,
     is_ambiguous_key,
+    page_count,
     prepare_out_dir,
     select_within_caps,
     write_manifest,
@@ -211,6 +214,35 @@ def test_documents_with_impossible_or_oversized_page_counts_are_skipped(pages):
         max_pages_per_document=8,
     )
     assert taken == []
+
+
+def test_page_count_raises_loudly_when_pdf2image_is_not_installed(tmp_path, monkeypatch):
+    """Codex finding on #233: a missing backend must not look like a bad document.
+
+    The console script declares no runtime dependency on `pdf2image` (it
+    lives only in the `pipeline-core`/`ocr-deepseek` extras), so a plain
+    `uv run janasunani-build-sarvam-sample` hits `ImportError` here. Before
+    the fix, the blanket `except Exception` caught it and returned a page
+    count of 0 -- indistinguishable from a corrupt PDF -- so every fetched
+    document was silently excluded and the CLI wrote an empty manifest and
+    exited 0. Setting `sys.modules["pdf2image"] = None` forces the same
+    `ImportError` regardless of whether pdf2image happens to be installed in
+    the environment running this test.
+    """
+    monkeypatch.setitem(sys.modules, "pdf2image", None)
+    pdf_path = tmp_path / "document.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4\n%fake\n")
+
+    with pytest.raises(PageCountBackendUnavailable):
+        page_count(pdf_path)
+
+
+def test_image_pages_do_not_need_the_pdf_backend(tmp_path, monkeypatch):
+    """The backend is only asked for when the file is actually a PDF."""
+    monkeypatch.setitem(sys.modules, "pdf2image", None)
+    image_path = tmp_path / "page.png"
+    image_path.write_bytes(b"fake-png-bytes")
+    assert page_count(image_path) == 1
 
 
 # --- the executable path ----------------------------------------------------
@@ -430,6 +462,37 @@ def test_build_sample_can_clear_a_non_empty_out_dir_on_request(tmp_path):
     assert on_disk == {d["file"] for d in manifest["documents"]}
 
 
+def test_build_sample_raises_loudly_when_the_page_backend_is_missing(tmp_path, monkeypatch):
+    """The composed path must fail loudly too, not just the unit under it.
+
+    Without `page_counter` overridden, `build_sample` uses the real
+    `page_count`, which needs `pdf2image` for the PDFs `FakeDocumentSource`
+    fetches. Before the fix this would have quietly produced an empty
+    manifest (every page count 0, every document excluded) and exited
+    successfully instead of raising.
+    """
+    monkeypatch.setitem(sys.modules, "pdf2image", None)
+    rows = _rows({"Housing": 4})
+
+    with pytest.raises(PageCountBackendUnavailable):
+        build_sample(
+            rows,
+            _source_for(rows),
+            out_dir=tmp_path / "stage",
+            slice_label="Sambalpur/2024",
+            seed=1,
+            target_pages=10,
+            floor=1,
+            max_documents=4,
+            max_pages_per_category=10,
+            max_pages_per_document=8,
+            # No page_counter override: exercise the real page_count.
+        )
+    # No manifest was written -- the failure must not look like a completed,
+    # merely-empty draw.
+    assert not (tmp_path / "stage" / "sample_manifest.json").exists()
+
+
 def test_prepare_out_dir_accepts_a_missing_or_already_empty_directory(tmp_path):
     fresh = tmp_path / "fresh"
     prepare_out_dir(fresh)
@@ -481,6 +544,38 @@ def test_allocation_never_exceeds_the_budget(counts, budget, floor):
     assert total <= budget, f"allocated {total} against a budget of {budget}"
     # And it should not leave the budget unspent when capacity exists.
     assert total == feasible or total >= min(feasible, sum(min(floor, c) for c in counts.values()))
+
+
+def test_allocation_rejects_floors_that_exceed_the_budget():
+    """Codex finding on #233: the floor stage was never checked against budget.
+
+    Three populated categories with `budget=2, floor=1` used to allocate 3
+    documents (the floor alone overshoots), which `choose_documents` then
+    resolved on its own by truncating in largest-category order -- silently
+    dropping whichever categories the floor was meant to protect. Infeasible
+    floor/budget combinations must be rejected, not quietly resolved twice in
+    two different places.
+    """
+    with pytest.raises(ValueError, match="floor"):
+        allocate({"A": 5, "B": 5, "C": 5}, budget=2, floor=1)
+
+
+def test_allocation_accepts_a_floor_that_exactly_fits_the_budget():
+    """The boundary case must not be rejected along with the infeasible one."""
+    alloc = allocate({"A": 5, "B": 5}, budget=2, floor=1)
+    assert alloc == {"A": 1, "B": 1}
+
+
+def test_choose_documents_propagates_the_infeasible_allocation_error():
+    """The composed path must not swallow the error and truncate instead."""
+    from janasunani.evaluation.sarvam_sample_builder import choose_documents
+
+    rows = _rows({"Housing": 5, "Social Welfare": 5, "Tourism": 5})
+    by_category, counts = draw_tickets(rows, seed=1)
+    source = _source_for(rows)
+
+    with pytest.raises(ValueError, match="floor"):
+        choose_documents(by_category, counts, source, max_documents=2, floor=1)
 
 
 def test_the_draw_does_not_depend_on_input_row_order():

--- a/tests/test_sarvam_sample_builder.py
+++ b/tests/test_sarvam_sample_builder.py
@@ -19,6 +19,7 @@ from janasunani.evaluation.sarvam_sample_builder import (
     draw_tickets,
     interleave,
     is_ambiguous_key,
+    prepare_out_dir,
     select_within_caps,
     write_manifest,
 )
@@ -369,6 +370,72 @@ def test_build_sample_leaves_no_unaccounted_files_on_disk(tmp_path):
     on_disk = {p.name for p in (tmp_path / "stage").iterdir() if p.suffix != ".json"}
     assert on_disk == {d["file"] for d in manifest["documents"]}
     assert len(on_disk) <= 3
+
+
+def test_build_sample_rejects_a_non_empty_out_dir_by_default(tmp_path):
+    """Codex finding on #233: a reused --out silently mixed a prior draw's
+    files into this one's manifest.
+
+    `sarvam_evaluate.discover_pages` enumerates every supported document
+    under the staging directory without consulting `sample_manifest.json`,
+    so a leftover file from an earlier run with a different seed or cap
+    would be submitted and billed even though the new manifest never
+    mentions it.
+    """
+    stage = tmp_path / "stage"
+    stage.mkdir()
+    (stage / "leftover_complaint.pdf").write_bytes(b"stale")
+
+    rows = _rows({"Housing": 4})
+    with pytest.raises(FileExistsError):
+        build_sample(
+            rows,
+            _source_for(rows),
+            out_dir=stage,
+            slice_label="Sambalpur/2024",
+            seed=1,
+            target_pages=10,
+            floor=1,
+            max_documents=4,
+            max_pages_per_category=10,
+            max_pages_per_document=8,
+            page_counter=lambda p: 1,
+        )
+    # The rejected run must not have touched what was already there.
+    assert (stage / "leftover_complaint.pdf").is_file()
+
+
+def test_build_sample_can_clear_a_non_empty_out_dir_on_request(tmp_path):
+    stage = tmp_path / "stage"
+    stage.mkdir()
+    (stage / "leftover_complaint.pdf").write_bytes(b"stale")
+
+    rows = _rows({"Housing": 4})
+    manifest = build_sample(
+        rows,
+        _source_for(rows),
+        out_dir=stage,
+        slice_label="Sambalpur/2024",
+        seed=1,
+        target_pages=10,
+        floor=1,
+        max_documents=4,
+        max_pages_per_category=10,
+        max_pages_per_document=8,
+        page_counter=lambda p: 1,
+        clean_out_dir=True,
+    )
+    assert not (stage / "leftover_complaint.pdf").exists()
+    on_disk = {p.name for p in stage.iterdir() if p.suffix != ".json"}
+    assert on_disk == {d["file"] for d in manifest["documents"]}
+
+
+def test_prepare_out_dir_accepts_a_missing_or_already_empty_directory(tmp_path):
+    fresh = tmp_path / "fresh"
+    prepare_out_dir(fresh)
+    assert fresh.is_dir()
+    # Calling again on the now-empty, now-existing directory must not raise.
+    prepare_out_dir(fresh)
 
 
 def test_the_same_seed_reproduces_the_same_sample(tmp_path):

--- a/tests/test_sarvam_sample_builder.py
+++ b/tests/test_sarvam_sample_builder.py
@@ -1,0 +1,211 @@
+"""Regression tests for the Sarvam benchmark sample draw.
+
+Each test here corresponds to a failure observed on a real staging run on
+2026-08-09. Every one produced a sample that looked fine in the selection log
+and was wrong in the manifest, which is why the manifest is the artifact worth
+asserting on.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from janasunani.evaluation.sarvam_sample_builder import (
+    allocate,
+    build_manifest,
+    draw_tickets,
+    interleave,
+    is_ambiguous_key,
+    select_within_caps,
+    write_manifest,
+)
+
+
+# The observed Sambalpur/2024 shape: heavily concentrated, long tail.
+SLICE_COUNTS = {
+    "Social Welfare": 10485,
+    "Miscellaneous": 8253,
+    "Housing": 7361,
+    "Infrastructure": 3993,
+    "General": 3623,
+    "COVID-19": 3,
+    "Tourism": 1,
+}
+
+
+def test_allocation_gives_every_category_its_floor():
+    alloc = allocate(SLICE_COUNTS, budget=220, floor=3)
+    for category, available in SLICE_COUNTS.items():
+        assert alloc[category] >= min(3, available)
+
+
+def test_allocation_never_exceeds_what_a_category_actually_has():
+    alloc = allocate(SLICE_COUNTS, budget=220, floor=8)
+    assert alloc["Tourism"] == 1
+    assert alloc["COVID-19"] == 3
+
+
+def test_allocation_budgets_documents_not_pages():
+    """A page-sized budget starves the tail; a document-sized one does not.
+
+    The first real run passed ``target_pages * 2`` here and selected 220
+    documents from 2 categories. Budgeting the document cap spreads the draw.
+    """
+    starved = allocate(SLICE_COUNTS, budget=600, floor=3)
+    correct = allocate(SLICE_COUNTS, budget=220, floor=3)
+    # With the larger budget the head takes far more of the draw.
+    assert starved["Social Welfare"] > correct["Social Welfare"] * 2
+    # The correct allocation leaves room for every category inside the cap.
+    assert sum(correct.values()) <= 220 + len(SLICE_COUNTS)
+
+
+def test_interleave_puts_one_of_each_category_before_repeating():
+    chosen = (
+        [{"gold_category": "Social Welfare", "file": f"sw{i}"} for i in range(3)]
+        + [{"gold_category": "Housing", "file": f"h{i}"} for i in range(3)]
+        + [{"gold_category": "Tourism", "file": "t0"}]
+    )
+    order = [d["gold_category"] for d in interleave(chosen, SLICE_COUNTS)]
+    assert order[:3] == ["Social Welfare", "Housing", "Tourism"]
+
+
+def test_interleave_preserves_coverage_when_the_budget_stops_early():
+    """Truncating an interleaved list keeps every category represented.
+
+    The failure this guards: 301 pages staged, 3 of 31 categories present,
+    because the list was in category order when the page budget ran out.
+    """
+    chosen = [
+        {"gold_category": c, "file": f"{c}-{i}"}
+        for c in ("Social Welfare", "Miscellaneous", "Housing", "COVID-19")
+        for i in range(5)
+    ]
+    truncated = interleave(chosen, SLICE_COUNTS)[:4]
+    assert len({d["gold_category"] for d in truncated}) == 4
+
+    in_category_order = chosen[:4]
+    assert len({d["gold_category"] for d in in_category_order}) == 1
+
+
+def test_page_cap_per_category_bounds_one_class():
+    documents = [{"gold_category": "COVID-19", "file": f"c{i}"} for i in range(10)]
+    pages = {f"c{i}": 5 for i in range(10)}
+    taken = select_within_caps(
+        documents,
+        page_counts=pages,
+        target_pages=300,
+        max_pages_per_category=25,
+        max_pages_per_document=8,
+    )
+    assert sum(d["pages"] for d in taken) <= 25
+
+
+def test_a_single_long_document_cannot_fill_a_category():
+    """The 22-page scan that took a whole category cell.
+
+    COVID-19 held 3 tickets in a 36,909-ticket slice and received 22 of its 25
+    allowed pages from one document, so the class result was really one scan.
+    """
+    documents = [
+        {"gold_category": "COVID-19", "file": "long"},
+        {"gold_category": "COVID-19", "file": "short-a"},
+        {"gold_category": "COVID-19", "file": "short-b"},
+    ]
+    pages = {"long": 22, "short-a": 3, "short-b": 4}
+    taken = select_within_caps(
+        documents,
+        page_counts=pages,
+        target_pages=300,
+        max_pages_per_category=25,
+        max_pages_per_document=8,
+    )
+    assert [d["file"] for d in taken] == ["short-a", "short-b"]
+    assert all(d["pages"] <= 8 for d in taken)
+
+
+def test_selection_stops_at_the_page_budget():
+    documents = [{"gold_category": f"c{i}", "file": f"f{i}"} for i in range(50)]
+    pages = {f"f{i}": 4 for i in range(50)}
+    taken = select_within_caps(
+        documents,
+        page_counts=pages,
+        target_pages=20,
+        max_pages_per_category=25,
+        max_pages_per_document=8,
+    )
+    assert sum(d["pages"] for d in taken) <= 20 + 4
+
+
+def test_keys_with_a_path_separator_are_rejected():
+    """``AN063/E/2021/00001_complaint_….pdf`` would join to ticket ``00001``."""
+    assert is_ambiguous_key("AN063/E/2021/00001_complaint_20250918.pdf")
+    assert not is_ambiguous_key("CMO202100019_complaint_20250915.pdf")
+
+
+def test_the_draw_is_reproducible_under_a_seed():
+    rows = [(f"T{i:04d}", "Social Welfare") for i in range(200)]
+    first, counts_a = draw_tickets(rows, seed=20260809)
+    second, counts_b = draw_tickets(rows, seed=20260809)
+    other, _ = draw_tickets(rows, seed=1)
+    assert first == second
+    assert counts_a == counts_b == {"Social Welfare": 200}
+    assert first["Social Welfare"] != other["Social Welfare"]
+
+
+def test_rows_without_a_category_are_dropped():
+    rows = [("T1", "Housing"), ("T2", ""), ("T3", "Housing")]
+    by_category, counts = draw_tickets(rows, seed=1)
+    assert counts == {"Housing": 2}
+
+
+def test_manifest_records_what_a_reviewer_needs_to_reproduce_the_draw():
+    documents = [
+        {"ticket": "T1", "gold_category": "Housing", "s3_key": "T1_a.pdf", "file": "T1_a.pdf", "pages": 4},
+        {"ticket": "T2", "gold_category": "Social Welfare", "s3_key": "T2_a.pdf", "file": "T2_a.pdf", "pages": 6},
+    ]
+    manifest = build_manifest(
+        documents,
+        slice_label="Sambalpur/2024",
+        seed=20260809,
+        target_pages=300,
+        floor=3,
+        max_pages_per_category=25,
+        max_pages_per_document=8,
+        restore_expiry="Mon, 31 Aug 2026 00:00:00 GMT",
+    )
+    assert manifest["pages_staged"] == 10
+    assert manifest["tickets"] == 2
+    assert manifest["categories"] == 2
+    assert manifest["seed"] == 20260809
+    assert manifest["estimated_cost_rupees_arm_both"] == 15.0
+    assert manifest["restore_expiry"].endswith("2026 00:00:00 GMT")
+    assert manifest["pages_by_category"]["Social Welfare"] == 6
+
+
+def test_manifest_round_trips_to_disk(tmp_path):
+    manifest = build_manifest(
+        [{"ticket": "T1", "gold_category": "Housing", "s3_key": "k", "file": "f", "pages": 2}],
+        slice_label="Sambalpur/2024",
+        seed=1,
+        target_pages=10,
+        floor=1,
+        max_pages_per_category=5,
+        max_pages_per_document=8,
+    )
+    path = write_manifest(manifest, tmp_path / "nested" / "sample_manifest.json")
+    assert json.loads(path.read_text())["pages_staged"] == 2
+
+
+@pytest.mark.parametrize("pages", [0, -1, 99])
+def test_documents_with_impossible_or_oversized_page_counts_are_skipped(pages):
+    documents = [{"gold_category": "Housing", "file": "f"}]
+    taken = select_within_caps(
+        documents,
+        page_counts={"f": pages},
+        target_pages=300,
+        max_pages_per_category=25,
+        max_pages_per_document=8,
+    )
+    assert taken == []


### PR DESCRIPTION
The 300-page Sarvam sample was drawn by a script living in a session scratchpad. Nobody else could reproduce it, and a scratchpad wipe would have taken both the sample and the code that produced it.

## The three failures this encodes

Each was found by running the draw for real on 9 August. Each produced a sample that looked correct in the selection log and was wrong in the manifest.

| # | Failure | Symptom |
|---|---|---|
| 1 | Allocation budgeted in pages, not documents | 301 pages covering **3 of 31** categories |
| 2 | Download order not interleaved | Page budget truncated the tail instead of thinning every class |
| 3 | No per-document page cap | One 22-page scan filled the COVID-19 cell, a category with **3 tickets** in a 36,909-ticket slice |

Each is now a named function with a regression test.

Also encoded: keys with a path separator are rejected. The evaluator derives the ticket from the file stem, so `AN063/E/2021/00001_complaint_….pdf` reads as ticket `00001` and joins to the wrong record.

## The lesson worth keeping

**The manifest is the artifact worth asserting on.** The selection log looked right in all three failures. Only the manifest showed the sample was not what was designed.

## Operational fact now recorded

Roughly **90% of the document corpus is in GLACIER**, where GetObject fails outright with `InvalidObjectState`. Restores must be requested and waited for, and the window has to outlast what the sample is for.

A 3-day window set on 9 August expired **13 August**, the day before the demo it was built for. Now extended to 31 August. This was not documented anywhere before today.

## Data safety

The manifest carries real ticket numbers and S3 keys, so it is citizen data by reference and must stay out of Git. `write_manifest` documents this and `data-check.yml` already refuses tracked files under `data/` and `outputs/`.

## Gate

    uv run ruff check .   -> All checks passed!
    uv run --extra serving --extra pipeline-core pytest -> 1292 passed, 8 skipped

## Note

This lands the draw as it exists today, which is **page-oriented for the Sarvam arm**. Moving to one shared sample across the standard pipeline, spam, dedup and routing will re-spine this on tickets. The pure functions here (allocation, interleaving, caps) are unit-agnostic and carry over; the S3/page projection is what changes.

Refs #53, #126, #127
---

## Merge note — Codex review round skipped

Merged without a further Codex round at the repository owner's explicit direction: *"the codex reviews keep returning issues each time without converging ... please then merge it idc"*.

Recording this plainly rather than implying a policy basis: `CONTRIBUTING.md` scopes the `codex-review-not-required` label to config-only branches and to Codex being out of review credits. **Neither applies here.** This is a deliberate override by the repository owner, labelled so the exception is visible in the record.

All findings raised on this PR were replied to in-thread and resolved. Any finding not fixed here is filed as a tracked issue rather than dropped.
