### PR TITLE
feat(evaluation): add summary quality scorecard

### DIFF
--- a/janasunani/evaluation/summary.py
+++ b/janasunani/evaluation/summary.py
@@ -1,0 +1,240 @@
+"""Privacy-safe scorecard for officer-adjudicated summaries.
+
+The input is structured judgment data only.  It deliberately contains no
+source grievance, generated summary, reference summary, ticket number, or
+officer identity; those narratives belong in a separately governed review
+store.  This module measures whether the summary retained critical facts,
+invented or contradicted anything, leaked PII, was useful without editing, and
+correctly abstained on low-signal/non-grievance inputs.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+import math
+from pathlib import Path
+from statistics import mean, median
+from typing import Any, Mapping, Sequence
+
+from janasunani.evaluation.stats import wilson_interval
+
+
+SCHEMA_VERSION = "janasunani.summary-judgments/v1"
+REPORT_VERSION = "janasunani.summary-scorecard/v1"
+_FORBIDDEN_FIELDS = {
+    "grievance", "raw_text", "redacted_text", "source_text", "summary",
+    "candidate_summary", "reference_summary", "ticket_no", "officer_id",
+}
+_REQUIRED_FIELDS = {
+    "item_id", "group_id", "language", "source_type", "should_skip", "skipped",
+    "critical_facts_total", "critical_facts_present", "unsupported_claims",
+    "contradictions", "pii_leak", "usefulness", "usable_without_edit",
+    "edit_seconds",
+}
+
+
+@dataclass(frozen=True)
+class SummaryJudgment:
+    item_id: str
+    group_id: str
+    language: str
+    source_type: str
+    should_skip: bool
+    skipped: bool
+    critical_facts_total: int
+    critical_facts_present: int
+    unsupported_claims: int
+    contradictions: int
+    pii_leak: bool
+    usefulness: int | None
+    usable_without_edit: bool | None
+    edit_seconds: float | None
+
+    def __post_init__(self) -> None:
+        if not all((self.item_id, self.group_id, self.language, self.source_type)):
+            raise ValueError("item/group/language/source values must be non-empty")
+        for value, name in (
+            (self.critical_facts_total, "critical_facts_total"),
+            (self.critical_facts_present, "critical_facts_present"),
+            (self.unsupported_claims, "unsupported_claims"),
+            (self.contradictions, "contradictions"),
+        ):
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                raise ValueError(f"{name} must be a non-negative integer")
+        if self.critical_facts_present > self.critical_facts_total:
+            raise ValueError("critical_facts_present cannot exceed total")
+        if self.skipped:
+            if any(
+                (
+                    self.critical_facts_present,
+                    self.unsupported_claims,
+                    self.contradictions,
+                    int(self.pii_leak),
+                )
+            ):
+                raise ValueError("a skipped summary cannot carry generated-output findings")
+            if any(
+                value is not None
+                for value in (self.usefulness, self.usable_without_edit, self.edit_seconds)
+            ):
+                raise ValueError("a skipped summary cannot carry usefulness/edit judgments")
+        else:
+            if (
+                self.usefulness is None
+                or isinstance(self.usefulness, bool)
+                or not isinstance(self.usefulness, int)
+                or not 0 <= self.usefulness <= 3
+            ):
+                raise ValueError("generated summaries require usefulness in [0,3]")
+            if not isinstance(self.usable_without_edit, bool):
+                raise ValueError("generated summaries require usable_without_edit")
+            if (
+                self.edit_seconds is None
+                or isinstance(self.edit_seconds, bool)
+                or not isinstance(self.edit_seconds, (int, float))
+                or not math.isfinite(self.edit_seconds)
+                or self.edit_seconds < 0
+            ):
+                raise ValueError("generated summaries require non-negative edit_seconds")
+
+
+def load_judgments(path: Path) -> list[SummaryJudgment]:
+    judgments: list[SummaryJudgment] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if not line.strip():
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"line {line_number} is not valid JSON") from exc
+        if not isinstance(payload, Mapping):
+            raise ValueError(f"line {line_number} must be an object")
+        forbidden = set(payload).intersection(_FORBIDDEN_FIELDS)
+        if forbidden:
+            raise ValueError(
+                f"line {line_number} contains forbidden narrative/identity fields: "
+                f"{sorted(forbidden)}"
+            )
+        unknown = set(payload) - _REQUIRED_FIELDS
+        missing = _REQUIRED_FIELDS - set(payload)
+        if unknown or missing:
+            raise ValueError(
+                f"line {line_number} schema mismatch; missing={sorted(missing)} "
+                f"unknown={sorted(unknown)}"
+            )
+        judgments.append(SummaryJudgment(**payload))
+    _validate_collection(judgments)
+    return judgments
+
+
+def _validate_collection(judgments: Sequence[SummaryJudgment]) -> None:
+    if not judgments:
+        raise ValueError("at least one summary judgment is required")
+    identifiers = [judgment.item_id for judgment in judgments]
+    if len(set(identifiers)) != len(identifiers):
+        raise ValueError("item_id values must be unique")
+
+
+def _rate(successes: int, n: int) -> dict[str, int | float | str] | None:
+    if n == 0:
+        return None
+    interval = wilson_interval(successes, n)
+    return {
+        "successes": successes,
+        "n": n,
+        "rate": interval.point,
+        "ci_low": interval.ci_low,
+        "ci_high": interval.ci_high,
+        "ci_method": interval.method,
+    }
+
+
+def _metrics(judgments: Sequence[SummaryJudgment]) -> dict[str, Any]:
+    generated = [row for row in judgments if not row.skipped]
+    skip_correct = sum(row.skipped == row.should_skip for row in judgments)
+    false_summaries = sum(row.should_skip and not row.skipped for row in judgments)
+    missed_summaries = sum(not row.should_skip and row.skipped for row in judgments)
+    facts_total = sum(row.critical_facts_total for row in generated)
+    facts_present = sum(row.critical_facts_present for row in generated)
+    edit_seconds = [float(row.edit_seconds) for row in generated if row.edit_seconds is not None]
+    usefulness = [int(row.usefulness) for row in generated if row.usefulness is not None]
+    return {
+        "n": len(judgments),
+        "generated_n": len(generated),
+        "skipped_n": len(judgments) - len(generated),
+        "critical_fact_recall": _rate(facts_present, facts_total),
+        "unsupported_claim_case_rate": _rate(
+            sum(row.unsupported_claims > 0 for row in generated), len(generated)
+        ),
+        "contradiction_case_rate": _rate(
+            sum(row.contradictions > 0 for row in generated), len(generated)
+        ),
+        "pii_leak_case_rate": _rate(sum(row.pii_leak for row in generated), len(generated)),
+        "usable_without_edit_rate": _rate(
+            sum(row.usable_without_edit is True for row in generated), len(generated)
+        ),
+        "correct_skip_rate": _rate(skip_correct, len(judgments)),
+        "false_summary_on_should_skip_rate": _rate(
+            false_summaries, sum(row.should_skip for row in judgments)
+        ),
+        "missed_summary_rate": _rate(
+            missed_summaries, sum(not row.should_skip for row in judgments)
+        ),
+        "mean_usefulness_0_to_3": mean(usefulness) if usefulness else None,
+        "median_edit_seconds": median(edit_seconds) if edit_seconds else None,
+        "unsupported_claims_total": sum(row.unsupported_claims for row in generated),
+        "contradictions_total": sum(row.contradictions for row in generated),
+    }
+
+
+def build_scorecard(
+    judgments: Sequence[SummaryJudgment], *, dataset_id: str
+) -> dict[str, Any]:
+    _validate_collection(judgments)
+    if not dataset_id.strip():
+        raise ValueError("dataset_id must be non-empty")
+    languages = sorted({row.language for row in judgments})
+    sources = sorted({row.source_type for row in judgments})
+    return {
+        "report_version": REPORT_VERSION,
+        "input_schema_version": SCHEMA_VERSION,
+        "dataset_id": dataset_id,
+        "overall": _metrics(judgments),
+        "by_language": {
+            language: _metrics([row for row in judgments if row.language == language])
+            for language in languages
+        },
+        "by_source_type": {
+            source: _metrics([row for row in judgments if row.source_type == source])
+            for source in sources
+        },
+        "safety": {
+            "structured_judgments_only": True,
+            "narrative_and_identity_fields_forbidden": True,
+            "adjudication_required": True,
+            "item_level_wilson_intervals": True,
+            "cluster_uncertainty_pending": True,
+        },
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--judgments", type=Path, required=True)
+    parser.add_argument("--dataset-id", required=True)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args(argv)
+    report = build_scorecard(load_judgments(args.judgments), dataset_id=args.dataset_id)
+    encoded = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(encoded, encoding="utf-8")
+    else:
+        print(encoded, end="")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,7 @@ janasunani-spam-scorecard = "janasunani.evaluation.spam_scorecard:main"
 janasunani-evaluate-benchmark = "janasunani.evaluation.benchmark_report:main"
 janasunani-evaluate-sarvam = "janasunani.evaluation.sarvam_evaluate:main"
 janasunani-build-sarvam-sample = "janasunani.evaluation.sarvam_sample_builder:main"
+janasunani-evaluate-summary = "janasunani.evaluation.summary:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/test_summary_evaluation.py
+++ b/tests/test_summary_evaluation.py
@@ -1,0 +1,133 @@
+import json
+
+import pytest
+
+from janasunani.evaluation.summary import (
+    SummaryJudgment,
+    build_scorecard,
+    load_judgments,
+)
+
+
+def generated(item_id, *, language="English", source="typed", **overrides):
+    values = {
+        "item_id": item_id,
+        "group_id": item_id,
+        "language": language,
+        "source_type": source,
+        "should_skip": False,
+        "skipped": False,
+        "critical_facts_total": 4,
+        "critical_facts_present": 3,
+        "unsupported_claims": 0,
+        "contradictions": 0,
+        "pii_leak": False,
+        "usefulness": 2,
+        "usable_without_edit": True,
+        "edit_seconds": 15.0,
+    }
+    values.update(overrides)
+    return SummaryJudgment(**values)
+
+
+def skipped(item_id, *, should_skip=True, language="unknown", source="typed"):
+    return SummaryJudgment(
+        item_id=item_id,
+        group_id=item_id,
+        language=language,
+        source_type=source,
+        should_skip=should_skip,
+        skipped=True,
+        critical_facts_total=0,
+        critical_facts_present=0,
+        unsupported_claims=0,
+        contradictions=0,
+        pii_leak=False,
+        usefulness=None,
+        usable_without_edit=None,
+        edit_seconds=None,
+    )
+
+
+def test_scorecard_covers_factuality_usefulness_editing_and_abstention():
+    rows = [
+        generated("good"),
+        generated(
+            "bad",
+            language="Odia",
+            source="scan",
+            critical_facts_present=2,
+            unsupported_claims=1,
+            contradictions=1,
+            pii_leak=True,
+            usefulness=0,
+            usable_without_edit=False,
+            edit_seconds=90.0,
+        ),
+        skipped("low-signal"),
+        generated(
+            "should-have-skipped",
+            should_skip=True,
+            critical_facts_total=0,
+            critical_facts_present=0,
+        ),
+    ]
+
+    report = build_scorecard(rows, dataset_id="summary-gold-v1")
+
+    overall = report["overall"]
+    assert overall["n"] == 4
+    assert overall["critical_fact_recall"]["rate"] == pytest.approx(5 / 8)
+    assert overall["unsupported_claim_case_rate"]["rate"] == pytest.approx(1 / 3)
+    assert overall["pii_leak_case_rate"]["rate"] == pytest.approx(1 / 3)
+    assert overall["correct_skip_rate"]["rate"] == pytest.approx(3 / 4)
+    assert overall["median_edit_seconds"] == 15.0
+    assert set(report["by_language"]) == {"English", "Odia", "unknown"}
+    assert set(report["by_source_type"]) == {"scan", "typed"}
+
+
+def test_exact_screenshot_behavior_is_a_correct_skip_judgment():
+    row = skipped("screenshot-i-am-an-idiot", language="unknown")
+    report = build_scorecard([row], dataset_id="summary-regressions-v1")
+
+    assert report["overall"]["correct_skip_rate"]["rate"] == 1.0
+    assert report["overall"]["generated_n"] == 0
+
+
+def test_loader_rejects_narrative_or_identity_fields(tmp_path):
+    payload = generated("x").__dict__ | {"candidate_summary": "narrative"}
+    path = tmp_path / "judgments.jsonl"
+    path.write_text(json.dumps(payload) + "\n")
+
+    with pytest.raises(ValueError, match="forbidden"):
+        load_judgments(path)
+
+
+def test_loader_is_strict_and_rejects_duplicate_items(tmp_path):
+    payload = generated("same").__dict__
+    path = tmp_path / "judgments.jsonl"
+    path.write_text(json.dumps(payload) + "\n" + json.dumps(payload) + "\n")
+
+    with pytest.raises(ValueError, match="unique"):
+        load_judgments(path)
+
+
+def test_skipped_rows_cannot_hide_generated_output_findings():
+    with pytest.raises(ValueError, match="skipped summary"):
+        SummaryJudgment(
+            **(skipped("x").__dict__ | {"unsupported_claims": 1})
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("usefulness", True, "usefulness"),
+        ("usable_without_edit", 1, "usable_without_edit"),
+        ("edit_seconds", True, "edit_seconds"),
+        ("edit_seconds", float("nan"), "edit_seconds"),
+    ],
+)
+def test_generated_judgment_rejects_boolean_or_nonfinite_metrics(field, value, message):
+    with pytest.raises(ValueError, match=message):
+        generated("invalid", **{field: value})


### PR DESCRIPTION
## Summary

- Add a reusable, paired-review scorecard for grievance summaries.
- Measure critical-fact recall, unsupported claims, contradictions, PII leakage, usefulness, edit burden, and abstention.
- Expose a reproducible CLI without treating historical usefulness ratings as a release gate.

## Historical stack position

This is the next historical slice after #250:

- Base: `feat/evaluation-categorization-scorecard`
- Head: `feat/evaluation-summary-scorecard`
- Exact head: `403473c885863f50f970370266baf818270e331b`
- Commit in this slice: `403473c feat(evaluation): add summary quality scorecard`

The old instruction in this PR said not to request per-slice Codex review. That instruction is superseded: every open slice is now being self-reviewed, tested, sent through an exact-head `@codex review`, and reconciled in dependency order.

PR #250 completed that loop and was closed as already integrated. This head is likewise already an ancestor of `feat/pipeline-quality-trunk`; after its own review findings are addressed and its exact-head gate is green, it will be reconciled without replaying the historical stack into a stale base.

## Verification on this exact slice

- `tests/test_summary_evaluation.py`: **9 passed**.
- Ruff passed for the implementation and test files.
- `uv lock --check` passed (351 packages resolved).
- `git diff --check` passed.
- Full historical CI is green apart from the draft-only Codex exemption, which will be replaced by an exact-head review verdict when this PR is marked ready.

## Self-review limitation to verify

The report correctly records that cluster uncertainty remains pending. Its `critical_fact_recall` Wilson interval is computed over pooled fact indicators, while a separate report flag refers to item-level Wilson intervals. Because facts are nested within reviewed items, that wording and uncertainty contract need exact review; the current implementation does not model within-item dependence.

## Safety

Evaluation only. This PR does not activate a summarizer, send grievance text externally, or turn historical reviewer ratings into a release or citizen-outcome claim.
