### PR TITLE
feat(evaluation): add categorization quality scorecard

### DIFF
--- a/janasunani/evaluation/categorization.py
+++ b/janasunani/evaluation/categorization.py
@@ -1,0 +1,302 @@
+"""Scalable local baseline and held-out scorecard for grievance categories.
+
+The baseline uses stateless word and character hashing followed by a
+probabilistic linear classifier.  It can train over a large corpus without a
+vocabulary-sized memory spike and gives MuRIL or a modern multilingual encoder
+an inexpensive CPU number to beat.  Promotion still depends on per-language,
+per-class, calibration, and abstention results from adjudicated or frozen
+administrative labels.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import Counter
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+from janasunani.evaluation.classification import (
+    ScoredExample,
+    assert_group_disjoint,
+    classification_metrics,
+    metrics_by_language,
+)
+
+
+MODEL_FAMILY = "hashing-word-char-sgd"
+MODEL_VERSION = "categorizer-hashing-v1"
+
+
+@dataclass(frozen=True)
+class CategorizationRecord:
+    item_id: str
+    group_id: str
+    redacted_text: str
+    category: str
+    split: str
+    language: str = "unknown"
+    source_kind: str = "typed"
+    subcategory: str | None = None
+
+
+def validate_records(records: Sequence[CategorizationRecord]) -> None:
+    if not records:
+        raise ValueError("categorization benchmark is empty")
+    ids = [record.item_id for record in records]
+    if len(ids) != len(set(ids)):
+        raise ValueError("item_id values must be unique")
+    if {record.split for record in records} != {"train", "validation", "test"}:
+        raise ValueError("benchmark requires train, validation, and test splits")
+    assert_group_disjoint((record.group_id, record.split) for record in records)
+    for record in records:
+        if record.split not in {"train", "validation", "test"}:
+            raise ValueError(f"invalid split {record.split!r}")
+        if any(
+            not isinstance(value, str) or not value.strip()
+            for value in (
+                record.item_id,
+                record.group_id,
+                record.redacted_text,
+                record.category,
+                record.language,
+                record.source_kind,
+            )
+        ):
+            raise ValueError("categorization string fields must be non-empty")
+
+
+def _build_classifier(*, alpha: float, n_features: int):
+    from sklearn.feature_extraction.text import HashingVectorizer
+    from sklearn.linear_model import SGDClassifier
+    from sklearn.pipeline import FeatureUnion, Pipeline
+
+    features = FeatureUnion(
+        [
+            (
+                "word",
+                HashingVectorizer(
+                    analyzer="word",
+                    ngram_range=(1, 2),
+                    n_features=n_features,
+                    alternate_sign=False,
+                    norm="l2",
+                    lowercase=True,
+                ),
+            ),
+            (
+                "char",
+                HashingVectorizer(
+                    analyzer="char_wb",
+                    ngram_range=(3, 5),
+                    n_features=n_features,
+                    alternate_sign=False,
+                    norm="l2",
+                    lowercase=True,
+                ),
+            ),
+        ]
+    )
+    return Pipeline(
+        [
+            ("features", features),
+            (
+                "classifier",
+                SGDClassifier(
+                    loss="log_loss",
+                    penalty="l2",
+                    alpha=alpha,
+                    class_weight="balanced",
+                    max_iter=100,
+                    tol=1e-4,
+                    average=True,
+                    random_state=1729,
+                ),
+            ),
+        ]
+    )
+
+
+def _score(
+    classifier,
+    records: Sequence[CategorizationRecord],
+    *,
+    expected_labels: Sequence[str],
+) -> list[ScoredExample]:
+    matrix = classifier.predict_proba([record.redacted_text for record in records])
+    trained_labels = tuple(str(label) for label in classifier.classes_)
+    return [
+        ScoredExample(
+            item_id=record.item_id,
+            gold_label=record.category,
+            probabilities={
+                label: (
+                    float(row[trained_labels.index(label)])
+                    if label in trained_labels
+                    else 0.0
+                )
+                for label in expected_labels
+            },
+            group_id=record.group_id,
+            language=record.language,
+        )
+        for record, row in zip(records, matrix, strict=True)
+    ]
+
+
+def select_abstention_threshold(
+    examples: Sequence[ScoredExample],
+    *,
+    min_selective_accuracy: float,
+    min_coverage: float,
+) -> tuple[float, dict[str, object]]:
+    """Maximize validation coverage subject to a minimum retained accuracy."""
+
+    if not 0.0 <= min_selective_accuracy <= 1.0:
+        raise ValueError("min_selective_accuracy must be in [0, 1]")
+    if not 0.0 <= min_coverage <= 1.0:
+        raise ValueError("min_coverage must be in [0, 1]")
+    thresholds = {0.0, 1.0}
+    thresholds.update(
+        max(float(value) for value in example.probabilities.values())
+        for example in examples
+    )
+    candidates = [
+        classification_metrics(
+            examples,
+            expected_labels=tuple(examples[0].probabilities),
+            abstain_threshold=threshold,
+        )
+        for threshold in sorted(thresholds)
+    ]
+    eligible = [
+        metrics
+        for metrics in candidates
+        if float(metrics["selective_accuracy"]) >= min_selective_accuracy
+        and float(metrics["coverage"]) >= min_coverage
+    ]
+    if not eligible:
+        fallback = max(
+            candidates,
+            key=lambda metrics: (
+                float(metrics["selective_accuracy"]),
+                float(metrics["coverage"]),
+                float(metrics["abstain_threshold"]),
+            ),
+        )
+        return float(fallback["abstain_threshold"]), fallback
+    chosen = max(
+        eligible,
+        key=lambda metrics: (
+            float(metrics["coverage"]),
+            float(metrics["selective_accuracy"]),
+            float(metrics["abstain_threshold"]),
+        ),
+    )
+    return float(chosen["abstain_threshold"]), chosen
+
+
+@dataclass
+class CategorizationBenchmark:
+    classifier: Any
+    abstain_threshold: float
+    report: dict[str, object]
+
+
+def benchmark_hashing_classifier(
+    records: Sequence[CategorizationRecord],
+    *,
+    alpha_values: Sequence[float] = (1e-6, 1e-5, 1e-4, 1e-3),
+    n_features: int = 2**18,
+    min_selective_accuracy: float = 0.8,
+    min_coverage: float = 0.5,
+) -> CategorizationBenchmark:
+    """Tune on validation and report the untouched test split once."""
+
+    validate_records(records)
+    if not alpha_values or any(
+        not math.isfinite(alpha) or alpha <= 0.0 for alpha in alpha_values
+    ):
+        raise ValueError("alpha_values must contain positive finite values")
+    if n_features < 2**10 or n_features & (n_features - 1):
+        raise ValueError("n_features must be a power of two of at least 1024")
+    train = [record for record in records if record.split == "train"]
+    validation = [record for record in records if record.split == "validation"]
+    test = [record for record in records if record.split == "test"]
+    expected_labels = tuple(sorted({record.category for record in records}))
+    missing_train = set(expected_labels).difference(record.category for record in train)
+
+    candidates: list[tuple[float, Any, list[ScoredExample], dict[str, object]]] = []
+    for alpha in alpha_values:
+        classifier = _build_classifier(alpha=alpha, n_features=n_features)
+        classifier.fit(
+            [record.redacted_text for record in train],
+            [record.category for record in train],
+        )
+        validation_examples = _score(
+            classifier, validation, expected_labels=expected_labels
+        )
+        metrics = classification_metrics(
+            validation_examples,
+            expected_labels=expected_labels,
+            top_k=(1, 3, 5),
+        )
+        candidates.append((alpha, classifier, validation_examples, metrics))
+    alpha, classifier, validation_examples, validation_metrics = max(
+        candidates,
+        key=lambda row: (
+            float(row[3]["macro_f1"]),
+            float(row[3]["top_k_accuracy"]["3"]),
+            -float(row[3]["log_loss"]),
+            -row[0],
+        ),
+    )
+    threshold, validation_selective = select_abstention_threshold(
+        validation_examples,
+        min_selective_accuracy=min_selective_accuracy,
+        min_coverage=min_coverage,
+    )
+    test_examples = _score(classifier, test, expected_labels=expected_labels)
+    test_metrics = classification_metrics(
+        test_examples,
+        expected_labels=expected_labels,
+        top_k=(1, 3, 5),
+        abstain_threshold=threshold,
+    )
+    report: dict[str, object] = {
+        "model_family": MODEL_FAMILY,
+        "model_version": MODEL_VERSION,
+        "selected_alpha": alpha,
+        "n_features_per_analyzer": n_features,
+        "abstain_threshold": threshold,
+        "split_counts": Counter(record.split for record in records),
+        "source_counts": Counter(record.source_kind for record in records),
+        "missing_training_labels": sorted(missing_train),
+        "validation": validation_metrics,
+        "validation_selective": validation_selective,
+        "test": test_metrics,
+        "test_by_language": metrics_by_language(
+            test_examples,
+            expected_labels=expected_labels,
+            top_k=(1, 3, 5),
+            abstain_threshold=threshold,
+        ),
+        "candidate_validation": [
+            {
+                "alpha": candidate_alpha,
+                "macro_f1": metrics["macro_f1"],
+                "top3_accuracy": metrics["top_k_accuracy"]["3"],
+                "log_loss": metrics["log_loss"],
+            }
+            for candidate_alpha, _, _, metrics in candidates
+        ],
+        "limitations": [
+            "administrative categories measure historical labels, not policy correctness",
+            "typed and scanned sources must be reported separately when both are present",
+            "subcategory remains a separate hierarchical task",
+        ],
+    }
+    return CategorizationBenchmark(
+        classifier=classifier,
+        abstain_threshold=threshold,
+        report=report,
+    )

--- a/tests/test_categorization_evaluation.py
+++ b/tests/test_categorization_evaluation.py
@@ -1,0 +1,130 @@
+import pytest
+
+from janasunani.evaluation.categorization import (
+    CategorizationRecord,
+    benchmark_hashing_classifier,
+    select_abstention_threshold,
+    validate_records,
+)
+from janasunani.evaluation.classification import ScoredExample
+
+
+def record(item_id, text, category, split, *, language="English", group=None):
+    return CategorizationRecord(
+        item_id=item_id,
+        group_id=group or item_id,
+        redacted_text=text,
+        category=category,
+        split=split,
+        language=language,
+    )
+
+
+PHRASES = {
+    "Water Supply": "broken hand pump drinking water pipeline leakage",
+    "Pensions": "old age pension payment beneficiary allowance",
+    "Roads": "damaged village road pothole bridge repair",
+}
+
+
+def dataset():
+    rows = []
+    for category, phrase in PHRASES.items():
+        for i in range(15):
+            rows.append(
+                record(
+                    f"train-{category}-{i}",
+                    f"{phrase} training example {i}",
+                    category,
+                    "train",
+                    language="Odia" if i % 2 else "English",
+                )
+            )
+        for split in ("validation", "test"):
+            for i in range(3):
+                rows.append(
+                    record(
+                        f"{split}-{category}-{i}",
+                        f"{phrase} heldout example {i}",
+                        category,
+                        split,
+                        language="Odia" if i % 2 else "English",
+                    )
+                )
+    return rows
+
+
+def test_group_leakage_fails_closed():
+    rows = dataset()
+    rows[-1] = record(
+        rows[-1].item_id,
+        rows[-1].redacted_text,
+        rows[-1].category,
+        "test",
+        group=rows[0].group_id,
+    )
+    with pytest.raises(ValueError, match="leaks"):
+        validate_records(rows)
+
+
+def test_abstention_threshold_is_selected_on_scored_validation_rows():
+    labels = ("A", "B")
+    examples = [
+        ScoredExample("1", "A", {"A": 0.9, "B": 0.1}, "1"),
+        ScoredExample("2", "A", {"A": 0.4, "B": 0.6}, "2"),
+        ScoredExample("3", "B", {"A": 0.2, "B": 0.8}, "3"),
+    ]
+    threshold, metrics = select_abstention_threshold(
+        examples,
+        min_selective_accuracy=1.0,
+        min_coverage=0.6,
+    )
+
+    assert labels == tuple(examples[0].probabilities)
+    assert threshold == pytest.approx(0.8)
+    assert metrics["coverage"] == pytest.approx(2 / 3)
+    assert metrics["selective_accuracy"] == 1.0
+
+
+def test_hashing_baseline_reports_per_class_language_and_calibration():
+    benchmark = benchmark_hashing_classifier(
+        dataset(),
+        alpha_values=(1e-5, 1e-4),
+        n_features=2**12,
+        min_selective_accuracy=0.5,
+        min_coverage=0.5,
+    )
+    report = benchmark.report
+
+    assert report["model_family"] == "hashing-word-char-sgd"
+    assert report["selected_alpha"] in {1e-5, 1e-4}
+    assert report["split_counts"] == {"train": 45, "validation": 9, "test": 9}
+    assert report["test"]["n"] == 9
+    assert set(report["test"]["per_class"]) == set(PHRASES)
+    assert set(report["test_by_language"]) == {"English", "Odia"}
+    assert 0.0 <= report["test"]["expected_calibration_error"] <= 1.0
+    assert report["missing_training_labels"] == []
+    assert len(report["candidate_validation"]) == 2
+
+
+def test_invalid_hash_width_is_rejected():
+    with pytest.raises(ValueError, match="power of two"):
+        benchmark_hashing_classifier(dataset(), n_features=3_000)
+
+
+def test_future_unseen_category_is_reported_not_silently_dropped():
+    rows = dataset()
+    rows.append(
+        record(
+            "test-new",
+            "new category grievance",
+            "New Category",
+            "test",
+        )
+    )
+    benchmark = benchmark_hashing_classifier(
+        rows, alpha_values=(1e-4,), n_features=2**12
+    )
+
+    assert benchmark.report["missing_training_labels"] == ["New Category"]
+    assert benchmark.report["test"]["accuracy"] < 1.0


### PR DESCRIPTION
## Summary

- specialize the shared classification scorecard for grievance categorization
- report accepted rescue, per-class and top-k quality, calibration, abstention, and language/source slices
- fail closed when declared category support or group-disjoint evidence is incomplete

## Stack position

This is **PR 2 of 12** in the pipeline-quality stack. Its predecessor is PR #249.

- Current review base: `feat/evaluation-classification-core`
- Head: `feat/evaluation-categorization-scorecard`
- Never retarget this stack to `main`
- No Codex review is requested on individual stack PRs

| Order | PR | Head branch | Review base | Scope |
|---:|---:|---|---|---|
| 1 | [#249](https://github.com/Data-Policy-and-Innovation-Centre/janasunani/pull/249) | `feat/evaluation-classification-core` | `feat/pipeline-quality-trunk` | Classification scorecards |
| 2 | [#250](https://github.com/Data-Policy-and-Innovation-Centre/janasunani/pull/250) | `feat/evaluation-categorization-scorecard` | `feat/evaluation-classification-core` | Categorization scorecard |
| 3 | [#251](https://github.com/Data-Policy-and-Innovation-Centre/janasunani/pull/251) | `feat/evaluation-summary-scorecard` | `feat/evaluation-categorization-scorecard` | Summary scorecard |
| 4 | [#252](https://github.com/Data-Policy-and-Innovation-Centre/janasunani/pull/252) | `feat/actionability-evaluation` | `feat/evaluation-summary-scorecard` | Actionability contract and evaluation |
| 5 | [#253](https://github.com/Data-Policy-and-Innovation-Centre/janasunani/pull/253) | `feat/actionability-adjudication` | `feat/actionability-evaluation` | Privacy-safe adjudication and candidates |
| 6 | [#254](https://github.com/Data-Policy-and-Innovation-Centre/janasunani/pull/254) | `feat/routing-incidence` | `feat/actionability-adjudication` | Routing incidence benchmark and serving |
| 7 | [#255](https://github.com/Data-Policy-and-Innovation-Centre/janasunani/pull/255) | `feat/model-release-control-plane` | `feat/routing-incidence` | Model release control plane |
| 8 | [#256](https://github.com/Data-Policy-and-Innovation-Centre/janasunani/pull/256) | `fix/local-model-resolution` | `feat/model-release-control-plane` | Approved local model resolution |
| 9 | [#257](https://github.com/Data-Policy-and-Innovation-Centre/janasunani/pull/257) | `feat/actionability-serving` | `fix/local-model-resolution` | Advisory actionability serving |
| 10 | [#258](https://github.com/Data-Policy-and-Innovation-Centre/janasunani/pull/258) | `feat/sarvam-cached-evidence` | `feat/actionability-serving` | Cached Sarvam evidence |
| 11 | [#259](https://github.com/Data-Policy-and-Innovation-Centre/janasunani/pull/259) | `docs/pipeline-quality-evidence` | `feat/sarvam-cached-evidence` | Quality and impact evidence docs |
| 12 | [#260](https://github.com/Data-Policy-and-Innovation-Centre/janasunani/pull/260) | `docs/value-add-report` | `docs/pipeline-quality-evidence` | Reproducible reports and briefs |

## How to integrate this stack

1. Review and test PRs in numerical order, starting with #249.
2. Merge the current PR into `feat/pipeline-quality-trunk` with a normal merge commit.
3. Change the next PR's base from its predecessor branch to `feat/pipeline-quality-trunk`.
4. Confirm the retargeted diff contains only that PR's listed commits and files.
5. Test and repair that PR before merging it; do not squash the listed commits.
6. Keep later PRs open and stacked on their immediate predecessors until their turn.
7. Request one Codex review only after #260 lands and the clean integrated trunk passes end to end.

## Verification

The integrated stack passed:

- `uv run ruff check .`
- `uv run --extra serving --extra pipeline-core pytest`
- **1,563 passed, 19 skipped**

Each PR should still be tested against its own base before merging.

## Safety

Evaluation only; it does not activate a categorizer or assign grievances.

## Reconciliation update — 23 August 2026

- PR #249 is merged into `feat/pipeline-quality-trunk`; this is the next logical slice.
- Exact head `aaac11c` is already an ancestor of integrated trunk `edf2126`. Do not replay or rewrite that integration.
- The project owner now requires the full per-PR Codex review loop. This PR is being made ready, self-reviewed, and sent to Codex despite the older stack note above.
- After the exact-head review gate is green and every finding is resolved with evidence, reconcile this PR as already integrated, then proceed to #251.

Self-review: the two-file, one-commit diff was read end to end. Exact-head targeted tests pass (19 passed), Ruff passes, and `git diff --check` is clean. The slice's best-effort abstention fallback does not itself declare an infeasible selective constraint; the integrated trunk later adds `selective_constraints_met` and keeps the benchmark non-release-eligible, so that downstream correction must be considered when triaging review findings.
