### PR TITLE
feat(seams): make routing and spam swappable to a trained model

### DIFF
--- a/janasunani/inference/service.py
+++ b/janasunani/inference/service.py
@@ -17,6 +17,7 @@ from typing import Any, Callable, Optional, Protocol
 
 from janasunani.config import DEFAULT_OLTP_DB_URL, MODELS_DIR, Settings
 from janasunani.inference.ocr import OcrQualityError, OcrResult
+from janasunani.inference.timing import NullTimer, StageTimer, TimingSink
 from janasunani.pipeline.stages.page_type_classifier import PAGE_TYPE_CLASS_BY_LABEL
 from janasunani.routing.provider import RoutingProvider, router_from_env, router_status
 from janasunani.serving.schemas import (
@@ -87,6 +88,7 @@ class PipelineGrievanceProcessor:
         detect_language: Callable[[str], str],
         triage_provider: TriageProvider | None = None,
         now: Callable[[], datetime] | None = None,
+        timing_sink: TimingSink | None = None,
     ) -> None:
         self._ocr = ocr
         self._redact = redact
@@ -98,6 +100,9 @@ class PipelineGrievanceProcessor:
         self._detect_language = detect_language
         self._triage_provider = triage_provider or UnwiredTriageProvider()
         self._now = now or (lambda: datetime.now(UTC))
+        # Side channel only. Timings must never reach GrievanceResult, which is
+        # the frozen serving contract the frontend and result store depend on.
+        self._timing_sink = timing_sink
 
     def process(
         self,
@@ -115,6 +120,7 @@ class PipelineGrievanceProcessor:
             document_name=document_name,
             document_bytes=document_bytes,
         )
+        timer = StageTimer() if self._timing_sink is not None else NullTimer()
 
         if text is not None:
             extracted_text = text
@@ -122,7 +128,8 @@ class PipelineGrievanceProcessor:
         else:
             assert document_name is not None and document_bytes is not None
             try:
-                ocr_result = self._ocr(document_bytes, document_name)
+                with timer.stage("ocr"):
+                    ocr_result = self._ocr(document_bytes, document_name)
             except OcrQualityError as exc:
                 # Quality-rejected input is a legitimate client error -> 422.
                 raise InferenceInputError(
@@ -163,9 +170,10 @@ class PipelineGrievanceProcessor:
             extracted_text = ocr_result.full_text
             # Redact each selected page before joining so no irrelevant page
             # (identification, bill, miscellaneous) reaches either model.
-            model_text_source = "\n\n".join(
-                self._redact(page_text) for page_text in relevant_pages
-            )
+            with timer.stage("redact"):
+                model_text_source = "\n\n".join(
+                    self._redact(page_text) for page_text in relevant_pages
+                )
             extraction = ExtractionResult(
                 source="document",
                 extracted_text=extracted_text,
@@ -173,39 +181,47 @@ class PipelineGrievanceProcessor:
                 pages=ocr_result.pages,
             )
 
-        redacted_text = self._redact(extracted_text)
-        pii_entities = [
-            PIIEntity(entity=span.entity, start=span.start, end=span.end)
-            for span in self._detect_pii(extracted_text)
-        ]
+        with timer.stage("redact"):
+            redacted_text = self._redact(extracted_text)
+        with timer.stage("detect_pii"):
+            pii_entities = [
+                PIIEntity(entity=span.entity, start=span.start, end=span.end)
+                for span in self._detect_pii(extracted_text)
+            ]
         redaction = RedactionResult(
             redacted_text=redacted_text,
             entities=pii_entities,
         )
         submitted_on = self._now()
-        try:
-            # The provider is intentionally called after redaction, never on
-            # raw OCR or typed citizen text.  Its result is advisory only.
-            triage = self._triage_provider.assess(
-                redacted_text=redaction.redacted_text,
-                district=district,
-                submitted_on=submitted_on,
-            )
-        except TriageUnavailableError:
-            # A triage outage cannot reject or delay a grievance.  Do not
-            # surface the provider exception: it may contain infrastructure
-            # details and is not an officer-facing explanation.
-            logger.warning("advisory triage unavailable; accepting grievance without it")
-            triage = unavailable_triage()
+        with timer.stage("triage"):
+            try:
+                # The provider is intentionally called after redaction, never on
+                # raw OCR or typed citizen text.  Its result is advisory only.
+                triage = self._triage_provider.assess(
+                    redacted_text=redaction.redacted_text,
+                    district=district,
+                    submitted_on=submitted_on,
+                )
+            except TriageUnavailableError:
+                # A triage outage cannot reject or delay a grievance.  Do not
+                # surface the provider exception: it may contain infrastructure
+                # details and is not an officer-facing explanation.
+                logger.warning(
+                    "advisory triage unavailable; accepting grievance without it"
+                )
+                triage = unavailable_triage()
 
         classifier_text = (
             redacted_text if extraction.source == "text" else model_text_source
         )
-        language = self._detect_language(classifier_text)
-        is_english = self._is_english_compatible(classifier_text)
+        with timer.stage("detect_language"):
+            language = self._detect_language(classifier_text)
+            is_english = self._is_english_compatible(classifier_text)
         if is_english:
-            category = self._categorizer.predict(classifier_text)
-            summary = self._summarizer.summarize(classifier_text)
+            with timer.stage("categorize"):
+                category = self._categorizer.predict(classifier_text)
+            with timer.stage("summarize"):
+                summary = self._summarizer.summarize(classifier_text)
         else:
             # Same gate as the categorizer: BART is only warmed for the
             # English demo target, and would otherwise hallucinate a summary
@@ -213,7 +229,10 @@ class PipelineGrievanceProcessor:
             # document paths share this single check).
             category = "Uncategorized"
             summary = UNSUPPORTED_LANGUAGE_SUMMARY
-        routing = self._router.route(category=category, district=district)
+        with timer.stage("route"):
+            routing = self._router.route(category=category, district=district)
+
+        timer.emit(self._timing_sink)
 
         return GrievanceResult(
             id=grievance_id,
@@ -779,6 +798,7 @@ def build_processor(
     *,
     router: "RoutingProvider | None" = None,
     triage_provider: TriageProvider | None = None,
+    timing_sink: TimingSink | None = None,
 ) -> PipelineGrievanceProcessor:
     """Strictly construct and warm the production processor.
 
@@ -853,4 +873,5 @@ def build_processor(
         triage_provider=(
             triage_provider if triage_provider is not None else triage_provider_from_env()
         ),
+        timing_sink=timing_sink,
     )

--- a/janasunani/inference/service.py
+++ b/janasunani/inference/service.py
@@ -121,134 +121,148 @@ class PipelineGrievanceProcessor:
             document_bytes=document_bytes,
         )
         timer = StageTimer() if self._timing_sink is not None else NullTimer()
+        # Tracks whether `process` reached its normal return, so the emitted
+        # timings are distinguishable from a submission that stopped partway
+        # through a raised stage -- otherwise a latency report would silently
+        # mix completed and partial measurements under the same label.
+        completed = False
+        try:
+            if text is not None:
+                extracted_text = text
+                extraction = ExtractionResult(source="text", extracted_text=text)
+            else:
+                assert document_name is not None and document_bytes is not None
+                try:
+                    with timer.stage("ocr"):
+                        ocr_result = self._ocr(document_bytes, document_name)
+                except OcrQualityError as exc:
+                    # Quality-rejected input is a legitimate client error -> 422.
+                    raise InferenceInputError(
+                        f"document OCR failed the quality check: {exc}"
+                    ) from exc
+                except Exception as exc:
+                    # Only genuine render/parse failures (corrupt or unsupported
+                    # file) map to a 422 here. `_is_document_input_failure` is
+                    # deliberately narrow: the injected page-type predictor also
+                    # runs inside `self._ocr` and is wrapped (see
+                    # `_guard_page_type_predict`) so its own bugs raise
+                    # `_PageTypeModelError` instead of a bare `ValueError`/
+                    # `IndexError` that could otherwise be misread as a corrupt
+                    # document — those propagate unchanged and become a 5xx.
+                    if not _is_document_input_failure(exc):
+                        raise
+                    raise InferenceInputError(
+                        f"document is corrupt or unsupported: {exc}"
+                    ) from exc
 
-        if text is not None:
-            extracted_text = text
-            extraction = ExtractionResult(source="text", extracted_text=text)
-        else:
-            assert document_name is not None and document_bytes is not None
-            try:
-                with timer.stage("ocr"):
-                    ocr_result = self._ocr(document_bytes, document_name)
-            except OcrQualityError as exc:
-                # Quality-rejected input is a legitimate client error -> 422.
-                raise InferenceInputError(
-                    f"document OCR failed the quality check: {exc}"
-                ) from exc
-            except Exception as exc:
-                # Only genuine render/parse failures (corrupt or unsupported
-                # file) map to a 422 here. `_is_document_input_failure` is
-                # deliberately narrow: the injected page-type predictor also
-                # runs inside `self._ocr` and is wrapped (see
-                # `_guard_page_type_predict`) so its own bugs raise
-                # `_PageTypeModelError` instead of a bare `ValueError`/
-                # `IndexError` that could otherwise be misread as a corrupt
-                # document — those propagate unchanged and become a 5xx.
-                if not _is_document_input_failure(exc):
-                    raise
-                raise InferenceInputError(
-                    f"document is corrupt or unsupported: {exc}"
-                ) from exc
+                if ocr_result.truncated:
+                    raise InferenceInputError(
+                        "document exceeds the live page limit; no partial result was used"
+                    )
+                if not ocr_result.full_text.strip():
+                    raise InferenceInputError("document OCR produced no text")
 
-            if ocr_result.truncated:
-                raise InferenceInputError(
-                    "document exceeds the live page limit; no partial result was used"
+                relevant_pages = [
+                    page_text
+                    for page_text, page_type in ocr_result.per_page
+                    if page_type in RELEVANT_PAGE_TYPES and page_text.strip()
+                ]
+                if not relevant_pages:
+                    raise InferenceInputError(
+                        "document contains no grievance-bearing pages"
+                    )
+
+                extracted_text = ocr_result.full_text
+                # Redact each selected page before joining so no irrelevant page
+                # (identification, bill, miscellaneous) reaches either model.
+                with timer.stage("redact"):
+                    model_text_source = "\n\n".join(
+                        self._redact(page_text) for page_text in relevant_pages
+                    )
+                extraction = ExtractionResult(
+                    source="document",
+                    extracted_text=extracted_text,
+                    ocr_model="pytesseract",
+                    pages=ocr_result.pages,
                 )
-            if not ocr_result.full_text.strip():
-                raise InferenceInputError("document OCR produced no text")
 
-            relevant_pages = [
-                page_text
-                for page_text, page_type in ocr_result.per_page
-                if page_type in RELEVANT_PAGE_TYPES and page_text.strip()
-            ]
-            if not relevant_pages:
-                raise InferenceInputError(
-                    "document contains no grievance-bearing pages"
-                )
-
-            extracted_text = ocr_result.full_text
-            # Redact each selected page before joining so no irrelevant page
-            # (identification, bill, miscellaneous) reaches either model.
             with timer.stage("redact"):
-                model_text_source = "\n\n".join(
-                    self._redact(page_text) for page_text in relevant_pages
-                )
-            extraction = ExtractionResult(
-                source="document",
-                extracted_text=extracted_text,
-                ocr_model="pytesseract",
-                pages=ocr_result.pages,
+                redacted_text = self._redact(extracted_text)
+            with timer.stage("detect_pii"):
+                pii_entities = [
+                    PIIEntity(entity=span.entity, start=span.start, end=span.end)
+                    for span in self._detect_pii(extracted_text)
+                ]
+            redaction = RedactionResult(
+                redacted_text=redacted_text,
+                entities=pii_entities,
             )
+            submitted_on = self._now()
+            with timer.stage("triage"):
+                try:
+                    # The provider is intentionally called after redaction, never on
+                    # raw OCR or typed citizen text.  Its result is advisory only.
+                    triage = self._triage_provider.assess(
+                        redacted_text=redaction.redacted_text,
+                        district=district,
+                        submitted_on=submitted_on,
+                    )
+                except TriageUnavailableError:
+                    # A triage outage cannot reject or delay a grievance.  Do not
+                    # surface the provider exception: it may contain infrastructure
+                    # details and is not an officer-facing explanation.
+                    logger.warning(
+                        "advisory triage unavailable; accepting grievance without it"
+                    )
+                    triage = unavailable_triage()
 
-        with timer.stage("redact"):
-            redacted_text = self._redact(extracted_text)
-        with timer.stage("detect_pii"):
-            pii_entities = [
-                PIIEntity(entity=span.entity, start=span.start, end=span.end)
-                for span in self._detect_pii(extracted_text)
-            ]
-        redaction = RedactionResult(
-            redacted_text=redacted_text,
-            entities=pii_entities,
-        )
-        submitted_on = self._now()
-        with timer.stage("triage"):
-            try:
-                # The provider is intentionally called after redaction, never on
-                # raw OCR or typed citizen text.  Its result is advisory only.
-                triage = self._triage_provider.assess(
-                    redacted_text=redaction.redacted_text,
-                    district=district,
-                    submitted_on=submitted_on,
-                )
-            except TriageUnavailableError:
-                # A triage outage cannot reject or delay a grievance.  Do not
-                # surface the provider exception: it may contain infrastructure
-                # details and is not an officer-facing explanation.
-                logger.warning(
-                    "advisory triage unavailable; accepting grievance without it"
-                )
-                triage = unavailable_triage()
+            classifier_text = (
+                redacted_text if extraction.source == "text" else model_text_source
+            )
+            with timer.stage("detect_language"):
+                language = self._detect_language(classifier_text)
+                is_english = self._is_english_compatible(classifier_text)
+            if is_english:
+                with timer.stage("categorize"):
+                    category = self._categorizer.predict(classifier_text)
+                with timer.stage("summarize"):
+                    summary = self._summarizer.summarize(classifier_text)
+            else:
+                # Same gate as the categorizer: BART is only warmed for the
+                # English demo target, and would otherwise hallucinate a summary
+                # over text it was never validated on (both the typed-text and
+                # document paths share this single check).
+                category = "Uncategorized"
+                summary = UNSUPPORTED_LANGUAGE_SUMMARY
+            with timer.stage("route"):
+                routing = self._router.route(category=category, district=district)
 
-        classifier_text = (
-            redacted_text if extraction.source == "text" else model_text_source
-        )
-        with timer.stage("detect_language"):
-            language = self._detect_language(classifier_text)
-            is_english = self._is_english_compatible(classifier_text)
-        if is_english:
-            with timer.stage("categorize"):
-                category = self._categorizer.predict(classifier_text)
-            with timer.stage("summarize"):
-                summary = self._summarizer.summarize(classifier_text)
-        else:
-            # Same gate as the categorizer: BART is only warmed for the
-            # English demo target, and would otherwise hallucinate a summary
-            # over text it was never validated on (both the typed-text and
-            # document paths share this single check).
-            category = "Uncategorized"
-            summary = UNSUPPORTED_LANGUAGE_SUMMARY
-        with timer.stage("route"):
-            routing = self._router.route(category=category, district=district)
-
-        timer.emit(self._timing_sink)
-
-        return GrievanceResult(
-            id=grievance_id,
-            ticket_no=ticket_no,
-            status="Submitted",
-            submitted_on=submitted_on,
-            extraction=extraction,
-            redaction=redaction,
-            classification=ClassificationResult(
-                category=category,
-                language=language,
-            ),
-            summary=summary,
-            routing=routing,
-            triage=triage,
-        )
+            result = GrievanceResult(
+                id=grievance_id,
+                ticket_no=ticket_no,
+                status="Submitted",
+                submitted_on=submitted_on,
+                extraction=extraction,
+                redaction=redaction,
+                classification=ClassificationResult(
+                    category=category,
+                    language=language,
+                ),
+                summary=summary,
+                routing=routing,
+                triage=triage,
+            )
+            completed = True
+            return result
+        finally:
+            # An outer `finally`, not a call at the end of the happy path: a
+            # stage's own `finally` (StageTimer.stage) already records elapsed
+            # time when that stage raises, but the previous code only reached
+            # `emit` after a normal return, so a raised stage discarded
+            # exactly the measurement that design was for. The original
+            # exception, if any, propagates unchanged -- this only ever adds a
+            # side-effecting emit, never swallows or replaces it.
+            timer.emit(self._timing_sink, ok=completed)
 
 
 def _validate_input(

--- a/janasunani/inference/service.py
+++ b/janasunani/inference/service.py
@@ -18,18 +18,20 @@ from typing import Any, Callable, Optional, Protocol
 from janasunani.config import DEFAULT_OLTP_DB_URL, MODELS_DIR, Settings
 from janasunani.inference.ocr import OcrQualityError, OcrResult
 from janasunani.pipeline.stages.page_type_classifier import PAGE_TYPE_CLASS_BY_LABEL
+from janasunani.routing.provider import RoutingProvider, router_from_env, router_status
 from janasunani.serving.schemas import (
     ClassificationResult,
     ExtractionResult,
     GrievanceResult,
     PIIEntity,
     RedactionResult,
-    RoutingResult,
 )
 from janasunani.serving.triage import (
     TriageProvider,
     TriageUnavailableError,
     UnwiredTriageProvider,
+    triage_provider_from_env,
+    triage_status,
     unavailable_triage,
 )
 
@@ -61,14 +63,10 @@ class _Summarizer(Protocol):
     def summarize(self, text: str) -> str: ...
 
 
-class _Router(Protocol):
-    def route(
-        self,
-        *,
-        category: str,
-        subcategory: Optional[str] = None,
-        district: Optional[str] = None,
-    ) -> RoutingResult: ...
+#: The routing seam now lives with the routers it describes. Kept as an alias
+#: because this private name is the annotation on the processor constructor and
+#: is imported by tests.
+_Router = RoutingProvider
 
 
 class PipelineGrievanceProcessor:
@@ -552,6 +550,38 @@ def _routing_mappings_check() -> DependencyCheck:
     return DependencyCheck("routing mappings", True, detail, required=False)
 
 
+def _router_check() -> DependencyCheck:
+    """Which routing rung will actually answer the first live submission.
+
+    ``_routing_mappings_check`` above covers the CSV masters, which are the
+    *second* rung. This one covers the selection itself, because those are
+    different failures: the masters can be present and healthy while the
+    crosswalk artifact is missing, and the demo then serves ``method:"rules"``
+    or ``"fallback"`` while everyone believes routing is learned.
+    PERFORMANCE.md recorded exactly that state on 7 August.
+    """
+    try:
+        name, ok, detail = router_status()
+    except Exception as exc:  # pragma: no cover - defensive; never raise
+        return DependencyCheck("router", False, f"unavailable: {exc}", required=False)
+    return DependencyCheck(f"router ({name})", ok, detail, required=False)
+
+
+def _triage_check() -> DependencyCheck:
+    """Which spam scorer is live, and whether it is learned or heuristic.
+
+    Reported so the distinction cannot be lost between the code and the
+    narrative: what ships today is ``spam-v1-bounded``, a deterministic
+    cascade, and a demo that calls it a trained model is claiming #74 without
+    having built it.
+    """
+    try:
+        name, ok, detail = triage_status()
+    except Exception as exc:  # pragma: no cover - defensive; never raise
+        return DependencyCheck("triage", False, f"unavailable: {exc}", required=False)
+    return DependencyCheck(f"triage ({name})", ok, detail, required=False)
+
+
 # The exact columns janasunani/serving/history.py's LakeHistory.search()
 # selects. Duplicated here (not imported) rather than sharing a constant with
 # janasunani.serving.history: preflight lives in this module specifically so
@@ -737,17 +767,30 @@ def preflight(models_dir: str | Path | None = None) -> list[DependencyCheck]:
     # OLTP_DB_URL is explicitly set: it opens a real, timeout-bounded
     # connection (_OLTP_PROBE_TIMEOUT_S) rather than just checking presence.
     checks.append(_routing_mappings_check())
+    checks.append(_router_check())
+    checks.append(_triage_check())
     checks.append(_lake_check())
     checks.append(_oltp_check())
     return checks
 
 
-def build_processor(models_dir: str | Path | None = None) -> PipelineGrievanceProcessor:
+def build_processor(
+    models_dir: str | Path | None = None,
+    *,
+    router: "RoutingProvider | None" = None,
+    triage_provider: TriageProvider | None = None,
+) -> PipelineGrievanceProcessor:
     """Strictly construct and warm the production processor.
 
     Local page-type and categorizer artifacts are mandatory.  Any missing
     dependency, artifact, public BART load, or Presidio initialization error
     propagates and aborts startup; this function never substitutes the mock.
+
+    ``router`` and ``triage_provider`` are the swap points. Both default to
+    the environment factories rather than to a hard-coded singleton, which is
+    what lets a trained model replace either one without a call-site change.
+    Explicit injection still wins over the environment, matching the idiom
+    ``create_app`` already uses for its providers.
     """
     root = _resolve_models_root(models_dir)
     categorizer_dir = root / "categorizer"
@@ -785,8 +828,6 @@ def build_processor(models_dir: str | Path | None = None) -> PipelineGrievancePr
     from janasunani.pipeline.stages.ocr_extraction.pytesseract_backend import (
         extract_text,
     )
-    from janasunani.routing.rules import DEFAULT_ROUTER
-
     def run_ocr(document_bytes: bytes, document_name: str) -> OcrResult:
         from janasunani.inference.ocr import ocr_document
 
@@ -806,7 +847,10 @@ def build_processor(models_dir: str | Path | None = None) -> PipelineGrievancePr
         detect_pii=detect_pii_spans,
         categorizer=categorizer,
         summarizer=summarizer,
-        router=DEFAULT_ROUTER,
+        router=router if router is not None else router_from_env(),
         is_english_compatible=_is_english,
         detect_language=_detect_language,
+        triage_provider=(
+            triage_provider if triage_provider is not None else triage_provider_from_env()
+        ),
     )

--- a/janasunani/inference/timing.py
+++ b/janasunani/inference/timing.py
@@ -1,0 +1,114 @@
+"""Per-stage wall-clock timing for one live grievance.
+
+There has never been per-stage instrumentation in this pipeline. The benchmark
+harness knew it: it recorded only end-to-end and explicitly refused to
+synthesise a per-stage split rather than invent one. That refusal was right,
+and this module is what makes it unnecessary.
+
+Two design constraints, both deliberate:
+
+**Timings never touch ``GrievanceResult``.** That is the frozen serving
+contract the frontend and the result store are built on. Timing is a side
+channel: the processor takes an optional sink and calls it once per
+submission. A benchmark passes a sink, production passes nothing, and the wire
+shape is identical either way.
+
+**A broken sink cannot break a submission.** Measurement is not worth a 500.
+``StageTimer`` swallows sink errors, and a stage that raises still records the
+time it burned before raising, because a slow failure is exactly the thing
+worth seeing in a latency profile.
+
+Wall clock, via ``time.perf_counter``, not CPU time. The question being asked
+is "how long does a citizen wait", and on a 2 vCPU box that includes time lost
+to contention.
+"""
+
+from __future__ import annotations
+
+import time
+from contextlib import contextmanager
+from typing import Callable, Iterator
+
+from loguru import logger
+
+#: The stages of one live submission, in execution order. Named here so a
+#: report can distinguish "this stage took no time" from "this stage did not
+#: run", which a bare dict cannot express.
+LIVE_STAGES = (
+    "ocr",
+    "redact",
+    "detect_pii",
+    "triage",
+    "detect_language",
+    "categorize",
+    "summarize",
+    "route",
+)
+
+TimingSink = Callable[[dict[str, float]], None]
+
+
+class StageTimer:
+    """Accumulate per-stage seconds for a single submission.
+
+    Not thread-safe and not meant to be: one instance measures one request.
+    The processor creates one per ``process`` call.
+    """
+
+    def __init__(self) -> None:
+        self._stages: dict[str, float] = {}
+        self._started = time.perf_counter()
+
+    @contextmanager
+    def stage(self, name: str) -> Iterator[None]:
+        """Time one stage, recording elapsed time even when the stage raises."""
+        start = time.perf_counter()
+        try:
+            yield
+        finally:
+            elapsed = time.perf_counter() - start
+            # Accumulate: the document path redacts once per page, and the
+            # honest total for `redact` is the sum of those calls rather than
+            # whichever one happened to run last.
+            self._stages[name] = self._stages.get(name, 0.0) + elapsed
+
+    def as_dict(self) -> dict[str, float]:
+        """Per-stage seconds plus the wall-clock total under ``e2e``.
+
+        ``e2e`` is measured independently rather than summed, so the gap
+        between it and the sum of stages is visible. That gap is real work
+        nobody has instrumented, and hiding it by construction would defeat
+        the point.
+        """
+        timings = dict(self._stages)
+        timings["e2e"] = time.perf_counter() - self._started
+        return timings
+
+    def emit(self, sink: TimingSink | None) -> None:
+        """Hand the timings to *sink*, swallowing anything it does about it."""
+        if sink is None:
+            return
+        try:
+            sink(self.as_dict())
+        except Exception:  # pragma: no cover - measurement must not break serving
+            logger.warning("timing sink raised; discarding the measurement")
+
+
+class NullTimer:
+    """A timer that measures nothing, for the default production path.
+
+    Exists so ``process`` has no ``if self._timer is not None`` branches
+    around every stage: the no-op costs one attribute lookup and a generator,
+    and it keeps the measured and unmeasured code paths textually identical.
+    """
+
+    @contextmanager
+    def stage(self, name: str) -> Iterator[None]:
+        del name
+        yield
+
+    def as_dict(self) -> dict[str, float]:
+        return {}
+
+    def emit(self, sink: TimingSink | None) -> None:
+        del sink

--- a/janasunani/inference/timing.py
+++ b/janasunani/inference/timing.py
@@ -16,7 +16,12 @@ shape is identical either way.
 **A broken sink cannot break a submission.** Measurement is not worth a 500.
 ``StageTimer`` swallows sink errors, and a stage that raises still records the
 time it burned before raising, because a slow failure is exactly the thing
-worth seeing in a latency profile.
+worth seeing in a latency profile. The caller (``PipelineGrievanceProcessor.
+process``) emits from an outer ``finally`` rather than only at the end of the
+happy path, so that recorded time actually reaches the sink instead of being
+discarded along with the exception -- and it marks those timings ``"ok": 0.0``
+so a report cannot silently mix a partial submission's numbers with a
+completed one's.
 
 Wall clock, via ``time.perf_counter``, not CPU time. The question being asked
 is "how long does a citizen wait", and on a 2 vCPU box that includes time lost
@@ -84,12 +89,25 @@ class StageTimer:
         timings["e2e"] = time.perf_counter() - self._started
         return timings
 
-    def emit(self, sink: TimingSink | None) -> None:
-        """Hand the timings to *sink*, swallowing anything it does about it."""
+    def emit(self, sink: TimingSink | None, *, ok: bool = True) -> None:
+        """Hand the timings to *sink*, swallowing anything it does about it.
+
+        ``ok`` distinguishes a submission that reached its normal return from
+        one whose caller is emitting from a `finally` after a stage raised.
+        Both cases must reach the sink -- a slow failure is exactly what a
+        latency profile should show -- but a report that cannot tell them
+        apart would silently average partial timings in with complete ones.
+        Carried as a value inside the emitted dict (``"ok": 1.0`` / ``0.0``)
+        rather than a second argument to *sink*, so the sink's own signature
+        -- a single ``dict[str, float]`` -- does not change; a sink such as
+        ``dict.update`` still works unmodified.
+        """
         if sink is None:
             return
+        payload = self.as_dict()
+        payload["ok"] = 1.0 if ok else 0.0
         try:
-            sink(self.as_dict())
+            sink(payload)
         except Exception:  # pragma: no cover - measurement must not break serving
             logger.warning("timing sink raised; discarding the measurement")
 
@@ -110,5 +128,5 @@ class NullTimer:
     def as_dict(self) -> dict[str, float]:
         return {}
 
-    def emit(self, sink: TimingSink | None) -> None:
-        del sink
+    def emit(self, sink: TimingSink | None, *, ok: bool = True) -> None:
+        del sink, ok

--- a/janasunani/pipeline/spam.py
+++ b/janasunani/pipeline/spam.py
@@ -45,7 +45,7 @@ import hashlib
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, Optional
+from typing import Literal, Optional, Protocol
 
 from janasunani.pipeline.ocr_quality import is_repetition_collapsed
 
@@ -164,6 +164,43 @@ def _is_no_grievance_like(text: str) -> bool:
     if low in {"test", "demo", "asdf", "blank"}:
         return True
     return False
+
+
+class SpamScorer(Protocol):
+    """Anything that can score one redacted text for low signal.
+
+    The return type is the load-bearing part. A scorer returns a
+    :class:`SpamScore`, never a ``SpamReview``, so it reaches the wire only
+    through :meth:`SpamScore.to_review_fields`. That adapter is what keeps
+    ``reason_code`` inside the closed set the serving contract admits: a
+    trained model cannot invent a new reason and have it silently published.
+
+    A learned scorer must also keep the two properties that make this signal
+    safe to show an officer: it is advisory, and it abstains rather than
+    guessing. Never auto-reject. A false positive is a citizen's grievance
+    discarded, which is a different class of harm from a mis-categorisation.
+    """
+
+    def score(
+        self,
+        redacted_text: str,
+        *,
+        is_repetition_collapsed: Optional[bool] = None,
+    ) -> SpamScore: ...
+
+
+class BoundedSpamScorer:
+    """Adapter presenting the shipped heuristic under the scorer Protocol."""
+
+    version = SPAM_VERSION
+
+    def score(
+        self,
+        redacted_text: str,
+        *,
+        is_repetition_collapsed: Optional[bool] = None,
+    ) -> SpamScore:
+        return score_spam(redacted_text, is_repetition_collapsed=is_repetition_collapsed)
 
 
 def score_spam(

--- a/janasunani/routing/provider.py
+++ b/janasunani/routing/provider.py
@@ -105,6 +105,20 @@ def router_status() -> tuple[str, bool, str]:
     same false assurance this probe was added to prevent. Reproducing the bug
     inside the check for it would be worse than having no check.
 
+    Loading successfully is still not sufficient: a crosswalk whose four
+    tables are all structurally valid but empty loads without error (an empty
+    dict is a valid, if useless, table -- see ``_valid_table``), yet every
+    lookup misses and routing falls straight through to the mapping tables.
+    That is the same false assurance under a different cause, so this also
+    checks that the base rung actually has entries. ``by_category`` is the
+    right table to gate on: ``Crosswalk.lookup`` always reaches it (it is the
+    only rung with no precondition on the caller supplying a subcategory or
+    district), so a populated ``by_category`` is necessary and sufficient for
+    the first live submission to have something to match against. The other
+    three tables cannot substitute: ``by_category_district`` is legitimately
+    empty in the currently shipped artifact (see the module docstring in
+    ``crosswalk.py``), so requiring it non-empty would fail a healthy artifact.
+
     The cost is loading one JSON artifact, which preflight can afford: it
     already opens a real OLTP connection when one is configured.
     """
@@ -140,6 +154,15 @@ def router_status() -> tuple[str, bool, str]:
         )
 
     if crosswalk is not None:
+        if not crosswalk.by_category:
+            return (
+                ROUTER_DEFAULT,
+                False,
+                f"crosswalk loaded from {DEFAULT_ARTIFACT.name} but the "
+                "category table is empty; every lookup misses and routing "
+                "degrades to mapping tables then fallback (run "
+                "janasunani-build-crosswalk to restore method:learned)",
+            )
         return (
             ROUTER_DEFAULT,
             True,

--- a/janasunani/routing/provider.py
+++ b/janasunani/routing/provider.py
@@ -114,10 +114,14 @@ def router_status() -> tuple[str, bool, str]:
     right table to gate on: ``Crosswalk.lookup`` always reaches it (it is the
     only rung with no precondition on the caller supplying a subcategory or
     district), so a populated ``by_category`` is necessary and sufficient for
-    the first live submission to have something to match against. The other
-    three tables cannot substitute: ``by_category_district`` is legitimately
-    empty in the currently shipped artifact (see the module docstring in
-    ``crosswalk.py``), so requiring it non-empty would fail a healthy artifact.
+    the first live submission to have something to match against.
+
+    The narrower tables are deliberately not gated on. They are populated in
+    the shipped artifact (34 / 257 / 971 / 5,084 entries across the four
+    rungs), but the live classifier predicts no subcategory, so ``by_full``
+    and ``by_subcategory`` are never consulted in production at all. Requiring
+    a rung the deployed path does not read would fail an artifact that routes
+    perfectly well.
 
     The cost is loading one JSON artifact, which preflight can afford: it
     already opens a real OLTP connection when one is configured.

--- a/janasunani/routing/provider.py
+++ b/janasunani/routing/provider.py
@@ -123,10 +123,25 @@ def router_status() -> tuple[str, bool, str]:
     a rung the deployed path does not read would fail an artifact that routes
     perfectly well.
 
-    The cost is loading one JSON artifact, which preflight can afford: it
-    already opens a real OLTP connection when one is configured.
+    A non-empty ``by_category`` is still not sufficient on its own: an entry
+    can be present and structurally valid yet fail ``Crosswalk.lookup``'s own
+    eligibility bar (``MIN_CONFIDENCE``, computed from support and share --
+    see ``CrosswalkRoute.confidence``). Four rows split evenly eight ways
+    loads fine and clears every structural check, but scores nowhere near
+    0.3. Reimplementing that threshold here would be a fifth parallel copy of
+    an eligibility rule that has already drifted from the real one four
+    times, so this instead calls ``crosswalk.lookup`` itself, once per
+    category in the table, and reports ``ok=True`` only when at least one of
+    those real calls actually returns a route. That is the same function and
+    the same thresholds the live router uses, so it cannot disagree with the
+    real router by construction -- there is no second copy of the rule left
+    to drift.
+
+    The cost is loading one JSON artifact and walking its category table,
+    which preflight can afford: it already opens a real OLTP connection when
+    one is configured.
     """
-    from janasunani.routing.crosswalk import DEFAULT_ARTIFACT, load_crosswalk
+    from janasunani.routing.crosswalk import DEFAULT_ARTIFACT, MIN_CONFIDENCE, load_crosswalk
 
     configured = os.environ.get(ROUTER_ENV_VAR, "").strip().lower() or ROUTER_DEFAULT
 
@@ -165,6 +180,27 @@ def router_status() -> tuple[str, bool, str]:
                 f"crosswalk loaded from {DEFAULT_ARTIFACT.name} but the "
                 "category table is empty; every lookup misses and routing "
                 "degrades to mapping tables then fallback (run "
+                "janasunani-build-crosswalk to restore method:learned)",
+            )
+        # Structural, not a sixth special case: this calls `Crosswalk.lookup`
+        # itself -- the exact function and thresholds a live request goes
+        # through -- rather than re-deriving "eligible" from the table's raw
+        # fields. `by_category` keys are already `_key(category, None, None)`
+        # (`_norm`-normalized, joined with the two empty rungs), and `_key`
+        # is idempotent under a second `_norm`, so splitting off the first
+        # segment and passing it back as `category` reaches the same table
+        # cell `lookup` would for the real (unnormalized) category text.
+        if not any(
+            crosswalk.lookup(category=key.split("|")[0]) is not None
+            for key in crosswalk.by_category
+        ):
+            return (
+                ROUTER_DEFAULT,
+                False,
+                f"crosswalk loaded from {DEFAULT_ARTIFACT.name} but no entry "
+                f"clears Crosswalk.lookup's confidence floor "
+                f"(MIN_CONFIDENCE={MIN_CONFIDENCE}); every lookup misses and "
+                "routing degrades to mapping tables then fallback (run "
                 "janasunani-build-crosswalk to restore method:learned)",
             )
         return (

--- a/janasunani/routing/provider.py
+++ b/janasunani/routing/provider.py
@@ -97,12 +97,18 @@ def router_from_env(value: str | None = None) -> RoutingProvider:
 def router_status() -> tuple[str, bool, str]:
     """Report ``(name, ok, detail)`` naming the rung that will answer first.
 
-    Deliberately cheap: it inspects the crosswalk artifact on disk rather than
-    constructing the router, so preflight can run before any model is warm.
-    ``ok`` is False only when the selection is degraded relative to what was
-    configured, not when routing is merely unavailable-but-expected.
+    Validates by **loading** the crosswalk, not by checking that a file
+    exists. Those differ exactly where it matters: ``load_crosswalk`` returns
+    ``None`` for a file that is present but corrupt or structurally invalid,
+    and the router then falls through to the mapping tables. A presence check
+    would report "first rung is learned" for precisely that file, which is the
+    same false assurance this probe was added to prevent. Reproducing the bug
+    inside the check for it would be worse than having no check.
+
+    The cost is loading one JSON artifact, which preflight can afford: it
+    already opens a real OLTP connection when one is configured.
     """
-    from janasunani.routing.crosswalk import DEFAULT_ARTIFACT
+    from janasunani.routing.crosswalk import DEFAULT_ARTIFACT, load_crosswalk
 
     configured = os.environ.get(ROUTER_ENV_VAR, "").strip().lower() or ROUTER_DEFAULT
 
@@ -120,15 +126,35 @@ def router_status() -> tuple[str, bool, str]:
             f"{ROUTER_ENV_VAR}={configured!r} is unknown; falling back to the default router",
         )
 
-    if DEFAULT_ARTIFACT.is_file():
+    try:
+        # Pass the path explicitly: `load_crosswalk`'s default is bound at
+        # definition time, so relying on it would report on a different file
+        # than the one named in the detail string.
+        crosswalk = load_crosswalk(DEFAULT_ARTIFACT)
+    except Exception as exc:  # pragma: no cover - load_crosswalk is documented not to raise
+        return (
+            ROUTER_DEFAULT,
+            False,
+            f"crosswalk could not be loaded ({exc}); routing degrades to mapping "
+            "tables then fallback",
+        )
+
+    if crosswalk is not None:
         return (
             ROUTER_DEFAULT,
             True,
-            f"crosswalk artifact present at {DEFAULT_ARTIFACT.name}; first rung is learned",
+            f"crosswalk loaded from {DEFAULT_ARTIFACT.name}; first rung is learned",
         )
+
+    present = DEFAULT_ARTIFACT.is_file()
+    reason = (
+        "present but unreadable or structurally invalid"
+        if present
+        else "missing"
+    )
     return (
         ROUTER_DEFAULT,
         False,
-        "crosswalk artifact missing; routing degrades to mapping tables then fallback "
-        "(run janasunani-build-crosswalk to restore method:learned)",
+        f"crosswalk artifact {reason}; routing degrades to mapping tables then "
+        "fallback (run janasunani-build-crosswalk to restore method:learned)",
     )

--- a/janasunani/routing/provider.py
+++ b/janasunani/routing/provider.py
@@ -1,0 +1,134 @@
+"""The routing seam: one Protocol, one env-gated factory, one status probe.
+
+Routing today is the empirical crosswalk backed by the ORTPSA mapping tables
+and a generic fallback (``rules.py``). A trained model is intended to replace
+the first rung later. Nothing about that swap should require touching a call
+site, so the selection happens here.
+
+The Protocol is deliberately the one that already existed as the private
+``_Router`` in ``janasunani/inference/service.py``. ``_LazyDefaultRouter``,
+``MappingRouter`` and ``RuleRouter`` already satisfy it structurally, so this
+declares an existing contract rather than imposing a new one.
+
+The factory follows ``supervisor_provider_from_env``
+(``janasunani/serving/intelligence.py``): read one environment variable,
+return a working provider for every input including nonsense, and never raise.
+A routing failure on demo day must degrade to a worse route, never to a 500.
+
+Why ``router_status`` exists separately: ``PERFORMANCE.md`` recorded a live
+submission returning ``method:"fallback"`` while the crosswalk artifact was
+present and believed live. The only way to catch that before an audience does
+is for preflight to say which rung is actually first, without loading the
+models to find out.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional, Protocol
+
+from loguru import logger
+
+from janasunani.serving.schemas import RoutingResult
+
+#: Environment variable selecting the routing implementation.
+ROUTER_ENV_VAR = "JANASUNANI_ROUTER"
+
+#: The shipped implementation: crosswalk, then mapping tables, then fallback.
+ROUTER_DEFAULT = "crosswalk"
+
+#: Rules and generic fallback only, skipping the empirical crosswalk. Useful to
+#: reproduce the pre-#33 behaviour and to isolate the crosswalk in a comparison.
+ROUTER_RULES = "rules"
+
+SUPPORTED_ROUTERS = (ROUTER_DEFAULT, ROUTER_RULES)
+
+
+class RoutingProvider(Protocol):
+    """Anything that can turn a classified grievance into a route.
+
+    A future learned router satisfies this by implementing ``route``. It must
+    also honour the ``RoutingResult`` contract in
+    ``janasunani/serving/schemas.py``, which enforces a biconditional between
+    ``method`` and the evidence object: ``method="learned"`` requires
+    ``empirical_evidence`` and every other method must not carry it. A model
+    whose evidence is a probability rather than support-and-concentration needs
+    a new evidence variant, not a reused one.
+    """
+
+    def route(
+        self,
+        *,
+        category: str,
+        subcategory: Optional[str] = None,
+        district: Optional[str] = None,
+    ) -> RoutingResult: ...
+
+
+def router_from_env(value: str | None = None) -> RoutingProvider:
+    """Select a router by environment, degrading to the default on anything odd.
+
+    Unset, unknown, or unconstructable all return the shipped router. An
+    operator typo must not take routing off the air, and it must not fail
+    silently either, so the fallback logs.
+    """
+    from janasunani.routing.rules import DEFAULT_ROUTER, RuleRouter, _LazyDefaultRouter
+
+    configured = (value if value is not None else os.environ.get(ROUTER_ENV_VAR, "")).strip().lower()
+    if not configured:
+        return DEFAULT_ROUTER
+    if configured == ROUTER_DEFAULT:
+        return DEFAULT_ROUTER
+    if configured == ROUTER_RULES:
+        try:
+            return _LazyDefaultRouter(enable_crosswalk=False)
+        except (OSError, RuntimeError, ValueError):
+            logger.warning("{}={} could not be constructed; using the default router", ROUTER_ENV_VAR, configured)
+            return RuleRouter()
+    logger.warning(
+        "{}={!r} is not one of {}; using the default router",
+        ROUTER_ENV_VAR,
+        configured,
+        ", ".join(SUPPORTED_ROUTERS),
+    )
+    return DEFAULT_ROUTER
+
+
+def router_status() -> tuple[str, bool, str]:
+    """Report ``(name, ok, detail)`` naming the rung that will answer first.
+
+    Deliberately cheap: it inspects the crosswalk artifact on disk rather than
+    constructing the router, so preflight can run before any model is warm.
+    ``ok`` is False only when the selection is degraded relative to what was
+    configured, not when routing is merely unavailable-but-expected.
+    """
+    from janasunani.routing.crosswalk import DEFAULT_ARTIFACT
+
+    configured = os.environ.get(ROUTER_ENV_VAR, "").strip().lower() or ROUTER_DEFAULT
+
+    if configured == ROUTER_RULES:
+        return (
+            ROUTER_RULES,
+            True,
+            "crosswalk disabled by configuration; first rung is the ORTPSA mapping tables",
+        )
+
+    if configured not in SUPPORTED_ROUTERS:
+        return (
+            ROUTER_DEFAULT,
+            False,
+            f"{ROUTER_ENV_VAR}={configured!r} is unknown; falling back to the default router",
+        )
+
+    if DEFAULT_ARTIFACT.is_file():
+        return (
+            ROUTER_DEFAULT,
+            True,
+            f"crosswalk artifact present at {DEFAULT_ARTIFACT.name}; first rung is learned",
+        )
+    return (
+        ROUTER_DEFAULT,
+        False,
+        "crosswalk artifact missing; routing degrades to mapping tables then fallback "
+        "(run janasunani-build-crosswalk to restore method:learned)",
+    )

--- a/janasunani/serving/triage.py
+++ b/janasunani/serving/triage.py
@@ -55,6 +55,29 @@ class TriageUnavailableError(RuntimeError):
     """An advisory provider could not be used without blocking submission."""
 
 
+class LearnedScorerUnresolved(RuntimeError):
+    """Base for the reasons ``_resolve_learned_scorer`` has no scorer to give.
+
+    Both subclasses degrade identically at request time -- neither may block
+    a citizen's submission -- but they are different states for an operator:
+    one says "produce and publish an artifact", the other says "the loader
+    hasn't been written yet, no artifact will fix it". Preflight needs to
+    tell them apart even though the request path does not.
+    """
+
+
+class ScorerArtifactAbsent(LearnedScorerUnresolved):
+    """No ``spam_scorer`` artifact resolves yet. Expected until #74 ships one."""
+
+
+class ScorerLoaderUnimplemented(LearnedScorerUnresolved):
+    """An artifact resolves, but nothing loads it into a ``SpamScorer`` yet.
+
+    A programming gap, not an operational one: supplying an artifact cannot
+    fix this by itself.
+    """
+
+
 class TriageProvider(Protocol):
     """Assess one submission after PII redaction and before classification."""
 
@@ -224,10 +247,19 @@ def triage_provider_from_env(value: str | None = None) -> TriageProvider:
     if configured == TRIAGE_OFF:
         return OffTriageProvider()
     if configured == TRIAGE_MODEL:
-        scorer = _resolve_learned_scorer()
-        if scorer is None:
+        try:
+            scorer = _resolve_learned_scorer()
+        except ScorerArtifactAbsent:
             logger.warning(
                 "{}={} but no learned scorer artifact resolved; using the bounded scorer",
+                TRIAGE_ENV_VAR,
+                TRIAGE_MODEL,
+            )
+            return UnwiredTriageProvider()
+        except ScorerLoaderUnimplemented:
+            logger.warning(
+                "{}={} but a scorer artifact resolved and no loader is "
+                "implemented yet (#74); using the bounded scorer",
                 TRIAGE_ENV_VAR,
                 TRIAGE_MODEL,
             )
@@ -242,8 +274,16 @@ def triage_provider_from_env(value: str | None = None) -> TriageProvider:
     return UnwiredTriageProvider()
 
 
-def _resolve_learned_scorer() -> "SpamScorer | None":
-    """Resolve a trained scorer artifact, or ``None`` when there is not one yet.
+def _resolve_learned_scorer() -> "SpamScorer":
+    """Resolve a trained scorer artifact.
+
+    Raises rather than returning ``None`` so the two ways this can fail stay
+    distinguishable to callers: :class:`ScorerArtifactAbsent` when no
+    artifact resolves (expected until #74 ships one -- an operator fixes this
+    by publishing an artifact) and :class:`ScorerLoaderUnimplemented` when one
+    resolves but nothing loads it yet (a programming gap -- no artifact fixes
+    this). Collapsing both into ``None`` is what let a status probe tell an
+    operator to go fix an artifact that was never the problem.
 
     Split out so the selection logic above is testable without a model, and so
     the day a learned scorer lands there is one function to fill in.
@@ -251,9 +291,10 @@ def _resolve_learned_scorer() -> "SpamScorer | None":
     from janasunani.tracking.artifacts import resolve_artifact
 
     if resolve_artifact("spam_scorer") is None:
-        return None
-    logger.warning("a spam scorer artifact is present but no loader is implemented yet")
-    return None
+        raise ScorerArtifactAbsent("no spam_scorer artifact resolved")
+    raise ScorerLoaderUnimplemented(
+        "a spam scorer artifact is present but no loader is implemented yet"
+    )
 
 
 def triage_status() -> tuple[str, bool, str]:
@@ -262,12 +303,23 @@ def triage_status() -> tuple[str, bool, str]:
     if configured == TRIAGE_OFF:
         return (TRIAGE_OFF, True, "advisory triage disabled by configuration")
     if configured == TRIAGE_MODEL:
-        if _resolve_learned_scorer() is None:
+        try:
+            _resolve_learned_scorer()
+        except ScorerArtifactAbsent:
             return (
                 TRIAGE_BOUNDED,
                 False,
                 f"{TRIAGE_ENV_VAR}=model but no scorer artifact resolved; "
                 f"serving the bounded heuristic scorer ({SPAM_VERSION})",
+            )
+        except ScorerLoaderUnimplemented:
+            return (
+                TRIAGE_BOUNDED,
+                False,
+                f"{TRIAGE_ENV_VAR}=model and a scorer artifact resolved, but "
+                "its loader is not implemented yet (#74) -- publishing "
+                "another artifact will not fix this; serving the bounded "
+                f"heuristic scorer ({SPAM_VERSION})",
             )
         return (TRIAGE_MODEL, True, "learned scorer artifact resolved")
     if configured not in SUPPORTED_TRIAGE_PROVIDERS:

--- a/janasunani/serving/triage.py
+++ b/janasunani/serving/triage.py
@@ -5,12 +5,21 @@ Live submissions are scored over redacted text only (never raw
 (pipeline/spam.py, spam-v1-bounded) — repetition collapse, length, and
 low-signal patterns — and is advisory only (never blocks submission).
 Duplicate matching remains slice-scoped and unavailable live.
+
+**What ships today is heuristic, not learned.** ``spam-v1-bounded`` is a
+cascade of deterministic rules. The learned scorer is #74. This module holds
+the seam that lets one replace the other without touching a call site, and
+``triage_status`` exists so a demo narrative cannot quietly describe the
+heuristic as a trained model.
 """
 
 from __future__ import annotations
 
+import os
 from datetime import datetime
 from typing import Optional, Protocol
+
+from loguru import logger
 
 from janasunani.pipeline.ocr_quality import is_repetition_collapsed
 from janasunani.serving.schemas import (
@@ -21,10 +30,25 @@ from janasunani.serving.schemas import (
 )
 
 try:
-    from janasunani.pipeline.spam import SPAM_VERSION, score_spam
+    from janasunani.pipeline.spam import SPAM_VERSION, SpamScorer, score_spam
 except Exception:  # pragma: no cover — scorer absent in minimal env
     SPAM_VERSION = "unavailable"  # type: ignore
+    SpamScorer = object  # type: ignore
     score_spam = None  # type: ignore
+
+#: Environment variable selecting the triage implementation.
+TRIAGE_ENV_VAR = "JANASUNANI_TRIAGE"
+
+#: The shipped heuristic scorer.
+TRIAGE_BOUNDED = "bounded"
+
+#: Advisory triage disabled; every submission reports unavailable.
+TRIAGE_OFF = "off"
+
+#: A trained scorer, when one exists (#74).
+TRIAGE_MODEL = "model"
+
+SUPPORTED_TRIAGE_PROVIDERS = (TRIAGE_BOUNDED, TRIAGE_OFF, TRIAGE_MODEL)
 
 
 class TriageUnavailableError(RuntimeError):
@@ -131,3 +155,127 @@ class UnwiredTriageProvider:
             # unavailable rather than surfacing an internal trace.
             return unavailable_triage()
         return TriageResult(spam=spam)
+
+
+class OffTriageProvider:
+    """Report advisory triage as unavailable without scoring anything.
+
+    Distinct from a broken provider on purpose: this is an operator saying
+    "do not run triage", and the response says exactly that rather than
+    implying the text was assessed and found clean.
+    """
+
+    def assess(
+        self,
+        *,
+        redacted_text: str,
+        district: Optional[str],
+        submitted_on: datetime,
+    ) -> TriageResult:
+        del redacted_text, district, submitted_on
+        return unavailable_triage()
+
+
+class ScoredTriageProvider:
+    """Run an injected scorer, degrading exactly as the default provider does.
+
+    This is the seam a trained model plugs into. The scorer returns a
+    ``SpamScore``, never a ``SpamReview``, so the taxonomy is enforced by
+    ``SpamScore.to_review_fields`` rather than by the model's good behaviour:
+    a reason code outside the closed set cannot reach the wire.
+
+    The two ``except`` clauses are copied from ``UnwiredTriageProvider`` and
+    are the whole safety story. A learned scorer that fails to load, times
+    out, or returns nonsense degrades to advisory-unavailable. It never
+    blocks a citizen's submission and never surfaces a trace.
+    """
+
+    def __init__(self, scorer: "SpamScorer") -> None:
+        self._scorer = scorer
+
+    def assess(
+        self,
+        *,
+        redacted_text: str,
+        district: Optional[str],
+        submitted_on: datetime,
+    ) -> TriageResult:
+        del district, submitted_on
+        try:
+            scored = self._scorer.score(redacted_text)
+            spam = SpamReview(**scored.to_review_fields())
+        except TriageUnavailableError:
+            return unavailable_triage()
+        except Exception:
+            return unavailable_triage()
+        return TriageResult(spam=spam)
+
+
+def triage_provider_from_env(value: str | None = None) -> TriageProvider:
+    """Select a triage provider by environment, never raising.
+
+    Unset keeps the shipped bounded scorer. ``off`` disables advisory triage.
+    ``model`` selects a learned scorer and falls back to the bounded one when
+    no artifact resolves, so setting it early costs nothing.
+    """
+    configured = (value if value is not None else os.environ.get(TRIAGE_ENV_VAR, "")).strip().lower()
+    if not configured or configured == TRIAGE_BOUNDED:
+        return UnwiredTriageProvider()
+    if configured == TRIAGE_OFF:
+        return OffTriageProvider()
+    if configured == TRIAGE_MODEL:
+        scorer = _resolve_learned_scorer()
+        if scorer is None:
+            logger.warning(
+                "{}={} but no learned scorer artifact resolved; using the bounded scorer",
+                TRIAGE_ENV_VAR,
+                TRIAGE_MODEL,
+            )
+            return UnwiredTriageProvider()
+        return ScoredTriageProvider(scorer)
+    logger.warning(
+        "{}={!r} is not one of {}; using the bounded scorer",
+        TRIAGE_ENV_VAR,
+        configured,
+        ", ".join(SUPPORTED_TRIAGE_PROVIDERS),
+    )
+    return UnwiredTriageProvider()
+
+
+def _resolve_learned_scorer() -> "SpamScorer | None":
+    """Resolve a trained scorer artifact, or ``None`` when there is not one yet.
+
+    Split out so the selection logic above is testable without a model, and so
+    the day a learned scorer lands there is one function to fill in.
+    """
+    from janasunani.tracking.artifacts import resolve_artifact
+
+    if resolve_artifact("spam_scorer") is None:
+        return None
+    logger.warning("a spam scorer artifact is present but no loader is implemented yet")
+    return None
+
+
+def triage_status() -> tuple[str, bool, str]:
+    """Report ``(name, ok, detail)`` for preflight without scoring anything."""
+    configured = os.environ.get(TRIAGE_ENV_VAR, "").strip().lower() or TRIAGE_BOUNDED
+    if configured == TRIAGE_OFF:
+        return (TRIAGE_OFF, True, "advisory triage disabled by configuration")
+    if configured == TRIAGE_MODEL:
+        if _resolve_learned_scorer() is None:
+            return (
+                TRIAGE_BOUNDED,
+                False,
+                f"{TRIAGE_ENV_VAR}=model but no scorer artifact resolved; "
+                f"serving the bounded heuristic scorer ({SPAM_VERSION})",
+            )
+        return (TRIAGE_MODEL, True, "learned scorer artifact resolved")
+    if configured not in SUPPORTED_TRIAGE_PROVIDERS:
+        return (
+            TRIAGE_BOUNDED,
+            False,
+            f"{TRIAGE_ENV_VAR}={configured!r} is unknown; serving the bounded scorer",
+        )
+    if score_spam is None:
+        return (TRIAGE_BOUNDED, False, "spam scorer import failed; triage reports unavailable")
+    return (TRIAGE_BOUNDED, True, f"bounded heuristic scorer ({SPAM_VERSION}); not a learned model")

--- a/janasunani/tracking/artifacts.py
+++ b/janasunani/tracking/artifacts.py
@@ -1,0 +1,111 @@
+"""Resolve a trained-model artifact to a path, or to nothing at all.
+
+``mlflow_utils`` in this package is registration-side only: it logs artifacts
+and creates model versions, and nothing in it resolves an alias back to
+something loadable. So a learned router or scorer has no way to find its own
+weights. This module is that missing half, deliberately kept to the smallest
+thing that works.
+
+Resolution order, first hit wins:
+
+1. ``JANASUNANI_<NAME>_ARTIFACT`` — an explicit operator override.
+2. ``<models_dir>/<name>`` — the DVC-mirrored convention the rest of the repo
+   already uses for the categorizer and page-type models.
+3. ``None``.
+
+**Never raises.** The degradation contract is copied from
+``janasunani.routing.crosswalk.load_crosswalk``: a missing *or structurally
+unusable* artifact returns ``None`` and the caller falls through to whatever
+it was doing before. A model that cannot be found must not be able to take
+the demo down, and an operator typo in a path must not either.
+
+Registry resolution (``models:/name@champion``) is deliberately absent. It
+would put a network call on the startup path of a box that has to come up in
+front of an audience, and there is no read side in ``mlflow_utils`` to build
+on. The seam is named below so the day it lands there is one place to put it.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from loguru import logger
+
+#: Set to route resolution through a model registry instead of the filesystem.
+REGISTRY_ENV_VAR = "JANASUNANI_MODEL_REGISTRY"
+
+
+def _env_var_for(name: str) -> str:
+    return f"JANASUNANI_{name.upper().replace('-', '_')}_ARTIFACT"
+
+
+def _models_dir(models_dir: Path | None) -> Path:
+    if models_dir is not None:
+        return models_dir
+    configured = os.environ.get("JANASUNANI_MODELS_DIR")
+    if configured:
+        return Path(configured)
+    return Path("models")
+
+
+def _usable(path: Path) -> bool:
+    """Whether the path is something a loader could actually open.
+
+    A directory has to be non-empty. An empty directory is the shape a failed
+    ``dvc pull`` leaves behind, and reporting it as present is how a demo box
+    ends up loading nothing while claiming a model is live.
+    """
+    try:
+        if path.is_file():
+            return path.stat().st_size > 0
+        if path.is_dir():
+            return any(path.iterdir())
+    except OSError:
+        return False
+    return False
+
+
+def resolve_artifact(name: str, *, models_dir: Path | None = None) -> Path | None:
+    """Return a usable artifact path for *name*, or ``None``.
+
+    Never raises, for any input, including a name containing path separators
+    or an override pointing somewhere unreadable.
+    """
+    try:
+        override = os.environ.get(_env_var_for(name))
+        if override:
+            candidate = Path(override)
+            if _usable(candidate):
+                return candidate
+            logger.warning(
+                "{}={} does not resolve to a usable artifact; ignoring it",
+                _env_var_for(name),
+                override,
+            )
+
+        if os.environ.get(REGISTRY_ENV_VAR):
+            resolved = _resolve_via_registry(name)
+            if resolved is not None:
+                return resolved
+
+        candidate = _models_dir(models_dir) / name
+        if _usable(candidate):
+            return candidate
+        return None
+    except Exception:  # pragma: no cover — the contract is "never raises"
+        logger.warning("artifact resolution for {!r} failed; treating it as absent", name)
+        return None
+
+
+def _resolve_via_registry(name: str) -> Path | None:
+    """Resolve through a model registry alias. Not implemented before 14 Aug.
+
+    Returns ``None`` rather than raising so that setting the env var early is
+    harmless: resolution simply falls through to the filesystem.
+    """
+    logger.warning(
+        "{} is set but registry resolution is not implemented; falling back to the filesystem",
+        REGISTRY_ENV_VAR,
+    )
+    return None

--- a/scripts/benchmark_pipeline.py
+++ b/scripts/benchmark_pipeline.py
@@ -385,11 +385,12 @@ def _measure_with_processor(
             is_warm = discard_warm and r == 0
             # Timing path: real processor vs fake
             if processor is not None:
-                # Real processor path — measure wall clock for the single
-                # process() call. Per-stage breakdown is not available from
-                # the monolithic PipelineGrievanceProcessor, so we record
-                # only e2e and leave per-stage as not_measured (fabricating
-                # from fake proportions would publish invented latency).
+                # Real processor path. Per-stage now comes from the processor's
+                # timing sink (janasunani/inference/timing.py) rather than being
+                # left not_measured: the sink reports what each stage actually
+                # took, so nothing here is synthesized from proportions.
+                captured: dict[str, float] = {}
+                processor._timing_sink = captured.update  # noqa: SLF001 - benchmark seam
                 start = time.perf_counter()
                 try:
                     processor.process(
@@ -407,12 +408,21 @@ def _measure_with_processor(
                 elapsed = time.perf_counter() - start
                 if is_warm:
                     continue
-                # Record only e2e; per-stage wall-clock not available
-                per_stage_times[E2E_KEY].append(elapsed)
-                per_stage_tickets[E2E_KEY].append(ticket)
-                # Do not synthesize per-stage durations — they would be
-                # fabricated and could sum to >e2e. Downstream report will
-                # show stages as not_measured.
+                # Prefer the sink's own e2e; fall back to the outer wall clock
+                # if the sink produced nothing (a processor built without one).
+                # Record whatever the live path actually ran, creating keys on
+                # demand. STAGES above is the *batch* pipeline's vocabulary
+                # (format / pii / spam / page_type); the live processor's stages
+                # are different (redact / detect_pii / triage / detect_language).
+                # Coercing one into the other would mislabel real measurements,
+                # so a real run reports its own stage names and the fake path
+                # keeps the old ones.
+                for stage_name, seconds in captured.items():
+                    per_stage_times.setdefault(stage_name, []).append(seconds)
+                    per_stage_tickets.setdefault(stage_name, []).append(ticket)
+                if E2E_KEY not in captured:
+                    per_stage_times[E2E_KEY].append(elapsed)
+                    per_stage_tickets[E2E_KEY].append(ticket)
             else:
                 # Fake timing path — deterministic, fast, no sleep unless
                 # BENCHMARK_FAKE_SLEEP is set (for manual wall-clock checks).
@@ -681,11 +691,25 @@ def main(argv: list[str] | None = None) -> int:
     is_fake = args.fake
     processor_factory: Any = None
     if not is_fake:
-        # Real processor wiring not yet implemented for benchmark harness;
-        # keep --fake explicit for CI publishable runs, fall back to fake
-        # for existing tests that omit it.
-        is_fake = True
-        processor_factory = None
+        # Real wiring. This used to force is_fake=True unconditionally, which
+        # meant every number this harness ever printed came from the constant
+        # table in _FAKE_STAGE_MEANS, with or without --fake. A run that cannot
+        # build a processor now FAILS rather than silently fabricating: a
+        # fabricated latency that looks real is worse than no latency at all.
+        try:
+            from janasunani.inference.service import build_processor
+        except Exception as exc:  # pragma: no cover - env-dependent
+            parser.error(
+                f"--fake was not passed but the real processor cannot be imported: {exc}. "
+                "Pass --fake explicitly to get synthetic timings."
+            )
+
+        warmed: dict[str, Any] = {}
+
+        def processor_factory(variant: str) -> Any:  # noqa: ARG001 - one warm processor serves every variant
+            if "processor" not in warmed:
+                warmed["processor"] = build_processor(timing_sink=lambda _timings: None)
+            return warmed["processor"]
 
     results: dict[str, dict[str, Any]] = {}
     for variant in variants:

--- a/tests/test_benchmark_pipeline.py
+++ b/tests/test_benchmark_pipeline.py
@@ -263,13 +263,59 @@ def test_write_latency_json_multi_variant_file(tmp_path):
 
 
 def test_cli_single_variant_writes_output(tmp_path):
+    # `--fake` is now explicit. It used to be implied for every run, because
+    # main() forced is_fake=True regardless, so this test exercised the
+    # synthetic table while appearing to exercise the CLI end to end.
     out = tmp_path / "latency.json"
-    rc = bench_mod.main(["--variant", "standard", "--n-docs", "2", "--n-image-docs", "1", "--repeats", "2", "--output", str(out), "--seed", "42"])
+    rc = bench_mod.main(["--fake", "--variant", "standard", "--n-docs", "2", "--n-image-docs", "1", "--repeats", "2", "--output", str(out), "--seed", "42"])
     assert rc == 0
     assert out.is_file()
     data = json.loads(out.read_text())
     assert data["variant"] == "standard"
     assert data["stages"]["e2e"]["n"] == 3 * 1  # (2+1)=3 docs * (2-1)=1 measured
+    assert data["is_fake_timing"] is True
+
+
+def test_a_run_without_fake_does_not_silently_fabricate(tmp_path, monkeypatch):
+    """The regression for the unconditional `is_fake = True` override.
+
+    Before this, `main()` forced fake timings whether or not `--fake` was
+    passed, so every latency number this harness ever produced came from
+    `_FAKE_STAGE_MEANS`. A run that cannot measure must fail, not invent.
+    """
+    out = tmp_path / "latency.json"
+
+    def _no_processor(*args, **kwargs):
+        raise RuntimeError("models are not available in this environment")
+
+    monkeypatch.setattr(
+        "janasunani.inference.service.build_processor", _no_processor, raising=False
+    )
+
+    with pytest.raises((SystemExit, RuntimeError)):
+        bench_mod.main(
+            ["--variant", "standard", "--n-docs", "1", "--n-image-docs", "0",
+             "--repeats", "2", "--output", str(out), "--seed", "42"]
+        )
+    # Nothing fabricated on the way out.
+    if out.exists():
+        assert json.loads(out.read_text()).get("is_fake_timing") is not False
+
+
+def test_real_run_records_per_stage_from_the_timing_sink():
+    """Per-stage comes from the processor, not from proportions of e2e."""
+    from janasunani.inference.timing import StageTimer
+
+    timer = StageTimer()
+    with timer.stage("redact"):
+        pass
+    with timer.stage("categorize"):
+        pass
+    timings = timer.as_dict()
+    assert {"redact", "categorize", "e2e"} <= set(timings)
+    # e2e is measured independently, so the gap to the sum of stages stays
+    # visible rather than being defined away.
+    assert timings["e2e"] >= 0.0
 
 
 def test_cli_multi_variants(tmp_path):

--- a/tests/test_benchmark_pipeline.py
+++ b/tests/test_benchmark_pipeline.py
@@ -319,9 +319,13 @@ def test_real_run_records_per_stage_from_the_timing_sink():
 
 
 def test_cli_multi_variants(tmp_path):
+    # `--fake` is explicit: this asserts the CLI's output shape, not latency.
+    # Without it the harness builds a real processor, which needs the DVC-
+    # mirrored models that CI deliberately does not pull.
     out = tmp_path / "latency.json"
     rc = bench_mod.main(
         [
+            "--fake",
             "--variants",
             "standard",
             "sarvam_digitise",
@@ -345,7 +349,7 @@ def test_cli_multi_variants(tmp_path):
 def test_cli_no_warm_discard(tmp_path):
     out = tmp_path / "latency.json"
     rc = bench_mod.main(
-        ["--variant", "standard", "--n-docs", "2", "--n-image-docs", "0", "--repeats", "2", "--output", str(out), "--no-warm-discard"]
+        ["--fake", "--variant", "standard", "--n-docs", "2", "--n-image-docs", "0", "--repeats", "2", "--output", str(out), "--no-warm-discard"]
     )
     assert rc == 0
     data = json.loads(out.read_text())

--- a/tests/test_inference_timing.py
+++ b/tests/test_inference_timing.py
@@ -1,0 +1,200 @@
+"""Codex finding on #234: emit recorded timings when a stage fails.
+
+`StageTimer.stage()` records elapsed time in a `finally` even when the stage
+raises -- deliberate, because a slow failure is exactly what a latency
+profile should show. But the old `process()` called `timer.emit(...)` only
+after its final `return`, so a raised stage discarded exactly the
+measurement that design existed for. These tests exercise the real
+`PipelineGrievanceProcessor.process` code path (not just `StageTimer` in
+isolation) so the fix is checked where the bug actually lived: the outer
+`finally` in `process()`, not just the timer primitive.
+
+Two properties are checked throughout:
+- Timings never touch `GrievanceResult` -- the frozen serving contract.
+- A sink that raises must not break a submission, on either the success or
+  the failure path.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from janasunani.inference.service import PipelineGrievanceProcessor
+from janasunani.inference.timing import NullTimer, StageTimer
+from janasunani.serving.schemas import RoutingResult
+
+
+def _make_processor(*, router, categorizer=None, timing_sink):
+    return PipelineGrievanceProcessor(
+        ocr=lambda b, n: None,
+        redact=lambda t: t,
+        detect_pii=lambda t: [],
+        categorizer=categorizer
+        or type("C", (), {"predict": lambda self, t: "Housing"})(),
+        summarizer=type("S", (), {"summarize": lambda self, t: "summary"})(),
+        router=router,
+        is_english_compatible=lambda t: True,
+        detect_language=lambda t: "en",
+        timing_sink=timing_sink,
+    )
+
+
+class _WorkingRouter:
+    def route(self, *, category, subcategory=None, district=None) -> RoutingResult:
+        return RoutingResult(
+            dept="Test Department", office="Test Office", confidence=0.5, method="fallback"
+        )
+
+
+class _RaisingRouter:
+    """Stands in for "a model, or routing raises" from the finding."""
+
+    def route(self, *, category, subcategory=None, district=None) -> RoutingResult:
+        raise ValueError("routing exploded")
+
+
+class _RaisingCategorizer:
+    def predict(self, text: str) -> str:
+        raise RuntimeError("categorizer exploded")
+
+
+# --- StageTimer.emit / NullTimer.emit signature -----------------------------
+
+
+def test_stage_timer_emit_marks_ok_true_by_default():
+    timer = StageTimer()
+    with timer.stage("route"):
+        pass
+    captured = []
+    timer.emit(captured.append)
+    assert captured[0]["ok"] == 1.0
+
+
+def test_stage_timer_emit_marks_ok_false_when_told():
+    timer = StageTimer()
+    with timer.stage("route"):
+        pass
+    captured = []
+    timer.emit(captured.append, ok=False)
+    assert captured[0]["ok"] == 0.0
+    # The stage that ran before the caller decided to mark failure is still
+    # in the payload -- ok is metadata alongside the timings, not a filter.
+    assert "route" in captured[0]
+
+
+def test_null_timer_emit_accepts_ok_and_stays_a_noop():
+    """NullTimer is only ever used with sink=None; the kwarg must not break it."""
+    NullTimer().emit(None, ok=False)
+    NullTimer().emit(None, ok=True)
+
+
+# --- the real process() code path --------------------------------------------
+
+
+def test_process_emits_on_success_with_ok_true():
+    captured: list[dict] = []
+    processor = _make_processor(router=_WorkingRouter(), timing_sink=captured.append)
+
+    result = processor.process(
+        grievance_id="g1",
+        ticket_no="T1",
+        text="the drain outside my house has been blocked for a month",
+        district="Sambalpur",
+    )
+
+    assert len(captured) == 1
+    payload = captured[0]
+    assert payload["ok"] == 1.0
+    assert "e2e" in payload
+    assert "route" in payload
+    # The frozen serving contract carries no timing data.
+    assert "timing" not in result.model_dump()
+
+
+def test_process_emits_when_the_final_stage_raises():
+    """The finding's exact scenario: routing raises, and the raise happens in
+    the last stage before the return, which is where the old code's single
+    end-of-happy-path `emit()` call was most obviously never reached."""
+    captured: list[dict] = []
+    processor = _make_processor(router=_RaisingRouter(), timing_sink=captured.append)
+
+    with pytest.raises(ValueError, match="routing exploded"):
+        processor.process(
+            grievance_id="g1",
+            ticket_no="T1",
+            text="the drain outside my house has been blocked for a month",
+            district="Sambalpur",
+        )
+
+    assert len(captured) == 1, "the finally-emit must fire exactly once, not be skipped"
+    payload = captured[0]
+    assert payload["ok"] == 0.0
+    # The raising stage's own `finally` (StageTimer.stage) still recorded it.
+    assert "route" in payload
+    assert "e2e" in payload
+
+
+def test_process_emits_a_partial_timing_set_when_a_mid_pipeline_stage_raises():
+    """A stage that never ran must not appear -- the failed set is a real
+    prefix of the pipeline, not padded or faked."""
+    captured: list[dict] = []
+    processor = _make_processor(
+        router=_WorkingRouter(),
+        categorizer=_RaisingCategorizer(),
+        timing_sink=captured.append,
+    )
+
+    with pytest.raises(RuntimeError, match="categorizer exploded"):
+        processor.process(
+            grievance_id="g1",
+            ticket_no="T1",
+            text="the drain outside my house has been blocked for a month",
+            district="Sambalpur",
+        )
+
+    payload = captured[0]
+    assert payload["ok"] == 0.0
+    # Stages before the raise ran and were recorded...
+    assert "redact" in payload
+    assert "detect_pii" in payload
+    assert "triage" in payload
+    assert "detect_language" in payload
+    assert "categorize" in payload  # recorded even though it's the one that raised
+    # ...but routing never ran, because the exception stopped the pipeline
+    # before that stage started.
+    assert "route" not in payload
+    assert "summarize" not in payload
+
+
+def test_a_raising_sink_does_not_mask_the_original_processing_exception():
+    """Measurement must not be worth more than the citizen's submission, in
+    either direction: a broken sink cannot manufacture a 500, and it cannot
+    swallow a real one either."""
+
+    def bad_sink(payload: dict) -> None:
+        raise RuntimeError("sink exploded")
+
+    processor = _make_processor(router=_RaisingRouter(), timing_sink=bad_sink)
+
+    with pytest.raises(ValueError, match="routing exploded"):
+        processor.process(
+            grievance_id="g1",
+            ticket_no="T1",
+            text="the drain outside my house has been blocked for a month",
+            district="Sambalpur",
+        )
+
+
+def test_a_raising_sink_does_not_break_a_successful_submission():
+    def bad_sink(payload: dict) -> None:
+        raise RuntimeError("sink exploded")
+
+    processor = _make_processor(router=_WorkingRouter(), timing_sink=bad_sink)
+
+    result = processor.process(
+        grievance_id="g1",
+        ticket_no="T1",
+        text="the drain outside my house has been blocked for a month",
+        district="Sambalpur",
+    )
+    assert result.routing.dept == "Test Department"

--- a/tests/test_scorer_seams.py
+++ b/tests/test_scorer_seams.py
@@ -1,0 +1,275 @@
+"""The routing and triage swap seams.
+
+Two properties matter here and neither is about the current implementations:
+
+1. A future trained model can be substituted without touching a call site.
+2. When that model is absent, broken, or misconfigured, the demo degrades to a
+   worse answer rather than to an error, and *says so* in preflight instead of
+   degrading quietly. PERFORMANCE.md recorded a live submission returning
+   ``method:"fallback"`` while everyone believed routing was learned; the
+   status probes exist to make that state visible before an audience sees it.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from janasunani.routing.provider import (
+    ROUTER_DEFAULT,
+    ROUTER_ENV_VAR,
+    ROUTER_RULES,
+    RoutingProvider,
+    router_from_env,
+    router_status,
+)
+from janasunani.serving.schemas import RoutingResult, SpamReview, TriageResult
+from janasunani.serving.triage import (
+    TRIAGE_BOUNDED,
+    TRIAGE_ENV_VAR,
+    TRIAGE_MODEL,
+    TRIAGE_OFF,
+    OffTriageProvider,
+    ScoredTriageProvider,
+    TriageUnavailableError,
+    UnwiredTriageProvider,
+    triage_provider_from_env,
+    triage_status,
+)
+
+
+class RecordingRouter:
+    """A stand-in trained router: satisfies the Protocol, records its calls."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def route(self, *, category, subcategory=None, district=None) -> RoutingResult:
+        self.calls.append(
+            {"category": category, "subcategory": subcategory, "district": district}
+        )
+        return RoutingResult(
+            dept="Test Department",
+            office="Test Office",
+            confidence=0.5,
+            method="fallback",
+        )
+
+
+# --- the Protocol is satisfied by what already exists -----------------------
+
+
+def test_the_shipped_routers_already_satisfy_the_public_protocol():
+    """The Protocol declares an existing contract; it does not impose a new one."""
+    from janasunani.routing.rules import DEFAULT_ROUTER, MappingRouter, RuleRouter
+
+    for router in (DEFAULT_ROUTER, MappingRouter(), RuleRouter()):
+        assert hasattr(router, "route")
+        result = router.route(category="Housing", district="Sambalpur")
+        assert isinstance(result, RoutingResult)
+
+
+def test_a_substitute_router_needs_only_the_route_method():
+    provider: RoutingProvider = RecordingRouter()
+    result = provider.route(category="Housing", district="Sambalpur")
+    assert result.dept == "Test Department"
+
+
+# --- env selection degrades rather than raising -----------------------------
+
+
+def test_router_from_env_returns_the_default_when_unset(monkeypatch):
+    monkeypatch.delenv(ROUTER_ENV_VAR, raising=False)
+    from janasunani.routing.rules import DEFAULT_ROUTER
+
+    assert router_from_env() is DEFAULT_ROUTER
+
+
+def test_router_from_env_can_select_the_crosswalk_free_ladder():
+    router = router_from_env(ROUTER_RULES)
+    assert router.route(category="Housing", district="Sambalpur").method in {
+        "rules",
+        "fallback",
+    }
+
+
+@pytest.mark.parametrize("value", ["nonsense", "LEARNED", "  ", "model"])
+def test_router_from_env_never_raises_on_a_bad_value(value):
+    """An operator typo must not take routing off the air."""
+    router = router_from_env(value)
+    assert isinstance(router.route(category="Housing"), RoutingResult)
+
+
+def test_router_status_reports_the_rung_that_answers_first(monkeypatch):
+    monkeypatch.delenv(ROUTER_ENV_VAR, raising=False)
+    name, ok, detail = router_status()
+    assert name == ROUTER_DEFAULT
+    # The artifact is committed, so this should be the learned rung.
+    assert ok is True
+    assert "learned" in detail
+
+
+def test_router_status_flags_an_unknown_configuration(monkeypatch):
+    monkeypatch.setenv(ROUTER_ENV_VAR, "nonsense")
+    name, ok, detail = router_status()
+    assert ok is False
+    assert "unknown" in detail
+
+
+# --- triage selection -------------------------------------------------------
+
+
+def test_triage_from_env_defaults_to_the_bounded_scorer(monkeypatch):
+    monkeypatch.delenv(TRIAGE_ENV_VAR, raising=False)
+    assert isinstance(triage_provider_from_env(), UnwiredTriageProvider)
+
+
+def test_triage_off_reports_unavailable_rather_than_clean():
+    """Disabled triage must not read as 'assessed and found fine'."""
+    provider = triage_provider_from_env(TRIAGE_OFF)
+    assert isinstance(provider, OffTriageProvider)
+    result = provider.assess(
+        redacted_text="a genuine grievance about water supply",
+        district="Sambalpur",
+        submitted_on=datetime.now(UTC),
+    )
+    assert result.spam.decision == "abstained"
+    assert result.spam.reason_code == "advisory_provider_unavailable"
+
+
+def test_triage_model_falls_back_to_bounded_when_no_artifact_resolves(monkeypatch):
+    monkeypatch.delenv("JANASUNANI_SPAM_SCORER_ARTIFACT", raising=False)
+    provider = triage_provider_from_env(TRIAGE_MODEL)
+    assert isinstance(provider, UnwiredTriageProvider)
+
+
+@pytest.mark.parametrize("value", ["nonsense", "  learned  ", "1"])
+def test_triage_from_env_never_raises_on_a_bad_value(value):
+    provider = triage_provider_from_env(value)
+    assert isinstance(
+        provider.assess(
+            redacted_text="text", district=None, submitted_on=datetime.now(UTC)
+        ),
+        TriageResult,
+    )
+
+
+def test_triage_status_says_the_shipped_scorer_is_heuristic(monkeypatch):
+    """The narrative guard: 'bounded' must never read as a trained model."""
+    monkeypatch.delenv(TRIAGE_ENV_VAR, raising=False)
+    name, ok, detail = triage_status()
+    assert name == TRIAGE_BOUNDED
+    assert ok is True
+    assert "not a learned model" in detail
+
+
+def test_triage_status_flags_model_configured_without_an_artifact(monkeypatch):
+    monkeypatch.setenv(TRIAGE_ENV_VAR, TRIAGE_MODEL)
+    monkeypatch.delenv("JANASUNANI_SPAM_SCORER_ARTIFACT", raising=False)
+    name, ok, detail = triage_status()
+    assert name == TRIAGE_BOUNDED
+    assert ok is False
+    assert "no scorer artifact resolved" in detail
+
+
+# --- a broken learned scorer must never reach the citizen -------------------
+
+
+class ExplodingScorer:
+    def score(self, redacted_text, *, is_repetition_collapsed=None):
+        raise RuntimeError("model weights are corrupt")
+
+
+class UnavailableScorer:
+    def score(self, redacted_text, *, is_repetition_collapsed=None):
+        raise TriageUnavailableError("not loaded")
+
+
+class OutOfTaxonomyScorer:
+    """Returns a score whose reason is not in the published set."""
+
+    def score(self, redacted_text, *, is_repetition_collapsed=None):
+        from janasunani.pipeline.spam import SpamScore
+
+        score = SpamScore(spam_score=0.9, spam_reason="clean", evidence=())
+        object.__setattr__(score, "spam_reason", "model_thinks_so")
+        return score
+
+
+@pytest.mark.parametrize("scorer", [ExplodingScorer(), UnavailableScorer()])
+def test_a_broken_learned_scorer_degrades_instead_of_raising(scorer):
+    """A failed model must not block a citizen's submission."""
+    provider = ScoredTriageProvider(scorer)
+    result = provider.assess(
+        redacted_text="water supply has been cut for three weeks",
+        district="Sambalpur",
+        submitted_on=datetime.now(UTC),
+    )
+    assert result.spam.decision == "abstained"
+    assert result.spam.reason_code == "advisory_provider_unavailable"
+
+
+def test_an_out_of_taxonomy_reason_cannot_reach_the_wire():
+    """The adapter is the enforcement, not the model's good behaviour."""
+    provider = ScoredTriageProvider(OutOfTaxonomyScorer())
+    result = provider.assess(
+        redacted_text="test", district=None, submitted_on=datetime.now(UTC)
+    )
+    # Degrades rather than publishing an invented reason code.
+    assert result.spam.reason_code == "advisory_provider_unavailable"
+
+
+def test_a_working_scorer_reaches_the_response():
+    from janasunani.pipeline.spam import BoundedSpamScorer
+
+    provider = ScoredTriageProvider(BoundedSpamScorer())
+    result = provider.assess(
+        redacted_text="test",
+        district=None,
+        submitted_on=datetime.now(UTC),
+    )
+    assert isinstance(result.spam, SpamReview)
+    assert 0.0 <= result.spam.spam_score <= 1.0
+
+
+# --- the injection points themselves ----------------------------------------
+
+
+def test_build_processor_exposes_both_swap_points():
+    """The two parameters are the whole point of this change."""
+    import inspect
+
+    from janasunani.inference.service import build_processor
+
+    params = inspect.signature(build_processor).parameters
+    assert "router" in params
+    assert "triage_provider" in params
+    # Keyword-only and defaulted, so both existing call sites keep working.
+    for name in ("router", "triage_provider"):
+        assert params[name].kind is inspect.Parameter.KEYWORD_ONLY
+        assert params[name].default is None
+
+
+def test_an_injected_router_is_the_one_the_processor_uses():
+    from janasunani.inference.service import PipelineGrievanceProcessor
+
+    router = RecordingRouter()
+    processor = PipelineGrievanceProcessor(
+        ocr=lambda b, n: None,
+        redact=lambda t: t,
+        detect_pii=lambda t: [],
+        categorizer=type("C", (), {"predict": lambda self, t: "Housing"})(),
+        summarizer=type("S", (), {"summarize": lambda self, t: "summary"})(),
+        router=router,
+        is_english_compatible=lambda t: True,
+        detect_language=lambda t: "en",
+    )
+    result = processor.process(
+        grievance_id="g1",
+        ticket_no="T1",
+        text="the drain outside my house has been blocked for a month",
+        district="Sambalpur",
+    )
+    assert router.calls, "the injected router was bypassed"
+    assert result.routing.dept == "Test Department"

--- a/tests/test_scorer_seams.py
+++ b/tests/test_scorer_seams.py
@@ -32,8 +32,11 @@ from janasunani.serving.triage import (
     TRIAGE_OFF,
     OffTriageProvider,
     ScoredTriageProvider,
+    ScorerArtifactAbsent,
+    ScorerLoaderUnimplemented,
     TriageUnavailableError,
     UnwiredTriageProvider,
+    _resolve_learned_scorer,
     triage_provider_from_env,
     triage_status,
 )
@@ -171,6 +174,62 @@ def test_triage_status_flags_model_configured_without_an_artifact(monkeypatch):
     assert name == TRIAGE_BOUNDED
     assert ok is False
     assert "no scorer artifact resolved" in detail
+
+
+def test_resolve_learned_scorer_raises_artifact_absent_when_nothing_resolves(monkeypatch):
+    monkeypatch.delenv("JANASUNANI_SPAM_SCORER_ARTIFACT", raising=False)
+    monkeypatch.setenv("JANASUNANI_MODELS_DIR", "/nonexistent-for-this-test")
+    with pytest.raises(ScorerArtifactAbsent):
+        _resolve_learned_scorer()
+
+
+def test_resolve_learned_scorer_raises_loader_unimplemented_when_an_artifact_exists(
+    tmp_path, monkeypatch
+):
+    artifact = tmp_path / "spam_scorer"
+    artifact.write_bytes(b"not a real model, just needs to be a usable path")
+    monkeypatch.setenv("JANASUNANI_SPAM_SCORER_ARTIFACT", str(artifact))
+    with pytest.raises(ScorerLoaderUnimplemented):
+        _resolve_learned_scorer()
+
+
+def test_triage_status_distinguishes_absent_artifact_from_unimplemented_loader(
+    tmp_path, monkeypatch
+):
+    """Codex finding on #234: these are different operator states.
+
+    Absent means "train and publish an artifact". Present-but-unimplemented
+    means "write the loader" -- publishing another artifact will not help.
+    Collapsing both into "no scorer artifact resolved" sends an operator to
+    fix the wrong thing.
+    """
+    artifact = tmp_path / "spam_scorer"
+    artifact.write_bytes(b"not a real model, just needs to be a usable path")
+    monkeypatch.setenv(TRIAGE_ENV_VAR, TRIAGE_MODEL)
+    monkeypatch.setenv("JANASUNANI_SPAM_SCORER_ARTIFACT", str(artifact))
+
+    name, ok, detail = triage_status()
+    assert name == TRIAGE_BOUNDED
+    assert ok is False
+    assert "loader is not implemented" in detail
+    # Distinct from the absent-artifact wording covered by the test above.
+    assert "no scorer artifact resolved" not in detail
+
+
+def test_triage_provider_falls_back_to_bounded_when_the_loader_is_unimplemented(
+    tmp_path, monkeypatch
+):
+    """The request path degrades the same way for both failure states.
+
+    Only the diagnostic in `triage_status` needs to tell them apart; a live
+    submission must reach the bounded scorer either way, never an error.
+    """
+    artifact = tmp_path / "spam_scorer"
+    artifact.write_bytes(b"not a real model, just needs to be a usable path")
+    monkeypatch.setenv("JANASUNANI_SPAM_SCORER_ARTIFACT", str(artifact))
+
+    provider = triage_provider_from_env(TRIAGE_MODEL)
+    assert isinstance(provider, UnwiredTriageProvider)
 
 
 # --- a broken learned scorer must never reach the citizen -------------------
@@ -343,3 +402,90 @@ def test_router_status_rejects_an_empty_crosswalk(tmp_path, monkeypatch):
     # Distinct from the missing/corrupt wording, which need different fixes.
     assert "missing" not in detail
     assert "unreadable or structurally invalid" not in detail
+
+
+def test_router_status_rejects_a_crosswalk_with_no_eligible_route(tmp_path, monkeypatch):
+    """Codex finding on #234: a non-empty ``by_category`` can still route nowhere.
+
+    ``Crosswalk.lookup`` refuses a candidate below ``MIN_CONFIDENCE`` (0.3).
+    Confidence is ``share * evidence(support)``; a row with ``support=3``
+    (the minimum ``_valid_entry`` accepts) and ``share=0.1`` scores about
+    0.026 -- the exact example from the finding. A table where every entry
+    is this thin is structurally valid, loads without error, and is
+    non-empty, but a real ``crosswalk.lookup`` call against every category in
+    it returns ``None`` every time -- exactly what a live request would get.
+    The previous check (``by_category`` non-empty) reported ``ok=True`` for
+    this file; this must not.
+    """
+    import json
+
+    import janasunani.routing.crosswalk as crosswalk_mod
+
+    thin = tmp_path / "routing_crosswalk.json"
+    thin.write_text(
+        json.dumps(
+            {
+                "by_full": {},
+                "by_subcategory": {},
+                "by_category_district": {},
+                "by_category": {
+                    "general||": {"dept": "General Administration", "support": 3, "share": 0.1},
+                    "housing||": {"dept": "Housing Dept", "support": 3, "share": 0.1},
+                },
+            }
+        )
+    )
+    monkeypatch.setattr(crosswalk_mod, "DEFAULT_ARTIFACT", thin)
+    monkeypatch.delenv(ROUTER_ENV_VAR, raising=False)
+
+    # Confirm the premise directly against the real `Crosswalk.lookup`, not
+    # just against `router_status`'s report of it.
+    crosswalk = crosswalk_mod.load_crosswalk(thin)
+    assert crosswalk is not None
+    assert crosswalk.by_category  # non-empty: the old gate would have passed it
+    assert crosswalk.lookup(category="general") is None
+    assert crosswalk.lookup(category="housing") is None
+
+    name, ok, detail = router_status()
+    assert name == ROUTER_DEFAULT
+    assert ok is False
+    assert "confidence floor" in detail
+    # Distinct from the empty-table wording -- this table has entries.
+    assert "empty" not in detail
+
+
+def test_router_status_accepts_a_crosswalk_with_at_least_one_eligible_route(
+    tmp_path, monkeypatch
+):
+    """The positive control for the fix above: one strong entry is enough."""
+    import json
+
+    import janasunani.routing.crosswalk as crosswalk_mod
+
+    mixed = tmp_path / "routing_crosswalk.json"
+    mixed.write_text(
+        json.dumps(
+            {
+                "by_full": {},
+                "by_subcategory": {},
+                "by_category_district": {},
+                "by_category": {
+                    # Too thin to clear MIN_CONFIDENCE on its own.
+                    "general||": {"dept": "General Administration", "support": 3, "share": 0.1},
+                    # Well-attested and concentrated: clears it easily.
+                    "housing||": {"dept": "Housing Dept", "support": 500, "share": 0.9},
+                },
+            }
+        )
+    )
+    monkeypatch.setattr(crosswalk_mod, "DEFAULT_ARTIFACT", mixed)
+    monkeypatch.delenv(ROUTER_ENV_VAR, raising=False)
+
+    crosswalk = crosswalk_mod.load_crosswalk(mixed)
+    assert crosswalk is not None
+    assert crosswalk.lookup(category="housing") is not None
+
+    name, ok, detail = router_status()
+    assert name == ROUTER_DEFAULT
+    assert ok is True
+    assert "learned" in detail

--- a/tests/test_scorer_seams.py
+++ b/tests/test_scorer_seams.py
@@ -273,3 +273,36 @@ def test_an_injected_router_is_the_one_the_processor_uses():
     )
     assert router.calls, "the injected router was bypassed"
     assert result.routing.dept == "Test Department"
+
+
+def test_router_status_rejects_a_corrupt_crosswalk(tmp_path, monkeypatch):
+    """Codex finding on #234: presence is not validity.
+
+    `load_crosswalk` returns None for a file that exists but is corrupt, and
+    the router then falls through to the mapping tables. A status probe based
+    on `is_file()` reports "first rung is learned" for exactly that file,
+    reproducing the false assurance the probe exists to prevent.
+    """
+    import janasunani.routing.crosswalk as crosswalk_mod
+
+    corrupt = tmp_path / "routing_crosswalk.json"
+    corrupt.write_text("{not valid json")
+    monkeypatch.setattr(crosswalk_mod, "DEFAULT_ARTIFACT", corrupt)
+    monkeypatch.delenv(ROUTER_ENV_VAR, raising=False)
+
+    name, ok, detail = router_status()
+    assert name == ROUTER_DEFAULT
+    assert ok is False
+    assert "unreadable or structurally invalid" in detail
+
+
+def test_router_status_distinguishes_missing_from_corrupt(tmp_path, monkeypatch):
+    """The two need different operator actions, so they must read differently."""
+    import janasunani.routing.crosswalk as crosswalk_mod
+
+    monkeypatch.setattr(crosswalk_mod, "DEFAULT_ARTIFACT", tmp_path / "absent.json")
+    monkeypatch.delenv(ROUTER_ENV_VAR, raising=False)
+
+    _, ok, detail = router_status()
+    assert ok is False
+    assert "missing" in detail

--- a/tests/test_scorer_seams.py
+++ b/tests/test_scorer_seams.py
@@ -306,3 +306,40 @@ def test_router_status_distinguishes_missing_from_corrupt(tmp_path, monkeypatch)
     _, ok, detail = router_status()
     assert ok is False
     assert "missing" in detail
+
+
+def test_router_status_rejects_an_empty_crosswalk(tmp_path, monkeypatch):
+    """Codex finding on #234: loading successfully is not the same as usable.
+
+    All four tables empty is structurally valid -- ``_valid_table({})``
+    succeeds -- so `load_crosswalk` returns a non-None `Crosswalk` for this
+    file. Every lookup still misses and falls through to the mapping tables,
+    so reporting "first rung is learned" here reproduces the exact false
+    assurance this probe exists to prevent, just from a different cause than
+    the corrupt-file case above.
+    """
+    import json
+
+    import janasunani.routing.crosswalk as crosswalk_mod
+
+    empty = tmp_path / "routing_crosswalk.json"
+    empty.write_text(
+        json.dumps(
+            {
+                "by_full": {},
+                "by_subcategory": {},
+                "by_category_district": {},
+                "by_category": {},
+            }
+        )
+    )
+    monkeypatch.setattr(crosswalk_mod, "DEFAULT_ARTIFACT", empty)
+    monkeypatch.delenv(ROUTER_ENV_VAR, raising=False)
+
+    name, ok, detail = router_status()
+    assert name == ROUTER_DEFAULT
+    assert ok is False
+    assert "empty" in detail
+    # Distinct from the missing/corrupt wording, which need different fixes.
+    assert "missing" not in detail
+    assert "unreadable or structurally invalid" not in detail


### PR DESCRIPTION
First of three PRs from the approved plan. This one is the seam; the measurement work follows.

## The diagnosis

Both seams were already 90% built and neither could be swapped.

`TriageProvider` (`serving/triage.py:34`) and a private `_Router` (`inference/service.py:64`) Protocols existed. `PipelineGrievanceProcessor` already accepted both by constructor injection. Tests already exercised the seam.

But `build_processor` hard-coded `router=DEFAULT_ROUTER` and never passed `triage_provider` at all. **Two missing parameters were the whole problem.**

## What changed

| File | Change |
|---|---|
| `routing/provider.py` (new) | `RoutingProvider` promoted from private `_Router`; `router_from_env`; `router_status` |
| `pipeline/spam.py` | `SpamScorer` Protocol, `BoundedSpamScorer` |
| `serving/triage.py` | `triage_provider_from_env`, `ScoredTriageProvider`, `OffTriageProvider`, `triage_status` |
| `tracking/artifacts.py` (new) | `resolve_artifact` — the read half `mlflow_utils` never had |
| `inference/service.py` | the two injection points, plus `_router_check` / `_triage_check` in preflight |

Existing patterns reused rather than invented: the Protocol shape from `TriageProvider`, the selection shape from `supervisor_provider_from_env`, the degradation contract from `crosswalk.load_crosswalk`. `PROVIDER_REGISTRY` deliberately not copied — it registers governance metadata, not implementations.

## The load-bearing design decision

**A learned scorer returns a `SpamScore`, never a `SpamReview`.** It therefore reaches the wire only through `SpamScore.to_review_fields()`, which is what keeps `reason_code` inside the closed 10-value Literal the serving contract admits. A trained model physically cannot invent a reason code and have it published.

That is enforcement, not convention, and there is a test that hands the seam a scorer which tries exactly that.

## Safety

`ScoredTriageProvider` copies `UnwiredTriageProvider`'s double `except` verbatim. A learned scorer that fails to load, times out, or returns nonsense degrades to advisory-unavailable. It never blocks a citizen's submission and never surfaces a trace. Tested with an exploding scorer, an unavailable scorer, and an out-of-taxonomy scorer.

`resolve_artifact` never raises for any input, and treats an **empty directory as absent** — that is the shape a failed `dvc pull` leaves behind, and reporting it as present is how a box ends up loading nothing while claiming a model is live.

## Why the status probes matter

PERFORMANCE.md recorded a live submission returning `method:"fallback"` while the crosswalk artifact was present and believed live. Nothing surfaced it. Preflight now says which rung answers first:

    router (crosswalk): crosswalk artifact present; first rung is learned
    triage (bounded):   bounded heuristic scorer (spam-v1-bounded); not a learned model

The second line is a narrative guard as much as an operational one. What ships today is a deterministic cascade. A demo describing it as a trained model would be claiming #74 without having built it.

## Deliberately not in this PR

- **`method="model"` and a model-shaped evidence variant.** `EmpiricalRoutingEvidence.width` is a closed Literal of crosswalk rung names, so a trained model cannot express "probability" in it. Widening a frozen response enum with no frontend branch would let the demo emit a badge the UI has no prose for. Staged post-demo: schema, then frontend, then producer.
- **MLflow registry resolution.** Stubbed with a named seam. It would put a network call on the startup path of a box that has to come up in front of an audience.

## Gate

    uv run ruff check .   -> All checks passed!
    uv run --extra serving --extra pipeline-core pytest -> 1300 passed, 8 skipped

24 new tests in `tests/test_scorer_seams.py`.

Refs #74, #106, #33
---

## Merge note — Codex review round skipped

Merged without a further Codex round at the repository owner's explicit direction: *"the codex reviews keep returning issues each time without converging ... please then merge it idc"*.

Recording this plainly rather than implying a policy basis: `CONTRIBUTING.md` scopes the `codex-review-not-required` label to config-only branches and to Codex being out of review credits. **Neither applies here.** This is a deliberate override by the repository owner, labelled so the exception is visible in the record.

All findings raised on this PR were replied to in-thread and resolved. Any finding not fixed here is filed as a tracked issue rather than dropped.
