### PR TITLE
feat(actionability): add advisory evaluation benchmark

### DIFF
--- a/dvc.lock
+++ b/dvc.lock
@@ -29,9 +29,9 @@ stages:
       md5: 4ad7a17893cb22a396f572b899e68c25
       size: 3925
   pipeline-sample:
-    cmd: uv run --extra pipeline-core janasunani-pipeline run --input 
-      data/raw/documents-sample --db data/processed/pipeline-sample.sqlite 
-      --models models --ocr-engine pytesseract --stages format_classifier 
+    cmd: uv run --extra pipeline-core janasunani-pipeline run --input
+      data/raw/documents-sample --db data/processed/pipeline-sample.sqlite
+      --models models --ocr-engine pytesseract --stages format_classifier
       ocr_extraction --workers 1 && uv run --extra pii janasunani-pipeline run
       --input data/raw/documents-sample --db
       data/processed/pipeline-sample.sqlite --models models --stages pii_tagger
@@ -189,3 +189,46 @@ stages:
       hash: md5
       md5: 903dc729212929dc0b8891df6487bd40
       size: 868
+  actionability-weak-label-audit:
+    cmd: uv run --frozen janasunani-audit-actionability-labels --complaints
+      data/interim/complaints.parquet --action-history
+      data/interim/action_history.parquet --min-office-support 100 --output
+      outputs/evaluation/actionability_weak_label_audit.json
+    deps:
+    - path: data/interim/action_history.parquet
+      hash: md5
+      md5: a69b4a902baa6bab082f3ee21dfcaeb5
+      size: 497002355
+    - path: data/interim/complaints.parquet
+      hash: md5
+      md5: f0eeb1379c88a70ecf2fac5bad07868f
+      size: 410159639
+    - path: janasunani/analytics/findings/discards.py
+      hash: md5
+      md5: 13e1b915153d273c589021b99813036a
+      size: 12020
+    - path: janasunani/evaluation/actionability.py
+      hash: md5
+      md5: 08570b2471796f49214c2f801d8791db
+      size: 33241
+    - path: janasunani/evaluation/classification.py
+      hash: md5
+      md5: 5be5a49505010f6b20ec6a183f30fd0f
+      size: 12995
+    - path: janasunani/evaluation/weak_labels.py
+      hash: md5
+      md5: 9d1731d003d9f8da8fda59a42b53cb45
+      size: 9383
+    - path: pyproject.toml
+      hash: md5
+      md5: 312152a943454973f9fdd51e68d82609
+      size: 9968
+    - path: uv.lock
+      hash: md5
+      md5: f895934178f603f5315683d02abc6449
+      size: 1038485
+    outs:
+    - path: outputs/evaluation/actionability_weak_label_audit.json
+      hash: md5
+      md5: f8a1a3d705c68959429278db77bf0ac0
+      size: 5538

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -116,3 +116,27 @@ stages:
       - outputs/findings/confirmed_duplicates.md
       - outputs/findings/misrouting_baseline.csv
       - outputs/findings/misrouting_baseline.md
+
+  actionability-weak-label-audit:
+    desc: >-
+      Reproduce the aggregate administrative weak-label audit used to decide
+      whether discard-family labels are safe enough for training. The stage
+      reads only the two declared lake tables and publishes no grievance text
+      or item-level rows.
+    cmd: >-
+      uv run --frozen janasunani-audit-actionability-labels
+      --complaints data/interim/complaints.parquet
+      --action-history data/interim/action_history.parquet
+      --min-office-support 100
+      --output outputs/evaluation/actionability_weak_label_audit.json
+    deps:
+      - data/interim/complaints.parquet
+      - data/interim/action_history.parquet
+      - janasunani/analytics/findings/discards.py
+      - janasunani/evaluation/actionability.py
+      - janasunani/evaluation/classification.py
+      - janasunani/evaluation/weak_labels.py
+      - pyproject.toml
+      - uv.lock
+    outs:
+      - outputs/evaluation/actionability_weak_label_audit.json

--- a/janasunani/evaluation/actionability.py
+++ b/janasunani/evaluation/actionability.py
@@ -1,0 +1,896 @@
+"""Train and evaluate a cheap local actionability baseline.
+
+The model is intentionally a strong classical baseline: word and character
+TF-IDF feeding multinomial logistic regression.  It is fast on CPU, handles
+misspellings and romanized text better than a word-only model, emits class
+probabilities, and gives every heavier candidate a real number to beat.
+
+Administrative discard reasons are weak labels, not gold.  They may augment
+training after the office-variation audit, but validation and test records
+must be independently adjudicated.  Duplicate families are excluded because
+deduplication is a separate task; out-of-scope and policy-blocked records keep
+their own labels rather than being called spam.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import tempfile
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal, Mapping, Sequence
+
+from janasunani.evaluation.classification import (
+    ScoredExample,
+    assert_group_disjoint,
+    classification_metrics,
+    metrics_by_language,
+)
+from janasunani.evaluation.stats import wilson_interval
+from janasunani.inference.actionability import (
+    ACTIONABILITY_ARTIFACT_FORMAT,
+    ACTIONABILITY_LABELS,
+    ACTIONABILITY_TAXONOMY_VERSION,
+    ActionabilityLabel,
+    LocalActionabilityScorer,
+    _sha256,
+)
+
+Split = Literal["train", "validation", "test"]
+LabelSource = Literal[
+    "adjudicated",
+    "frontier_adjudicated",
+    "administrative_weak",
+]
+
+MODEL_FAMILY = "tfidf-word-char-logreg"
+MODEL_VERSION = "actionability-tfidf-v1"
+BINARY_MODEL_VERSION = "actionability-review-tfidf-v1"
+
+
+@dataclass(frozen=True)
+class ActionabilityRecord:
+    item_id: str
+    redacted_text: str
+    label: ActionabilityLabel
+    group_id: str
+    language: str
+    split: Split
+    label_source: LabelSource
+    office: str | None = None
+    sampling_stratum: str | None = None
+
+
+@dataclass(frozen=True)
+class WeakLabel:
+    label: ActionabilityLabel | None
+    eligible_for_training: bool
+    rationale: str
+
+
+WEAK_LABELS_BY_DISCARD_FAMILY: Mapping[str, WeakLabel] = {
+    "details_inadequate": WeakLabel(
+        "underspecified", True, "officer requested more grievance detail"
+    ),
+    "documents_not_attached": WeakLabel(
+        "underspecified", True, "required supporting material was absent"
+    ),
+    "address_not_given": WeakLabel(
+        "underspecified", True, "required location or contact detail was absent"
+    ),
+    "no_specific_grievance": WeakLabel(
+        "irrelevant", True, "officer recorded no specific grievance"
+    ),
+    "outside_grievance_cell_purview": WeakLabel(
+        "out_of_scope", True, "routing or jurisdiction failure, never spam"
+    ),
+    "policy_decision_required": WeakLabel(
+        "policy_blocked", True, "resolution requires a policy decision"
+    ),
+    "case_already_taken_up": WeakLabel(
+        None, False, "duplicate signal belongs to the deduplication task"
+    ),
+    "duplicate_copy": WeakLabel(
+        None, False, "duplicate signal belongs to the deduplication task"
+    ),
+}
+
+_RAW_TEXT_KEYS = {
+    "grievance",
+    "complaint_text",
+    "raw_text",
+    "grievance_text",
+    "unredacted_text",
+}
+
+
+def weak_label_for_discard_family(family: str) -> WeakLabel:
+    """Map an exact administrative family without inventing a catch-all."""
+
+    try:
+        return WEAK_LABELS_BY_DISCARD_FAMILY[family]
+    except KeyError as exc:
+        raise ValueError(f"unknown discard family {family!r}") from exc
+
+
+def load_jsonl(path: Path) -> list[ActionabilityRecord]:
+    """Load a governed manifest containing redacted text only."""
+
+    records: list[ActionabilityRecord] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if not line.strip():
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"line {line_number}: invalid JSON") from exc
+        if not isinstance(payload, dict):
+            raise ValueError(f"line {line_number}: record must be an object")
+        forbidden = _RAW_TEXT_KEYS.intersection(payload)
+        if forbidden:
+            raise ValueError(
+                f"line {line_number}: raw-text fields are forbidden: {sorted(forbidden)!r}"
+            )
+        required = {
+            "item_id",
+            "redacted_text",
+            "label",
+            "group_id",
+            "language",
+            "split",
+            "label_source",
+        }
+        missing = required.difference(payload)
+        if missing:
+            raise ValueError(f"line {line_number}: missing fields {sorted(missing)!r}")
+        unknown = set(payload).difference(required | {"office", "sampling_stratum"})
+        if unknown:
+            raise ValueError(f"line {line_number}: unknown fields {sorted(unknown)!r}")
+
+        label = payload["label"]
+        split = payload["split"]
+        label_source = payload["label_source"]
+        if label not in ACTIONABILITY_LABELS:
+            raise ValueError(f"line {line_number}: label is outside the taxonomy")
+        if split not in {"train", "validation", "test"}:
+            raise ValueError(f"line {line_number}: invalid split")
+        if label_source not in {
+            "adjudicated",
+            "frontier_adjudicated",
+            "administrative_weak",
+        }:
+            raise ValueError(f"line {line_number}: invalid label_source")
+        if split != "train" and label_source == "administrative_weak":
+            raise ValueError(
+                f"line {line_number}: validation/test labels must be adjudicated independently"
+            )
+
+        values = {
+            key: payload[key]
+            for key in ("item_id", "redacted_text", "group_id", "language")
+        }
+        if any(not isinstance(value, str) or not value.strip() for value in values.values()):
+            raise ValueError(f"line {line_number}: string fields must be non-empty")
+        office = payload.get("office")
+        if office is not None and (not isinstance(office, str) or not office.strip()):
+            raise ValueError(f"line {line_number}: office must be null or non-empty")
+        sampling_stratum = payload.get("sampling_stratum")
+        if sampling_stratum is not None and (
+            not isinstance(sampling_stratum, str) or not sampling_stratum.strip()
+        ):
+            raise ValueError(
+                f"line {line_number}: sampling_stratum must be null or non-empty"
+            )
+        records.append(
+            ActionabilityRecord(
+                item_id=payload["item_id"],
+                redacted_text=payload["redacted_text"],
+                label=label,
+                group_id=payload["group_id"],
+                language=payload["language"],
+                split=split,
+                label_source=label_source,
+                office=office,
+                sampling_stratum=sampling_stratum,
+            )
+        )
+    validate_records(records)
+    return records
+
+
+def validate_records(records: Sequence[ActionabilityRecord]) -> None:
+    if not records:
+        raise ValueError("actionability manifest is empty")
+    item_ids = [record.item_id for record in records]
+    if len(item_ids) != len(set(item_ids)):
+        raise ValueError("item_id values must be unique")
+    assert_group_disjoint((record.group_id, record.split) for record in records)
+    splits = {record.split for record in records}
+    if splits != {"train", "validation", "test"}:
+        raise ValueError("manifest must contain train, validation, and test splits")
+    for record in records:
+        if record.split != "train" and record.label_source == "administrative_weak":
+            raise ValueError("validation/test labels must be adjudicated independently")
+        if record.label_source == "administrative_weak" and record.label == "actionable":
+            raise ValueError("administrative weak labels cannot establish actionability")
+
+
+def sample_design_summary(
+    records: Sequence[ActionabilityRecord],
+) -> dict[str, object]:
+    """Describe whether prevalence-sensitive metrics can be generalized."""
+
+    strata = Counter(
+        record.sampling_stratum
+        for record in records
+        if record.sampling_stratum is not None
+    )
+    if strata:
+        return {
+            "sampling_scheme": "fixed quotas across opaque sampling strata",
+            "sampling_stratum_counts": dict(sorted(strata.items())),
+            "production_prevalence_representative": False,
+            "limitation": (
+                "accuracy, precision, PPV, and review workload are specific to "
+                "this designed sample composition and are not production prevalence"
+            ),
+        }
+    return {
+        "sampling_scheme": "unavailable_not_recorded",
+        "sampling_stratum_counts": {},
+        "production_prevalence_representative": "unavailable",
+        "limitation": (
+            "sampling design is unavailable; prevalence-sensitive metrics must not "
+            "be generalized to production"
+        ),
+    }
+
+
+def office_variation_audit(
+    records: Sequence[ActionabilityRecord], *, min_office_support: int = 20
+) -> dict[str, object]:
+    """Measure how strongly weak administrative labels vary by office.
+
+    Total-variation distance compares each sufficiently represented office's
+    label distribution with the global weak-label distribution.  It does not
+    prove bias or remove confounding; it is the pre-training alarm required by
+    issue #74.  No office field is ever passed to the text model.
+    """
+
+    if min_office_support < 1:
+        raise ValueError("min_office_support must be positive")
+    weak = [
+        record
+        for record in records
+        if record.label_source == "administrative_weak" and record.office
+    ]
+    if not weak:
+        return {
+            "status": "not_measured",
+            "n": 0,
+            "eligible_offices": 0,
+            "max_total_variation": None,
+            "by_office": {},
+        }
+
+    def distribution(rows: Sequence[ActionabilityRecord]) -> dict[str, float]:
+        counts = {label: 0 for label in ACTIONABILITY_LABELS}
+        for row in rows:
+            counts[row.label] += 1
+        return {label: counts[label] / len(rows) for label in ACTIONABILITY_LABELS}
+
+    global_distribution = distribution(weak)
+    offices = sorted({record.office for record in weak if record.office})
+    by_office: dict[str, object] = {}
+    max_tv = 0.0
+    for office in offices:
+        rows = [record for record in weak if record.office == office]
+        if len(rows) < min_office_support:
+            continue
+        observed = distribution(rows)
+        tv = 0.5 * sum(
+            abs(observed[label] - global_distribution[label])
+            for label in ACTIONABILITY_LABELS
+        )
+        max_tv = max(max_tv, tv)
+        by_office[office] = {
+            "n": len(rows),
+            "total_variation": tv,
+            "distribution": observed,
+        }
+    return {
+        "status": "measured" if by_office else "insufficient_support",
+        "n": len(weak),
+        "eligible_offices": len(by_office),
+        "max_total_variation": max_tv if by_office else None,
+        "global_distribution": global_distribution,
+        "by_office": by_office,
+        "note": "descriptive bias alarm; not proof of office causation",
+    }
+
+
+def _build_classifier(c: float, *, min_df: int, max_features: int | None):
+    from sklearn.feature_extraction.text import TfidfVectorizer
+    from sklearn.linear_model import LogisticRegression
+    from sklearn.pipeline import FeatureUnion, Pipeline
+
+    features = FeatureUnion(
+        [
+            (
+                "word",
+                TfidfVectorizer(
+                    analyzer="word",
+                    ngram_range=(1, 2),
+                    min_df=min_df,
+                    max_features=max_features,
+                    sublinear_tf=True,
+                    strip_accents=None,
+                ),
+            ),
+            (
+                "char",
+                TfidfVectorizer(
+                    analyzer="char_wb",
+                    ngram_range=(3, 5),
+                    min_df=min_df,
+                    max_features=max_features,
+                    sublinear_tf=True,
+                    strip_accents=None,
+                ),
+            ),
+        ]
+    )
+    return Pipeline(
+        [
+            ("features", features),
+            (
+                "classifier",
+                LogisticRegression(
+                    C=c,
+                    class_weight="balanced",
+                    max_iter=2_000,
+                    random_state=1729,
+                ),
+            ),
+        ]
+    )
+
+
+def _scored_examples(classifier, records: Sequence[ActionabilityRecord]) -> list[ScoredExample]:
+    matrix = classifier.predict_proba([record.redacted_text for record in records])
+    classes = tuple(str(label) for label in classifier.classes_)
+    return [
+        ScoredExample(
+            item_id=record.item_id,
+            gold_label=record.label,
+            probabilities={
+                label: float(value)
+                for label, value in zip(classes, row, strict=True)
+            },
+            group_id=record.group_id,
+            language=record.language,
+        )
+        for record, row in zip(records, matrix, strict=True)
+    ]
+
+
+def review_metrics(
+    examples: Sequence[ScoredExample], *, threshold: float
+) -> dict[str, int | float]:
+    """Binary review utility: non-actionable vs actionable."""
+
+    if not 0.0 <= threshold <= 1.0:
+        raise ValueError("threshold must be in [0, 1]")
+    flagged = 0
+    correct_review = 0
+    actionable_flagged = 0
+    actionable_total = 0
+    non_actionable_total = 0
+    for example in examples:
+        predicted = min(
+            ACTIONABILITY_LABELS,
+            key=lambda label: (-example.probabilities[label], label),
+        )
+        confidence = example.probabilities[predicted]
+        is_flagged = bool(
+            predicted != "actionable"
+            and threshold < 1.0
+            and confidence >= threshold
+        )
+        is_non_actionable = example.gold_label != "actionable"
+        actionable_total += not is_non_actionable
+        non_actionable_total += is_non_actionable
+        flagged += is_flagged
+        correct_review += is_flagged and is_non_actionable
+        actionable_flagged += is_flagged and not is_non_actionable
+    return {
+        "threshold": threshold,
+        "flagged": flagged,
+        "review_precision": correct_review / flagged if flagged else 1.0,
+        "review_recall": (
+            correct_review / non_actionable_total if non_actionable_total else 0.0
+        ),
+        "actionable_review_rate": (
+            actionable_flagged / actionable_total if actionable_total else 0.0
+        ),
+    }
+
+
+def select_review_threshold(
+    examples: Sequence[ScoredExample],
+    *,
+    min_precision: float = 0.9,
+    max_actionable_review_rate: float = 0.05,
+) -> tuple[float, dict[str, int | float]]:
+    """Maximize review recall subject to validation-only harm constraints."""
+
+    if not 0.0 <= min_precision <= 1.0:
+        raise ValueError("min_precision must be in [0, 1]")
+    if not 0.0 <= max_actionable_review_rate <= 1.0:
+        raise ValueError("max_actionable_review_rate must be in [0, 1]")
+    thresholds = {1.0}
+    for example in examples:
+        thresholds.update(float(value) for value in example.probabilities.values())
+    candidates = [
+        review_metrics(examples, threshold=threshold)
+        for threshold in sorted(thresholds)
+    ]
+    eligible = [
+        row
+        for row in candidates
+        if float(row["review_precision"]) >= min_precision
+        and float(row["actionable_review_rate"]) <= max_actionable_review_rate
+    ]
+    chosen = max(
+        eligible,
+        key=lambda row: (
+            float(row["review_recall"]),
+            int(row["flagged"]),
+            float(row["threshold"]),
+        ),
+    )
+    return float(chosen["threshold"]), chosen
+
+
+@dataclass
+class ActionabilityBenchmark:
+    classifier: Any
+    method: str
+    review_threshold: float
+    report: dict[str, object]
+
+    def scorer(self) -> LocalActionabilityScorer:
+        return LocalActionabilityScorer(
+            self.classifier,
+            method=self.method,
+            review_threshold=self.review_threshold,
+        )
+
+    def save(self, out_dir: Path) -> dict[str, Path]:
+        """Write a checksummed model artifact and its non-sensitive report.
+
+        Refuses a non-empty target so a prior promoted artifact cannot be
+        silently replaced.  Promotion remains a separate DVC-tracked action.
+        """
+
+        import joblib
+
+        target = Path(out_dir)
+        if target.exists() and any(target.iterdir()):
+            raise FileExistsError(f"artifact directory is not empty: {target}")
+        target.mkdir(parents=True, exist_ok=True)
+        model_path = target / "classifier.joblib"
+        report_path = target / "benchmark.json"
+        manifest_path = target / "manifest.json"
+
+        report_json = json.dumps(self.report, indent=2, sort_keys=True)
+        handle, temporary_name = tempfile.mkstemp(
+            prefix=".classifier-", suffix=".joblib", dir=target
+        )
+        os.close(handle)
+        temporary_path = Path(temporary_name)
+        try:
+            joblib.dump(self.classifier, temporary_path)
+            temporary_path.replace(model_path)
+        finally:
+            if temporary_path.exists():
+                temporary_path.unlink()
+        report_path.write_text(report_json, encoding="utf-8")
+        manifest = {
+            "artifact_format": ACTIONABILITY_ARTIFACT_FORMAT,
+            "taxonomy_version": ACTIONABILITY_TAXONOMY_VERSION,
+            "labels": list(ACTIONABILITY_LABELS),
+            "method": self.method,
+            "review_threshold": self.review_threshold,
+            "model_file": model_path.name,
+            "model_sha256": _sha256(model_path),
+        }
+        manifest_path.write_text(
+            json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8"
+        )
+        return {
+            "model": model_path,
+            "manifest": manifest_path,
+            "benchmark": report_path,
+        }
+
+
+def benchmark_tfidf(
+    records: Sequence[ActionabilityRecord],
+    *,
+    c_values: Sequence[float] = (0.5, 1.0, 2.0, 4.0),
+    min_df: int = 2,
+    max_features: int | None = 250_000,
+    min_review_precision: float = 0.9,
+    max_actionable_review_rate: float = 0.05,
+    office_min_support: int = 20,
+    max_office_total_variation: float = 0.25,
+) -> ActionabilityBenchmark:
+    """Select hyperparameters and threshold on validation, report test once."""
+
+    validate_records(records)
+    if not c_values or any(not math.isfinite(c) or c <= 0 for c in c_values):
+        raise ValueError("c_values must contain positive finite values")
+    if min_df < 1:
+        raise ValueError("min_df must be positive")
+    train = [record for record in records if record.split == "train"]
+    validation = [record for record in records if record.split == "validation"]
+    test = [record for record in records if record.split == "test"]
+
+    missing_train = set(ACTIONABILITY_LABELS).difference(record.label for record in train)
+    if missing_train:
+        raise ValueError(f"training split is missing classes: {sorted(missing_train)!r}")
+    for split_name, rows in (("validation", validation), ("test", test)):
+        missing = set(ACTIONABILITY_LABELS).difference(record.label for record in rows)
+        if missing:
+            raise ValueError(
+                f"{split_name} split is missing classes: {sorted(missing)!r}"
+            )
+
+    weak_train = [record for record in train if record.label_source == "administrative_weak"]
+    office_audit = office_variation_audit(
+        records, min_office_support=office_min_support
+    )
+    if weak_train:
+        if int(office_audit["eligible_offices"]) < 2:
+            raise ValueError(
+                "administrative weak labels require at least two offices with "
+                "enough support for the office-variation audit"
+            )
+        max_variation = float(office_audit["max_total_variation"])
+        if max_variation > max_office_total_variation:
+            raise ValueError(
+                "office-label total variation exceeds the training gate: "
+                f"{max_variation:.3f} > {max_office_total_variation:.3f}"
+            )
+
+    candidates: list[tuple[float, Any, list[ScoredExample], dict[str, object]]] = []
+    for c in c_values:
+        classifier = _build_classifier(c, min_df=min_df, max_features=max_features)
+        classifier.fit(
+            [record.redacted_text for record in train],
+            [record.label for record in train],
+        )
+        validation_examples = _scored_examples(classifier, validation)
+        metrics = classification_metrics(
+            validation_examples,
+            expected_labels=ACTIONABILITY_LABELS,
+            top_k=(1, 2, 3),
+        )
+        candidates.append((c, classifier, validation_examples, metrics))
+
+    c, classifier, validation_examples, validation_metrics = max(
+        candidates,
+        key=lambda row: (
+            float(row[3]["macro_f1"]),
+            -float(row[3]["log_loss"]),
+            -row[0],
+        ),
+    )
+    threshold, validation_review = select_review_threshold(
+        validation_examples,
+        min_precision=min_review_precision,
+        max_actionable_review_rate=max_actionable_review_rate,
+    )
+    test_examples = _scored_examples(classifier, test)
+    test_metrics = classification_metrics(
+        test_examples,
+        expected_labels=ACTIONABILITY_LABELS,
+        top_k=(1, 2, 3),
+        abstain_threshold=threshold,
+    )
+    test_by_language = metrics_by_language(
+        test_examples,
+        expected_labels=ACTIONABILITY_LABELS,
+        top_k=(1, 2, 3),
+        abstain_threshold=threshold,
+    )
+    method = f"{MODEL_VERSION}-c{c:g}"
+    report: dict[str, object] = {
+        "model_family": MODEL_FAMILY,
+        "model_version": MODEL_VERSION,
+        "method": method,
+        "taxonomy_version": ACTIONABILITY_TAXONOMY_VERSION,
+        "selected_c": c,
+        "review_threshold": threshold,
+        "split_counts": {
+            "train": len(train),
+            "validation": len(validation),
+            "test": len(test),
+        },
+        "validation": validation_metrics,
+        "validation_review": validation_review,
+        "test": test_metrics,
+        "test_review": review_metrics(test_examples, threshold=threshold),
+        "test_by_language": test_by_language,
+        "office_variation": office_audit,
+        "candidate_validation": [
+            {
+                "c": candidate_c,
+                "macro_f1": metrics["macro_f1"],
+                "log_loss": metrics["log_loss"],
+            }
+            for candidate_c, _, _, metrics in candidates
+        ],
+        "sample_design": sample_design_summary(records),
+        "safety": {
+            "raw_text_fields_forbidden": True,
+            "validation_test_require_adjudication": True,
+            "duplicate_families_excluded": True,
+            "advisory_only": True,
+        },
+    }
+    return ActionabilityBenchmark(
+        classifier=classifier,
+        method=method,
+        review_threshold=threshold,
+        report=report,
+    )
+
+
+def _binary_review_metrics(
+    review_probabilities: Sequence[float],
+    records: Sequence[ActionabilityRecord],
+    *,
+    threshold: float,
+) -> dict[str, object]:
+    if len(review_probabilities) != len(records) or not records:
+        raise ValueError("binary review metrics require aligned non-empty inputs")
+    if not 0.0 <= threshold <= 1.0:
+        raise ValueError("threshold must be in [0, 1]")
+    if any(
+        not math.isfinite(value) or not 0.0 <= value <= 1.0
+        for value in review_probabilities
+    ):
+        raise ValueError("review probabilities must be finite and in [0, 1]")
+    flagged = [threshold < 1.0 and value >= threshold for value in review_probabilities]
+    gold_review = [record.label != "actionable" for record in records]
+    true_positive = sum(
+        predicted and gold
+        for predicted, gold in zip(flagged, gold_review, strict=True)
+    )
+    false_positive = sum(
+        predicted and not gold
+        for predicted, gold in zip(flagged, gold_review, strict=True)
+    )
+    true_negative = sum(
+        not predicted and not gold
+        for predicted, gold in zip(flagged, gold_review, strict=True)
+    )
+    false_negative = sum(
+        not predicted and gold
+        for predicted, gold in zip(flagged, gold_review, strict=True)
+    )
+    predicted_review = true_positive + false_positive
+    actual_review = true_positive + false_negative
+    actionable = true_negative + false_positive
+    precision = true_positive / predicted_review if predicted_review else 1.0
+    recall = true_positive / actual_review if actual_review else 0.0
+    actionable_review_rate = false_positive / actionable if actionable else 0.0
+    accuracy = (true_positive + true_negative) / len(records)
+    f1 = 2.0 * precision * recall / (precision + recall) if precision + recall else 0.0
+
+    def interval(successes: int, total: int) -> list[float]:
+        estimate = wilson_interval(successes, total)
+        return [estimate.ci_low, estimate.ci_high]
+
+    by_reason: dict[str, dict[str, int | float]] = {}
+    for label in ACTIONABILITY_LABELS:
+        if label == "actionable":
+            continue
+        indices = [index for index, record in enumerate(records) if record.label == label]
+        caught = sum(flagged[index] for index in indices)
+        by_reason[label] = {
+            "support": len(indices),
+            "review_recall": caught / len(indices) if indices else 0.0,
+        }
+    return {
+        "n": len(records),
+        "threshold": threshold,
+        "actual_review": actual_review,
+        "flagged": predicted_review,
+        "confusion": {
+            "true_review": true_positive,
+            "false_review": false_positive,
+            "true_actionable": true_negative,
+            "missed_review": false_negative,
+        },
+        "accuracy": accuracy,
+        "accuracy_ci": interval(true_positive + true_negative, len(records)),
+        "review_precision": precision,
+        "review_precision_ci": (
+            interval(true_positive, predicted_review) if predicted_review else None
+        ),
+        "review_recall": recall,
+        "review_recall_ci": (
+            interval(true_positive, actual_review) if actual_review else None
+        ),
+        "actionable_review_rate": actionable_review_rate,
+        "actionable_review_rate_ci": (
+            interval(false_positive, actionable) if actionable else None
+        ),
+        "f1": f1,
+        "by_non_actionable_reason": by_reason,
+    }
+
+
+def _select_binary_review_threshold(
+    review_probabilities: Sequence[float],
+    records: Sequence[ActionabilityRecord],
+    *,
+    min_precision: float,
+    max_actionable_review_rate: float,
+) -> tuple[float, dict[str, object]]:
+    thresholds = sorted({0.0, 1.0, *(float(value) for value in review_probabilities)})
+    candidates = [
+        _binary_review_metrics(review_probabilities, records, threshold=threshold)
+        for threshold in thresholds
+    ]
+    eligible = [
+        metrics
+        for metrics in candidates
+        if float(metrics["review_precision"]) >= min_precision
+        and float(metrics["actionable_review_rate"]) <= max_actionable_review_rate
+    ]
+    chosen = max(
+        eligible,
+        key=lambda metrics: (
+            float(metrics["review_recall"]),
+            float(metrics["review_precision"]),
+            float(metrics["accuracy"]),
+            float(metrics["threshold"]),
+        ),
+    )
+    return float(chosen["threshold"]), chosen
+
+
+@dataclass
+class BinaryReviewBenchmark:
+    classifier: Any
+    review_threshold: float
+    report: dict[str, object]
+
+
+def benchmark_binary_review(
+    records: Sequence[ActionabilityRecord],
+    *,
+    c_values: Sequence[float] = (0.1, 0.5, 1.0, 2.0, 10.0),
+    min_df: int = 1,
+    max_features: int | None = 250_000,
+    min_review_precision: float = 0.9,
+    max_actionable_review_rate: float = 0.05,
+) -> BinaryReviewBenchmark:
+    """Benchmark actionable-versus-review when five-class support is incomplete.
+
+    This is a development scorecard, not a deployable substitute for the full
+    five-class contract. It answers the immediate operational question—whether
+    a grievance should be shown for extra officer review—while retaining each
+    non-actionable reason in the held-out breakdown.
+    """
+
+    validate_records(records)
+    if not c_values or any(not math.isfinite(c) or c <= 0.0 for c in c_values):
+        raise ValueError("c_values must contain positive finite values")
+    if not 0.0 <= min_review_precision <= 1.0:
+        raise ValueError("min_review_precision must be in [0, 1]")
+    if not 0.0 <= max_actionable_review_rate <= 1.0:
+        raise ValueError("max_actionable_review_rate must be in [0, 1]")
+    splits = {
+        name: [record for record in records if record.split == name]
+        for name in ("train", "validation", "test")
+    }
+    for name, rows in splits.items():
+        binary_labels = {record.label != "actionable" for record in rows}
+        if binary_labels != {False, True}:
+            raise ValueError(f"{name} split must contain actionable and review examples")
+
+    candidates: list[tuple[float, Any, float, dict[str, object]]] = []
+    for c in c_values:
+        classifier = _build_classifier(c, min_df=min_df, max_features=max_features)
+        # ``liblinear`` is a stable sparse binary solver and avoids routing this
+        # two-class objective through the multinomial-oriented LBFGS path.
+        classifier.set_params(classifier__solver="liblinear")
+        classifier.fit(
+            [record.redacted_text for record in splits["train"]],
+            [
+                "review" if record.label != "actionable" else "actionable"
+                for record in splits["train"]
+            ],
+        )
+        classes = tuple(str(label) for label in classifier.classes_)
+        review_index = classes.index("review")
+        validation_probabilities = [
+            float(row[review_index])
+            for row in classifier.predict_proba(
+                [record.redacted_text for record in splits["validation"]]
+            )
+        ]
+        threshold, metrics = _select_binary_review_threshold(
+            validation_probabilities,
+            splits["validation"],
+            min_precision=min_review_precision,
+            max_actionable_review_rate=max_actionable_review_rate,
+        )
+        candidates.append((c, classifier, threshold, metrics))
+    c, classifier, threshold, validation_metrics = max(
+        candidates,
+        key=lambda row: (
+            float(row[3]["review_recall"]),
+            float(row[3]["review_precision"]),
+            float(row[3]["accuracy"]),
+            -row[0],
+        ),
+    )
+    classes = tuple(str(label) for label in classifier.classes_)
+    review_index = classes.index("review")
+    test_probabilities = [
+        float(row[review_index])
+        for row in classifier.predict_proba(
+            [record.redacted_text for record in splits["test"]]
+        )
+    ]
+    test_metrics = _binary_review_metrics(
+        test_probabilities, splits["test"], threshold=threshold
+    )
+    observed_labels = set(record.label for record in records)
+    missing_labels = sorted(set(ACTIONABILITY_LABELS).difference(observed_labels))
+    report: dict[str, object] = {
+        "model_family": MODEL_FAMILY,
+        "model_version": BINARY_MODEL_VERSION,
+        "objective": "actionable_vs_officer_review",
+        "selected_c": c,
+        "review_threshold": threshold,
+        "split_counts": {name: len(rows) for name, rows in splits.items()},
+        "gold_label_distribution": dict(
+            sorted(Counter(record.label for record in records).items())
+        ),
+        "missing_five_class_support": missing_labels,
+        "validation": validation_metrics,
+        "test": test_metrics,
+        "candidate_validation": [
+            {
+                "c": candidate_c,
+                "threshold": candidate_threshold,
+                "review_precision": metrics["review_precision"],
+                "review_recall": metrics["review_recall"],
+                "actionable_review_rate": metrics["actionable_review_rate"],
+            }
+            for candidate_c, _, candidate_threshold, metrics in candidates
+        ],
+        "sample_design": sample_design_summary(records),
+        "release_eligible": False,
+        "limitations": [
+            "frontier-adjudicated development gold is not officer-confirmed truth",
+            "single-snapshot hash splits are not chronological release evidence",
+            "duplicate-group isolation is unavailable in this pilot sample",
+            "binary review does not replace the complete five-class production contract",
+        ],
+    }
+    return BinaryReviewBenchmark(
+        classifier=classifier,
+        review_threshold=threshold,
+        report=report,
+    )

--- a/janasunani/evaluation/weak_labels.py
+++ b/janasunani/evaluation/weak_labels.py
@@ -1,0 +1,265 @@
+"""Audit administrative discard families before weak-label training.
+
+Officer remarks are matched only to an enumerated exact-template registry.
+The free-text tail is neither returned nor classified.  Duplicate families
+remain outside the actionability taxonomy, and out-of-purview cases retain an
+``out_of_scope`` label instead of being called spam.
+
+The office field in ``complaints`` describes the complaint's recorded office,
+not necessarily the actor who entered a historical action.  Office variation
+is therefore a confounding alarm, not evidence about an office or an officer.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Iterable
+
+from janasunani.analytics.findings.discards import TEMPLATES
+from janasunani.evaluation.actionability import WEAK_LABELS_BY_DISCARD_FAMILY
+
+
+_NORMALIZED_REMARK = (
+    "regexp_replace(regexp_replace(lower(trim(action_taken_remark)), "
+    "'\\s+', ' ', 'g'), '\\.$', '')"
+)
+
+
+def _template_rows() -> list[tuple[str, str]]:
+    return [
+        (family, template)
+        for family, templates in TEMPLATES.items()
+        for template in templates
+    ]
+
+
+def _eligible_label_rows() -> list[tuple[str, str]]:
+    return [
+        (family, weak.label)
+        for family, weak in WEAK_LABELS_BY_DISCARD_FAMILY.items()
+        if weak.eligible_for_training and weak.label is not None
+    ]
+
+
+def _total_variation(
+    observed: dict[str, float], reference: dict[str, float]
+) -> float:
+    labels = set(observed).union(reference)
+    return 0.5 * sum(
+        abs(observed.get(label, 0.0) - reference.get(label, 0.0))
+        for label in labels
+    )
+
+
+def _distribution(counts: Counter[str]) -> dict[str, float]:
+    total = sum(counts.values())
+    return {
+        label: count / total
+        for label, count in sorted(counts.items())
+    }
+
+
+def _percentile(values: Iterable[float], probability: float) -> float | None:
+    ordered = sorted(values)
+    if not ordered:
+        return None
+    index = round((len(ordered) - 1) * probability)
+    return ordered[index]
+
+
+def audit_weak_labels(
+    complaints_path: Path,
+    action_history_path: Path,
+    *,
+    min_office_support: int = 100,
+) -> dict[str, object]:
+    """Return aggregate label counts and office-variation diagnostics."""
+
+    if not complaints_path.is_file():
+        raise FileNotFoundError(complaints_path)
+    if not action_history_path.is_file():
+        raise FileNotFoundError(action_history_path)
+    if min_office_support < 1:
+        raise ValueError("min_office_support must be positive")
+
+    import duckdb
+
+    connection = duckdb.connect(":memory:")
+    try:
+        connection.execute(
+            "CREATE TEMP TABLE discard_template(family VARCHAR, template VARCHAR)"
+        )
+        connection.executemany(
+            "INSERT INTO discard_template VALUES (?, ?)", _template_rows()
+        )
+        connection.execute(
+            "CREATE TEMP TABLE eligible_label(family VARCHAR, label VARCHAR)"
+        )
+        connection.executemany(
+            "INSERT INTO eligible_label VALUES (?, ?)", _eligible_label_rows()
+        )
+        connection.from_parquet(str(complaints_path)).create_view(
+            "complaints_parquet"
+        )
+        connection.from_parquet(str(action_history_path)).create_view(
+            "action_history_parquet"
+        )
+        connection.execute(
+            "CREATE TEMP VIEW complaints AS SELECT ticket_no, office, created_year "
+            "FROM complaints_parquet"
+        )
+        connection.execute(
+            "CREATE TEMP VIEW action_history AS SELECT ticket_no, action_taken_remark "
+            "FROM action_history_parquet"
+        )
+        connection.execute(
+            f"""
+            CREATE TEMP VIEW matched_action AS
+            SELECT a.ticket_no, d.family
+            FROM (
+                SELECT ticket_no, {_NORMALIZED_REMARK} AS normalized_remark
+                FROM action_history
+                WHERE action_taken_remark IS NOT NULL
+            ) a
+            INNER JOIN discard_template d ON d.template = a.normalized_remark
+            """
+        )
+        family_rows = connection.execute(
+            """
+            SELECT family, count(*)::BIGINT action_rows,
+                   count(DISTINCT ticket_no)::BIGINT tickets
+            FROM matched_action
+            GROUP BY family
+            ORDER BY family
+            """
+        ).fetchall()
+        label_rows = connection.execute(
+            """
+            WITH ticket_label AS (
+                SELECT DISTINCT m.ticket_no, e.label AS label_name
+                FROM matched_action m
+                INNER JOIN eligible_label e USING (family)
+            ), ticket_summary AS (
+                SELECT ticket_no, count(*) AS label_count,
+                       min(label_name) AS label_name
+                FROM ticket_label
+                GROUP BY ticket_no
+            )
+            SELECT
+                t.ticket_no,
+                t.label_count,
+                t.label_name,
+                coalesce(nullif(trim(c.office), ''), '(missing)') office,
+                c.created_year
+            FROM ticket_summary t
+            LEFT JOIN complaints c USING (ticket_no)
+            """
+        ).fetchall()
+    finally:
+        connection.close()
+
+    valid = [row for row in label_rows if int(row[1]) == 1]
+    conflicts = [row for row in label_rows if int(row[1]) > 1]
+    missing_complaint = sum(row[4] is None for row in label_rows)
+
+    global_counts: Counter[str] = Counter(str(row[2]) for row in valid)
+    global_distribution = _distribution(global_counts)
+    office_counts: dict[str, Counter[str]] = defaultdict(Counter)
+    year_counts: dict[str, Counter[str]] = defaultdict(Counter)
+    for _, _, label, office, year in valid:
+        office_counts[str(office)][str(label)] += 1
+        year_counts[str(year) if year is not None else "(missing)"][str(label)] += 1
+
+    office_rows = []
+    for office, counts in office_counts.items():
+        support = sum(counts.values())
+        if support < min_office_support:
+            continue
+        distribution = _distribution(counts)
+        office_rows.append(
+            {
+                "office": office,
+                "n": support,
+                "total_variation": _total_variation(
+                    distribution, global_distribution
+                ),
+                "distribution": distribution,
+            }
+        )
+    office_rows.sort(
+        key=lambda row: (-float(row["total_variation"]), -int(row["n"]), str(row["office"]))
+    )
+    variations = [float(row["total_variation"]) for row in office_rows]
+
+    family_lookup = {
+        family: {"action_rows": int(action_rows), "tickets": int(tickets)}
+        for family, action_rows, tickets in family_rows
+    }
+    return {
+        "source": {
+            "complaints": str(complaints_path),
+            "action_history": str(action_history_path),
+        },
+        "matching": "exact_enumerated_templates_after_mechanical_normalization",
+        "family_counts": {
+            family: family_lookup.get(family, {"action_rows": 0, "tickets": 0})
+            for family in TEMPLATES
+        },
+        "eligible_ticket_labels": {
+            "valid_single_label": len(valid),
+            "conflicting_labels_excluded": len(conflicts),
+            "missing_complaint_join": missing_complaint,
+            "distribution": dict(sorted(global_counts.items())),
+            "by_created_year": {
+                year: dict(sorted(counts.items()))
+                for year, counts in sorted(year_counts.items())
+            },
+        },
+        "office_variation": {
+            "office_field": "complaints.office_current_not_action_actor",
+            "min_support": min_office_support,
+            "eligible_offices": len(office_rows),
+            "global_distribution": global_distribution,
+            "max_total_variation": max(variations) if variations else None,
+            "median_total_variation": _percentile(variations, 0.5),
+            "p90_total_variation": _percentile(variations, 0.9),
+            "worst_supported_offices": office_rows[:10],
+            "interpretation": "descriptive confounding alarm, not proof of office bias",
+        },
+        "training_gate": {
+            "weak_labels_train_only": True,
+            "adjudicated_validation_and_test_required": True,
+            "duplicates_excluded": True,
+            "out_of_scope_never_spam": True,
+        },
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Audit exact discard-family weak labels before model training"
+    )
+    parser.add_argument("--complaints", type=Path, required=True)
+    parser.add_argument("--action-history", type=Path, required=True)
+    parser.add_argument("--min-office-support", type=int, default=100)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    result = audit_weak_labels(
+        args.complaints,
+        args.action_history,
+        min_office_support=args.min_office_support,
+    )
+    rendered = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/janasunani/inference/actionability.py
+++ b/janasunani/inference/actionability.py
@@ -1,0 +1,239 @@
+"""Local, advisory actionability scoring over PII-redacted text.
+
+Actionability is deliberately not squeezed into the existing spam score.
+An underspecified grievance may need one missing fact; an out-of-scope one
+needs a better route; a policy-blocked one may be entirely legitimate.  Those
+are different officer actions and different model errors.
+
+The scorer is import-light and model-agnostic.  Training lives in
+``janasunani.evaluation``; this module only validates a local classifier's
+probabilities and turns them into an advisory result.  It never performs I/O,
+changes submission status, or accepts raw grievance fields.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, Mapping, Protocol, Sequence
+
+
+ACTIONABILITY_TAXONOMY_VERSION = "actionability-v1"
+ACTIONABILITY_ARTIFACT_FORMAT = 1
+
+ActionabilityLabel = Literal[
+    "actionable",
+    "underspecified",
+    "irrelevant",
+    "out_of_scope",
+    "policy_blocked",
+]
+
+ACTIONABILITY_LABELS: tuple[ActionabilityLabel, ...] = (
+    "actionable",
+    "underspecified",
+    "irrelevant",
+    "out_of_scope",
+    "policy_blocked",
+)
+
+ActionabilityDecision = Literal["review", "abstained"]
+
+
+class ProbabilityClassifier(Protocol):
+    """The small subset of a fitted local classifier the scorer needs."""
+
+    classes_: Sequence[str]
+
+    def predict_proba(self, texts: Sequence[str]) -> object: ...
+
+
+@dataclass(frozen=True)
+class ActionabilityAssessment:
+    """One non-blocking assessment suitable for an additive API field."""
+
+    decision: ActionabilityDecision
+    predicted_label: ActionabilityLabel
+    confidence: float
+    probabilities: Mapping[ActionabilityLabel, float]
+    method: str
+    taxonomy_version: str = ACTIONABILITY_TAXONOMY_VERSION
+
+    def __post_init__(self) -> None:
+        if self.decision not in {"review", "abstained"}:
+            raise ValueError("decision must be review or abstained")
+        if self.predicted_label not in ACTIONABILITY_LABELS:
+            raise ValueError("predicted_label is outside the actionability taxonomy")
+        if (
+            isinstance(self.confidence, bool)
+            or not isinstance(self.confidence, (int, float))
+            or not 0.0 <= self.confidence <= 1.0
+            or not math.isfinite(self.confidence)
+        ):
+            raise ValueError("confidence must be finite and in [0, 1]")
+        _validate_probabilities(self.probabilities)
+        expected_confidence = self.probabilities[self.predicted_label]
+        if not math.isclose(self.confidence, expected_confidence, abs_tol=1e-9):
+            raise ValueError("confidence must equal the predicted label probability")
+        if self.decision == "review" and self.predicted_label == "actionable":
+            raise ValueError("actionable predictions do not request non-actionability review")
+        if not isinstance(self.method, str) or not self.method.strip():
+            raise ValueError("method must be non-empty")
+        if self.taxonomy_version != ACTIONABILITY_TAXONOMY_VERSION:
+            raise ValueError("taxonomy_version must match the actionability taxonomy")
+
+
+def _validate_probabilities(
+    probabilities: Mapping[ActionabilityLabel, float] | Mapping[str, float],
+) -> None:
+    if set(probabilities) != set(ACTIONABILITY_LABELS):
+        raise ValueError("probabilities must cover the complete actionability taxonomy")
+    values = tuple(probabilities[label] for label in ACTIONABILITY_LABELS)
+    if any(
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(value)
+        or value < 0.0
+        or value > 1.0
+        for value in values
+    ):
+        raise ValueError("probabilities must be finite and in [0, 1]")
+    if not math.isclose(sum(values), 1.0, rel_tol=0.0, abs_tol=1e-6):
+        raise ValueError("probabilities must sum to one")
+
+
+class LocalActionabilityScorer:
+    """Validate and expose a fitted local classifier as an advisory scorer.
+
+    ``review_threshold`` is selected on validation data, never on the held-out
+    test split.  Below it the scorer abstains.  Above it, a non-actionable
+    label asks an officer to review the reason; it still cannot reject or
+    reroute the submission by itself.
+    """
+
+    def __init__(
+        self,
+        classifier: ProbabilityClassifier,
+        *,
+        method: str,
+        review_threshold: float,
+    ) -> None:
+        if not isinstance(method, str) or not method.strip():
+            raise ValueError("method must be non-empty")
+        if (
+            isinstance(review_threshold, bool)
+            or not isinstance(review_threshold, (int, float))
+            or not math.isfinite(review_threshold)
+            or not 0.0 <= review_threshold <= 1.0
+        ):
+            raise ValueError("review_threshold must be in [0, 1]")
+        classes = tuple(str(label) for label in classifier.classes_)
+        if len(classes) != len(set(classes)) or set(classes) != set(ACTIONABILITY_LABELS):
+            raise ValueError("classifier classes must exactly match the taxonomy")
+        self._classifier = classifier
+        self._classes = classes
+        self.method = method
+        self.review_threshold = review_threshold
+
+    def score(self, redacted_text: str) -> ActionabilityAssessment:
+        """Score one redacted string; callers remain responsible for redaction."""
+
+        if not isinstance(redacted_text, str):
+            raise TypeError("redacted_text must be a string")
+        matrix = self._classifier.predict_proba([redacted_text])
+        try:
+            row = matrix[0]  # type: ignore[index]
+            values = tuple(float(value) for value in row)
+        except (IndexError, TypeError, ValueError) as exc:
+            raise ValueError("classifier returned an invalid probability row") from exc
+        if len(values) != len(self._classes):
+            raise ValueError("classifier probability width does not match its classes")
+        probabilities = dict(zip(self._classes, values, strict=True))
+        _validate_probabilities(probabilities)
+
+        predicted = min(
+            ACTIONABILITY_LABELS,
+            key=lambda label: (-probabilities[label], label),
+        )
+        confidence = probabilities[predicted]
+        decision: ActionabilityDecision = (
+            "review"
+            if (
+                predicted != "actionable"
+                and self.review_threshold < 1.0
+                and confidence >= self.review_threshold
+            )
+            else "abstained"
+        )
+        return ActionabilityAssessment(
+            decision=decision,
+            predicted_label=predicted,
+            confidence=confidence,
+            probabilities=probabilities,
+            method=self.method,
+        )
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_actionability_scorer(path: Path) -> LocalActionabilityScorer:
+    """Load a checksummed local model directory, failing closed on drift."""
+
+    artifact_dir = Path(path)
+    manifest_path = artifact_dir / "manifest.json"
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("actionability artifact manifest is unreadable") from exc
+    if not isinstance(manifest, dict):
+        raise ValueError("actionability artifact manifest must be an object")
+    expected_keys = {
+        "artifact_format",
+        "taxonomy_version",
+        "labels",
+        "method",
+        "review_threshold",
+        "model_file",
+        "model_sha256",
+    }
+    if set(manifest) != expected_keys:
+        raise ValueError("actionability artifact manifest has an unexpected shape")
+    if manifest["artifact_format"] != ACTIONABILITY_ARTIFACT_FORMAT:
+        raise ValueError("unsupported actionability artifact format")
+    if manifest["taxonomy_version"] != ACTIONABILITY_TAXONOMY_VERSION:
+        raise ValueError("actionability taxonomy version mismatch")
+    if manifest["labels"] != list(ACTIONABILITY_LABELS):
+        raise ValueError("actionability artifact labels do not match the taxonomy")
+    model_file = manifest["model_file"]
+    if (
+        not isinstance(model_file, str)
+        or not model_file
+        or Path(model_file).name != model_file
+    ):
+        raise ValueError("model_file must be one filename inside the artifact")
+    model_path = artifact_dir / model_file
+    if not model_path.is_file() or model_path.stat().st_size == 0:
+        raise ValueError("actionability model file is absent or empty")
+    if _sha256(model_path) != manifest["model_sha256"]:
+        raise ValueError("actionability model checksum mismatch")
+
+    try:
+        import joblib
+
+        classifier = joblib.load(model_path)
+    except Exception as exc:
+        raise ValueError("actionability model could not be loaded") from exc
+    return LocalActionabilityScorer(
+        classifier,
+        method=manifest["method"],
+        review_threshold=manifest["review_threshold"],
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,7 @@ janasunani-evaluate-benchmark = "janasunani.evaluation.benchmark_report:main"
 janasunani-evaluate-sarvam = "janasunani.evaluation.sarvam_evaluate:main"
 janasunani-build-sarvam-sample = "janasunani.evaluation.sarvam_sample_builder:main"
 janasunani-evaluate-summary = "janasunani.evaluation.summary:main"
+janasunani-audit-actionability-labels = "janasunani.evaluation.weak_labels:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/test_actionability.py
+++ b/tests/test_actionability.py
@@ -1,0 +1,186 @@
+import math
+
+import pytest
+
+from janasunani.inference.actionability import (
+    ACTIONABILITY_LABELS,
+    ACTIONABILITY_TAXONOMY_VERSION,
+    ActionabilityAssessment,
+    LocalActionabilityScorer,
+)
+
+
+class Classifier:
+    classes_ = ACTIONABILITY_LABELS
+
+    def __init__(self, row):
+        self.row = row
+        self.seen = None
+
+    def predict_proba(self, texts):
+        self.seen = texts
+        return [self.row]
+
+
+def probabilities(**overrides):
+    values = {
+        "actionable": 0.7,
+        "underspecified": 0.1,
+        "irrelevant": 0.05,
+        "out_of_scope": 0.1,
+        "policy_blocked": 0.05,
+    }
+    values.update(overrides)
+    return [values[label] for label in ACTIONABILITY_LABELS]
+
+
+def test_high_confidence_non_actionable_prediction_requests_review():
+    classifier = Classifier(
+        probabilities(
+            actionable=0.1,
+            underspecified=0.7,
+            irrelevant=0.1,
+            out_of_scope=0.05,
+        )
+    )
+    scorer = LocalActionabilityScorer(
+        classifier,
+        method="tfidf-logreg-v1",
+        review_threshold=0.6,
+    )
+
+    result = scorer.score("[VILLAGE] road location missing")
+
+    assert result.decision == "review"
+    assert result.predicted_label == "underspecified"
+    assert result.confidence == pytest.approx(0.7)
+    assert result.taxonomy_version == ACTIONABILITY_TAXONOMY_VERSION
+    assert classifier.seen == ["[VILLAGE] road location missing"]
+
+
+def test_actionable_prediction_abstains_instead_of_approving_or_rejecting():
+    scorer = LocalActionabilityScorer(
+        Classifier(probabilities()),
+        method="model-v1",
+        review_threshold=0.6,
+    )
+
+    result = scorer.score("The hand pump has been broken for two weeks")
+
+    assert result.predicted_label == "actionable"
+    assert result.decision == "abstained"
+
+
+def test_low_confidence_non_actionable_prediction_abstains():
+    row = [0.19, 0.24, 0.25, 0.18, 0.14]
+    scorer = LocalActionabilityScorer(
+        Classifier(row),
+        method="model-v1",
+        review_threshold=0.6,
+    )
+
+    result = scorer.score("uncertain text")
+
+    assert result.predicted_label == "irrelevant"
+    assert result.decision == "abstained"
+
+
+def test_threshold_one_is_explicit_review_nothing_failsafe():
+    scorer = LocalActionabilityScorer(
+        Classifier([0.0, 0.0, 1.0, 0.0, 0.0]),
+        method="model-v1",
+        review_threshold=1.0,
+    )
+
+    result = scorer.score("certain but unsafe candidate")
+
+    assert result.predicted_label == "irrelevant"
+    assert result.decision == "abstained"
+
+
+@pytest.mark.parametrize(
+    "row, message",
+    [
+        ([0.2] * 5, None),
+        ([0.2, 0.2, 0.2, 0.2, 0.1], "sum to one"),
+        ([math.nan, 0.25, 0.25, 0.25, 0.25], "finite"),
+        ([1.0, 0.0], "width"),
+    ],
+)
+def test_probability_contract(row, message):
+    scorer = LocalActionabilityScorer(
+        Classifier(row),
+        method="model-v1",
+        review_threshold=0.6,
+    )
+    if message is None:
+        assert scorer.score("text").confidence == pytest.approx(0.2)
+    else:
+        with pytest.raises(ValueError, match=message):
+            scorer.score("text")
+
+
+def test_classifier_classes_must_match_closed_taxonomy():
+    classifier = Classifier(probabilities())
+    classifier.classes_ = (*ACTIONABILITY_LABELS[:-1], "spam")
+
+    with pytest.raises(ValueError, match="exactly match"):
+        LocalActionabilityScorer(
+            classifier,
+            method="model-v1",
+            review_threshold=0.6,
+        )
+
+
+def test_assessment_rejects_review_for_actionable_label():
+    probs = dict(zip(ACTIONABILITY_LABELS, probabilities(), strict=True))
+    with pytest.raises(ValueError, match="do not request"):
+        ActionabilityAssessment(
+            decision="review",
+            predicted_label="actionable",
+            confidence=0.7,
+            probabilities=probs,
+            method="model-v1",
+        )
+
+
+@pytest.mark.parametrize(
+    "field,value,message",
+    [
+        ("decision", "approve", "decision"),
+        ("confidence", True, "confidence"),
+        ("method", None, "method"),
+        ("taxonomy_version", "actionability-v2", "taxonomy_version"),
+    ],
+)
+def test_assessment_rejects_invalid_runtime_contract_values(field, value, message):
+    kwargs = {
+        "decision": "abstained",
+        "predicted_label": "actionable",
+        "confidence": 0.7,
+        "probabilities": dict(zip(ACTIONABILITY_LABELS, probabilities(), strict=True)),
+        "method": "model-v1",
+    }
+    kwargs[field] = value
+    with pytest.raises(ValueError, match=message):
+        ActionabilityAssessment(**kwargs)
+
+
+@pytest.mark.parametrize("threshold", [True, float("nan"), float("inf")])
+def test_scorer_rejects_boolean_or_nonfinite_thresholds(threshold):
+    with pytest.raises(ValueError, match="review_threshold"):
+        LocalActionabilityScorer(
+            Classifier(probabilities()),
+            method="model-v1",
+            review_threshold=threshold,
+        )
+
+
+def test_only_redacted_text_shape_is_accepted():
+    scorer = LocalActionabilityScorer(
+        Classifier(probabilities()),
+        method="model-v1",
+        review_threshold=0.6,
+    )
+    with pytest.raises(TypeError, match="redacted_text"):
+        scorer.score({"grievance": "raw citizen text"})  # type: ignore[arg-type]

--- a/tests/test_actionability_evaluation.py
+++ b/tests/test_actionability_evaluation.py
@@ -1,0 +1,425 @@
+import json
+
+import pytest
+
+from janasunani.evaluation.actionability import (
+    ActionabilityRecord,
+    _binary_review_metrics,
+    _select_binary_review_threshold,
+    benchmark_binary_review,
+    benchmark_tfidf,
+    load_jsonl,
+    office_variation_audit,
+    select_review_threshold,
+    weak_label_for_discard_family,
+)
+from janasunani.evaluation.classification import ScoredExample
+from janasunani.inference.actionability import ACTIONABILITY_LABELS
+from janasunani.inference.actionability import load_actionability_scorer
+
+
+def record(
+    item_id,
+    text,
+    label,
+    split,
+    *,
+    language="English",
+    source="adjudicated",
+    office=None,
+):
+    return ActionabilityRecord(
+        item_id=item_id,
+        redacted_text=text,
+        label=label,
+        group_id=item_id,
+        language=language,
+        split=split,
+        label_source=source,
+        office=office,
+    )
+
+
+PHRASES = {
+    "actionable": [
+        "hand pump broken near school for two weeks",
+        "pension payment not received since January",
+        "street light is not working in ward seven",
+    ],
+    "underspecified": [
+        "please solve my problem details not provided",
+        "document missing please attach required paper",
+        "location and address are not given",
+    ],
+    "irrelevant": [
+        "test message no specific grievance hello",
+        "nothing to report this is a demo entry",
+        "random greeting without any grievance",
+    ],
+    "out_of_scope": [
+        "private company matter outside government jurisdiction",
+        "court appeal is outside grievance cell purview",
+        "request belongs to another jurisdiction and department",
+    ],
+    "policy_blocked": [
+        "benefit requires a new government policy decision",
+        "scheme change cannot proceed until policy is approved",
+        "requested entitlement needs cabinet policy approval",
+    ],
+}
+
+
+def dataset():
+    rows = []
+    for label, phrases in PHRASES.items():
+        for i in range(10):
+            rows.append(
+                record(
+                    f"train-{label}-{i}",
+                    f"{phrases[i % len(phrases)]} case {i}",
+                    label,
+                    "train",
+                    language="Odia" if i % 2 else "English",
+                    source=(
+                        "administrative_weak"
+                        if i < 4 and label != "actionable"
+                        else "adjudicated"
+                    ),
+                    office="Office A" if i < 2 else "Office B",
+                )
+            )
+        rows.append(
+            record(
+                f"validation-{label}",
+                f"{phrases[0]} validation",
+                label,
+                "validation",
+            )
+        )
+        rows.append(
+            record(
+                f"test-{label}",
+                f"{phrases[1]} heldout",
+                label,
+                "test",
+                language="Odia" if label in {"actionable", "irrelevant"} else "English",
+            )
+        )
+    return rows
+
+
+def test_weak_labels_keep_non_spam_reasons_distinct_and_exclude_duplicates():
+    assert weak_label_for_discard_family("details_inadequate").label == "underspecified"
+    out_of_scope = weak_label_for_discard_family("outside_grievance_cell_purview")
+    assert out_of_scope.label == "out_of_scope"
+    assert "never spam" in out_of_scope.rationale
+    duplicate = weak_label_for_discard_family("duplicate_copy")
+    assert duplicate.label is None
+    assert duplicate.eligible_for_training is False
+    with pytest.raises(ValueError, match="unknown discard"):
+        weak_label_for_discard_family("anything_else")
+
+
+def test_jsonl_rejects_raw_text_and_weak_holdout(tmp_path):
+    raw = {
+        "item_id": "1",
+        "redacted_text": "safe",
+        "grievance": "raw",
+        "label": "actionable",
+        "group_id": "g1",
+        "language": "English",
+        "split": "train",
+        "label_source": "adjudicated",
+    }
+    path = tmp_path / "manifest.jsonl"
+    path.write_text(json.dumps(raw) + "\n")
+    with pytest.raises(ValueError, match="raw-text fields"):
+        load_jsonl(path)
+
+    raw.pop("grievance")
+    raw["split"] = "test"
+    raw["label_source"] = "administrative_weak"
+    path.write_text(json.dumps(raw) + "\n")
+    with pytest.raises(ValueError, match="must be adjudicated"):
+        load_jsonl(path)
+
+
+def test_jsonl_requires_group_disjoint_splits(tmp_path):
+    rows = []
+    for split, suffix in (("train", "a"), ("validation", "b"), ("test", "c")):
+        rows.append(
+            {
+                "item_id": suffix,
+                "redacted_text": "safe redacted content",
+                "label": "actionable",
+                "group_id": "same-group" if split != "validation" else "other-group",
+                "language": "English",
+                "split": split,
+                "label_source": "adjudicated",
+            }
+        )
+    path = tmp_path / "manifest.jsonl"
+    path.write_text("\n".join(json.dumps(row) for row in rows))
+    with pytest.raises(ValueError, match="leaks"):
+        load_jsonl(path)
+
+
+def test_office_variation_is_descriptive_and_never_a_model_feature():
+    rows = [
+        record(
+            f"train-{i}",
+            "redacted",
+            "irrelevant" if i < 3 else "actionable",
+            "train",
+            source="administrative_weak",
+            office="A" if i < 3 else "B",
+        )
+        for i in range(6)
+    ]
+    result = office_variation_audit(rows, min_office_support=2)
+
+    assert result["status"] == "measured"
+    assert result["eligible_offices"] == 2
+    assert result["max_total_variation"] == pytest.approx(0.5)
+    assert "office" not in benchmark_tfidf.__doc__.lower()
+
+
+def test_threshold_selection_maximizes_recall_under_precision_constraint():
+    def scored(item_id, gold, actionable, irrelevant):
+        rest = (1.0 - actionable - irrelevant) / 3
+        return ScoredExample(
+            item_id=item_id,
+            gold_label=gold,
+            probabilities={
+                "actionable": actionable,
+                "underspecified": rest,
+                "irrelevant": irrelevant,
+                "out_of_scope": rest,
+                "policy_blocked": rest,
+            },
+            group_id=item_id,
+        )
+
+    rows = [
+        scored("a", "actionable", 0.8, 0.05),
+        scored("b", "actionable", 0.4, 0.45),
+        scored("c", "irrelevant", 0.1, 0.7),
+        scored("d", "irrelevant", 0.2, 0.6),
+    ]
+    threshold, metrics = select_review_threshold(
+        rows,
+        min_precision=1.0,
+        max_actionable_review_rate=0.0,
+    )
+
+    assert threshold == pytest.approx(0.6)
+    assert metrics["review_precision"] == 1.0
+    assert metrics["review_recall"] == 1.0
+
+
+def test_tfidf_benchmark_selects_on_validation_and_reports_heldout_slices():
+    benchmark = benchmark_tfidf(
+        dataset(),
+        c_values=(0.5, 1.0),
+        min_df=1,
+        max_features=5_000,
+        min_review_precision=0.0,
+        max_actionable_review_rate=1.0,
+        office_min_support=5,
+    )
+
+    report = benchmark.report
+    assert report["model_family"] == "tfidf-word-char-logreg"
+    assert report["selected_c"] in {0.5, 1.0}
+    assert report["split_counts"] == {"train": 50, "validation": 5, "test": 5}
+    assert report["test"]["n"] == 5
+    assert set(report["test"]["per_class"]) == set(ACTIONABILITY_LABELS)
+    assert set(report["test_by_language"]) == {"English", "Odia"}
+    assert report["safety"]["advisory_only"] is True
+    assert len(report["candidate_validation"]) == 2
+
+    result = benchmark.scorer().score("random greeting without any grievance")
+    assert result.method == benchmark.method
+    assert result.predicted_label in ACTIONABILITY_LABELS
+
+
+def test_binary_threshold_selection_honors_harm_constraints():
+    rows = [
+        record("a1", "actionable one", "actionable", "validation"),
+        record("a2", "actionable two", "actionable", "validation"),
+        record("r1", "irrelevant", "irrelevant", "validation"),
+        record("r2", "underspecified", "underspecified", "validation"),
+        record("r3", "policy", "policy_blocked", "validation"),
+    ]
+
+    threshold, metrics = _select_binary_review_threshold(
+        [0.05, 0.4, 0.9, 0.8, 0.3],
+        rows,
+        min_precision=1.0,
+        max_actionable_review_rate=0.0,
+    )
+
+    assert threshold == pytest.approx(0.8)
+    assert metrics["review_precision"] == 1.0
+    assert metrics["review_recall"] == pytest.approx(2 / 3)
+    assert metrics["actionable_review_rate"] == 0.0
+    assert metrics["confusion"] == {
+        "true_review": 2,
+        "false_review": 0,
+        "true_actionable": 2,
+        "missed_review": 1,
+    }
+
+
+def test_binary_metrics_report_missing_reason_support_and_intervals():
+    rows = [
+        record("a", "actionable", "actionable", "test"),
+        record("i", "irrelevant", "irrelevant", "test"),
+        record("u", "underspecified", "underspecified", "test"),
+    ]
+
+    metrics = _binary_review_metrics([0.1, 0.9, 0.2], rows, threshold=0.5)
+
+    assert metrics["confusion"] == {
+        "true_review": 1,
+        "false_review": 0,
+        "true_actionable": 1,
+        "missed_review": 1,
+    }
+    assert metrics["accuracy"] == pytest.approx(2 / 3)
+    assert len(metrics["accuracy_ci"]) == 2
+    assert metrics["by_non_actionable_reason"]["out_of_scope"] == {
+        "support": 0,
+        "review_recall": 0.0,
+    }
+
+
+def test_binary_benchmark_allows_development_gold_with_missing_class_support():
+    rows = [row for row in dataset() if row.label != "out_of_scope"]
+    rows = [
+        ActionabilityRecord(
+            **{
+                **row.__dict__,
+                "label_source": "frontier_adjudicated",
+                "sampling_stratum": "s5",
+            }
+        )
+        for row in rows
+    ]
+
+    benchmark = benchmark_binary_review(
+        rows,
+        c_values=(0.5, 1.0),
+        min_df=1,
+        max_features=5_000,
+        min_review_precision=0.0,
+        max_actionable_review_rate=1.0,
+    )
+
+    assert benchmark.report["objective"] == "actionable_vs_officer_review"
+    assert benchmark.report["selected_c"] in {0.5, 1.0}
+    assert benchmark.report["split_counts"] == {
+        "train": 40,
+        "validation": 4,
+        "test": 4,
+    }
+    assert benchmark.report["missing_five_class_support"] == ["out_of_scope"]
+    assert benchmark.report["test"]["by_non_actionable_reason"]["out_of_scope"] == {
+        "support": 0,
+        "review_recall": 0.0,
+    }
+    assert benchmark.report["release_eligible"] is False
+    assert benchmark.report["sample_design"] == {
+        "sampling_scheme": "fixed quotas across opaque sampling strata",
+        "sampling_stratum_counts": {"s5": 48},
+        "production_prevalence_representative": False,
+        "limitation": (
+            "accuracy, precision, PPV, and review workload are specific to "
+            "this designed sample composition and are not production prevalence"
+        ),
+    }
+    assert len(benchmark.report["candidate_validation"]) == 2
+
+
+def test_artifact_round_trip_is_checksummed_and_refuses_overwrite(tmp_path):
+    benchmark = benchmark_tfidf(
+        dataset(),
+        c_values=(1.0,),
+        min_df=1,
+        max_features=2_000,
+        min_review_precision=0.0,
+        max_actionable_review_rate=1.0,
+        office_min_support=5,
+    )
+    artifact_dir = tmp_path / "actionability"
+    paths = benchmark.save(artifact_dir)
+
+    assert set(paths) == {"model", "manifest", "benchmark"}
+    loaded = load_actionability_scorer(artifact_dir)
+    assert loaded.method == benchmark.method
+    assert loaded.score("test message no specific grievance").predicted_label in (
+        ACTIONABILITY_LABELS
+    )
+
+    with pytest.raises(FileExistsError, match="not empty"):
+        benchmark.save(artifact_dir)
+
+    paths["model"].write_bytes(paths["model"].read_bytes() + b"tamper")
+    with pytest.raises(ValueError, match="checksum mismatch"):
+        load_actionability_scorer(artifact_dir)
+
+
+def test_artifact_loader_rejects_manifest_path_escape(tmp_path):
+    artifact_dir = tmp_path / "actionability"
+    artifact_dir.mkdir()
+    (artifact_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "artifact_format": 1,
+                "taxonomy_version": "actionability-v1",
+                "labels": list(ACTIONABILITY_LABELS),
+                "method": "model",
+                "review_threshold": 0.5,
+                "model_file": "../outside.joblib",
+                "model_sha256": "0" * 64,
+            }
+        )
+    )
+    with pytest.raises(ValueError, match="one filename"):
+        load_actionability_scorer(artifact_dir)
+
+
+def test_weak_labels_are_blocked_when_office_variation_is_too_large():
+    rows = dataset()
+    rows = [
+        ActionabilityRecord(
+            **{
+                **row.__dict__,
+                "office": (
+                    "Biased Office"
+                    if row.label_source == "administrative_weak"
+                    and row.label == "irrelevant"
+                    else row.office
+                ),
+            }
+        )
+        for row in rows
+    ]
+    with pytest.raises(ValueError, match="total variation exceeds"):
+        benchmark_tfidf(
+            rows,
+            c_values=(1.0,),
+            min_df=1,
+            max_features=1_000,
+            office_min_support=2,
+            max_office_total_variation=0.01,
+        )
+
+
+def test_administrative_labels_cannot_call_a_record_actionable():
+    rows = dataset()
+    rows[0] = ActionabilityRecord(
+        **{**rows[0].__dict__, "label_source": "administrative_weak"}
+    )
+    with pytest.raises(ValueError, match="cannot establish actionability"):
+        benchmark_tfidf(rows, c_values=(1.0,), min_df=1)

--- a/tests/test_weak_label_audit.py
+++ b/tests/test_weak_label_audit.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from janasunani.evaluation.weak_labels import audit_weak_labels
+
+
+def fixtures(path: Path) -> tuple[Path, Path]:
+    complaints = path / "complaints.parquet"
+    actions = path / "action_history.parquet"
+    pl.DataFrame(
+        {
+            "ticket_no": ["T1", "T2", "T3", "T4", "T5", "T6"],
+            "office": ["A", "A", "B", "B", "B", "B"],
+            "created_year": [2023, 2023, 2024, 2024, 2025, 2025],
+            "grievance": ["must", "never", "be", "selected", "or", "reported"],
+        }
+    ).write_parquet(complaints)
+    pl.DataFrame(
+        {
+            "ticket_no": ["T1", "T2", "T3", "T4", "T5", "T5", "T6"],
+            "action_taken_remark": [
+                "Complaint details inadequate.",
+                "No specific grievance",
+                "This is not within the purview of this grievance cell",
+                "Duplicate copy",
+                "No specific grievance",
+                "Complaint details inadequate",
+                "citizen prose outside the governed templates",
+            ],
+        }
+    ).write_parquet(actions)
+    return complaints, actions
+
+
+def test_audit_counts_exact_families_and_excludes_conflicts(tmp_path):
+    complaints, actions = fixtures(tmp_path)
+    result = audit_weak_labels(complaints, actions, min_office_support=1)
+
+    assert result["family_counts"]["details_inadequate"] == {
+        "action_rows": 2,
+        "tickets": 2,
+    }
+    assert result["family_counts"]["duplicate_copy"]["tickets"] == 1
+    assert result["eligible_ticket_labels"]["valid_single_label"] == 3
+    assert result["eligible_ticket_labels"]["conflicting_labels_excluded"] == 1
+    assert result["eligible_ticket_labels"]["distribution"] == {
+        "irrelevant": 1,
+        "out_of_scope": 1,
+        "underspecified": 1,
+    }
+    assert result["training_gate"]["out_of_scope_never_spam"] is True
+
+
+def test_office_variation_is_aggregate_and_support_gated(tmp_path):
+    complaints, actions = fixtures(tmp_path)
+    result = audit_weak_labels(complaints, actions, min_office_support=2)
+
+    office = result["office_variation"]
+    assert office["eligible_offices"] == 1
+    assert office["worst_supported_offices"][0]["office"] == "A"
+    assert office["interpretation"].startswith("descriptive")
+
+
+def test_audit_validates_inputs(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        audit_weak_labels(tmp_path / "missing", tmp_path / "also-missing")
+
+    complaints, actions = fixtures(tmp_path)
+    with pytest.raises(ValueError, match="positive"):
+        audit_weak_labels(complaints, actions, min_office_support=0)


### PR DESCRIPTION
## Summary

- Define a five-class, advisory actionability contract that keeps underspecified, irrelevant, out-of-scope, and policy-blocked grievances distinct.
- Add validation-selected five-class and binary development benchmarks with explicit abstention/harm constraints.
- Audit exact administrative discard templates as train-only weak labels and fail closed when office variation exceeds the declared gate.
- Add checksummed local artifact loading plus a reproducible aggregate DVC audit stage.

## Historical stack position

This is the next historical slice after #251:

- Base: `feat/evaluation-summary-scorecard`
- Head: `feat/actionability-evaluation`
- Exact head: `26a284b6d35da28c81001aa6fd11d94ba931bc95`
- Commits: `32b48c6`, `d80964b`, `3b38675`, and `26a284b`

The old instruction not to request per-slice Codex review is superseded. PRs #250 and #251 have completed exact-head review and were closed as already integrated. This head is also an ancestor of `feat/pipeline-quality-trunk` (0 commits unique here; 86 integration commits after it). It will be reconciled only after its own review findings are addressed and the exact-head gate is green.

## Verification on this exact slice

- `tests/test_actionability.py`, `tests/test_actionability_evaluation.py`, and `tests/test_weak_label_audit.py`: **34 passed**.
- Six joblib/NumPy deprecation warnings were emitted during artifact round-trip tests; no test failed.
- Ruff passed for all six implementation/test files.
- `git diff --check` passed.
- Historical GitHub pipeline, lint, and raw-data checks are green; the draft-only Codex exemption must be replaced by an exact-head review verdict.

The DVC stage was reviewed as a declared aggregate interface but was not rerun during this slice-local check. It names only `complaints.parquet` and `action_history.parquet` as inputs and promises no item-level output.

## Evidence and safety boundaries

- `frontier_adjudicated` labels are development evidence, not officer-confirmed truth.
- Administrative labels are train-only weak evidence and cannot establish the `actionable` class.
- The binary benchmark is explicitly `release_eligible: false` and does not replace the five-class serving contract.
- Scores are advisory: they cannot reject, close, reroute, or otherwise change a grievance.
- The scorer accepts only redacted text; no external egress is introduced.

## Self-review points for exact review

- Verify malformed JSON field types fail with governed schema errors rather than incidental Python exceptions.
- Verify the no-review fallback at threshold 1.0 remains the safe result when harm constraints cannot be met.
- Verify checksummed joblib loading is appropriately scoped to trusted local/DVC artifacts.
