### PR TITLE
evaluation: extract stats.py, fix critical-value and small-cluster defects

### DIFF
--- a/janasunani/evaluation/sarvam_scorecard.py
+++ b/janasunani/evaluation/sarvam_scorecard.py
@@ -37,17 +37,21 @@ recorded Sarvam markdown fixtures; no live network call is made.
 from __future__ import annotations
 
 import json
-import math
 import random
 import re
 import unicodedata
 from collections import defaultdict
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from statistics import NormalDist
 from typing import Any
 
 from janasunani.config import DEMO_SLICE_DISTRICT, DEMO_SLICE_LABEL, DEMO_SLICE_YEAR
+from janasunani.evaluation.stats import (
+    clustered_se as _clustered_se,
+    critical_value,
+    paired_difference as paired_difference,
+    required_pages_mcnemar as required_pages_mcnemar,
+)
 
 NORMALIZER_VERSION = "1.0"
 
@@ -175,92 +179,34 @@ class PageRecord:
 # ---------------------------------------------------------------------------
 # Paired estimator with ticket-clustered SE
 # ---------------------------------------------------------------------------
-
-def _clustered_se(diffs: list[float], clusters: list[str]) -> float:
-    """Cluster-robust SE for the mean of ``diffs`` clustered by ``clusters``.
-
-    Uses the sandwich estimator for a mean:
-      Var = sum_c (sum_{i in c} (d_i - mean))^2 / n^2 * C/(C-1)
-    where n = len(diffs), C = number of clusters. When C == 1 or C == n,
-    reduces to the usual variance of the mean (with finite-sample correction).
-    Returns 0.0 for n < 2.
-    """
-    n = len(diffs)
-    if n < 2:
-        return 0.0
-    mean = sum(diffs) / n
-    # per-cluster sum of deviations
-    cluster_sums: dict[str, float] = defaultdict(float)
-    for d, c in zip(diffs, clusters):
-        cluster_sums[c] += d - mean
-    C = len(cluster_sums)
-    summed_sq = sum(s * s for s in cluster_sums.values())
-    # finite-sample correction for clusters; when C==1 fall back to simple
-    if C <= 1:
-        # simple SE: sqrt( sum (d - mean)^2 / (n*(n-1)) )
-        s2 = sum((d - mean) ** 2 for d in diffs) / (n - 1) if n > 1 else 0.0
-        return math.sqrt(s2 / n) if n else 0.0
-    correction = C / (C - 1)
-    var = summed_sq / (n * n) * correction
-    # numerical guard
-    if var < 0:
-        var = 0.0
-    return math.sqrt(var)
-
-
-def paired_difference(
-    a_correct: list[int],
-    b_correct: list[int],
-    clusters: list[str],
-    alpha: float = 0.05,
-) -> dict[str, float]:
-    """Paired difference in accuracy with ticket-clustered CI.
-
-    Args:
-      a_correct: 1/0 per page for system A (e.g. Sarvam)
-      b_correct: 1/0 per page for system B (e.g. pytesseract/pipeline)
-      clusters: ticket id per page
-      alpha: two-sided level (0.05 -> 95% CI, z=1.96)
-
-    Returns dict with diff, se, z, ci_low, ci_high, n, n_clusters.
-    The difference is mean(a) - mean(b). Positive favours A.
-    """
-    if not (len(a_correct) == len(b_correct) == len(clusters)):
-        raise ValueError("a_correct, b_correct, clusters must have equal length")
-    n = len(a_correct)
-    if n == 0:
-        return {"diff": 0.0, "se": 0.0, "z": 1.96, "ci_low": 0.0, "ci_high": 0.0, "n": 0, "n_clusters": 0}
-    diffs = [float(a - b) for a, b in zip(a_correct, b_correct)]
-    diff = sum(diffs) / n
-    se = _clustered_se(diffs, clusters)
-    # Normal critical value; for large n the t correction is negligible.
-    # Use 1.96 for 95%, else approximate via normal quantile.
-    if alpha == 0.05:
-        z = 1.96
-    else:
-        # approximate via inverse normal (simple); for non-95% use 1.96 as fallback
-        # Keep dependency-light: use 1.96 for 95% else 2.576 for 99% else 1.645 for 90%
-        if abs(alpha - 0.01) < 1e-9:
-            z = 2.576
-        elif abs(alpha - 0.10) < 1e-9:
-            z = 1.645
-        else:
-            z = 1.96
-    ci_low = diff - z * se
-    ci_high = diff + z * se
-    n_clusters = len(set(clusters))
-    return {"diff": diff, "se": se, "z": z, "ci_low": ci_low, "ci_high": ci_high, "n": n, "n_clusters": n_clusters}
+#
+# ``_clustered_se``, ``paired_difference`` and ``required_pages_mcnemar`` now
+# live in ``janasunani.evaluation.stats`` (see that module's docstring for the
+# two defects fixed on the move: a hardcoded z-lookup that silently returned
+# 1.96 for any alpha outside {0.05, 0.01, 0.10}, and no small-cluster t
+# correction). ``_clustered_se`` is re-exported here under its original
+# private name — via the ``import ... as`` above — so this module's own call
+# sites and ``paired_difference``/``required_pages_mcnemar`` are re-exported
+# by their public names so ``tests/test_sarvam_scorecard.py`` does not churn.
 
 
 def divergence_rate(
     pytesseract_texts: list[str],
     sarvam_markdowns: list[str],
     clusters: list[str],
+    alpha: float = 0.05,
 ) -> dict[str, float]:
     """Divergence rate: share of pages where normalised texts differ.
 
     Used when no transcription referee exists (issue #84 fallback). Reports
     a descriptive disagreement rate with ticket-clustered CI, not a verdict.
+
+    Critical value comes from ``stats.critical_value`` at
+    ``df = n_clusters - 1`` (falling back to the normal quantile for 0 or 1
+    clusters) instead of the previously hardcoded ``z=1.96`` — the same
+    small-cluster t correction applied everywhere else a clustered SE backs
+    a CI in this module; see ``stats.py``. This widens the reported interval
+    versus previously published numbers, which is intended.
     """
     if not (len(pytesseract_texts) == len(sarvam_markdowns) == len(clusters)):
         raise ValueError("inputs must have equal length")
@@ -274,72 +220,18 @@ def divergence_rate(
     # SE for a proportion with clustering: treat disagreements as 1/0 and
     # apply clustered SE for the mean.
     se = _clustered_se([float(x) for x in disagreements], clusters)
-    z = 1.96
-    return {"rate": rate, "se": se, "ci_low": rate - z * se, "ci_high": rate + z * se, "n": n, "n_clusters": len(set(clusters))}
+    n_clusters = len(set(clusters))
+    z = critical_value(alpha, df=(n_clusters - 1 if n_clusters > 1 else None))
+    return {"rate": rate, "se": se, "ci_low": rate - z * se, "ci_high": rate + z * se, "n": n, "n_clusters": n_clusters}
 
 
-def summary_divergence(
-    sarvam_summaries: list[str | None],
-    pipeline_summaries: list[str | None],
-    clusters: list[str],
-) -> dict[str, float]:
-    """Divergence rate for summaries — exploratory, no gold referee.
-
-    Compares Sarvam Extract ``summary`` vs pipeline BART ``summary`` after the
-    same ``normalize_text`` applied to OCR. Cluster-robust SE by ticket, like
-    ``divergence_rate``. ``None`` is treated as empty string so a missing
-    summary on one side counts as divergence; callers that want to omit
-    missing pairs should filter before calling.
-    """
-    if not (len(sarvam_summaries) == len(pipeline_summaries) == len(clusters)):
-        raise ValueError("inputs must have equal length")
-    n = len(sarvam_summaries)
-    if n == 0:
-        return {"rate": 0.0, "se": 0.0, "ci_low": 0.0, "ci_high": 0.0, "n": 0, "n_clusters": 0}
-    disagreements: list[int] = []
-    for a, b in zip(sarvam_summaries, pipeline_summaries):
-        a_norm = normalize_text(a or "")
-        b_norm = normalize_text(b or "")
-        disagreements.append(0 if a_norm == b_norm else 1)
-    rate = sum(disagreements) / n
-    se = _clustered_se([float(x) for x in disagreements], clusters)
-    z = 1.96
-    return {"rate": rate, "se": se, "ci_low": rate - z * se, "ci_high": rate + z * se, "n": n, "n_clusters": len(set(clusters))}
-
-
-# ---------------------------------------------------------------------------
-# Power helpers (McNemar, paired)
-# ---------------------------------------------------------------------------
-
-def required_pages_mcnemar(gap: float, discordance: float, alpha: float = 0.05, power: float = 0.8) -> int:
-    """Approximate required pages for a paired (McNemar) comparison.
-
-    ``gap`` is the accuracy difference to detect (e.g. 0.10 for 10 points),
-    ``discordance`` is the expected share where the two systems disagree.
-    Uses the normal approximation for McNemar's test. Returns ceiling.
-
-    The table in #127 was computed with the same approximation; values are
-    indicative — the recommmended 200-250 stratified sample is powered for
-    ~10 points at 20-30% discordance.
-    """
-    if not (0 < gap < 1 and 0 < gap < discordance <= 1):
-        raise ValueError("need 0 < gap < discordance <= 1")
-    if not 0 < alpha < 1:
-        raise ValueError("alpha must be in (0, 1)")
-    if not 0 < power < 1:
-        raise ValueError("power must be in (0, 1)")
-    # Actual quantiles, not the 0.05/0.80 constants. Both ternaries here
-    # returned the same value on either branch, so asking for 90% power or a
-    # 1% level silently returned the 80%/5% sample size — a deliberately
-    # under-powered study reporting itself as powered, which is the failure
-    # #127 exists to prevent, and every page submitted costs money.
-    z_alpha = NormalDist().inv_cdf(1 - alpha / 2)
-    z_beta = NormalDist().inv_cdf(power)
-    # McNemar: n = (z_alpha*sqrt(p_d) + z_beta*sqrt(p_d - gap^2))^2 / gap^2
-    p_d = discordance
-    numerator = (z_alpha * math.sqrt(p_d) + z_beta * math.sqrt(max(p_d - gap * gap, 1e-9))) ** 2
-    n = numerator / (gap * gap)
-    return int(math.ceil(n))
+# ``summary_divergence`` was byte-identical logic to ``divergence_rate`` with
+# a different docstring (comparing Sarvam Extract ``summary`` vs pipeline
+# BART ``summary`` instead of OCR text) — folded into one implementation.
+# ``None`` still becomes "" via ``normalize_text``'s own None handling, so a
+# missing summary on one side still counts as divergence, matching the old
+# behaviour exactly.
+summary_divergence = divergence_rate
 
 
 # ---------------------------------------------------------------------------

--- a/janasunani/evaluation/stats.py
+++ b/janasunani/evaluation/stats.py
@@ -370,6 +370,10 @@ def stratified_mean(
     The critical value uses ``df = n_strata - 1`` via :func:`critical_value`
     — the same small-sample t-correction as every other estimator here.
 
+    Every stratum must supply at least 2 sampled units and a constant weight
+    across its members, or this raises ``ValueError`` — see the comments in
+    the loop below for why both are hard requirements, not warnings.
+
     ``estimand`` is required, keyword-only, no default — see
     :class:`Estimate`.
     """
@@ -381,6 +385,14 @@ def stratified_mean(
     if n == 0:
         raise ValueError("stratified_mean needs at least one observation")
     w = list(weights) if weights is not None else [1.0] * n
+    if weights is not None:
+        # A Horvitz-Thompson weight is an inverse inclusion probability; it
+        # cannot be zero or negative. Rejecting this here means w_h (the
+        # per-stratum weight sum) can never be <= 0 below, so that no longer
+        # needs its own silent-skip branch.
+        for wt in w:
+            if wt <= 0:
+                raise ValueError("weights must be positive")
 
     by_stratum: dict[str, list[tuple[float, float]]] = defaultdict(list)
     for v, s, wt in zip(values, strata, w):
@@ -393,14 +405,57 @@ def stratified_mean(
 
     var = 0.0
     df_units = 0
-    for members in by_stratum.values():
+    for stratum, members in by_stratum.items():
         n_h = len(members)
-        w_h = sum(wt for _, wt in members)
-        if n_h < 2 or w_h <= 0:
-            continue
-        mean_h = sum(v * wt for v, wt in members) / w_h
-        # The within-stratum sample variance is UNWEIGHTED.
+        # A singleton stratum's within-stratum variance is not estimable --
+        # there is no deviation to measure it from. The previous code
+        # `continue`d past it, which drops its ENTIRE variance contribution
+        # while its weight stays in the point estimate above: values [0, 10]
+        # in strata ['A', 'B'] returned se=0 and the zero-width interval
+        # [5, 5], a silently downward-biased interval, not a conservative
+        # one. That is the dangerous direction, so this raises instead of
+        # guessing.
         #
+        # A real survey design sometimes has a deliberate certainty
+        # stratum (a self-representing unit sampled with probability 1,
+        # contributing zero variance by design) -- but that is a design
+        # decision the caller must make explicitly, not something this
+        # function can infer from n_h == 1 alone. If that is the intent,
+        # exclude the stratum's variance contribution explicitly at the call
+        # site with a comment saying so; otherwise collapse the singleton
+        # into a neighboring stratum, or draw n_h >= 2, before calling this.
+        if n_h < 2:
+            raise ValueError(
+                f"stratum {stratum!r} has only {n_h} sampled unit(s); its "
+                "variance is not estimable. Collapse it into a neighboring "
+                "stratum, or draw n_h >= 2, before calling stratified_mean. "
+                "(If it is a deliberate certainty stratum, exclude its "
+                "variance contribution explicitly at the call site instead "
+                "of relying on this function to guess that.)"
+            )
+        stratum_weights = [wt for _, wt in members]
+        # The within-stratum sample variance below is UNWEIGHTED, which is
+        # only a valid estimator when every unit in the stratum shares the
+        # same inclusion probability (the constant-weight assumption
+        # stratified sampling relies on). The public API accepts arbitrary
+        # per-observation weights, so nothing stopped a caller from passing
+        # a PPS / unequal-probability design here and getting a plausible
+        # but invalid SE back with no warning. Enforce the assumption the
+        # estimator actually relies on instead of leaving it as a comment
+        # nobody reading only the call site would see.
+        first_wt = stratum_weights[0]
+        if any(not math.isclose(wt, first_wt, rel_tol=1e-9, abs_tol=1e-12) for wt in stratum_weights[1:]):
+            raise ValueError(
+                f"stratum {stratum!r} has varying weights within it "
+                f"({sorted(set(stratum_weights))}); stratified_mean's "
+                "variance estimator assumes a constant weight (constant "
+                "inclusion probability) within each stratum. Split the "
+                "stratum so weights are constant within each part, or use a "
+                "different estimator for unequal-probability (PPS) sampling "
+                "-- this function does not implement one."
+            )
+        w_h = sum(stratum_weights)
+        mean_h = sum(v * wt for v, wt in members) / w_h
         # Weighting the squared deviations and still dividing by (n_h - 1)
         # inflates s2_h by the weight itself, and the stratum share below
         # already carries the population size, so the weight was being counted
@@ -410,12 +465,6 @@ def stratified_mean(
         # It bit only the weighted path, which is why the unweighted tests
         # never saw it -- and the weighted path is the one an inverse-
         # probability sample uses, so it was wrong exactly where it matters.
-        #
-        # This assumes inclusion probability is constant WITHIN a stratum,
-        # which is what stratified sampling means and what the sample frame
-        # guarantees by construction. Unequal probabilities within one stratum
-        # would need a different estimator, and would mean the strata are
-        # mis-specified.
         s2_h = sum((v - mean_h) ** 2 for v, _wt in members) / (n_h - 1)
         fpc = 1.0
         if w_h > n_h:

--- a/janasunani/evaluation/stats.py
+++ b/janasunani/evaluation/stats.py
@@ -96,6 +96,18 @@ def clustered_se(values: Sequence[float], clusters: Sequence[str]) -> float:
     critical value itself.
     """
     n = len(values)
+    if n != len(clusters):
+        # `zip` would truncate to the shorter sequence, so the unmatched
+        # observations would drop out of the cluster sums while `n` and the
+        # mean still counted them. That does not fail: it returns a smaller,
+        # plausible-looking SE for a design that was never estimated. Same
+        # failure shape as the two defects this module was extracted to fix,
+        # so it is rejected rather than tolerated. `paired_difference` already
+        # validates lengths this way.
+        raise ValueError(
+            f"clustered_se needs one cluster label per value: got {n} values "
+            f"and {len(clusters)} cluster labels"
+        )
     if n < 2:
         return 0.0
     mean = sum(values) / n

--- a/janasunani/evaluation/stats.py
+++ b/janasunani/evaluation/stats.py
@@ -1,0 +1,536 @@
+"""Statistics primitives shared across evaluation scorecards.
+
+Lifted out of ``sarvam_scorecard.py`` (see #127, #84) where the only
+estimator in this repo — a cluster-robust sandwich SE for a mean — lived
+private and had already been copy-pasted verbatim into
+``scripts/benchmark_pipeline.py``. Every confidence interval this repo
+publishes traces back to that one function, so it is public, tested here in
+isolation, and fixed on the way out:
+
+* **Defect (a) — wrong critical value for non-standard alpha.** The old code
+  (``sarvam_scorecard.paired_difference``, formerly lines 238-248) was a
+  lookup table for ``{0.05, 0.01, 0.10}`` that silently fell back to
+  ``z=1.96`` for *any other* alpha — a 90%-CI-shaped bug that never raised.
+  ``required_pages_mcnemar`` in the same module already computed critical
+  values correctly via ``NormalDist().inv_cdf``; :func:`critical_value` below
+  is that fix, generalised and made the one path every caller uses.
+* **Defect (b) — no small-cluster correction.** A clustered SE is a sandwich
+  estimator with ``C - 1`` effective degrees of freedom, not infinite. This
+  repo's benchmark designs run 30-40 clusters (tickets/documents), where
+  ``t(29) = 2.045`` vs ``z = 1.96`` — about 4% wider. Every clustered SE in
+  this module now defaults to the ``t`` quantile at ``df = n_clusters - 1``
+  instead of the normal quantile. This widens every published CI that used
+  the old code; that widening is correct, not a regression.
+
+Pure stdlib — no scipy, no numpy (numpy sits in a conflicting extra; see
+``[tool.uv].conflicts``). :func:`t_quantile` inverts the Student's t CDF via
+the regularized incomplete beta function (continued-fraction evaluation,
+Numerical Recipes ``betacf``) and bisection. This is mathematically the same
+quantile Hill's (1970) Algorithm 396 approximates directly; bisection on the
+incomplete-beta relation was chosen over reconstructing Hill's rational
+approximation from memory because it is easy to verify against a published
+table by hand and cannot silently drift from the true quantile the way a
+mistyped polynomial coefficient would.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import defaultdict
+from collections.abc import Sequence
+from dataclasses import dataclass
+from statistics import NormalDist
+
+# ---------------------------------------------------------------------------
+# Estimate — the container every estimator below returns
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Estimate:
+    """A point estimate with its interval and the population it describes.
+
+    Every field is required — in particular ``estimand``, which is not a
+    label of convenience. A confidence interval with no stated estimand is
+    how a 300-page stratified sample's category-accuracy difference gets
+    read, three slides later, as a claim about all 1.37M complaints in the
+    lake. Making the field mandatory pushes that question onto the type
+    system instead of relying on whoever writes the report remembering to
+    say it: every ``Estimate`` must say, in one line, what population this
+    number is about (e.g. "category accuracy difference on the 312-page
+    Sambalpur/2024 stratified sample", not "category accuracy").
+    """
+
+    point: float
+    se: float
+    ci_low: float
+    ci_high: float
+    n: int
+    n_clusters: int
+    alpha: float
+    method: str
+    weighted: bool
+    estimand: str
+
+
+# ---------------------------------------------------------------------------
+# Cluster-robust SE for a mean
+# ---------------------------------------------------------------------------
+
+
+def clustered_se(values: Sequence[float], clusters: Sequence[str]) -> float:
+    """Cluster-robust SE for the mean of ``values`` clustered by ``clusters``.
+
+    Sandwich estimator for a mean:
+
+        Var = sum_c (sum_{i in c} (x_i - mean))^2 / n^2 * C/(C-1)
+
+    where ``n = len(values)``, ``C`` = number of distinct clusters. When
+    ``C <= 1`` (no cluster structure, or everything in one cluster), falls
+    back to the ordinary variance of the mean. Returns 0.0 for ``n < 2``.
+
+    Maths unchanged from the original private
+    ``sarvam_scorecard._clustered_se`` (#127) — this is that function, made
+    public. Pairs with :func:`critical_value` (``df=n_clusters - 1``) to turn
+    this SE into a confidence interval; this function does not pick the
+    critical value itself.
+    """
+    n = len(values)
+    if n < 2:
+        return 0.0
+    mean = sum(values) / n
+    cluster_sums: dict[str, float] = defaultdict(float)
+    for v, c in zip(values, clusters):
+        cluster_sums[c] += v - mean
+    num_clusters = len(cluster_sums)
+    summed_sq = sum(s * s for s in cluster_sums.values())
+    if num_clusters <= 1:
+        # simple SE: sqrt( sum (x - mean)^2 / (n*(n-1)) )
+        s2 = sum((v - mean) ** 2 for v in values) / (n - 1) if n > 1 else 0.0
+        return math.sqrt(s2 / n) if n else 0.0
+    correction = num_clusters / (num_clusters - 1)
+    var = summed_sq / (n * n) * correction
+    if var < 0:  # numerical guard
+        var = 0.0
+    return math.sqrt(var)
+
+
+# ---------------------------------------------------------------------------
+# Student's t quantile — pure stdlib, no scipy/numpy
+# ---------------------------------------------------------------------------
+
+
+def _log_beta(a: float, b: float) -> float:
+    return math.lgamma(a) + math.lgamma(b) - math.lgamma(a + b)
+
+
+def _betacf(x: float, a: float, b: float) -> float:
+    """Continued-fraction evaluation of the incomplete beta function.
+
+    Standard Numerical Recipes ``betacf`` (Lentz's algorithm). Used only by
+    :func:`_betainc` below; not part of the public API.
+    """
+    max_iter = 200
+    eps = 3e-14
+    fpmin = 1e-300
+    qab = a + b
+    qap = a + 1.0
+    qam = a - 1.0
+    c = 1.0
+    d = 1.0 - qab * x / qap
+    if abs(d) < fpmin:
+        d = fpmin
+    d = 1.0 / d
+    h = d
+    for m in range(1, max_iter + 1):
+        m2 = 2 * m
+        aa = m * (b - m) * x / ((qam + m2) * (a + m2))
+        d = 1.0 + aa * d
+        if abs(d) < fpmin:
+            d = fpmin
+        c = 1.0 + aa / c
+        if abs(c) < fpmin:
+            c = fpmin
+        d = 1.0 / d
+        h *= d * c
+        aa = -(a + m) * (qab + m) * x / ((a + m2) * (qap + m2))
+        d = 1.0 + aa * d
+        if abs(d) < fpmin:
+            d = fpmin
+        c = 1.0 + aa / c
+        if abs(c) < fpmin:
+            c = fpmin
+        d = 1.0 / d
+        delta = d * c
+        h *= delta
+        if abs(delta - 1.0) < eps:
+            break
+    return h
+
+
+def _betainc(x: float, a: float, b: float) -> float:
+    """Regularized incomplete beta function I_x(a, b) for 0 <= x <= 1."""
+    if x <= 0.0:
+        return 0.0
+    if x >= 1.0:
+        return 1.0
+    bt = math.exp(-_log_beta(a, b) + a * math.log(x) + b * math.log(1.0 - x))
+    if x < (a + 1.0) / (a + b + 2.0):
+        return bt * _betacf(x, a, b) / a
+    return 1.0 - bt * _betacf(1.0 - x, b, a) / b
+
+
+def _t_cdf(t: float, df: float) -> float:
+    """CDF of Student's t with ``df`` degrees of freedom, via I_x(df/2, 1/2)."""
+    x = df / (df + t * t)
+    prob = _betainc(x, df / 2.0, 0.5)
+    return 1.0 - 0.5 * prob if t >= 0 else 0.5 * prob
+
+
+def t_quantile(p: float, df: float) -> float:
+    """Inverse CDF (quantile) of Student's t with ``df`` degrees of freedom.
+
+    Returns ``x`` such that ``P(T <= x) = p``. ``df`` need not be an integer
+    (a clustered SE's effective ``df`` is ``n_clusters - 1``, always an
+    integer in this repo, but the algorithm does not require it). Monotone
+    bisection on :func:`_t_cdf`, which is itself exact via the incomplete
+    beta relation — see the module docstring for why this replaces a direct
+    port of Hill's (1970) rational approximation.
+    """
+    if not 0.0 < p < 1.0:
+        raise ValueError("p must be in (0, 1)")
+    if df <= 0:
+        raise ValueError("df must be positive")
+    if p == 0.5:
+        return 0.0
+    lo, hi = -1.0, 1.0
+    while _t_cdf(lo, df) > p:
+        lo *= 2.0
+    while _t_cdf(hi, df) < p:
+        hi *= 2.0
+    for _ in range(200):
+        mid = (lo + hi) / 2.0
+        if hi - lo < 1e-12:
+            break
+        if _t_cdf(mid, df) < p:
+            lo = mid
+        else:
+            hi = mid
+    return (lo + hi) / 2.0
+
+
+def critical_value(alpha: float, *, df: float | None = None) -> float:
+    """Two-sided critical value for a ``1 - alpha`` confidence interval.
+
+    ``df=None`` uses the normal quantile (``NormalDist().inv_cdf``) — the
+    asymptotic case, or a caller with no cluster structure. ``df`` given uses
+    the Student's t quantile at that many degrees of freedom, which is wider
+    for small ``df`` and converges to the normal quantile as ``df`` grows.
+
+    This is **defect (a)**'s fix: the code this replaced
+    (``sarvam_scorecard.paired_difference``, formerly lines 238-248) was a
+    lookup table for ``alpha in {0.05, 0.01, 0.10}`` that silently returned
+    ``z=1.96`` for any other alpha — an unannounced 90%-CI substitution.
+    ``required_pages_mcnemar`` in the same module already did this correctly;
+    every caller of a clustered SE in this module now goes through here.
+    """
+    if not 0.0 < alpha < 1.0:
+        raise ValueError("alpha must be in (0, 1)")
+    p = 1.0 - alpha / 2.0
+    if df is None:
+        return NormalDist().inv_cdf(p)
+    if df <= 0:
+        raise ValueError("df must be positive")
+    return t_quantile(p, df)
+
+
+def _df_for_clusters(n_clusters: int) -> float | None:
+    """``n_clusters - 1`` when there is cluster structure to correct for.
+
+    Shared by every clustered-SE call site so "default df = C - 1 wherever a
+    clustered SE is used" is one decision, not one per caller. Falls back to
+    ``None`` (normal quantile) when there are 0 or 1 clusters, where a t
+    quantile is undefined.
+    """
+    return n_clusters - 1 if n_clusters > 1 else None
+
+
+# ---------------------------------------------------------------------------
+# Proportion confidence intervals
+# ---------------------------------------------------------------------------
+
+
+def wilson_interval(successes: int, n: int, alpha: float = 0.05) -> Estimate:
+    """Wilson score interval for a binomial proportion.
+
+    No proportion CI existed anywhere in this repo before this module; the
+    scorecards computed proportions (divergence rates, PII detection rates)
+    and reported a plain normal interval, which can leave ``[0, 1]`` and
+    collapses to a zero-width interval at ``successes=0`` or
+    ``successes=n`` — exactly the shape a 0/89 PII-detection cell produces.
+    Wilson's interval is bounded in ``[0, 1]`` by construction and does not
+    collapse at the extremes.
+
+    ``se`` on the returned :class:`Estimate` is the naive Wald SE
+    (``sqrt(p_hat * (1 - p_hat) / n)``), reported for reference only — it is
+    *not* what determines ``ci_low``/``ci_high``, which come from inverting
+    the score test directly. ``estimand`` describes the proportion measured
+    (e.g. "PII detection rate on the redaction gold set"), not restated here
+    since it is caller-supplied.
+    """
+    if n <= 0:
+        raise ValueError("n must be positive")
+    if not 0 <= successes <= n:
+        raise ValueError("successes must be in [0, n]")
+    z = critical_value(alpha)
+    p_hat = successes / n
+    denom = 1.0 + z * z / n
+    center = p_hat + z * z / (2 * n)
+    margin = z * math.sqrt(p_hat * (1 - p_hat) / n + z * z / (4 * n * n))
+    ci_low = max(0.0, (center - margin) / denom)
+    ci_high = min(1.0, (center + margin) / denom)
+    wald_se = math.sqrt(p_hat * (1 - p_hat) / n)
+    return Estimate(
+        point=p_hat,
+        se=wald_se,
+        ci_low=ci_low,
+        ci_high=ci_high,
+        n=n,
+        n_clusters=n,
+        alpha=alpha,
+        method="wilson",
+        weighted=False,
+        estimand=f"proportion ({successes}/{n})",
+    )
+
+
+def agresti_coull(successes: int, n: int, alpha: float = 0.05) -> Estimate:
+    """Agresti-Coull interval for a binomial proportion.
+
+    Simpler-to-explain cousin of :func:`wilson_interval`: add ``z^2 / 2``
+    "successes" and ``z^2`` "trials" before computing a plain Wald interval
+    on the adjusted proportion. Bounded in ``[0, 1]`` for the same reason
+    Wilson is; offered alongside Wilson because different consumers of a
+    scorecard expect different textbook conventions for a small-sample
+    proportion CI.
+    """
+    if n <= 0:
+        raise ValueError("n must be positive")
+    if not 0 <= successes <= n:
+        raise ValueError("successes must be in [0, n]")
+    z = critical_value(alpha)
+    n_tilde = n + z * z
+    p_tilde = (successes + z * z / 2.0) / n_tilde
+    margin = z * math.sqrt(p_tilde * (1 - p_tilde) / n_tilde)
+    ci_low = max(0.0, p_tilde - margin)
+    ci_high = min(1.0, p_tilde + margin)
+    return Estimate(
+        point=p_tilde,
+        se=math.sqrt(p_tilde * (1 - p_tilde) / n_tilde),
+        ci_low=ci_low,
+        ci_high=ci_high,
+        n=n,
+        n_clusters=n,
+        alpha=alpha,
+        method="agresti-coull",
+        weighted=False,
+        estimand=f"proportion ({successes}/{n}, Agresti-Coull adjusted)",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stratified (Horvitz-Thompson) mean
+# ---------------------------------------------------------------------------
+
+
+def stratified_mean(
+    values: Sequence[float],
+    strata: Sequence[str],
+    weights: Sequence[float] | None = None,
+    *,
+    alpha: float = 0.05,
+    estimand: str,
+) -> Estimate:
+    """Horvitz-Thompson stratified mean with per-stratum variance and FPC.
+
+    ``weights`` are Horvitz-Thompson (inverse inclusion-probability) weights,
+    one per observation; omit for an unweighted stratified mean, in which
+    case every unit gets weight 1 and, with a single stratum, this reduces
+    exactly to the ordinary sample mean and its SRS variance (design effect
+    1 — see the test of the same name).
+
+    Within each stratum the estimated population size is
+    ``N_h_hat = sum(weights in stratum)`` and the sample size is
+    ``n_h = count in stratum``. The finite-population correction
+    ``(N_h_hat - n_h) / (N_h_hat - 1)`` is applied to that stratum's
+    contribution to the variance whenever ``N_h_hat > n_h`` (real
+    finite-population information was supplied via the weights); otherwise
+    the correction is 1 (no FPC), which is what an unweighted call gets.
+
+    The critical value uses ``df = n_strata - 1`` via :func:`critical_value`
+    — the same small-sample t-correction as every other estimator here.
+
+    ``estimand`` is required, keyword-only, no default — see
+    :class:`Estimate`.
+    """
+    n = len(values)
+    if len(strata) != n:
+        raise ValueError("values and strata must have equal length")
+    if weights is not None and len(weights) != n:
+        raise ValueError("weights must have the same length as values")
+    if n == 0:
+        raise ValueError("stratified_mean needs at least one observation")
+    w = list(weights) if weights is not None else [1.0] * n
+
+    by_stratum: dict[str, list[tuple[float, float]]] = defaultdict(list)
+    for v, s, wt in zip(values, strata, w):
+        by_stratum[s].append((v, wt))
+
+    total_weight = sum(w)
+    if total_weight <= 0:
+        raise ValueError("total weight must be positive")
+    point = sum(v * wt for v, wt in zip(values, w)) / total_weight
+
+    var = 0.0
+    for members in by_stratum.values():
+        n_h = len(members)
+        w_h = sum(wt for _, wt in members)
+        if n_h < 2 or w_h <= 0:
+            continue
+        mean_h = sum(v * wt for v, wt in members) / w_h
+        s2_h = sum(wt * (v - mean_h) ** 2 for v, wt in members) / (n_h - 1)
+        fpc = 1.0
+        if w_h > n_h:
+            fpc = (w_h - n_h) / (w_h - 1)
+        stratum_weight_share = w_h / total_weight
+        var += (stratum_weight_share**2) * fpc * s2_h / n_h
+
+    se = math.sqrt(var) if var > 0 else 0.0
+    n_strata = len(by_stratum)
+    z = critical_value(alpha, df=_df_for_clusters(n_strata))
+    return Estimate(
+        point=point,
+        se=se,
+        ci_low=point - z * se,
+        ci_high=point + z * se,
+        n=n,
+        n_clusters=n_strata,
+        alpha=alpha,
+        method="stratified-mean-horvitz-thompson",
+        weighted=weights is not None,
+        estimand=estimand,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Paired difference with ticket-clustered CI
+# ---------------------------------------------------------------------------
+
+
+def paired_difference(
+    a_correct: Sequence[int],
+    b_correct: Sequence[int],
+    clusters: Sequence[str],
+    alpha: float = 0.05,
+) -> dict[str, float]:
+    """Paired difference in accuracy with ticket-clustered CI.
+
+    Args:
+      a_correct: 1/0 per page for system A (e.g. Sarvam)
+      b_correct: 1/0 per page for system B (e.g. pytesseract/pipeline)
+      clusters: ticket id per page
+      alpha: two-sided level (0.05 -> 95% CI)
+
+    Returns dict with diff, se, z, ci_low, ci_high, n, n_clusters.
+    The difference is mean(a) - mean(b). Positive favours A.
+
+    Moved from ``sarvam_scorecard.paired_difference`` (formerly lines
+    211-252) with both defects fixed in place: the critical value now comes
+    from :func:`critical_value` for arbitrary alpha (defect a), at
+    ``df = n_clusters - 1`` (defect b) instead of a hardcoded ``z=1.96``.
+    Both fixes widen every previously published CI from this function; see
+    the module docstring.
+    """
+    if not (len(a_correct) == len(b_correct) == len(clusters)):
+        raise ValueError("a_correct, b_correct, clusters must have equal length")
+    n = len(a_correct)
+    if n == 0:
+        return {
+            "diff": 0.0,
+            "se": 0.0,
+            "z": critical_value(alpha),
+            "ci_low": 0.0,
+            "ci_high": 0.0,
+            "n": 0,
+            "n_clusters": 0,
+        }
+    diffs = [float(a - b) for a, b in zip(a_correct, b_correct)]
+    diff = sum(diffs) / n
+    se = clustered_se(diffs, clusters)
+    n_clusters = len(set(clusters))
+    crit = critical_value(alpha, df=_df_for_clusters(n_clusters))
+    ci_low = diff - crit * se
+    ci_high = diff + crit * se
+    return {
+        "diff": diff,
+        "se": se,
+        "z": crit,
+        "ci_low": ci_low,
+        "ci_high": ci_high,
+        "n": n,
+        "n_clusters": n_clusters,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Power (McNemar, paired) — already correct; moved unchanged
+# ---------------------------------------------------------------------------
+
+
+def required_pages_mcnemar(gap: float, discordance: float, alpha: float = 0.05, power: float = 0.8) -> int:
+    """Approximate required pages for a paired (McNemar) comparison.
+
+    ``gap`` is the accuracy difference to detect (e.g. 0.10 for 10 points),
+    ``discordance`` is the expected share where the two systems disagree.
+    Uses the normal approximation for McNemar's test. Returns ceiling.
+
+    The table in #127 was computed with the same approximation; values are
+    indicative — the recommmended 200-250 stratified sample is powered for
+    ~10 points at 20-30% discordance.
+
+    Moved unchanged from ``sarvam_scorecard.required_pages_mcnemar`` (formerly
+    lines 314-342) — this one already used real quantiles
+    (``NormalDist().inv_cdf``) rather than the hardcoded-lookup pattern that
+    was defect (a) elsewhere in the module.
+    """
+    if not (0 < gap < 1 and 0 < gap < discordance <= 1):
+        raise ValueError("need 0 < gap < discordance <= 1")
+    if not 0 < alpha < 1:
+        raise ValueError("alpha must be in (0, 1)")
+    if not 0 < power < 1:
+        raise ValueError("power must be in (0, 1)")
+    # Actual quantiles, not the 0.05/0.80 constants. Both ternaries here
+    # returned the same value on either branch, so asking for 90% power or a
+    # 1% level silently returned the 80%/5% sample size — a deliberately
+    # under-powered study reporting itself as powered, which is the failure
+    # #127 exists to prevent, and every page submitted costs money.
+    z_alpha = NormalDist().inv_cdf(1 - alpha / 2)
+    z_beta = NormalDist().inv_cdf(power)
+    # McNemar: n = (z_alpha*sqrt(p_d) + z_beta*sqrt(p_d - gap^2))^2 / gap^2
+    p_d = discordance
+    numerator = (z_alpha * math.sqrt(p_d) + z_beta * math.sqrt(max(p_d - gap * gap, 1e-9))) ** 2
+    n = numerator / (gap * gap)
+    return int(math.ceil(n))
+
+
+__all__ = [
+    "Estimate",
+    "agresti_coull",
+    "clustered_se",
+    "critical_value",
+    "paired_difference",
+    "required_pages_mcnemar",
+    "stratified_mean",
+    "t_quantile",
+    "wilson_interval",
+]

--- a/janasunani/evaluation/stats.py
+++ b/janasunani/evaluation/stats.py
@@ -392,22 +392,52 @@ def stratified_mean(
     point = sum(v * wt for v, wt in zip(values, w)) / total_weight
 
     var = 0.0
+    df_units = 0
     for members in by_stratum.values():
         n_h = len(members)
         w_h = sum(wt for _, wt in members)
         if n_h < 2 or w_h <= 0:
             continue
         mean_h = sum(v * wt for v, wt in members) / w_h
-        s2_h = sum(wt * (v - mean_h) ** 2 for v, wt in members) / (n_h - 1)
+        # The within-stratum sample variance is UNWEIGHTED.
+        #
+        # Weighting the squared deviations and still dividing by (n_h - 1)
+        # inflates s2_h by the weight itself, and the stratum share below
+        # already carries the population size, so the weight was being counted
+        # twice. On values [0,2,10,12] with weights [50,50,100,100] that
+        # reported SE 7.05 against a true 0.743, a 9.5x overwide interval.
+        #
+        # It bit only the weighted path, which is why the unweighted tests
+        # never saw it -- and the weighted path is the one an inverse-
+        # probability sample uses, so it was wrong exactly where it matters.
+        #
+        # This assumes inclusion probability is constant WITHIN a stratum,
+        # which is what stratified sampling means and what the sample frame
+        # guarantees by construction. Unequal probabilities within one stratum
+        # would need a different estimator, and would mean the strata are
+        # mis-specified.
+        s2_h = sum((v - mean_h) ** 2 for v, _wt in members) / (n_h - 1)
         fpc = 1.0
         if w_h > n_h:
             fpc = (w_h - n_h) / (w_h - 1)
         stratum_weight_share = w_h / total_weight
         var += (stratum_weight_share**2) * fpc * s2_h / n_h
+        df_units += n_h - 1
 
     se = math.sqrt(var) if var > 0 else 0.0
     n_strata = len(by_stratum)
-    z = critical_value(alpha, df=_df_for_clusters(n_strata))
+    # Degrees of freedom come from the SAMPLED UNITS, sum_h (n_h - 1), not
+    # from the stratum count.
+    #
+    # Strata are not the independent clusters the clustered-SE correction
+    # counts: the variance estimate rests on the within-stratum variances, so
+    # it is those that supply the degrees of freedom. Using n_strata - 1 gave
+    # a two-stratum design df=1 and a critical value of 12.706 no matter how
+    # many units were drawn, so a 300-unit sample got an interval more than
+    # six times too wide. Two- and three-stratum designs are the common case,
+    # which is where it did the most damage.
+    df = df_units if df_units >= 1 else 1
+    z = critical_value(alpha, df=df)
     return Estimate(
         point=point,
         se=se,

--- a/tests/test_evaluation_stats.py
+++ b/tests/test_evaluation_stats.py
@@ -156,6 +156,44 @@ def test_clustered_se_short_input_returns_zero():
     assert clustered_se([], []) == 0.0
 
 
+def test_clustered_se_rejects_mismatched_cluster_length():
+    """Too few labels must raise, not silently drop the unmatched values.
+
+    `zip` truncates to the shorter sequence, so the dropped observations
+    would leave the cluster sums while still counting toward `n` and the
+    mean. The result is a smaller, entirely plausible SE for a design that
+    was never estimated — the same silent-wrong-number shape as the two
+    defects this module was extracted to fix.
+    """
+    with pytest.raises(ValueError, match="one cluster label per value"):
+        clustered_se([1.0, 2.0, 3.0], ["T1", "T2"])
+
+    with pytest.raises(ValueError, match="one cluster label per value"):
+        clustered_se([1.0, 2.0], ["T1", "T2", "T3"])
+
+
+def test_clustered_se_mismatch_would_have_understated_the_se():
+    """Pin the magnitude, so the guard is not mistaken for pedantry.
+
+    Truncation is not a rounding error: dropping one observation from the
+    cluster sums while the mean still counts it changes the reported SE
+    substantially, and always in the direction that makes a result look
+    more certain than the data supports.
+    """
+    values = [0.0, 10.0, 20.0]
+    honest = clustered_se(values, ["T1", "T2", "T3"])
+
+    # What the old code silently computed: third value dropped from the
+    # cluster sums, but n=3 and the 3-value mean retained.
+    mean = sum(values) / 3
+    sums = [values[0] - mean, values[1] - mean]
+    truncated = math.sqrt(sum(s * s for s in sums) / 9 * (2 / 1))
+
+    assert truncated < honest
+    assert truncated == pytest.approx(4.714, abs=1e-3)
+    assert honest == pytest.approx(5.7735, abs=1e-3)
+
+
 # ---------------------------------------------------------------------------
 # Proportion CIs — Wilson and Agresti-Coull
 # ---------------------------------------------------------------------------

--- a/tests/test_evaluation_stats.py
+++ b/tests/test_evaluation_stats.py
@@ -1,0 +1,301 @@
+"""Tests for janasunani.evaluation.stats — the estimator every scorecard CI depends on.
+
+Real-code-path: no mocking, these call the actual maths. The regressions below
+correspond to the two defects fixed when ``_clustered_se`` (formerly private,
+copy-pasted into ``scripts/benchmark_pipeline.py``) was lifted out of
+``sarvam_scorecard.py`` into this module:
+
+  (a) a hardcoded z-lookup that silently returned 1.96 for any alpha outside
+      {0.05, 0.01, 0.10}.
+  (b) no small-cluster t correction, even though the working regime here is
+      30-40 clusters where t(29) = 2.045 vs z = 1.96.
+"""
+
+import math
+import statistics
+
+import pytest
+
+from janasunani.evaluation.stats import (
+    Estimate,
+    agresti_coull,
+    clustered_se,
+    critical_value,
+    paired_difference,
+    required_pages_mcnemar,
+    stratified_mean,
+    t_quantile,
+    wilson_interval,
+)
+
+
+# ---------------------------------------------------------------------------
+# t_quantile — against a published table
+# ---------------------------------------------------------------------------
+
+
+# (p, df, published two-tailed critical value) — standard Student's t table.
+_PUBLISHED_T_TABLE = [
+    (0.975, 1, 12.706),
+    (0.975, 5, 2.571),
+    (0.975, 10, 2.228),
+    (0.975, 20, 2.086),
+    (0.975, 29, 2.045),
+    (0.975, 30, 2.042),
+    (0.975, 60, 2.000),
+    (0.975, 120, 1.980),
+    (0.95, 1, 6.314),
+    (0.95, 10, 1.812),
+    (0.95, 30, 1.697),
+    (0.995, 1, 63.657),
+    (0.995, 10, 3.169),
+    (0.995, 30, 2.750),
+]
+
+
+@pytest.mark.parametrize("p,df,expected", _PUBLISHED_T_TABLE)
+def test_t_quantile_matches_published_table(p, df, expected):
+    got = t_quantile(p, df)
+    assert got == pytest.approx(expected, abs=0.005)
+
+
+def test_t_quantile_symmetric_and_converges_to_normal_for_large_df():
+    # Symmetric: quantile at 1-p is the negative of the quantile at p.
+    assert t_quantile(0.9, 10) == pytest.approx(-t_quantile(0.1, 10), abs=1e-9)
+    # As df grows, t -> normal; 1.96 is the familiar 95% two-sided z.
+    assert t_quantile(0.975, 100_000) == pytest.approx(1.95996, abs=1e-3)
+
+
+def test_t_quantile_rejects_bad_input():
+    with pytest.raises(ValueError):
+        t_quantile(0.0, 10)
+    with pytest.raises(ValueError):
+        t_quantile(1.0, 10)
+    with pytest.raises(ValueError):
+        t_quantile(0.5, 0)
+
+
+# ---------------------------------------------------------------------------
+# critical_value — regression for defect (a)
+# ---------------------------------------------------------------------------
+
+
+def test_critical_value_honours_non_standard_alpha():
+    """The old lookup only knew {0.05, 0.01, 0.10} and fell back to 1.96 for
+    anything else — silently. alpha=0.02 (98% CI) must NOT return 1.96.
+    """
+    z = critical_value(0.02)
+    assert z != pytest.approx(1.96, abs=1e-6)
+    # Independently verified via statistics.NormalDist.
+    assert z == pytest.approx(statistics.NormalDist().inv_cdf(1 - 0.02 / 2), abs=1e-9)
+
+
+def test_critical_value_matches_normal_for_standard_alphas_without_df():
+    assert critical_value(0.05) == pytest.approx(1.959964, abs=1e-5)
+    assert critical_value(0.01) == pytest.approx(2.575829, abs=1e-5)
+    assert critical_value(0.10) == pytest.approx(1.644854, abs=1e-5)
+
+
+def test_critical_value_with_df_uses_t_not_normal():
+    # A small-df critical value must be strictly wider than the normal one.
+    z = critical_value(0.05)
+    t29 = critical_value(0.05, df=29)
+    assert t29 > z
+    assert t29 == pytest.approx(2.045, abs=0.005)
+
+
+def test_critical_value_rejects_bad_alpha():
+    with pytest.raises(ValueError):
+        critical_value(0.0)
+    with pytest.raises(ValueError):
+        critical_value(1.0)
+
+
+# ---------------------------------------------------------------------------
+# clustered_se + paired_difference — regression for defect (b)
+# ---------------------------------------------------------------------------
+
+
+def test_clustered_se_uses_t_when_clusters_are_few():
+    """With few clusters, the CI half-width must come from the t quantile at
+    df = n_clusters - 1, not the normal quantile — this is what makes the
+    30-40 cluster regime ~4% wider than the old code reported.
+    """
+    # 3 tickets (clusters), several pages each — deliberately few clusters.
+    a = [1, 1, 1, 0, 0, 0, 1, 0, 1]
+    b = [0, 0, 0, 0, 0, 0, 0, 0, 0]
+    clusters = ["T1"] * 3 + ["T2"] * 3 + ["T3"] * 3
+    res = paired_difference(a, b, clusters)
+    assert res["n_clusters"] == 3
+    se = clustered_se([float(x - y) for x, y in zip(a, b)], clusters)
+    expected_t_crit = t_quantile(0.975, df=2)
+    assert res["z"] == pytest.approx(expected_t_crit, abs=1e-9)
+    assert res["z"] > 1.96  # the widening defect (b) fixes
+    assert res["ci_high"] - res["ci_low"] == pytest.approx(2 * expected_t_crit * se, abs=1e-9)
+
+
+def test_clustered_se_converges_to_normal_with_many_clusters():
+    # 62 clusters -> df=61 -> t(61) is within a whisker of z.
+    a = [1, 0] * 31
+    b = [0, 0] * 31
+    clusters = [f"T{i}" for i in range(62)]
+    res = paired_difference(a, b, clusters)
+    assert res["n_clusters"] == 62
+    assert res["z"] == pytest.approx(1.96, abs=0.05)
+
+
+def test_clustered_se_matches_naive_variance_for_single_cluster():
+    values = [1.0, 2.0, 3.0, 4.0, 5.0]
+    se_one_cluster = clustered_se(values, ["T1"] * 5)
+    naive = math.sqrt(statistics.variance(values) / 5)
+    assert se_one_cluster == pytest.approx(naive, abs=1e-9)
+
+
+def test_clustered_se_short_input_returns_zero():
+    assert clustered_se([1.0], ["T1"]) == 0.0
+    assert clustered_se([], []) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Proportion CIs — Wilson and Agresti-Coull
+# ---------------------------------------------------------------------------
+
+
+def test_wilson_bounded_and_nonzero_width_at_zero_successes():
+    """The plain normal CI on a 0/89 cell (a shape the PII scorecard
+    produces) collapses to zero width and can leave [0, 1]. Wilson must not.
+    """
+    est = wilson_interval(0, 89)
+    assert 0.0 <= est.ci_low <= est.ci_high <= 1.0
+    assert est.ci_high > 0.0  # non-zero width even though point estimate is 0
+    assert est.point == 0.0
+
+
+def test_wilson_bounded_at_n_successes():
+    est = wilson_interval(89, 89)
+    assert 0.0 <= est.ci_low <= est.ci_high <= 1.0
+    assert est.ci_low < 1.0  # non-zero width at the top too
+
+
+def test_wilson_interval_reasonable_for_mid_proportion():
+    est = wilson_interval(45, 100)
+    assert est.point == pytest.approx(0.45)
+    assert est.ci_low < 0.45 < est.ci_high
+    assert est.method == "wilson"
+    assert est.estimand  # required, non-empty
+
+
+def test_wilson_rejects_bad_input():
+    with pytest.raises(ValueError):
+        wilson_interval(-1, 10)
+    with pytest.raises(ValueError):
+        wilson_interval(11, 10)
+    with pytest.raises(ValueError):
+        wilson_interval(0, 0)
+
+
+def test_agresti_coull_bounded_and_nonzero_width_at_zero_successes():
+    est = agresti_coull(0, 89)
+    assert 0.0 <= est.ci_low <= est.ci_high <= 1.0
+    assert est.ci_high > 0.0
+    assert est.method == "agresti-coull"
+
+
+# ---------------------------------------------------------------------------
+# stratified_mean — Horvitz-Thompson
+# ---------------------------------------------------------------------------
+
+
+def test_stratified_mean_recovers_known_population_mean():
+    """Two strata with known population sizes and known selection
+    probabilities; every sampled value equals its stratum's true mean, so
+    the Horvitz-Thompson estimate must recover the exact population mean.
+    """
+    # Stratum A: population 100, sample 2 units (selection prob 2/100),
+    # HT weight = 1/prob = 50; every sampled value is the true stratum mean.
+    # Stratum B: population 300, sample 3 units, HT weight = 100.
+    values = [10.0, 10.0, 20.0, 20.0, 20.0]
+    strata = ["A", "A", "B", "B", "B"]
+    weights = [50.0, 50.0, 100.0, 100.0, 100.0]
+
+    est = stratified_mean(values, strata, weights, estimand="test population mean")
+    true_population_mean = (100 * 10.0 + 300 * 20.0) / 400
+    assert est.point == pytest.approx(true_population_mean)
+    assert est.se == pytest.approx(0.0, abs=1e-9)  # no within-stratum variance
+    assert est.weighted is True
+    assert est.n == 5
+    assert est.n_clusters == 2
+    assert est.estimand == "test population mean"
+
+
+def test_stratified_mean_requires_estimand():
+    with pytest.raises(TypeError):
+        stratified_mean([1.0, 2.0], ["A", "A"])  # missing required estimand kwarg
+
+
+def test_stratified_mean_rejects_mismatched_lengths():
+    with pytest.raises(ValueError):
+        stratified_mean([1.0, 2.0], ["A"], estimand="x")
+    with pytest.raises(ValueError):
+        stratified_mean([1.0, 2.0], ["A", "A"], weights=[1.0], estimand="x")
+
+
+def test_design_effect_is_one_for_simple_random_sample():
+    """Unweighted, single-stratum stratified_mean must reduce exactly to the
+    ordinary SRS variance of the mean — design effect (deff) 1.
+    """
+    values = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+    strata = ["A"] * len(values)
+    est = stratified_mean(values, strata, estimand="srs mean")
+    srs_variance = statistics.variance(values) / len(values)
+    deff = (est.se**2) / srs_variance
+    assert deff == pytest.approx(1.0, abs=1e-9)
+    assert est.point == pytest.approx(statistics.mean(values))
+    assert est.weighted is False
+
+
+# ---------------------------------------------------------------------------
+# Estimate — estimand is mandatory
+# ---------------------------------------------------------------------------
+
+
+def test_estimate_estimand_is_required():
+    with pytest.raises(TypeError):
+        Estimate(  # type: ignore[call-arg]
+            point=0.5,
+            se=0.1,
+            ci_low=0.3,
+            ci_high=0.7,
+            n=10,
+            n_clusters=5,
+            alpha=0.05,
+            method="test",
+            weighted=False,
+        )
+
+
+def test_estimate_holds_all_fields():
+    est = Estimate(
+        point=0.5,
+        se=0.1,
+        ci_low=0.3,
+        ci_high=0.7,
+        n=10,
+        n_clusters=5,
+        alpha=0.05,
+        method="test",
+        weighted=False,
+        estimand="share of pages that diverge, Sambalpur/2024 sample",
+    )
+    assert est.estimand == "share of pages that diverge, Sambalpur/2024 sample"
+
+
+# ---------------------------------------------------------------------------
+# required_pages_mcnemar — moved unchanged; smoke that the move didn't break it
+# ---------------------------------------------------------------------------
+
+
+def test_required_pages_mcnemar_smoke():
+    assert 140 <= required_pages_mcnemar(0.10, 0.20) <= 180
+    with pytest.raises(ValueError):
+        required_pages_mcnemar(0.10, 0.05)  # gap must be < discordance

--- a/tests/test_evaluation_stats.py
+++ b/tests/test_evaluation_stats.py
@@ -375,3 +375,75 @@ def test_a_single_stratum_still_has_usable_degrees_of_freedom():
     estimate = stratified_mean(values, ["A"] * 5, estimand="one stratum")
     assert estimate.se > 0
     assert estimate.ci_low < estimate.point < estimate.ci_high
+
+
+def test_singleton_stratum_is_rejected_not_silently_zero_variance():
+    """Codex finding on #237: a stratum with a single sampled unit has no
+    estimable within-stratum variance. The old code ``continue``d past it,
+    dropping its ENTIRE variance contribution while its weight stayed in the
+    point estimate -- values [0, 10] in strata ['A', 'B'] returned se=0 and
+    the zero-width interval [5, 5]. That is a silently downward-biased
+    interval (dangerous), not a conservative one, so this must raise instead
+    of guessing.
+    """
+    with pytest.raises(ValueError, match="only 1 sampled unit"):
+        stratified_mean([0.0, 10.0], ["A", "B"], estimand="singleton strata")
+
+
+def test_singleton_stratum_rejected_even_when_mixed_with_a_real_stratum():
+    # Stratum A has 5 real observations; stratum B is a lone extreme value.
+    # Before the fix this silently dropped B's uncertainty and reported a
+    # tighter interval than was justified.
+    values = [0.0, 2.0, 4.0, 6.0, 8.0, 100.0]
+    strata = ["A", "A", "A", "A", "A", "B"]
+    with pytest.raises(ValueError, match="only 1 sampled unit"):
+        stratified_mean(values, strata, estimand="mixed singleton")
+
+
+def test_two_units_per_stratum_is_the_minimum_that_works():
+    # n_h=2 in every stratum is exactly the boundary the singleton rejection
+    # sits above -- must not raise, and must report a nonzero SE derivable
+    # from an actual within-stratum spread.
+    values = [0.0, 4.0, 10.0, 14.0]
+    strata = ["A", "A", "B", "B"]
+    estimate = stratified_mean(values, strata, estimand="boundary n_h=2")
+    assert estimate.se > 0
+
+
+def test_varying_weight_within_a_stratum_is_rejected():
+    """Codex finding on #237: the within-stratum sample variance is only a
+    valid estimator when every unit in a stratum shares the same inclusion
+    probability. The public API accepted arbitrary per-observation weights
+    with no check, so a PPS / unequal-probability design silently got back a
+    plausible-looking but statistically invalid SE. Demonstrate the defect
+    directly: holding stratum B's weights constant and stratum A's total
+    weight fixed, swapping an even weight split for a wildly skewed one
+    changes nothing about how the "variance" is computed (it is derived only
+    from raw values and the weighted mean, never from the weights'
+    dispersion) even though the two designs have very different reliability.
+    Enforcing the assumption is safer than reporting that invalid number.
+    """
+    values = [0.0, 10.0, 20.0, 22.0]
+    strata = ["A", "A", "B", "B"]
+    with pytest.raises(ValueError, match="varying weights"):
+        stratified_mean(values, strata, [1.0, 99.0, 50.0, 50.0], estimand="varying weight")
+
+
+def test_constant_weight_within_stratum_is_accepted():
+    # The common, valid design -- weights differ ACROSS strata but are
+    # constant WITHIN each -- must not raise.
+    values = [0.0, 2.0, 10.0, 12.0]
+    strata = ["A", "A", "B", "B"]
+    estimate = stratified_mean(values, strata, [50.0, 50.0, 100.0, 100.0], estimand="valid design")
+    assert estimate.se > 0
+
+
+def test_stratified_mean_rejects_nonpositive_weights():
+    # A Horvitz-Thompson weight is an inverse inclusion probability; it
+    # cannot be zero or negative. Rejecting this upfront is what makes the
+    # per-stratum weight sum provably positive, removing the need for a
+    # separate silent-skip branch for a degenerate weight sum.
+    with pytest.raises(ValueError, match="positive"):
+        stratified_mean([1.0, 2.0], ["A", "A"], [0.0, 5.0], estimand="zero weight")
+    with pytest.raises(ValueError, match="positive"):
+        stratified_mean([1.0, 2.0], ["A", "A"], [-1.0, 5.0], estimand="negative weight")

--- a/tests/test_evaluation_stats.py
+++ b/tests/test_evaluation_stats.py
@@ -299,3 +299,79 @@ def test_required_pages_mcnemar_smoke():
     assert 140 <= required_pages_mcnemar(0.10, 0.20) <= 180
     with pytest.raises(ValueError):
         required_pages_mcnemar(0.10, 0.05)  # gap must be < discordance
+
+
+# --- the weighted variance path, which the unweighted tests could not see ---
+
+
+def test_stratified_variance_does_not_double_count_the_weight():
+    """Codex finding on #237, reproduced exactly before fixing.
+
+    The within-stratum sample variance was computed with the weights inside
+    it and still divided by (n_h - 1), while the stratum share below already
+    carried the population size. The weight was counted twice, inflating the
+    interval by the weight itself.
+
+    This bit ONLY the weighted path, which is why every unweighted test
+    passed -- and the weighted path is the one an inverse-probability sample
+    uses, so it was wrong exactly where it matters.
+    """
+    estimate = stratified_mean(
+        [0, 2, 10, 12],
+        ["A", "A", "B", "B"],
+        [50, 50, 100, 100],
+        estimand="Codex #237 reproduction",
+    )
+    # Hand-derived: W_A=1/3, W_B=2/3; s2_h=2 in both; fpc 98/99 and 198/199.
+    assert estimate.se == pytest.approx(0.743, abs=0.005)
+    # The defect reported 7.05 here, a 9.5x overwide interval.
+    assert estimate.se < 1.0
+
+
+def test_stratified_variance_matches_an_analytic_population():
+    """Draw with unequal probabilities from a population whose stratified
+    variance is known in closed form, and check the estimator recovers it.
+
+    A test that only checks the point estimate cannot catch a variance bug,
+    which is how the double-counted weight survived the first round.
+    """
+    # Two strata, N_A=100 N_B=400, sampled n_h=5 each -> weights 20 and 80.
+    values_a = [10.0, 12.0, 14.0, 16.0, 18.0]  # s2 = 10
+    values_b = [20.0, 24.0, 28.0, 32.0, 36.0]  # s2 = 40
+    values = values_a + values_b
+    strata = ["A"] * 5 + ["B"] * 5
+    weights = [20.0] * 5 + [80.0] * 5
+
+    estimate = stratified_mean(values, strata, weights, estimand="analytic check")
+
+    total = 100.0 + 400.0
+    expected_var = 0.0
+    for s2, n_h, n_pop in ((10.0, 5, 100.0), (40.0, 5, 400.0)):
+        share = n_pop / total
+        fpc = (n_pop - n_h) / (n_pop - 1)
+        expected_var += share**2 * fpc * s2 / n_h
+    assert estimate.se == pytest.approx(expected_var**0.5, rel=1e-9)
+
+
+def test_degrees_of_freedom_come_from_sampled_units_not_strata():
+    """Codex finding on #237: two strata gave df=1 and t=12.706 regardless
+    of how many units were drawn, so a large sample got an interval more
+    than six times too wide."""
+    values = [float(i) for i in range(300)]
+    strata = ["A"] * 150 + ["B"] * 150
+    estimate = stratified_mean(values, strata, estimand="300 units, 2 strata")
+
+    # df = sum(n_h - 1) = 298, so the critical value is essentially normal.
+    assert estimate.ci_high - estimate.ci_low == pytest.approx(
+        2 * critical_value(0.05, df=298) * estimate.se, rel=1e-9
+    )
+    # The defect used df = n_strata - 1 = 1 -> t = 12.706.
+    naive_width = 2 * critical_value(0.05, df=1) * estimate.se
+    assert (estimate.ci_high - estimate.ci_low) < naive_width / 5
+
+
+def test_a_single_stratum_still_has_usable_degrees_of_freedom():
+    values = [1.0, 2.0, 3.0, 4.0, 5.0]
+    estimate = stratified_mean(values, ["A"] * 5, estimand="one stratum")
+    assert estimate.se > 0
+    assert estimate.ci_low < estimate.point < estimate.ci_high


### PR DESCRIPTION
## Why

The only estimator in this repo is a cluster-robust sandwich SE for a mean.
It lived private (`_clustered_se`) inside `janasunani/evaluation/sarvam_scorecard.py`
and was already copy-pasted verbatim into `scripts/benchmark_pipeline.py`.
Every reported confidence interval in the Sarvam scorecard, and therefore in
the 14 August findings, depends on it. This PR moves it to a public, tested
module and fixes two defects found on the way.

## What moved

New `janasunani/evaluation/stats.py`:

- `clustered_se` — the sandwich SE, public, maths unchanged.
- `critical_value(alpha, *, df=None)` — normal quantile when `df=None`, else
  Student's t at that many degrees of freedom.
- `t_quantile(p, df)` — pure stdlib Student's t inverse CDF (regularized
  incomplete beta via continued fraction + bisection; no scipy/numpy — numpy
  sits in a conflicting extra). Tested against a published t table.
- `wilson_interval` / `agresti_coull` — proportion CIs; none existed before.
- `stratified_mean` — Horvitz-Thompson stratified mean with per-stratum
  variance and finite-population correction.
- `paired_difference`, `required_pages_mcnemar` — moved from
  `sarvam_scorecard.py`; the latter was already correct.
- `Estimate` dataclass, with `estimand` a **required** field (see below).

`sarvam_scorecard.py` now re-exports these (thin aliases, e.g.
`clustered_se as _clustered_se`) so its own call sites and
`tests/test_sarvam_scorecard.py` don't churn. `summary_divergence` was
byte-identical logic to `divergence_rate` with a different docstring; it's
now `summary_divergence = divergence_rate` instead of a second copy.

**Not touched:** `scripts/benchmark_pipeline.py`'s own duplicate
`_clustered_se`. Another change is landing in that file right now; deleting
the duplicate there is an obvious, small follow-up once that lands.

## The two defects

**(a) Wrong critical value for non-standard alpha.** The old
`paired_difference` had a lookup table for `alpha in {0.05, 0.01, 0.10}`
that silently returned `z=1.96` for *any other* alpha — a 90%-CI-shaped bug
that never raised an error. `required_pages_mcnemar`, in the same file,
already computed critical values correctly via `NormalDist().inv_cdf`.
`critical_value()` is that fix, made the one path every caller uses.
Regression test: `critical_value(0.02)` must not equal `1.96`.

**(b) No small-cluster t correction.** A clustered SE is a sandwich
estimator with `C - 1` effective degrees of freedom, not infinite. This
repo's benchmark designs run 30-40 clusters (tickets/documents) — at
`df=29`, `t=2.045` vs `z=1.96`, about 4% wider. Every clustered SE here
(`paired_difference`, `divergence_rate`/`summary_divergence`,
`stratified_mean`) now defaults to `df = n_clusters - 1`.

## Which published numbers move

**Every CI produced by `paired_difference`, `divergence_rate`, and
`summary_divergence` gets wider** — that's intended, not a regression. The
size of the widening is `t_quantile(0.975, df) / 1.96`, which depends only
on cluster count:

| n_clusters | df | t / z ratio | widening |
|---|---|---|---|
| 3 | 2 | 4.30/1.96 | ~2.2x |
| 10 | 9 | 2.26/1.96 | ~15% |
| 20 | 19 | 2.09/1.96 | ~7% |
| 30 | 29 | 2.045/1.96 | ~4% |
| 60 | 59 | 2.00/1.96 | ~2% |

The Sarvam benchmark design (`BENCHMARK_SAMPLE_SIZE=300`, few-hundred pages)
lands in the 20-40 cluster (ticket) range depending on how many tickets each
sampled page belongs to, so the realistic widening for the headline
category-accuracy CI and the handwritten/printed/language divergence splits
is in the **4-10% range**, not the 2x shown for pathologically few clusters.

I could not recompute the *actual* already-published figures in
`docs/DELIVERY.md` or `docs/FINDINGS.pptx` against this fix — that requires
running the benchmark against real data under `data/`, which this task was
scoped not to touch. `docs/DELIVERY.md` itself carries no baked-in numeric
CI values (it's descriptive of what will be reported), but `docs/FINDINGS.pptx`
is a binary deck I have not opened; if it contains concrete CI numbers from
a prior scorecard run, they should be treated as stale and re-run against
this fix before the 14 August findings are finalized. Flagging this for the
maintainer rather than guessing at numbers I can't verify.

## Why `estimand` is required, not optional

It's the one-line answer to "what population is this number about." Making
it mandatory on `Estimate` pushes that question onto the type system instead
of relying on whoever writes a report remembering to state it — a sample
statistic on a 300-page stratified slice is exactly the kind of number that
gets read, a few slides later, as a claim about all 1.37M complaints in the
lake if nothing forces the scope to be written down next to it.

## Tests

New `tests/test_evaluation_stats.py`, real-code-path:
- `t_quantile` against a published Student's t table (several df, several p).
- `critical_value(0.02)` regression for defect (a).
- `paired_difference` with few clusters uses the t quantile at `df=C-1`,
  not `z=1.96` (defect b), and converges to `z` as clusters grow.
- Wilson/Agresti-Coull bounded in `[0, 1]`, non-zero width at 0 and N
  successes (the 0/89 shape the PII scorecard produces).
- `stratified_mean` recovers a known population mean under known
  Horvitz-Thompson selection weights.
- Design effect is exactly 1 for an unweighted single-stratum sample (SRS).
- `Estimate` without `estimand` raises `TypeError`.

## Gate

```
uv run ruff check .                                                          # clean
JANASUNANI_MODELS_DIR=/nonexistent uv run --extra serving --extra pipeline-core pytest
# 1208 passed, 19 skipped (pre-existing, unrelated)
```
---

## Merge note — Codex review round skipped

Merged without a further Codex round at the repository owner's explicit direction: *"the codex reviews keep returning issues each time without converging ... please then merge it idc"*.

Recording this plainly rather than implying a policy basis: `CONTRIBUTING.md` scopes the `codex-review-not-required` label to config-only branches and to Codex being out of review credits. **Neither applies here.** This is a deliberate override by the repository owner, labelled so the exception is visible in the record.

All findings raised on this PR were replied to in-thread and resolved. Any finding not fixed here is filed as a tracked issue rather than dropped.
