### PR TITLE
fix(ci): stop the review gate cancelling its own runs

### DIFF
--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -54,9 +54,23 @@ permissions:
 # actually evaluated, so a late run cannot mislabel a newer commit) but it is
 # not free: it makes a passing gate look like a failing one. Runs are short,
 # and the cron sweep keys on run_id so it never queues behind anything.
+#
+# cancel-in-progress: false only protects the RUNNING job. GitHub's own
+# default still cancels a PENDING one: "only one job or workflow run can be
+# pending in a concurrency group at a time" -- a third event arriving while a
+# second is queued behind the first replaces (cancels) that second run, even
+# though nothing is in progress on it yet. A push followed quickly by
+# `@codex review` followed by a review submission reaches this: the review's
+# run supersedes the still-queued comment's run. `queue: max` is the
+# documented way to stop that -- up to 100 runs wait in the group instead of
+# the newest replacing the previous pending one -- and it is the only queue
+# mode allowed alongside cancel-in-progress: false (queue: max plus
+# cancel-in-progress: true is a validation error, since they describe
+# conflicting handling of in-progress runs).
 concurrency:
   group: codex-review-gate-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr || github.run_id }}
   cancel-in-progress: false
+  queue: max
 
 jobs:
   evaluate:

--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -41,9 +41,22 @@ permissions:
   contents: read
   pull-requests: read
 
+# Queue rather than cancel. This workflow fires on pull_request,
+# pull_request_review, pull_request_review_comment, issue_comment and a
+# 5-minute cron, and every per-PR trigger shares one group. With
+# cancel-in-progress the commonest sequence -- push a fix, then comment
+# `@codex review` -- had the comment's run cancel the push's run, leaving a
+# CANCELLED `evaluate` job attached to the head commit forever. The verdict
+# check itself was green, so every pull request sat at UNSTABLE with a
+# permanently unhappy check that had to be reasoned about by hand each time.
+#
+# Cancelling is safe for the verdict (each run posts against the head_sha it
+# actually evaluated, so a late run cannot mislabel a newer commit) but it is
+# not free: it makes a passing gate look like a failing one. Runs are short,
+# and the cron sweep keys on run_id so it never queues behind anything.
 concurrency:
   group: codex-review-gate-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   evaluate:

--- a/.gitignore
+++ b/.gitignore
@@ -255,3 +255,7 @@ mlruns/
 
 # Generated Word docs (management/technical briefs rendered from docs/*.md)
 docs/*.docx
+
+# Agent worktrees (created by the harness; never part of the tree)
+.claude/wt/
+.claude/worktrees/

--- a/tests/test_check_codex_review.py
+++ b/tests/test_check_codex_review.py
@@ -15,8 +15,10 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+import yaml
 
 _SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+_GATE_WORKFLOW_PATH = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "codex-review-gate.yml"
 
 
 def _load(name: str):
@@ -496,3 +498,25 @@ def test_paginated_review_threads_are_all_inspected():
     unresolved = check.unresolved_codex_threads(graphql, "owner", "name", 207)
     assert seen == [None, "cursor1"]
     assert len(unresolved) == 1
+
+
+def test_gate_workflow_queues_pending_runs_instead_of_cancelling_them():
+    """The gate fires on five overlapping per-PR triggers sharing one
+    concurrency group (push, review, review comment, issue comment, cron).
+    `cancel-in-progress: false` alone is not enough: GitHub still cancels a
+    *pending* run the instant another event queues behind it in the same
+    group -- that is the documented default, independent of
+    cancel-in-progress -- so a push followed quickly by `@codex review`
+    followed by a review submission still produced the CANCELLED `evaluate`
+    jobs this gate exists to eliminate (Codex round-N finding on #238).
+    `queue: max` is the only way to let more than one run wait in a group,
+    and GitHub rejects it paired with `cancel-in-progress: true`, so both
+    settings must hold together."""
+    workflow = yaml.safe_load(_GATE_WORKFLOW_PATH.read_text())
+    concurrency = workflow["concurrency"]
+
+    assert concurrency["cancel-in-progress"] is False
+    assert concurrency["queue"] == "max"
+    # Per-PR, not per-workflow-run or repo-wide: two different PRs must not
+    # queue behind each other.
+    assert "github.event.pull_request.number" in concurrency["group"]


### PR DESCRIPTION
## The symptom

Every pull request has been sitting at `UNSTABLE` with a `CANCELLED` `evaluate` job on its head commit. #236 is the latest: `codex-review=SUCCESS`, ruff green, tests green, and still not showing clean.

## The cause

**The gate cancels itself.**

It fires on `pull_request`, `pull_request_review`, `pull_request_review_comment`, `issue_comment` and a 5-minute cron, and every per-PR trigger shares one concurrency group. With `cancel-in-progress: true`, the commonest sequence in this repo does it:

1. Push a fix -> `pull_request` run starts
2. Comment `@codex review` -> `issue_comment` run starts in the same group
3. Step 2 cancels step 1, leaving a CANCELLED job attached to the commit

## Why it is worth fixing rather than explaining each time

Cancelling was never a **correctness** problem. Each run posts its check against the `head_sha` it actually evaluated, so a late run cannot mislabel a newer commit, and the surviving run posted the verdict green. The PR was mergeable throughout.

It is a **legibility** problem. On a gate whose entire purpose is to make degraded states visible, "a passing gate that looks like a failing one" is the wrong failure mode to ship. It also costs a judgement call on every single PR, which is exactly the kind of recurring tax that gets normalised until someone merges past a real red check by pattern-matching.

## The change

`cancel-in-progress: false`. Runs queue instead. They are short, and the cron sweep keys on `run_id` so it never queues behind anything.

## Reviewing this one carefully

This touches the gating workflow itself, which is the file most deserving of suspicion in the repo. To be explicit about scope: it changes **only scheduling**. It does not change what is enforced, who may bypass, the docs-only exemption, the `codex-review-not-required` label, or the SHA-binding of a verdict.

## Also here

`.gitignore` for the agent worktree directories. `git add -A` from the repo root picks them up as embedded git repositories, and five gitlinks nearly landed in this commit. Caught before pushing, but the guard is worth having.
---

## Merge note — Codex review round skipped

Merged without a further Codex round at the repository owner's explicit direction: *"the codex reviews keep returning issues each time without converging ... please then merge it idc"*.

Recording this plainly rather than implying a policy basis: `CONTRIBUTING.md` scopes the `codex-review-not-required` label to config-only branches and to Codex being out of review credits. **Neither applies here.** This is a deliberate override by the repository owner, labelled so the exception is visible in the record.

All findings raised on this PR were replied to in-thread and resolved. Any finding not fixed here is filed as a tracked issue rather than dropped.
