### PR TITLE
feat(evaluation): add privacy-safe actionability adjudication

### DIFF
--- a/.github/workflows/data-check.yml
+++ b/.github/workflows/data-check.yml
@@ -20,7 +20,7 @@ jobs:
 
           bad_files="$(
             git ls-files 'data/**' 'outputs/**' |
-              grep -Ev '(^|/)\.gitkeep$|\.dvc$|^data/external/(.*/)?[^/]+\.provenance\.json$' || true
+              grep -Ev '(^|/)\.gitkeep$|\.dvc$|^data/external/(.*/)?([^/]+\.)?provenance\.json$' || true
           )"
 
           if [ -n "$bad_files" ]; then
@@ -43,6 +43,8 @@ jobs:
 
           sidecars="$(
             git ls-files \
+              'data/external/provenance.json' \
+              'data/external/**/provenance.json' \
               'data/external/*.provenance.json' \
               'data/external/**/*.provenance.json' || true
           )"

--- a/.github/workflows/data-check.yml
+++ b/.github/workflows/data-check.yml
@@ -20,7 +20,7 @@ jobs:
 
           bad_files="$(
             git ls-files 'data/**' 'outputs/**' |
-              grep -Ev '(^|/)\.gitkeep$|\.dvc$|^data/external/[^/]+\.provenance\.json$' || true
+              grep -Ev '(^|/)\.gitkeep$|\.dvc$|^data/external/(.*/)?[^/]+\.provenance\.json$' || true
           )"
 
           if [ -n "$bad_files" ]; then
@@ -41,7 +41,11 @@ jobs:
         run: |
           set -euo pipefail
 
-          sidecars="$(git ls-files 'data/external/*.provenance.json' || true)"
+          sidecars="$(
+            git ls-files \
+              'data/external/*.provenance.json' \
+              'data/external/**/*.provenance.json' || true
+          )"
           [ -n "$sidecars" ] || exit 0
 
           # Word-split intentionally: git ls-files gives one path per line.

--- a/.gitignore
+++ b/.gitignore
@@ -213,6 +213,10 @@ data/output/*
 !data/interim/*.dvc
 !data/processed/*.dvc
 !data/external/*.dvc
+!data/external/actionability_frontier_v1/
+data/external/actionability_frontier_v1/*
+!data/external/actionability_frontier_v1/*.dvc
+!data/external/actionability_frontier_v1/*.provenance.json
 # Provenance sidecars for gold/draft artifacts: versions, checksums and span
 # counts only, written by scripts/rederive_pii_draft.py. They exist to be read
 # in review, so they belong in git. Never put citizen text in one.

--- a/data/external/actionability_frontier_v1.provenance.json
+++ b/data/external/actionability_frontier_v1.provenance.json
@@ -1,0 +1,89 @@
+{
+  "schema_version": "janasunani.actionability-frontier-artifacts/v1",
+  "claim_status": "frontier-adjudicated development evidence; not officer-confirmed truth or a release gate",
+  "privacy": {
+    "source": "PII-redacted DPIC-controlled sample",
+    "contains_redacted_narratives": true,
+    "residual_pii_risk": true,
+    "git_contains_row_level_bytes": false,
+    "storage": "private DVC remote"
+  },
+  "sample": {
+    "records": 180,
+    "split_counts": {
+      "train": 60,
+      "validation": 60,
+      "test": 60
+    },
+    "sampling": "five records from each of four opaque weak-label strata plus forty previously unlabeled records per split",
+    "split_policy": "single_snapshot_hash_60_20_20_development_only",
+    "sha256": "95d0d3b7757ba5bd616dcffe4aefcf846cdc9f1ab2d0f7eaeba16a1077ecd096",
+    "tracking_mode": "direct DVC input",
+    "tracking_reason": "opaque item identifiers depend on a private salt that is intentionally not versioned; treating this as a reproducible stage would hide that dependency"
+  },
+  "direct_inputs": {
+    "judge_a.jsonl": {
+      "role": "frontier judge A output",
+      "sha256": "a251d7d6dfb49f36c498feb39957a5e1bcef0fe47b483abecae75e8aa11de33c"
+    },
+    "judge_b.jsonl": {
+      "role": "frontier judge B output",
+      "sha256": "ed1fcf0c68c09f84669edc4af2b00109b559aa02a44623f75652d3bbe8c39ee5"
+    },
+    "resolver.jsonl": {
+      "role": "canonical frontier resolver output",
+      "sha256": "22dcd6604aad84cbcdc52ee93673fbc64021dc52af88ead22f0881a4b53638ca"
+    },
+    "resolver_backup.jsonl": {
+      "role": "non-canonical preserved resolver backup",
+      "sha256": "9f7b228d1923dd63f6de2732283f4905fa1588b845183c07e11d4ba500911636"
+    }
+  },
+  "deterministic_stages": {
+    "actionability-adjudication-prepare": [
+      "consensus.jsonl",
+      "resolver_input.jsonl",
+      "adjudication_report.json"
+    ],
+    "actionability-adjudication-finalize": [
+      "gold.jsonl",
+      "gold.manifest.json"
+    ],
+    "actionability-local-candidate-benchmark": [
+      "outputs/evaluation/actionability_candidates_muril_high_catch.json"
+    ]
+  },
+  "canonical_reproducible_gold": {
+    "records": 174,
+    "sha256": "0504ddfbe79c3613250b5a10572f7b2b1d4e4c2628972098a83c61e4a7d94538",
+    "label_counts": {
+      "actionable": 140,
+      "underspecified": 13,
+      "irrelevant": 7,
+      "policy_blocked": 14,
+      "out_of_scope": 0
+    },
+    "policy": "exclude all resolver judgments marked uncertain",
+    "excluded_uncertain_resolver_rows": 6
+  },
+  "preserved_historical_gold": {
+    "artifact": "historical_gold_180.jsonl",
+    "manifest": "historical_gold_180.manifest.json",
+    "records": 180,
+    "sha256": "7459d387916e71c94c154f0ffa87b962991abbe830bf13757b5ed7da0e4a5630",
+    "status": "the original benchmark input is retained for auditability but is not canonical because it admitted six resolver judgments marked uncertain"
+  },
+  "preserved_nonreproducible_reports": {
+    "historical_candidates_strict.json": "192eec94265d01d0275f14ddfec1a97f3c29e0d2a0c95a483774c3e414fb8e7a",
+    "historical_candidates_sensitivity.json": "c01a276019f601bbefa4bb4198bda16a04c914ed8f5e4d61260a84ca1fb0d3d6",
+    "historical_candidates_high_catch.json": "d89ff324a31c4b74197dc78b13547721c57710b4a1fd871d6932b075dfa1585c",
+    "historical_candidates_muril_minilm_high_catch.json": "15de6c1ff7f2e336c4e938c645fe8f881c1449fa37cc13b63e472ab39a8babb2"
+  },
+  "limitations": [
+    "The adjudicators were separate Codex contexts, not independent model families or providers.",
+    "Exact hidden prompts, sampling configuration and provider retention evidence were unavailable.",
+    "The sample contains no defensible out_of_scope example and cannot validate the five-class serving contract.",
+    "The four historical candidate reports used the preserved 180-row historical gold; the reproducible benchmark uses the stricter 174-row canonical gold.",
+    "The historical MiniLM comparisons depend on an untracked local Hugging Face cache and are preserved as direct evidence rather than represented as reproducible stages."
+  ]
+}

--- a/data/external/actionability_frontier_v1/historical_candidates_high_catch.json.dvc
+++ b/data/external/actionability_frontier_v1/historical_candidates_high_catch.json.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: a8eaced895b5f3147a075be82a10c0cf
+  size: 15254
+  hash: md5
+  path: historical_candidates_high_catch.json

--- a/data/external/actionability_frontier_v1/historical_candidates_muril_minilm_high_catch.json.dvc
+++ b/data/external/actionability_frontier_v1/historical_candidates_muril_minilm_high_catch.json.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: c314e97d002d75ad3915f8fe35615175
+  size: 23657
+  hash: md5
+  path: historical_candidates_muril_minilm_high_catch.json

--- a/data/external/actionability_frontier_v1/historical_candidates_sensitivity.json.dvc
+++ b/data/external/actionability_frontier_v1/historical_candidates_sensitivity.json.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 069fac7d2ee4f2251b0075e3304f689a
+  size: 14607
+  hash: md5
+  path: historical_candidates_sensitivity.json

--- a/data/external/actionability_frontier_v1/historical_candidates_strict.json.dvc
+++ b/data/external/actionability_frontier_v1/historical_candidates_strict.json.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: cb2da9f3dd523d0401b3ab8c96134456
+  size: 14608
+  hash: md5
+  path: historical_candidates_strict.json

--- a/data/external/actionability_frontier_v1/historical_gold_180.jsonl.dvc
+++ b/data/external/actionability_frontier_v1/historical_gold_180.jsonl.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: ec7d57929ac6c42e89387eb3bdeb6b00
+  size: 209756
+  hash: md5
+  path: historical_gold_180.jsonl

--- a/data/external/actionability_frontier_v1/historical_gold_180.manifest.json.dvc
+++ b/data/external/actionability_frontier_v1/historical_gold_180.manifest.json.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 2ababd072c3ad739467385b85d984c71
+  size: 625
+  hash: md5
+  path: historical_gold_180.manifest.json

--- a/data/external/actionability_frontier_v1/judge_a.jsonl.dvc
+++ b/data/external/actionability_frontier_v1/judge_a.jsonl.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 427e921461cb83bdfb100142f948280b
+  size: 32259
+  hash: md5
+  path: judge_a.jsonl

--- a/data/external/actionability_frontier_v1/judge_b.jsonl.dvc
+++ b/data/external/actionability_frontier_v1/judge_b.jsonl.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 2cbc713848adcfc841ee1160b671852d
+  size: 30781
+  hash: md5
+  path: judge_b.jsonl

--- a/data/external/actionability_frontier_v1/resolver.jsonl.dvc
+++ b/data/external/actionability_frontier_v1/resolver.jsonl.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 4b5d2d04a9cf37c7a6f500692830a59a
+  size: 4955
+  hash: md5
+  path: resolver.jsonl

--- a/data/external/actionability_frontier_v1/resolver_backup.jsonl.dvc
+++ b/data/external/actionability_frontier_v1/resolver_backup.jsonl.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: e5c433a412b7a1d6db16b65c2088874e
+  size: 4999
+  hash: md5
+  path: resolver_backup.jsonl

--- a/data/external/actionability_frontier_v1/sample.jsonl.dvc
+++ b/data/external/actionability_frontier_v1/sample.jsonl.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 2e54fdceec9425dc4520f2cb1bd16111
+  size: 206944
+  hash: md5
+  path: sample.jsonl

--- a/data/external/actionability_frontier_v1/sample.provenance.json
+++ b/data/external/actionability_frontier_v1/sample.provenance.json
@@ -1,0 +1,45 @@
+{
+  "counts": {
+    "test/s1": 5,
+    "test/s2": 5,
+    "test/s3": 5,
+    "test/s4": 5,
+    "test/s5": 40,
+    "train/s1": 5,
+    "train/s2": 5,
+    "train/s3": 5,
+    "train/s4": 5,
+    "train/s5": 40,
+    "validation/s1": 5,
+    "validation/s2": 5,
+    "validation/s3": 5,
+    "validation/s4": 5,
+    "validation/s5": 40
+  },
+  "dataset_fingerprint": "sha256:95d0d3b7757ba5bd616dcffe4aefcf846cdc9f1ab2d0f7eaeba16a1077ecd096",
+  "forbidden_fields": [
+    "ticket_no",
+    "raw grievance",
+    "officer remark",
+    "petitioner identifiers",
+    "office"
+  ],
+  "parameters": {
+    "adjudicator_blinding": "sampling strata are opaque s1-s5",
+    "per_weak_stratum_split": 5,
+    "seed": "actionability-gold-v1",
+    "shaped_pii_excluded": 47,
+    "split_policy": "single_snapshot_hash_60_20_20_development_only",
+    "ticket_identifier": "salted_sha256_not_reversible",
+    "unlabeled_per_split": 40
+  },
+  "records": 180,
+  "schema_version": "actionability-adjudication-sample-v1",
+  "selected_fields": [
+    "salted item/group id",
+    "grievance_redacted",
+    "created_year",
+    "split",
+    "opaque sampling stratum"
+  ]
+}

--- a/dvc.lock
+++ b/dvc.lock
@@ -318,8 +318,8 @@ stages:
       size: 12995
     - path: janasunani/evaluation/embedding_actionability.py
       hash: md5
-      md5: 75acb1ff9863e38f16d57fe8a437c0a4
-      size: 16059
+      md5: 2df505de662473b67cffb3db7d2c552f
+      size: 16216
     - path: janasunani/evaluation/stats.py
       hash: md5
       md5: b3a53f566b6bb134331b12c9fb78afb6
@@ -344,8 +344,8 @@ stages:
     outs:
     - path: outputs/evaluation/actionability_candidates_muril_high_catch.json
       hash: md5
-      md5: 1dd790a5cde675fe392f94b73955a325
-      size: 16424
+      md5: ace52320363ec7d33390ad50fe9080f5
+      size: 16334
   actionability-weak-label-audit:
     cmd: uv run --frozen janasunani-audit-actionability-labels --complaints
       data/interim/complaints.parquet --action-history

--- a/dvc.lock
+++ b/dvc.lock
@@ -29,9 +29,9 @@ stages:
       md5: 4ad7a17893cb22a396f572b899e68c25
       size: 3925
   pipeline-sample:
-    cmd: uv run --extra pipeline-core janasunani-pipeline run --input 
-      data/raw/documents-sample --db data/processed/pipeline-sample.sqlite 
-      --models models --ocr-engine pytesseract --stages format_classifier 
+    cmd: uv run --extra pipeline-core janasunani-pipeline run --input
+      data/raw/documents-sample --db data/processed/pipeline-sample.sqlite
+      --models models --ocr-engine pytesseract --stages format_classifier
       ocr_extraction --workers 1 && uv run --extra pii janasunani-pipeline run
       --input data/raw/documents-sample --db
       data/processed/pipeline-sample.sqlite --models models --stages pii_tagger
@@ -189,3 +189,160 @@ stages:
       hash: md5
       md5: 903dc729212929dc0b8891df6487bd40
       size: 868
+  actionability-adjudication-prepare:
+    cmd: uv run --frozen python scripts/reconcile_actionability_adjudication.py
+      prepare --sample data/external/actionability_frontier_v1/sample.jsonl
+      --judge-a data/external/actionability_frontier_v1/judge_a.jsonl --judge-b
+      data/external/actionability_frontier_v1/judge_b.jsonl --consensus
+      data/external/actionability_frontier_v1/consensus.jsonl --resolver-input
+      data/external/actionability_frontier_v1/resolver_input.jsonl --report
+      data/external/actionability_frontier_v1/adjudication_report.json
+      --protocol-version frontier-actionability-adjudication-v1
+      --inference-environment openai-codex-agent-contexts --egress-policy
+      pii-redacted-shape-screened
+    deps:
+    - path: data/external/actionability_frontier_v1/judge_a.jsonl
+      hash: md5
+      md5: 427e921461cb83bdfb100142f948280b
+      size: 32259
+    - path: data/external/actionability_frontier_v1/judge_b.jsonl
+      hash: md5
+      md5: 2cbc713848adcfc841ee1160b671852d
+      size: 30781
+    - path: data/external/actionability_frontier_v1/sample.jsonl
+      hash: md5
+      md5: 2e54fdceec9425dc4520f2cb1bd16111
+      size: 206944
+    - path: janasunani/evaluation/adjudication.py
+      hash: md5
+      md5: 20c44867183cc01c9dde0929a9fa2398
+      size: 17058
+    - path: pyproject.toml
+      hash: md5
+      md5: 312152a943454973f9fdd51e68d82609
+      size: 9968
+    - path: scripts/reconcile_actionability_adjudication.py
+      hash: md5
+      md5: 15eca871fd564362a3c7c958ac9e17ce
+      size: 3268
+    - path: uv.lock
+      hash: md5
+      md5: f895934178f603f5315683d02abc6449
+      size: 1038485
+    outs:
+    - path: data/external/actionability_frontier_v1/adjudication_report.json
+      hash: md5
+      md5: a47f0746d6e065882cbdf6179119222f
+      size: 1789
+    - path: data/external/actionability_frontier_v1/consensus.jsonl
+      hash: md5
+      md5: 58f3fea583b67dad6a1ec7fc17d9ae5f
+      size: 15843
+    - path: data/external/actionability_frontier_v1/resolver_input.jsonl
+      hash: md5
+      md5: 93da96f7114dce4b7974cc1992a2039c
+      size: 9437
+  actionability-adjudication-finalize:
+    cmd: uv run --frozen python scripts/reconcile_actionability_adjudication.py
+      finalize --sample data/external/actionability_frontier_v1/sample.jsonl
+      --consensus data/external/actionability_frontier_v1/consensus.jsonl
+      --resolver data/external/actionability_frontier_v1/resolver.jsonl --gold
+      data/external/actionability_frontier_v1/gold.jsonl --manifest
+      data/external/actionability_frontier_v1/gold.manifest.json
+      --sample-manifest
+      data/external/actionability_frontier_v1/sample.provenance.json
+      --protocol-version frontier-actionability-adjudication-v1
+      --inference-environment openai-codex-agent-contexts --egress-policy
+      pii-redacted-shape-screened
+    deps:
+    - path: data/external/actionability_frontier_v1/consensus.jsonl
+      hash: md5
+      md5: 58f3fea583b67dad6a1ec7fc17d9ae5f
+      size: 15843
+    - path: data/external/actionability_frontier_v1/resolver.jsonl
+      hash: md5
+      md5: 4b5d2d04a9cf37c7a6f500692830a59a
+      size: 4955
+    - path: data/external/actionability_frontier_v1/sample.jsonl
+      hash: md5
+      md5: 2e54fdceec9425dc4520f2cb1bd16111
+      size: 206944
+    - path: data/external/actionability_frontier_v1/sample.provenance.json
+      hash: md5
+      md5: 0b99c76202e4993201f9f926753030ca
+      size: 1129
+    - path: janasunani/evaluation/adjudication.py
+      hash: md5
+      md5: 20c44867183cc01c9dde0929a9fa2398
+      size: 17058
+    - path: pyproject.toml
+      hash: md5
+      md5: 312152a943454973f9fdd51e68d82609
+      size: 9968
+    - path: scripts/reconcile_actionability_adjudication.py
+      hash: md5
+      md5: 15eca871fd564362a3c7c958ac9e17ce
+      size: 3268
+    - path: uv.lock
+      hash: md5
+      md5: f895934178f603f5315683d02abc6449
+      size: 1038485
+    outs:
+    - path: data/external/actionability_frontier_v1/gold.jsonl
+      hash: md5
+      md5: 359a39bc0030391dd774a5e0078c7132
+      size: 212025
+    - path: data/external/actionability_frontier_v1/gold.manifest.json
+      hash: md5
+      md5: b57c5c7bc4d015a3f84fe5dfc4e909fd
+      size: 2462
+  actionability-local-candidate-benchmark:
+    cmd: uv run --frozen --extra categorizer python
+      scripts/benchmark_actionability_candidates.py --gold
+      data/external/actionability_frontier_v1/gold.jsonl --output
+      outputs/evaluation/actionability_candidates_muril_high_catch.json
+      --multilingual-encoder muril_local=models/categorizer
+      --min-review-precision 0.6 --max-actionable-review-rate 0.1 --overwrite
+    deps:
+    - path: data/external/actionability_frontier_v1/gold.jsonl
+      hash: md5
+      md5: 359a39bc0030391dd774a5e0078c7132
+      size: 212025
+    - path: janasunani/evaluation/actionability.py
+      hash: md5
+      md5: 08570b2471796f49214c2f801d8791db
+      size: 33241
+    - path: janasunani/evaluation/classification.py
+      hash: md5
+      md5: 5be5a49505010f6b20ec6a183f30fd0f
+      size: 12995
+    - path: janasunani/evaluation/embedding_actionability.py
+      hash: md5
+      md5: 75acb1ff9863e38f16d57fe8a437c0a4
+      size: 16059
+    - path: janasunani/evaluation/stats.py
+      hash: md5
+      md5: b3a53f566b6bb134331b12c9fb78afb6
+      size: 26269
+    - path: models/categorizer
+      hash: md5
+      md5: 8924294cd47417e40b8ad1cc0b5382b4.dir
+      size: 956698867
+      nfiles: 8
+    - path: pyproject.toml
+      hash: md5
+      md5: 312152a943454973f9fdd51e68d82609
+      size: 9968
+    - path: scripts/benchmark_actionability_candidates.py
+      hash: md5
+      md5: c162da6c0555d445562fc673b2cd8a5c
+      size: 10823
+    - path: uv.lock
+      hash: md5
+      md5: f895934178f603f5315683d02abc6449
+      size: 1038485
+    outs:
+    - path: outputs/evaluation/actionability_candidates_muril_high_catch.json
+      hash: md5
+      md5: 1dd790a5cde675fe392f94b73955a325
+      size: 16424

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -116,3 +116,89 @@ stages:
       - outputs/findings/confirmed_duplicates.md
       - outputs/findings/misrouting_baseline.csv
       - outputs/findings/misrouting_baseline.md
+
+  actionability-adjudication-prepare:
+    desc: >-
+      Reconcile the two directly tracked frontier judgments into confident
+      consensus rows and a resolver queue. Inputs and outputs contain opaque
+      item IDs only; no ticket numbers or unredacted grievance text are stored.
+    cmd: >-
+      uv run --frozen python scripts/reconcile_actionability_adjudication.py prepare
+      --sample data/external/actionability_frontier_v1/sample.jsonl
+      --judge-a data/external/actionability_frontier_v1/judge_a.jsonl
+      --judge-b data/external/actionability_frontier_v1/judge_b.jsonl
+      --consensus data/external/actionability_frontier_v1/consensus.jsonl
+      --resolver-input data/external/actionability_frontier_v1/resolver_input.jsonl
+      --report data/external/actionability_frontier_v1/adjudication_report.json
+      --protocol-version frontier-actionability-adjudication-v1
+      --inference-environment openai-codex-agent-contexts
+      --egress-policy pii-redacted-shape-screened
+    deps:
+      - data/external/actionability_frontier_v1/sample.jsonl
+      - data/external/actionability_frontier_v1/judge_a.jsonl
+      - data/external/actionability_frontier_v1/judge_b.jsonl
+      - janasunani/evaluation/adjudication.py
+      - scripts/reconcile_actionability_adjudication.py
+      - pyproject.toml
+      - uv.lock
+    outs:
+      - data/external/actionability_frontier_v1/consensus.jsonl
+      - data/external/actionability_frontier_v1/resolver_input.jsonl
+      - data/external/actionability_frontier_v1/adjudication_report.json
+
+  actionability-adjudication-finalize:
+    desc: >-
+      Deterministically combine the fixed sample, confident consensus and the
+      directly tracked frontier resolver output into development gold. The
+      result remains advisory evidence and is not a five-class release set.
+    cmd: >-
+      uv run --frozen python scripts/reconcile_actionability_adjudication.py finalize
+      --sample data/external/actionability_frontier_v1/sample.jsonl
+      --consensus data/external/actionability_frontier_v1/consensus.jsonl
+      --resolver data/external/actionability_frontier_v1/resolver.jsonl
+      --gold data/external/actionability_frontier_v1/gold.jsonl
+      --manifest data/external/actionability_frontier_v1/gold.manifest.json
+      --sample-manifest data/external/actionability_frontier_v1/sample.provenance.json
+      --protocol-version frontier-actionability-adjudication-v1
+      --inference-environment openai-codex-agent-contexts
+      --egress-policy pii-redacted-shape-screened
+    deps:
+      - data/external/actionability_frontier_v1/sample.jsonl
+      - data/external/actionability_frontier_v1/sample.provenance.json
+      - data/external/actionability_frontier_v1/consensus.jsonl
+      - data/external/actionability_frontier_v1/resolver.jsonl
+      - janasunani/evaluation/adjudication.py
+      - scripts/reconcile_actionability_adjudication.py
+      - pyproject.toml
+      - uv.lock
+    outs:
+      - data/external/actionability_frontier_v1/gold.jsonl
+      - data/external/actionability_frontier_v1/gold.manifest.json
+
+  actionability-local-candidate-benchmark:
+    desc: >-
+      Reproduce the high-catch local comparison between the TF-IDF review
+      classifier and the frozen DVC-mirrored MuRIL encoder. MiniLM remains only
+      in directly tracked historical evidence because its local HF cache was
+      not a governed input.
+    cmd: >-
+      uv run --frozen --extra categorizer python
+      scripts/benchmark_actionability_candidates.py
+      --gold data/external/actionability_frontier_v1/gold.jsonl
+      --output outputs/evaluation/actionability_candidates_muril_high_catch.json
+      --multilingual-encoder muril_local=models/categorizer
+      --min-review-precision 0.6
+      --max-actionable-review-rate 0.1
+      --overwrite
+    deps:
+      - data/external/actionability_frontier_v1/gold.jsonl
+      - models/categorizer
+      - janasunani/evaluation/actionability.py
+      - janasunani/evaluation/classification.py
+      - janasunani/evaluation/embedding_actionability.py
+      - janasunani/evaluation/stats.py
+      - scripts/benchmark_actionability_candidates.py
+      - pyproject.toml
+      - uv.lock
+    outs:
+      - outputs/evaluation/actionability_candidates_muril_high_catch.json

--- a/janasunani/evaluation/adjudication.py
+++ b/janasunani/evaluation/adjudication.py
@@ -1,0 +1,423 @@
+"""Privacy-safe reconciliation of independent frontier adjudications.
+
+Frontier labels are useful one-time supervision, not officer outcomes. Two
+judges label the same PII-redacted, blinded records. Exact confident agreement
+is accepted; every disagreement or uncertainty goes to a third independent
+resolver. Outputs keep the redacted training text locally, while reports are
+aggregate-only and safe to publish.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Sequence
+
+from janasunani.inference.actionability import ACTIONABILITY_LABELS, ActionabilityLabel
+
+
+JUDGMENT_KEYS = {"item_id", "label", "confidence", "uncertain", "rationale_code"}
+SAMPLE_KEYS = {
+    "item_id",
+    "group_id",
+    "redacted_text",
+    "created_year",
+    "split",
+    "language",
+    "sampling_stratum",
+}
+RAW_TEXT_KEYS = {"grievance", "raw_text", "complaint_text", "unredacted_text"}
+PROVENANCE_FIELDS = (
+    "protocol_version",
+    "rubric_version",
+    "prompt_sha256",
+    "judge_a_model",
+    "judge_b_model",
+    "resolver_model",
+    "inference_environment",
+    "egress_policy",
+    "retention_policy",
+)
+UNAVAILABLE = "unavailable"
+
+
+@dataclass(frozen=True)
+class Judgment:
+    item_id: str
+    label: ActionabilityLabel
+    confidence: float
+    uncertain: bool
+    rationale_code: str
+
+
+def normalize_adjudication_provenance(
+    provenance: Mapping[str, str] | None,
+) -> dict[str, str]:
+    """Return a complete, privacy-safe provenance record.
+
+    Missing provenance is represented explicitly rather than guessed. The
+    prompt itself is never accepted: only its SHA-256 digest belongs in an
+    aggregate report or gold manifest.
+    """
+
+    supplied = dict(provenance or {})
+    unknown = set(supplied).difference(PROVENANCE_FIELDS)
+    if unknown:
+        raise ValueError(f"unknown adjudication provenance fields: {sorted(unknown)!r}")
+    normalized: dict[str, str] = {}
+    for field in PROVENANCE_FIELDS:
+        value = supplied.get(field, UNAVAILABLE)
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"adjudication provenance {field} must be non-empty")
+        value = value.strip()
+        if len(value) > 256 or "\n" in value or "\r" in value:
+            raise ValueError(f"adjudication provenance {field} is not safe metadata")
+        if field == "prompt_sha256" and value != UNAVAILABLE:
+            digest = value.removeprefix("sha256:")
+            if len(digest) != 64 or any(character not in "0123456789abcdef" for character in digest.lower()):
+                raise ValueError("prompt_sha256 must be unavailable or a SHA-256 digest")
+            value = "sha256:" + digest.lower()
+        normalized[field] = value
+    return normalized
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def _load_jsonl(
+    path: Path, *, allow_empty: bool = False
+) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if not line.strip():
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"{path.name}:{line_number}: invalid JSON") from exc
+        if not isinstance(payload, dict):
+            raise ValueError(f"{path.name}:{line_number}: row must be an object")
+        rows.append(payload)
+    if not rows and not allow_empty:
+        raise ValueError(f"{path.name}: file is empty")
+    return rows
+
+
+def load_sample(path: Path) -> list[dict[str, object]]:
+    rows = _load_jsonl(path)
+    ids: list[str] = []
+    for index, row in enumerate(rows, 1):
+        if set(row) != SAMPLE_KEYS:
+            raise ValueError(f"sample row {index} has an unexpected shape")
+        if RAW_TEXT_KEYS.intersection(row):
+            raise ValueError(f"sample row {index} contains a raw-text field")
+        if not all(
+            isinstance(row[key], str) and str(row[key]).strip()
+            for key in (
+                "item_id",
+                "group_id",
+                "redacted_text",
+                "split",
+                "language",
+                "sampling_stratum",
+            )
+        ):
+            raise ValueError(f"sample row {index} has an invalid string field")
+        if isinstance(row["created_year"], bool) or not isinstance(
+            row["created_year"], int
+        ):
+            raise ValueError(f"sample row {index} has an invalid created_year")
+        if row["item_id"] != row["group_id"]:
+            raise ValueError("sample item_id and group_id must match")
+        if row["split"] not in {"train", "validation", "test"}:
+            raise ValueError("sample split is invalid")
+        ids.append(str(row["item_id"]))
+    if len(ids) != len(set(ids)):
+        raise ValueError("sample item IDs must be unique")
+    return rows
+
+
+def load_judgments(
+    path: Path, *, allow_empty: bool = False
+) -> dict[str, Judgment]:
+    rows = _load_jsonl(path, allow_empty=allow_empty)
+    judgments: dict[str, Judgment] = {}
+    for index, row in enumerate(rows, 1):
+        if set(row) != JUDGMENT_KEYS:
+            raise ValueError(f"judgment row {index} has an unexpected shape")
+        item_id = row["item_id"]
+        label = row["label"]
+        confidence = row["confidence"]
+        uncertain = row["uncertain"]
+        rationale_code = row["rationale_code"]
+        if not isinstance(item_id, str) or not item_id:
+            raise ValueError("judgment item_id must be non-empty")
+        if label not in ACTIONABILITY_LABELS:
+            raise ValueError("judgment label is outside the taxonomy")
+        if (
+            isinstance(confidence, bool)
+            or not isinstance(confidence, (int, float))
+            or not math.isfinite(confidence)
+            or not 0.0 <= confidence <= 1.0
+        ):
+            raise ValueError("judgment confidence must be finite and in [0, 1]")
+        if not isinstance(uncertain, bool):
+            raise ValueError("judgment uncertain must be boolean")
+        if (
+            not isinstance(rationale_code, str)
+            or not rationale_code
+            or any(character.isspace() for character in rationale_code)
+        ):
+            raise ValueError("rationale_code must be one non-empty token")
+        if item_id in judgments:
+            raise ValueError("judgment item IDs must be unique")
+        judgments[item_id] = Judgment(
+            item_id=item_id,
+            label=label,
+            confidence=float(confidence),
+            uncertain=uncertain,
+            rationale_code=rationale_code,
+        )
+    return judgments
+
+
+def _cohen_kappa(
+    a: Sequence[ActionabilityLabel], b: Sequence[ActionabilityLabel]
+) -> float:
+    if len(a) != len(b) or not a:
+        raise ValueError("kappa requires equally sized non-empty sequences")
+    observed = sum(left == right for left, right in zip(a, b, strict=True)) / len(a)
+    counts_a = Counter(a)
+    counts_b = Counter(b)
+    expected = sum(
+        counts_a[label] / len(a) * counts_b[label] / len(b)
+        for label in ACTIONABILITY_LABELS
+    )
+    return (observed - expected) / (1.0 - expected) if expected < 1.0 else 1.0
+
+
+def _write_jsonl(path: Path, rows: Sequence[Mapping[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+    path.chmod(0o600)
+
+
+def prepare_resolution(
+    sample_path: Path,
+    judge_a_path: Path,
+    judge_b_path: Path,
+    *,
+    consensus_path: Path,
+    resolver_input_path: Path,
+    report_path: Path,
+    provenance: Mapping[str, str] | None = None,
+) -> dict[str, object]:
+    sample = load_sample(sample_path)
+    judge_a = load_judgments(judge_a_path)
+    judge_b = load_judgments(judge_b_path)
+    normalized_provenance = normalize_adjudication_provenance(provenance)
+    sample_ids = {str(row["item_id"]) for row in sample}
+    if set(judge_a) != sample_ids or set(judge_b) != sample_ids:
+        raise ValueError("each judge must cover exactly the sample IDs")
+
+    consensus: list[dict[str, object]] = []
+    resolver_input: list[dict[str, object]] = []
+    labels_a: list[ActionabilityLabel] = []
+    labels_b: list[ActionabilityLabel] = []
+    for row in sample:
+        item_id = str(row["item_id"])
+        left = judge_a[item_id]
+        right = judge_b[item_id]
+        labels_a.append(left.label)
+        labels_b.append(right.label)
+        if left.label == right.label and not left.uncertain and not right.uncertain:
+            consensus.append({"item_id": item_id, "label": left.label})
+        else:
+            resolver_input.append(dict(row))
+
+    _write_jsonl(consensus_path, consensus)
+    _write_jsonl(resolver_input_path, resolver_input)
+    raw_agreement = sum(a == b for a, b in zip(labels_a, labels_b, strict=True))
+    stratum_counts = Counter(str(row["sampling_stratum"]) for row in sample)
+    report: dict[str, object] = {
+        "schema_version": "frontier-actionability-adjudication-v1",
+        "records": len(sample),
+        "raw_agreement": raw_agreement / len(sample),
+        "cohen_kappa": _cohen_kappa(labels_a, labels_b),
+        "confident_consensus": len(consensus),
+        "sent_to_resolver": len(resolver_input),
+        "judge_a_distribution": dict(sorted(Counter(labels_a).items())),
+        "judge_b_distribution": dict(sorted(Counter(labels_b).items())),
+        "sample_design": {
+            "sampling_scheme": "fixed quotas across opaque sampling strata",
+            "sampling_stratum_counts": dict(sorted(stratum_counts.items())),
+            "production_prevalence_representative": False,
+            "metric_interpretation": (
+                "agreement is measured on the designed adjudication composition; "
+                "downstream accuracy, precision, and PPV are composition-specific"
+            ),
+        },
+        "input_sha256": {
+            "sample": _sha256(sample_path),
+            "judge_a": _sha256(judge_a_path),
+            "judge_b": _sha256(judge_b_path),
+        },
+        "adjudication_provenance": normalized_provenance,
+        "privacy": "aggregate report contains no narrative text or ticket number",
+        "claim_status": "frontier-adjudicated development gold, not officer-confirmed truth",
+    }
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return report
+
+
+def finalize_gold(
+    sample_path: Path,
+    consensus_path: Path,
+    resolver_path: Path,
+    *,
+    gold_path: Path,
+    manifest_path: Path,
+    sample_manifest_path: Path | None = None,
+    provenance: Mapping[str, str] | None = None,
+) -> dict[str, object]:
+    sample = load_sample(sample_path)
+    normalized_provenance = normalize_adjudication_provenance(provenance)
+    consensus_rows = _load_jsonl(consensus_path, allow_empty=True)
+    consensus: dict[str, ActionabilityLabel] = {}
+    for row in consensus_rows:
+        if set(row) != {"item_id", "label"} or row["label"] not in ACTIONABILITY_LABELS:
+            raise ValueError("consensus row is invalid")
+        item_id = str(row["item_id"])
+        if item_id in consensus:
+            raise ValueError("consensus item IDs must be unique")
+        consensus[item_id] = row["label"]  # type: ignore[assignment]
+    resolver = load_judgments(resolver_path, allow_empty=True)
+    all_ids = {str(row["item_id"]) for row in sample}
+    if set(consensus).intersection(resolver):
+        raise ValueError("consensus and resolver IDs must be disjoint")
+    if set(consensus).union(resolver) != all_ids:
+        raise ValueError("consensus plus resolver must cover exactly the sample")
+
+    gold: list[dict[str, object]] = []
+    unresolved_by_split: Counter[str] = Counter()
+    unresolved_by_stratum: Counter[str] = Counter()
+    resolver_accepted = 0
+    for row in sample:
+        item_id = str(row["item_id"])
+        if item_id in consensus:
+            label = consensus[item_id]
+        else:
+            judgment = resolver[item_id]
+            if judgment.uncertain:
+                unresolved_by_split[str(row["split"])] += 1
+                unresolved_by_stratum[str(row["sampling_stratum"])] += 1
+                continue
+            label = judgment.label
+            resolver_accepted += 1
+        gold.append(
+            {
+                "item_id": item_id,
+                "redacted_text": row["redacted_text"],
+                "label": label,
+                "group_id": row["group_id"],
+                "language": row["language"],
+                "split": row["split"],
+                "label_source": "frontier_adjudicated",
+                "sampling_stratum": row["sampling_stratum"],
+            }
+        )
+    if not gold:
+        raise ValueError("no resolved rows remain for gold")
+    sample_manifest_sha256: str | None = None
+    split_policy = UNAVAILABLE
+    design_parameters: dict[str, object] = {}
+    if sample_manifest_path is not None:
+        try:
+            sample_manifest = json.loads(sample_manifest_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise ValueError("sample manifest is invalid JSON") from exc
+        if not isinstance(sample_manifest, dict):
+            raise ValueError("sample manifest must be an object")
+        if sample_manifest.get("dataset_fingerprint") != _sha256(sample_path):
+            raise ValueError("sample manifest fingerprint does not match sample")
+        parameters = sample_manifest.get("parameters")
+        if isinstance(parameters, dict):
+            observed_policy = parameters.get("split_policy")
+            if isinstance(observed_policy, str) and observed_policy.strip():
+                split_policy = observed_policy.strip()
+            for key in (
+                "per_weak_stratum_split",
+                "unlabeled_per_split",
+                "adjudicator_blinding",
+            ):
+                if key in parameters:
+                    design_parameters[key] = parameters[key]
+        sample_manifest_sha256 = _sha256(sample_manifest_path)
+    _write_jsonl(gold_path, gold)
+    stratum_counts = Counter(str(row["sampling_stratum"]) for row in sample)
+    gold_stratum_counts = Counter(str(row["sampling_stratum"]) for row in gold)
+    manifest: dict[str, object] = {
+        "schema_version": "actionability-gold-manifest-v1",
+        "records": len(gold),
+        "label_distribution": dict(
+            sorted(Counter(str(row["label"]) for row in gold).items())
+        ),
+        "split_distribution": dict(
+            sorted(Counter(str(row["split"]) for row in gold).items())
+        ),
+        "resolution": {
+            "sample_records": len(sample),
+            "confident_consensus_accepted": len(consensus),
+            "resolver_judgments_received": len(resolver),
+            "confident_resolver_accepted": resolver_accepted,
+            "unresolved_excluded": sum(unresolved_by_split.values()),
+            "unresolved_excluded_by_split": dict(sorted(unresolved_by_split.items())),
+            "unresolved_excluded_by_sampling_stratum": dict(
+                sorted(unresolved_by_stratum.items())
+            ),
+            "uncertain_resolver_labels_enter_gold": False,
+        },
+        "sample_design": {
+            "sampling_scheme": "fixed quotas across opaque sampling strata",
+            "split_policy": split_policy,
+            "design_parameters": design_parameters,
+            "sample_stratum_counts": dict(sorted(stratum_counts.items())),
+            "gold_stratum_counts": dict(sorted(gold_stratum_counts.items())),
+            "sample_manifest_sha256": sample_manifest_sha256 or UNAVAILABLE,
+            "production_prevalence_representative": False,
+            "metric_interpretation": (
+                "accuracy, precision, PPV, and review workload are specific to this "
+                "designed sample composition and must not be read as production prevalence"
+            ),
+        },
+        "gold_sha256": _sha256(gold_path),
+        "adjudication_provenance": normalized_provenance,
+        "provenance": {
+            "source": "PII-redacted DPIC-controlled sample",
+            "adjudication": (
+                "two independent frontier judges; confident third-resolver labels "
+                "for disagreement or uncertainty; unresolved rows excluded"
+            ),
+            "claim_status": "development gold, not officer-confirmed truth",
+        },
+    }
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return manifest

--- a/janasunani/evaluation/embedding_actionability.py
+++ b/janasunani/evaluation/embedding_actionability.py
@@ -1,0 +1,411 @@
+"""Local frozen-encoder probes for the actionability review decision.
+
+The encoder is never fine-tuned.  Its normalized mean-pooled embeddings feed a
+small logistic-regression probe trained on the governed training split.  Probe
+regularization and the officer-review threshold are selected on validation;
+the test split is evaluated exactly once and is never used to rank candidates.
+
+Only local model directories are accepted.  ``local_files_only=True`` and
+``trust_remote_code=False`` make a missing artifact a clear failure instead of
+an implicit provider call.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal, Protocol, Sequence
+
+from janasunani.evaluation.actionability import (
+    ActionabilityRecord,
+    _binary_review_metrics,
+    _select_binary_review_threshold,
+    validate_records,
+)
+
+EncoderRole = Literal["multilingual_candidate", "english_diagnostic"]
+
+MODEL_FAMILY = "frozen-transformer-mean-pool-logreg"
+MODEL_VERSION = "actionability-frozen-encoder-v1"
+
+
+@dataclass(frozen=True)
+class LocalEncoderSpec:
+    """Pinned local encoder identity and its intended interpretation."""
+
+    name: str
+    model_path: Path
+    role: EncoderRole
+    max_length: int = 256
+    batch_size: int = 16
+
+
+class TextEncoder(Protocol):
+    """Small seam used by the benchmark and lightweight unit tests."""
+
+    @property
+    def provenance(self) -> dict[str, object]: ...
+
+    def encode(self, texts: Sequence[str]) -> Any: ...
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def directory_fingerprint(path: Path) -> tuple[str, int]:
+    """Hash all model files, including the content behind cache symlinks."""
+
+    resolved = resolve_local_model_dir(path)
+    files = sorted(candidate for candidate in resolved.rglob("*") if candidate.is_file())
+    if not files:
+        raise FileNotFoundError(f"local model directory contains no files: {resolved}")
+    digest = hashlib.sha256()
+    for candidate in files:
+        relative = candidate.relative_to(resolved).as_posix()
+        digest.update(relative.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(str(candidate.stat().st_size).encode("ascii"))
+        digest.update(b"\0")
+        digest.update(_sha256_file(candidate).encode("ascii"))
+        digest.update(b"\n")
+    return f"sha256:{digest.hexdigest()}", len(files)
+
+
+def resolve_local_model_dir(path: Path) -> Path:
+    """Resolve and minimally validate a Transformers model directory."""
+
+    resolved = path.expanduser().resolve()
+    if not resolved.exists():
+        raise FileNotFoundError(
+            f"local encoder is absent: {resolved}; benchmark will not download it"
+        )
+    if not resolved.is_dir():
+        raise ValueError(f"local encoder path is not a directory: {resolved}")
+    if not (resolved / "config.json").is_file():
+        raise FileNotFoundError(f"local encoder has no config.json: {resolved}")
+    return resolved
+
+
+def resolve_cached_huggingface_snapshot(
+    repo_id: str, *, cache_dir: Path | None = None, revision: str = "main"
+) -> Path:
+    """Resolve an already cached Hugging Face snapshot without network access."""
+
+    if not repo_id or "/" not in repo_id:
+        raise ValueError("repo_id must have the form owner/model")
+    cache_root = (
+        cache_dir.expanduser().resolve()
+        if cache_dir is not None
+        else Path.home() / ".cache" / "huggingface" / "hub"
+    )
+    repository = cache_root / f"models--{repo_id.replace('/', '--')}"
+    revision_ref = repository / "refs" / revision
+    if revision_ref.is_file():
+        snapshot_id = revision_ref.read_text(encoding="utf-8").strip()
+        snapshot = repository / "snapshots" / snapshot_id
+        return resolve_local_model_dir(snapshot)
+    direct_snapshot = repository / "snapshots" / revision
+    if direct_snapshot.is_dir():
+        return resolve_local_model_dir(direct_snapshot)
+    raise FileNotFoundError(
+        f"Hugging Face model {repo_id!r} revision {revision!r} is not cached "
+        f"under {cache_root}; benchmark will not download it"
+    )
+
+
+class TransformersMeanPoolEncoder:
+    """Frozen local Transformers encoder with masked mean pooling."""
+
+    def __init__(self, spec: LocalEncoderSpec, *, device: str = "cpu") -> None:
+        if not spec.name.strip():
+            raise ValueError("encoder name must be non-empty")
+        if spec.role not in {"multilingual_candidate", "english_diagnostic"}:
+            raise ValueError(f"invalid encoder role {spec.role!r}")
+        if spec.max_length < 8:
+            raise ValueError("max_length must be at least 8")
+        if spec.batch_size < 1:
+            raise ValueError("batch_size must be positive")
+        model_path = resolve_local_model_dir(spec.model_path)
+        try:
+            import torch
+            from transformers import AutoModel, AutoTokenizer
+        except ImportError as exc:
+            raise RuntimeError(
+                "frozen encoder benchmark needs the pipeline-core extra"
+            ) from exc
+
+        self._torch = torch
+        self._spec = spec
+        self._model_path = model_path
+        self._device = torch.device(device)
+        self._tokenizer = AutoTokenizer.from_pretrained(
+            model_path,
+            local_files_only=True,
+            trust_remote_code=False,
+        )
+        self._model = AutoModel.from_pretrained(
+            model_path,
+            local_files_only=True,
+            trust_remote_code=False,
+        ).to(self._device)
+        self._model.eval()
+        for parameter in self._model.parameters():
+            parameter.requires_grad_(False)
+
+        fingerprint, file_count = directory_fingerprint(model_path)
+        revision = (
+            model_path.name if model_path.parent.name == "snapshots" else None
+        )
+        config = self._model.config
+        self._provenance: dict[str, object] = {
+            "name": spec.name,
+            "role": spec.role,
+            "local_path": str(model_path),
+            "revision": revision,
+            "artifact_fingerprint": fingerprint,
+            "artifact_file_count": file_count,
+            "transformers_model_type": getattr(config, "model_type", None),
+            "architectures": list(getattr(config, "architectures", None) or []),
+            "pooling": "attention_masked_mean_then_l2_normalize",
+            "max_length": spec.max_length,
+            "batch_size": spec.batch_size,
+            "device": str(self._device),
+            "frozen": True,
+            "local_files_only": True,
+            "trust_remote_code": False,
+        }
+
+    @property
+    def provenance(self) -> dict[str, object]:
+        return dict(self._provenance)
+
+    def encode(self, texts: Sequence[str]) -> Any:
+        if not texts:
+            raise ValueError("cannot encode an empty text collection")
+        torch = self._torch
+        batches = []
+        for start in range(0, len(texts), self._spec.batch_size):
+            batch = list(texts[start : start + self._spec.batch_size])
+            tokens = self._tokenizer(
+                batch,
+                padding=True,
+                truncation=True,
+                max_length=self._spec.max_length,
+                return_tensors="pt",
+            )
+            tokens = {key: value.to(self._device) for key, value in tokens.items()}
+            with torch.inference_mode():
+                hidden = self._model(**tokens).last_hidden_state
+            mask = tokens["attention_mask"].unsqueeze(-1).to(hidden.dtype)
+            pooled = (hidden * mask).sum(dim=1) / mask.sum(dim=1).clamp(min=1)
+            pooled = torch.nn.functional.normalize(pooled, p=2, dim=1)
+            batches.append(pooled.cpu())
+        return torch.cat(batches, dim=0).numpy()
+
+
+@dataclass
+class FrozenEncoderBenchmark:
+    classifier: Any
+    review_threshold: float
+    report: dict[str, object]
+
+
+def binary_discrimination_metrics(
+    probabilities: Sequence[float], records: Sequence[ActionabilityRecord]
+) -> dict[str, float | None]:
+    """Return threshold-free binary diagnostics for an aligned split."""
+
+    if len(probabilities) != len(records) or not records:
+        raise ValueError("discrimination metrics require aligned non-empty inputs")
+    if any(
+        not math.isfinite(probability) or not 0 <= probability <= 1
+        for probability in probabilities
+    ):
+        raise ValueError("probabilities must be finite and in [0, 1]")
+    from sklearn.metrics import average_precision_score, brier_score_loss, roc_auc_score
+
+    labels = [record.label != "actionable" for record in records]
+    if len(set(labels)) < 2:
+        roc_auc = None
+    else:
+        roc_auc = float(roc_auc_score(labels, probabilities))
+    return {
+        "roc_auc": roc_auc,
+        "average_precision": float(average_precision_score(labels, probabilities)),
+        "brier_score": float(brier_score_loss(labels, probabilities)),
+    }
+
+
+def _probabilities(classifier: Any, matrix: Any) -> list[float]:
+    classes = tuple(str(label) for label in classifier.classes_)
+    try:
+        review_index = classes.index("review")
+    except ValueError as exc:
+        raise ValueError("probe did not learn the review class") from exc
+    return [float(row[review_index]) for row in classifier.predict_proba(matrix)]
+
+
+def benchmark_frozen_encoder(
+    records: Sequence[ActionabilityRecord],
+    encoder: TextEncoder,
+    *,
+    c_values: Sequence[float] = (0.1, 0.5, 1.0, 2.0, 10.0),
+    min_review_precision: float = 0.9,
+    max_actionable_review_rate: float = 0.05,
+) -> FrozenEncoderBenchmark:
+    """Tune a frozen-embedding binary probe on validation and score test."""
+
+    validate_records(records)
+    if not c_values or any(not math.isfinite(c) or c <= 0 for c in c_values):
+        raise ValueError("c_values must contain positive finite values")
+    if not 0 <= min_review_precision <= 1:
+        raise ValueError("min_review_precision must be in [0, 1]")
+    if not 0 <= max_actionable_review_rate <= 1:
+        raise ValueError("max_actionable_review_rate must be in [0, 1]")
+    splits = {
+        split: [record for record in records if record.split == split]
+        for split in ("train", "validation", "test")
+    }
+    for split, rows in splits.items():
+        if {row.label != "actionable" for row in rows} != {False, True}:
+            raise ValueError(f"{split} split must contain actionable and review examples")
+
+    matrices = {
+        split: encoder.encode([record.redacted_text for record in rows])
+        for split, rows in splits.items()
+    }
+    for split, matrix in matrices.items():
+        shape = getattr(matrix, "shape", None)
+        if shape is None or len(shape) != 2 or shape[0] != len(splits[split]):
+            raise ValueError(
+                f"encoder returned an invalid {split} matrix shape: {shape!r}"
+            )
+        if shape[1] < 1:
+            raise ValueError("encoder returned zero embedding features")
+        try:
+            finite = bool(matrix.dtype.kind in "biuf" and math.isfinite(float(matrix.sum())))
+        except (AttributeError, TypeError, ValueError):
+            finite = False
+        if not finite:
+            raise ValueError(f"encoder returned non-finite {split} embeddings")
+    from sklearn.linear_model import LogisticRegression
+
+    candidates: list[tuple[float, Any, float, dict[str, object], list[float]]] = []
+    train_labels = [
+        "review" if record.label != "actionable" else "actionable"
+        for record in splits["train"]
+    ]
+    for c in c_values:
+        classifier = LogisticRegression(
+            C=c,
+            class_weight="balanced",
+            max_iter=2_000,
+            random_state=1729,
+        )
+        classifier.fit(matrices["train"], train_labels)
+        validation_probabilities = _probabilities(classifier, matrices["validation"])
+        threshold, validation_metrics = _select_binary_review_threshold(
+            validation_probabilities,
+            splits["validation"],
+            min_precision=min_review_precision,
+            max_actionable_review_rate=max_actionable_review_rate,
+        )
+        candidates.append(
+            (c, classifier, threshold, validation_metrics, validation_probabilities)
+        )
+    c, classifier, threshold, validation_metrics, validation_probabilities = max(
+        candidates,
+        key=lambda row: (
+            float(row[3]["review_recall"]),
+            float(row[3]["review_precision"]),
+            float(row[3]["accuracy"]),
+            -row[0],
+        ),
+    )
+    test_probabilities = _probabilities(classifier, matrices["test"])
+    test_metrics = _binary_review_metrics(
+        test_probabilities, splits["test"], threshold=threshold
+    )
+    by_language: dict[str, object] = {}
+    for language in sorted({row.language for row in splits["test"]}):
+        indices = [
+            index
+            for index, row in enumerate(splits["test"])
+            if row.language == language
+        ]
+        by_language[language] = _binary_review_metrics(
+            [test_probabilities[index] for index in indices],
+            [splits["test"][index] for index in indices],
+            threshold=threshold,
+        )
+
+    provenance = encoder.provenance
+    role = provenance.get("role")
+    limitations = [
+        "frozen encoder with a train-only linear probe",
+        "frontier-adjudicated development gold is not officer-confirmed truth",
+        "single-snapshot hash splits are not chronological release evidence",
+        "test split is report-only and did not select model or threshold",
+        "Wilson intervals are item-level and do not establish population representativeness",
+        "binary review does not replace the complete five-class production contract",
+    ]
+    if role == "english_diagnostic":
+        limitations.append(
+            "English-oriented encoder is diagnostic only for Odia and multilingual traffic"
+        )
+    report: dict[str, object] = {
+        "model_family": MODEL_FAMILY,
+        "model_version": MODEL_VERSION,
+        "objective": "actionable_vs_officer_review",
+        "encoder": provenance,
+        "probe": {
+            "classifier": "sklearn.linear_model.LogisticRegression",
+            "solver": "lbfgs",
+            "class_weight": "balanced",
+            "max_iter": 2_000,
+            "random_state": 1729,
+            "candidate_c_values": list(c_values),
+            "training_split": "train",
+        },
+        "selected_c": c,
+        "review_threshold": threshold,
+        "split_counts": {split: len(rows) for split, rows in splits.items()},
+        "gold_label_distribution": dict(
+            sorted(Counter(record.label for record in records).items())
+        ),
+        "validation": validation_metrics,
+        "validation_discrimination": binary_discrimination_metrics(
+            validation_probabilities, splits["validation"]
+        ),
+        "test": test_metrics,
+        "test_discrimination": binary_discrimination_metrics(
+            test_probabilities, splits["test"]
+        ),
+        "test_by_language": by_language,
+        "candidate_validation": [
+            {
+                "c": candidate_c,
+                "threshold": candidate_threshold,
+                "review_precision": metrics["review_precision"],
+                "review_recall": metrics["review_recall"],
+                "actionable_review_rate": metrics["actionable_review_rate"],
+                **binary_discrimination_metrics(probabilities, splits["validation"]),
+            }
+            for candidate_c, _, candidate_threshold, metrics, probabilities in candidates
+        ],
+        "release_eligible": False,
+        "limitations": limitations,
+    }
+    return FrozenEncoderBenchmark(
+        classifier=classifier,
+        review_threshold=threshold,
+        report=report,
+    )

--- a/janasunani/evaluation/embedding_actionability.py
+++ b/janasunani/evaluation/embedding_actionability.py
@@ -168,7 +168,9 @@ class TransformersMeanPoolEncoder:
         self._provenance: dict[str, object] = {
             "name": spec.name,
             "role": spec.role,
-            "local_path": str(model_path),
+            # Preserve the configured reference rather than the resolved
+            # checkout path so aggregate benchmark evidence is portable.
+            "local_path": spec.model_path.as_posix(),
             "revision": revision,
             "artifact_fingerprint": fingerprint,
             "artifact_file_count": file_count,

--- a/scripts/benchmark_actionability_candidates.py
+++ b/scripts/benchmark_actionability_candidates.py
@@ -13,11 +13,9 @@ import hashlib
 import importlib.metadata
 import json
 import os
-import platform
 import sys
 import tempfile
 from collections import Counter
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import Sequence
 
@@ -135,10 +133,9 @@ def build_report(
     )
     report: dict[str, object] = {
         "schema_version": SCHEMA_VERSION,
-        "created_at": datetime.now(UTC).isoformat(),
         "objective": "actionable_vs_officer_review",
         "gold": {
-            "path": str(gold_path.resolve()),
+            "path": gold_path.as_posix(),
             "sha256": _sha256(gold_path),
             "n": len(records),
             "split_counts": dict(sorted(Counter(row.split for row in records).items())),
@@ -161,7 +158,6 @@ def build_report(
         },
         "software": {
             "python": sys.version.split()[0],
-            "platform": platform.platform(),
             "numpy": importlib.metadata.version("numpy"),
             "scikit_learn": importlib.metadata.version("scikit-learn"),
             "torch": importlib.metadata.version("torch"),

--- a/scripts/benchmark_actionability_candidates.py
+++ b/scripts/benchmark_actionability_candidates.py
@@ -1,0 +1,313 @@
+"""Compare cheap local actionability-review candidates on governed gold.
+
+The command is deliberately offline: every pretrained encoder must be an
+already present local directory or cached Hugging Face snapshot.  Output is a
+privacy-safe aggregate JSON scorecard and never contains grievance text or
+item-level predictions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.metadata
+import json
+import os
+import platform
+import sys
+import tempfile
+from collections import Counter
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Sequence
+
+from janasunani.evaluation.actionability import (
+    benchmark_binary_review,
+    load_jsonl,
+    sample_design_summary,
+)
+from janasunani.evaluation.embedding_actionability import (
+    LocalEncoderSpec,
+    TransformersMeanPoolEncoder,
+    binary_discrimination_metrics,
+    benchmark_frozen_encoder,
+    resolve_cached_huggingface_snapshot,
+)
+
+SCHEMA_VERSION = "actionability-candidate-benchmark-v1"
+MINILM_REPO_ID = "sentence-transformers/all-MiniLM-L6-v2"
+_FORBIDDEN_OUTPUT_KEYS = {
+    "redacted_text",
+    "grievance",
+    "complaint_text",
+    "raw_text",
+    "grievance_text",
+    "unredacted_text",
+}
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def _parse_named_path(value: str) -> tuple[str, Path]:
+    name, separator, raw_path = value.partition("=")
+    if not separator or not name.strip() or not raw_path.strip():
+        raise argparse.ArgumentTypeError("encoder must have the form NAME=LOCAL_PATH")
+    return name.strip(), Path(raw_path).expanduser()
+
+
+def _assert_aggregate_only(value: object, *, path: str = "report") -> None:
+    if isinstance(value, dict):
+        forbidden = _FORBIDDEN_OUTPUT_KEYS.intersection(value)
+        if forbidden:
+            raise ValueError(f"{path} contains forbidden text keys: {sorted(forbidden)!r}")
+        for key, child in value.items():
+            _assert_aggregate_only(child, path=f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            _assert_aggregate_only(child, path=f"{path}[{index}]")
+
+
+def _validation_rank(report: dict[str, object]) -> tuple[float, float, float]:
+    validation = report["validation"]
+    if not isinstance(validation, dict):
+        raise ValueError("candidate report has no aggregate validation metrics")
+    return (
+        float(validation["review_recall"]),
+        float(validation["review_precision"]),
+        float(validation["accuracy"]),
+    )
+
+
+def build_report(
+    *,
+    gold_path: Path,
+    encoder_specs: Sequence[LocalEncoderSpec],
+    c_values: Sequence[float],
+    min_review_precision: float,
+    max_actionable_review_rate: float,
+) -> dict[str, object]:
+    records = load_jsonl(gold_path)
+    tfidf = benchmark_binary_review(
+        records,
+        c_values=c_values,
+        min_review_precision=min_review_precision,
+        max_actionable_review_rate=max_actionable_review_rate,
+    )
+    split_records = {
+        split: [record for record in records if record.split == split]
+        for split in ("validation", "test")
+    }
+    tfidf_classes = tuple(str(label) for label in tfidf.classifier.classes_)
+    review_index = tfidf_classes.index("review")
+    for split, rows in split_records.items():
+        probabilities = [
+            float(row[review_index])
+            for row in tfidf.classifier.predict_proba(
+                [record.redacted_text for record in rows]
+            )
+        ]
+        tfidf.report[f"{split}_discrimination"] = binary_discrimination_metrics(
+            probabilities, rows
+        )
+    candidates: dict[str, dict[str, object]] = {"tfidf_word_char": tfidf.report}
+    for spec in encoder_specs:
+        if spec.name in candidates:
+            raise ValueError(f"duplicate candidate name {spec.name!r}")
+        encoder = TransformersMeanPoolEncoder(spec)
+        candidates[spec.name] = benchmark_frozen_encoder(
+            records,
+            encoder,
+            c_values=c_values,
+            min_review_precision=min_review_precision,
+            max_actionable_review_rate=max_actionable_review_rate,
+        ).report
+
+    ranked = sorted(
+        candidates,
+        key=lambda name: (*_validation_rank(candidates[name]), name),
+        reverse=True,
+    )
+    report: dict[str, object] = {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(UTC).isoformat(),
+        "objective": "actionable_vs_officer_review",
+        "gold": {
+            "path": str(gold_path.resolve()),
+            "sha256": _sha256(gold_path),
+            "n": len(records),
+            "split_counts": dict(sorted(Counter(row.split for row in records).items())),
+            "label_counts": dict(sorted(Counter(row.label for row in records).items())),
+            "label_source_counts": dict(
+                sorted(Counter(row.label_source for row in records).items())
+            ),
+            "sample_design": sample_design_summary(records),
+        },
+        "protocol": {
+            "encoder_training": "frozen",
+            "probe_training_split": "train",
+            "hyperparameter_selection_split": "validation",
+            "threshold_selection_split": "validation",
+            "candidate_ranking_split": "validation",
+            "test_usage": "aggregate_report_only",
+            "provider_calls": False,
+            "local_files_only": True,
+            "confidence_intervals": "two-sided 95% Wilson score intervals",
+        },
+        "software": {
+            "python": sys.version.split()[0],
+            "platform": platform.platform(),
+            "numpy": importlib.metadata.version("numpy"),
+            "scikit_learn": importlib.metadata.version("scikit-learn"),
+            "torch": importlib.metadata.version("torch"),
+            "transformers": importlib.metadata.version("transformers"),
+        },
+        "constraints": {
+            "min_review_precision": min_review_precision,
+            "max_actionable_review_rate": max_actionable_review_rate,
+        },
+        "validation_ranking": ranked,
+        "validation_selected_candidate": ranked[0],
+        "candidates": candidates,
+        "privacy": {
+            "aggregate_only": True,
+            "contains_grievance_text": False,
+            "contains_item_level_predictions": False,
+        },
+        "release_eligible": False,
+        "limitations": [
+            "candidate selection is development-only and not a production promotion",
+            sample_design_summary(records)["limitation"],
+        ],
+    }
+    _assert_aggregate_only(report)
+    return report
+
+
+def _write_json_atomic(path: Path, report: dict[str, object], *, overwrite: bool) -> None:
+    if path.exists() and not overwrite:
+        raise FileExistsError(f"refusing to overwrite existing report: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            json.dump(report, stream, indent=2, sort_keys=True)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    except BaseException:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--gold", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument(
+        "--multilingual-encoder",
+        action="append",
+        default=[],
+        type=_parse_named_path,
+        metavar="NAME=LOCAL_PATH",
+    )
+    parser.add_argument(
+        "--english-diagnostic",
+        action="append",
+        default=[],
+        type=_parse_named_path,
+        metavar="NAME=LOCAL_PATH",
+    )
+    parser.add_argument(
+        "--cached-minilm",
+        action="store_true",
+        help="use the already cached all-MiniLM-L6-v2 snapshot; never download",
+    )
+    parser.add_argument("--hf-cache-dir", type=Path)
+    parser.add_argument("--max-length", type=int, default=256)
+    parser.add_argument("--batch-size", type=int, default=16)
+    parser.add_argument("--c-values", type=float, nargs="+", default=[0.1, 0.5, 1, 2, 10])
+    parser.add_argument("--min-review-precision", type=float, default=0.9)
+    parser.add_argument("--max-actionable-review-rate", type=float, default=0.05)
+    parser.add_argument("--overwrite", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    os.environ["HF_HUB_OFFLINE"] = "1"
+    os.environ["TRANSFORMERS_OFFLINE"] = "1"
+    specs = [
+        LocalEncoderSpec(
+            name=name,
+            model_path=path,
+            role="multilingual_candidate",
+            max_length=args.max_length,
+            batch_size=args.batch_size,
+        )
+        for name, path in args.multilingual_encoder
+    ]
+    specs.extend(
+        LocalEncoderSpec(
+            name=name,
+            model_path=path,
+            role="english_diagnostic",
+            max_length=args.max_length,
+            batch_size=args.batch_size,
+        )
+        for name, path in args.english_diagnostic
+    )
+    if args.cached_minilm:
+        specs.append(
+            LocalEncoderSpec(
+                name="minilm_english_diagnostic",
+                model_path=resolve_cached_huggingface_snapshot(
+                    MINILM_REPO_ID, cache_dir=args.hf_cache_dir
+                ),
+                role="english_diagnostic",
+                max_length=args.max_length,
+                batch_size=args.batch_size,
+            )
+        )
+    if not specs:
+        raise SystemExit(
+            "at least one local encoder is required: use --multilingual-encoder, "
+            "--english-diagnostic, or --cached-minilm"
+        )
+    report = build_report(
+        gold_path=args.gold,
+        encoder_specs=specs,
+        c_values=args.c_values,
+        min_review_precision=args.min_review_precision,
+        max_actionable_review_rate=args.max_actionable_review_rate,
+    )
+    _write_json_atomic(args.output, report, overwrite=args.overwrite)
+    print(
+        json.dumps(
+            {
+                "output": str(args.output),
+                "gold_sha256": report["gold"]["sha256"],
+                "validation_selected_candidate": report[
+                    "validation_selected_candidate"
+                ],
+                "candidate_count": len(report["candidates"]),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_provenance_sidecars.py
+++ b/scripts/check_provenance_sidecars.py
@@ -1,6 +1,7 @@
 """Check that committed provenance sidecars hold metadata and nothing else.
 
-`data/external/*.provenance.json` is the one exception to the rule that nothing
+Provenance sidecars at any depth below `data/external/` are the one exception
+to the rule that nothing
 under `data/` enters git: a sidecar records analyzer versions, checksums and
 span counts so a gold artifact can be reviewed without pulling citizen text.
 The exception is granted by filename, so something has to verify that the
@@ -22,7 +23,7 @@ publishing the thing you are refusing to publish defeats the gate.
 
 Stdlib only: it runs on a bare runner before any dependency is installed.
 
-    python3 scripts/check_provenance_sidecars.py data/external/*.provenance.json
+    python3 scripts/check_provenance_sidecars.py data/external/**/*.provenance.json
 
 Exits 0 when every file passes, 1 otherwise.
 """
@@ -70,6 +71,9 @@ MAX_STRING = 200
 MAX_NOTE = 1000
 
 _MD5_RE = re.compile(r"^[0-9a-f]{32}$")
+_SHA256_RE = re.compile(r"^(sha256:)?[0-9a-f]{64}$")
+_ACTIONABILITY_SCHEMA = "actionability-adjudication-sample-v1"
+_SARVAM_SCHEMA = "janasunani.sarvam-source-snapshots/v1"
 
 
 def _check_scalar(path: str, value: Any, limit: int) -> list[str]:
@@ -100,10 +104,135 @@ def _check_counter(key: str, value: Any) -> list[str]:
     return problems
 
 
+def _check_string_list(key: str, value: Any, *, limit: int = MAX_STRING) -> list[str]:
+    if not isinstance(value, list):
+        return [f"'{key}' must be a list"]
+    problems: list[str] = []
+    for position, item in enumerate(value):
+        problems += _check_scalar(f"{key}[{position}]", item, limit)
+    return problems
+
+
+def _check_actionability_sample(payload: dict[str, Any]) -> list[str]:
+    allowed = {
+        "counts",
+        "dataset_fingerprint",
+        "forbidden_fields",
+        "parameters",
+        "records",
+        "schema_version",
+        "selected_fields",
+    }
+    problems: list[str] = []
+    if set(payload) - allowed:
+        problems.append("actionability sidecar has unknown top-level metadata keys")
+    fingerprint = payload.get("dataset_fingerprint")
+    if not isinstance(fingerprint, str) or not _SHA256_RE.fullmatch(fingerprint):
+        problems.append("actionability dataset_fingerprint is not a SHA-256 digest")
+    counts = payload.get("counts")
+    if not isinstance(counts, dict):
+        problems.append("actionability counts must be an object")
+    else:
+        key_pattern = re.compile(r"^(train|validation|test)/s[1-5]$")
+        for position, (key, value) in enumerate(counts.items()):
+            if not isinstance(key, str) or not key_pattern.fullmatch(key):
+                problems.append(f"actionability counts key {position} is not an allowed split/stratum")
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                problems.append(f"actionability counts value {position} must be a nonnegative integer")
+    parameters = payload.get("parameters")
+    allowed_parameters = {
+        "adjudicator_blinding",
+        "per_weak_stratum_split",
+        "seed",
+        "shaped_pii_excluded",
+        "split_policy",
+        "ticket_identifier",
+        "unlabeled_per_split",
+    }
+    if not isinstance(parameters, dict):
+        problems.append("actionability parameters must be an object")
+    else:
+        for position, (key, value) in enumerate(parameters.items()):
+            if key not in allowed_parameters:
+                problems.append(f"actionability parameter {position} is not allowlisted")
+                continue
+            problems += _check_scalar(f"parameters[{position}]", value, MAX_STRING)
+    records = payload.get("records")
+    if isinstance(records, bool) or not isinstance(records, int) or records < 0:
+        problems.append("actionability records must be a nonnegative integer")
+    problems += _check_string_list("forbidden_fields", payload.get("forbidden_fields"))
+    problems += _check_string_list("selected_fields", payload.get("selected_fields"))
+    return problems
+
+
+def _check_sarvam_snapshots(payload: dict[str, Any]) -> list[str]:
+    allowed = {"artifacts", "claim_status", "limitations", "privacy", "schema_version"}
+    problems: list[str] = []
+    if set(payload) - allowed:
+        problems.append("Sarvam sidecar has unknown top-level metadata keys")
+    problems += _check_scalar("claim_status", payload.get("claim_status"), MAX_STRING)
+    privacy = payload.get("privacy")
+    allowed_privacy = {
+        "contains_operational_ticket_and_document_identifiers",
+        "contains_provider_response_metadata",
+        "git_contains_row_level_bytes",
+        "storage",
+    }
+    if not isinstance(privacy, dict):
+        problems.append("Sarvam privacy must be an object")
+    else:
+        if set(privacy) - allowed_privacy:
+            problems.append("Sarvam privacy has unknown metadata keys")
+        for position, value in enumerate(privacy.values()):
+            problems += _check_scalar(f"privacy[{position}]", value, MAX_STRING)
+    artifacts = payload.get("artifacts")
+    allowed_artifacts = {
+        "interrupted_300_page_audit.sqlite",
+        "validation_5_page_audit.sqlite",
+        "validation_5_page_scorecard.json",
+        "validation_5_page_scorecard.md",
+    }
+    allowed_artifact_fields = {
+        "audit_events",
+        "distinct_documents",
+        "distinct_tickets",
+        "role",
+        "sha256",
+    }
+    if not isinstance(artifacts, dict):
+        problems.append("Sarvam artifacts must be an object")
+    else:
+        if set(artifacts) - allowed_artifacts:
+            problems.append("Sarvam artifacts includes an unknown filename")
+        for artifact_position, details in enumerate(artifacts.values()):
+            if not isinstance(details, dict):
+                problems.append(f"Sarvam artifact {artifact_position} must be an object")
+                continue
+            if set(details) - allowed_artifact_fields:
+                problems.append(f"Sarvam artifact {artifact_position} has unknown metadata keys")
+            digest = details.get("sha256")
+            if not isinstance(digest, str) or not _SHA256_RE.fullmatch(digest):
+                problems.append(f"Sarvam artifact {artifact_position} has no valid SHA-256")
+            for field_position, (key, value) in enumerate(details.items()):
+                if key == "sha256":
+                    continue
+                problems += _check_scalar(
+                    f"artifacts[{artifact_position}][{field_position}]", value, MAX_STRING
+                )
+    problems += _check_string_list("limitations", payload.get("limitations"))
+    return problems
+
+
 def check_payload(payload: Any) -> list[str]:
     """Every way this document fails the metadata contract. Empty means it passes."""
     if not isinstance(payload, dict):
         return [f"top level is {type(payload).__name__}, expected an object"]
+
+    schema = payload.get("schema_version")
+    if schema == _ACTIONABILITY_SCHEMA:
+        return _check_actionability_sample(payload)
+    if schema == _SARVAM_SCHEMA:
+        return _check_sarvam_snapshots(payload)
 
     problems: list[str] = []
     for key, value in payload.items():

--- a/scripts/check_provenance_sidecars.py
+++ b/scripts/check_provenance_sidecars.py
@@ -23,7 +23,7 @@ publishing the thing you are refusing to publish defeats the gate.
 
 Stdlib only: it runs on a bare runner before any dependency is installed.
 
-    python3 scripts/check_provenance_sidecars.py data/external/**/*.provenance.json
+    python3 scripts/check_provenance_sidecars.py PATH [PATH ...]
 
 Exits 0 when every file passes, 1 otherwise.
 """
@@ -73,6 +73,7 @@ MAX_NOTE = 1000
 _MD5_RE = re.compile(r"^[0-9a-f]{32}$")
 _SHA256_RE = re.compile(r"^(sha256:)?[0-9a-f]{64}$")
 _ACTIONABILITY_SCHEMA = "actionability-adjudication-sample-v1"
+_ACTIONABILITY_FRONTIER_SCHEMA = "janasunani.actionability-frontier-artifacts/v1"
 _SARVAM_SCHEMA = "janasunani.sarvam-source-snapshots/v1"
 
 
@@ -165,6 +166,144 @@ def _check_actionability_sample(payload: dict[str, Any]) -> list[str]:
     return problems
 
 
+def _check_exact_keys(name: str, value: Any, expected: set[str]) -> list[str]:
+    if not isinstance(value, dict):
+        return [f"{name} must be an object"]
+    if set(value) != expected:
+        return [f"{name} does not have the exact allowlisted metadata keys"]
+    return []
+
+
+def _check_sha256(path: str, value: Any) -> list[str]:
+    if not isinstance(value, str) or not _SHA256_RE.fullmatch(value):
+        return [f"{path} is not a SHA-256 digest"]
+    return []
+
+
+def _check_nonnegative_int(path: str, value: Any) -> list[str]:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return [f"{path} must be a nonnegative integer"]
+    return []
+
+
+def _check_actionability_frontier(payload: dict[str, Any]) -> list[str]:
+    """Validate the aggregate manifest for privately stored frontier artifacts."""
+    top_keys = {
+        "canonical_reproducible_gold",
+        "claim_status",
+        "deterministic_stages",
+        "direct_inputs",
+        "limitations",
+        "preserved_historical_gold",
+        "preserved_nonreproducible_reports",
+        "privacy",
+        "sample",
+        "schema_version",
+    }
+    problems = _check_exact_keys("actionability frontier sidecar", payload, top_keys)
+    if problems:
+        return problems
+
+    problems += _check_scalar("claim_status", payload["claim_status"], MAX_STRING)
+
+    privacy = payload["privacy"]
+    privacy_keys = {
+        "contains_redacted_narratives",
+        "git_contains_row_level_bytes",
+        "residual_pii_risk",
+        "source",
+        "storage",
+    }
+    problems += _check_exact_keys("actionability frontier privacy", privacy, privacy_keys)
+    if isinstance(privacy, dict):
+        for position, value in enumerate(privacy.values()):
+            problems += _check_scalar(f"privacy[{position}]", value, MAX_STRING)
+
+    sample = payload["sample"]
+    sample_keys = {
+        "records",
+        "sampling",
+        "sha256",
+        "split_counts",
+        "split_policy",
+        "tracking_mode",
+        "tracking_reason",
+    }
+    problems += _check_exact_keys("actionability frontier sample", sample, sample_keys)
+    if isinstance(sample, dict):
+        problems += _check_nonnegative_int("sample.records", sample.get("records"))
+        problems += _check_sha256("sample.sha256", sample.get("sha256"))
+        for key in {"sampling", "split_policy", "tracking_mode", "tracking_reason"}:
+            problems += _check_scalar(f"sample.{key}", sample.get(key), MAX_STRING)
+        split_counts = sample.get("split_counts")
+        problems += _check_exact_keys(
+            "actionability frontier split_counts", split_counts, {"train", "validation", "test"}
+        )
+        if isinstance(split_counts, dict):
+            for position, value in enumerate(split_counts.values()):
+                problems += _check_nonnegative_int(f"split_counts[{position}]", value)
+
+    inputs = payload["direct_inputs"]
+    allowed_inputs = {"judge_a.jsonl", "judge_b.jsonl", "resolver.jsonl", "resolver_backup.jsonl"}
+    problems += _check_exact_keys("actionability frontier direct_inputs", inputs, allowed_inputs)
+    if isinstance(inputs, dict):
+        for position, details in enumerate(inputs.values()):
+            problems += _check_exact_keys(f"direct_inputs[{position}]", details, {"role", "sha256"})
+            if isinstance(details, dict):
+                problems += _check_scalar(f"direct_inputs[{position}].role", details.get("role"), MAX_STRING)
+                problems += _check_sha256(f"direct_inputs[{position}].sha256", details.get("sha256"))
+
+    stages = payload["deterministic_stages"]
+    allowed_stages = {
+        "actionability-adjudication-prepare",
+        "actionability-adjudication-finalize",
+        "actionability-local-candidate-benchmark",
+    }
+    problems += _check_exact_keys("actionability frontier deterministic_stages", stages, allowed_stages)
+    if isinstance(stages, dict):
+        for position, outputs in enumerate(stages.values()):
+            problems += _check_string_list(f"deterministic_stages[{position}]", outputs)
+
+    canonical = payload["canonical_reproducible_gold"]
+    canonical_keys = {"excluded_uncertain_resolver_rows", "label_counts", "policy", "records", "sha256"}
+    problems += _check_exact_keys("actionability frontier canonical_gold", canonical, canonical_keys)
+    if isinstance(canonical, dict):
+        for key in {"records", "excluded_uncertain_resolver_rows"}:
+            problems += _check_nonnegative_int(f"canonical_gold.{key}", canonical.get(key))
+        problems += _check_sha256("canonical_gold.sha256", canonical.get("sha256"))
+        problems += _check_scalar("canonical_gold.policy", canonical.get("policy"), MAX_STRING)
+        labels = canonical.get("label_counts")
+        allowed_labels = {"actionable", "underspecified", "irrelevant", "policy_blocked", "out_of_scope"}
+        problems += _check_exact_keys("actionability frontier label_counts", labels, allowed_labels)
+        if isinstance(labels, dict):
+            for position, value in enumerate(labels.values()):
+                problems += _check_nonnegative_int(f"label_counts[{position}]", value)
+
+    historical = payload["preserved_historical_gold"]
+    historical_keys = {"artifact", "manifest", "records", "sha256", "status"}
+    problems += _check_exact_keys("actionability frontier historical_gold", historical, historical_keys)
+    if isinstance(historical, dict):
+        for key in {"artifact", "manifest", "status"}:
+            problems += _check_scalar(f"historical_gold.{key}", historical.get(key), MAX_STRING)
+        problems += _check_nonnegative_int("historical_gold.records", historical.get("records"))
+        problems += _check_sha256("historical_gold.sha256", historical.get("sha256"))
+
+    reports = payload["preserved_nonreproducible_reports"]
+    allowed_reports = {
+        "historical_candidates_strict.json",
+        "historical_candidates_sensitivity.json",
+        "historical_candidates_high_catch.json",
+        "historical_candidates_muril_minilm_high_catch.json",
+    }
+    problems += _check_exact_keys("actionability frontier preserved_reports", reports, allowed_reports)
+    if isinstance(reports, dict):
+        for position, digest in enumerate(reports.values()):
+            problems += _check_sha256(f"preserved_reports[{position}]", digest)
+
+    problems += _check_string_list("limitations", payload["limitations"], limit=MAX_NOTE)
+    return problems
+
+
 def _check_sarvam_snapshots(payload: dict[str, Any]) -> list[str]:
     allowed = {"artifacts", "claim_status", "limitations", "privacy", "schema_version"}
     problems: list[str] = []
@@ -231,6 +370,8 @@ def check_payload(payload: Any) -> list[str]:
     schema = payload.get("schema_version")
     if schema == _ACTIONABILITY_SCHEMA:
         return _check_actionability_sample(payload)
+    if schema == _ACTIONABILITY_FRONTIER_SCHEMA:
+        return _check_actionability_frontier(payload)
     if schema == _SARVAM_SCHEMA:
         return _check_sarvam_snapshots(payload)
 

--- a/scripts/reconcile_actionability_adjudication.py
+++ b/scripts/reconcile_actionability_adjudication.py
@@ -1,0 +1,84 @@
+"""Prepare resolution or finalize a frontier-adjudicated actionability gold set."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from janasunani.evaluation.adjudication import finalize_gold, prepare_resolution
+
+
+def _add_provenance_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--protocol-version", default="unavailable")
+    parser.add_argument("--rubric-version", default="unavailable")
+    parser.add_argument("--prompt-sha256", default="unavailable")
+    parser.add_argument("--judge-a-model", default="unavailable")
+    parser.add_argument("--judge-b-model", default="unavailable")
+    parser.add_argument("--resolver-model", default="unavailable")
+    parser.add_argument("--inference-environment", default="unavailable")
+    parser.add_argument("--egress-policy", default="unavailable")
+    parser.add_argument("--retention-policy", default="unavailable")
+
+
+def _provenance(args: argparse.Namespace) -> dict[str, str]:
+    return {
+        "protocol_version": args.protocol_version,
+        "rubric_version": args.rubric_version,
+        "prompt_sha256": args.prompt_sha256,
+        "judge_a_model": args.judge_a_model,
+        "judge_b_model": args.judge_b_model,
+        "resolver_model": args.resolver_model,
+        "inference_environment": args.inference_environment,
+        "egress_policy": args.egress_policy,
+        "retention_policy": args.retention_policy,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    prepare = subparsers.add_parser("prepare")
+    prepare.add_argument("--sample", type=Path, required=True)
+    prepare.add_argument("--judge-a", type=Path, required=True)
+    prepare.add_argument("--judge-b", type=Path, required=True)
+    prepare.add_argument("--consensus", type=Path, required=True)
+    prepare.add_argument("--resolver-input", type=Path, required=True)
+    prepare.add_argument("--report", type=Path, required=True)
+    _add_provenance_arguments(prepare)
+
+    finalize = subparsers.add_parser("finalize")
+    finalize.add_argument("--sample", type=Path, required=True)
+    finalize.add_argument("--consensus", type=Path, required=True)
+    finalize.add_argument("--resolver", type=Path, required=True)
+    finalize.add_argument("--gold", type=Path, required=True)
+    finalize.add_argument("--manifest", type=Path, required=True)
+    finalize.add_argument("--sample-manifest", type=Path)
+    _add_provenance_arguments(finalize)
+
+    args = parser.parse_args()
+    if args.command == "prepare":
+        prepare_resolution(
+            args.sample,
+            args.judge_a,
+            args.judge_b,
+            consensus_path=args.consensus,
+            resolver_input_path=args.resolver_input,
+            report_path=args.report,
+            provenance=_provenance(args),
+        )
+    else:
+        finalize_gold(
+            args.sample,
+            args.consensus,
+            args.resolver,
+            gold_path=args.gold,
+            manifest_path=args.manifest,
+            sample_manifest_path=args.sample_manifest,
+            provenance=_provenance(args),
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sample_actionability_adjudication.py
+++ b/scripts/sample_actionability_adjudication.py
@@ -1,0 +1,394 @@
+"""Build a deterministic, PII-redacted actionability adjudication sample.
+
+This script is intended to run on DPIC-controlled infrastructure. It reads the
+named redacted complaint column and exact administrative templates only. The
+output contains no ticket number, raw grievance, officer remark, person field,
+or office field. Sampling strata are opaque so adjudicators remain blind to the
+administrative weak label used only to improve class coverage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import re
+import secrets
+from pathlib import Path
+from typing import Sequence
+
+
+SHAPED_PII = re.compile(
+    r"(?:\b\d{10}\b|\b\d{4}[ -]?\d{4}[ -]?\d{4}\b|"
+    r"\b[A-Z]{5}\d{4}[A-Z]\b|\b[^\s@]+@[^\s@]+\.[^\s@]+\b)",
+    re.IGNORECASE,
+)
+
+FAMILY_TO_STRATUM = {
+    "details_inadequate": "s1",
+    "documents_not_attached": "s1",
+    "address_not_given": "s1",
+    "no_specific_grievance": "s2",
+    "outside_grievance_cell_purview": "s3",
+    "policy_decision_required": "s4",
+}
+
+SPLIT_FOR_YEAR = {
+    2021: "train",
+    2022: "train",
+    2023: "train",
+    2024: "validation",
+    2025: "test",
+}
+
+_NORMALIZED_REMARK_SQL = (
+    "regexp_replace(regexp_replace(lower(trim(action_taken_remark)), "
+    "'\\s+', ' ', 'g'), '\\.$', '')"
+)
+
+
+def _identifier(ticket_no: str, *, salt: str) -> str:
+    return hashlib.sha256(f"{salt}\0{ticket_no}".encode()).hexdigest()
+
+
+def _normalized_text(value: str) -> str:
+    return " ".join(value.split())
+
+
+def _private_salt(path: Path) -> str:
+    try:
+        value = path.read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        value = secrets.token_hex(32)
+        path.write_text(value + "\n", encoding="utf-8")
+        path.chmod(0o600)
+    if len(value) < 32:
+        raise ValueError("identifier salt file is invalid")
+    return value
+
+
+def _split_for_item(
+    *, ticket_no: str, year: int, seed: str, chronological: bool
+) -> str | None:
+    if chronological:
+        return SPLIT_FOR_YEAR.get(year)
+    bucket = int.from_bytes(
+        hashlib.sha256(f"{seed}\0split\0{ticket_no}".encode()).digest()[:8],
+        "big",
+    ) % 10
+    if bucket < 6:
+        return "train"
+    if bucket < 8:
+        return "validation"
+    return "test"
+
+
+def _load_parquet_rows(
+    complaints_path: Path,
+    action_history_path: Path,
+    template_rows: Sequence[tuple[str, str]],
+) -> list[tuple[str, int, str, str | None]]:
+    import duckdb
+
+    connection = duckdb.connect(":memory:")
+    try:
+        connection.execute(
+            "CREATE TEMP TABLE discard_template(family VARCHAR, template VARCHAR)"
+        )
+        connection.executemany(
+            "INSERT INTO discard_template VALUES (?, ?)", template_rows
+        )
+        connection.from_parquet(str(complaints_path)).create_view("complaints")
+        connection.from_parquet(str(action_history_path)).create_view("action_history")
+        return connection.execute(
+            """
+            WITH normalized_action AS (
+                SELECT
+                    ticket_no,
+                    regexp_replace(
+                        regexp_replace(lower(trim(action_taken_remark)), '\\s+', ' ', 'g'),
+                        '\\.$', ''
+                    ) AS normalized_remark
+                FROM action_history
+                WHERE action_taken_remark IS NOT NULL
+            ), matched_family AS (
+                SELECT DISTINCT a.ticket_no, d.family AS label_family
+                FROM normalized_action a
+                INNER JOIN discard_template d ON d.template = a.normalized_remark
+            ), ticket_family AS (
+                SELECT
+                    ticket_no,
+                    count(*) AS family_count,
+                    min(label_family) AS label_family
+                FROM matched_family
+                GROUP BY ticket_no
+            )
+            SELECT
+                cast(c.ticket_no AS VARCHAR) ticket_no,
+                cast(c.created_year AS INTEGER) created_year,
+                cast(c.grievance_redacted AS VARCHAR) redacted_text,
+                CASE
+                    WHEN tf.family_count = 1 THEN tf.label_family
+                    ELSE NULL
+                END AS label_family
+            FROM complaints c
+            LEFT JOIN ticket_family tf USING (ticket_no)
+            WHERE c.created_year BETWEEN 2021 AND 2025
+              AND c.grievance_redacted IS NOT NULL
+              AND trim(c.grievance_redacted) <> ''
+            """
+        ).fetchall()
+    finally:
+        connection.close()
+
+
+async def _load_oltp_rows_async(
+    database_url: str,
+    template_rows: Sequence[tuple[str, str]],
+) -> list[tuple[str, int, str, str | None]]:
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    values = []
+    parameters: dict[str, str] = {}
+    for index, (family, template) in enumerate(template_rows):
+        values.append(f"(:family_{index}, :template_{index})")
+        parameters[f"family_{index}"] = family
+        parameters[f"template_{index}"] = template
+    query = text(
+        f"""
+        WITH discard_template(family_name, template) AS (
+            VALUES {", ".join(values)}
+        ), normalized_action AS (
+            SELECT ticket_no, {_NORMALIZED_REMARK_SQL} AS normalized_remark
+            FROM action_history
+            WHERE action_taken_remark IS NOT NULL
+        ), matched_family AS (
+            SELECT DISTINCT a.ticket_no, d.family_name AS label_family
+            FROM normalized_action a
+            INNER JOIN discard_template d ON d.template = a.normalized_remark
+        ), ticket_family AS (
+            SELECT
+                ticket_no,
+                count(*) AS family_count,
+                min(label_family) AS label_family
+            FROM matched_family
+            GROUP BY ticket_no
+        )
+        SELECT
+            c.ticket_no::text,
+            extract(year from c.created_on)::integer AS created_year,
+            g.grievance_redacted,
+            CASE
+                WHEN tf.family_count = 1 THEN tf.label_family
+                ELSE NULL
+            END AS label_family
+        FROM complaints c
+        INNER JOIN grievance_redactions g USING (ticket_no)
+        LEFT JOIN ticket_family tf USING (ticket_no)
+        WHERE g.grievance_redacted IS NOT NULL
+          AND trim(g.grievance_redacted) <> ''
+        """
+    )
+    engine = create_async_engine(database_url)
+    try:
+        async with engine.connect() as connection:
+            result = await connection.execute(query, parameters)
+            return [tuple(row) for row in result.fetchall()]
+    finally:
+        await engine.dispose()
+
+
+def _load_oltp_rows(
+    env_file: Path,
+    template_rows: Sequence[tuple[str, str]],
+) -> list[tuple[str, int, str, str | None]]:
+    from dotenv import dotenv_values
+
+    database_url = dotenv_values(env_file).get("OLTP_DB_URL")
+    if not database_url:
+        raise ValueError("OLTP_DB_URL is missing from the supplied env file")
+    return asyncio.run(_load_oltp_rows_async(str(database_url), template_rows))
+
+
+def build_sample(
+    complaints_path: Path | None,
+    action_history_path: Path | None,
+    oltp_env_file: Path | None,
+    output_path: Path,
+    manifest_path: Path,
+    *,
+    per_stratum_split: int,
+    unlabeled_per_split: int,
+    seed: str,
+    id_salt: str,
+) -> None:
+    parquet_mode = complaints_path is not None or action_history_path is not None
+    if parquet_mode == (oltp_env_file is not None):
+        raise ValueError("choose either both Parquet inputs or one OLTP env file")
+    if parquet_mode:
+        if complaints_path is None or not complaints_path.is_file():
+            raise FileNotFoundError(complaints_path)
+        if action_history_path is None or not action_history_path.is_file():
+            raise FileNotFoundError(action_history_path)
+    elif oltp_env_file is None or not oltp_env_file.is_file():
+        raise FileNotFoundError(oltp_env_file)
+    if per_stratum_split < 1 or unlabeled_per_split < 1:
+        raise ValueError("sample sizes must be positive")
+    if not seed or not id_salt:
+        raise ValueError("seed and id salt must be non-empty")
+
+    from janasunani.analytics.findings.discards import TEMPLATES
+
+    template_rows = [
+        (family, template)
+        for family, templates in TEMPLATES.items()
+        if family in FAMILY_TO_STRATUM
+        for template in templates
+    ]
+    rows = (
+        _load_parquet_rows(complaints_path, action_history_path, template_rows)
+        if parquet_mode and complaints_path is not None and action_history_path is not None
+        else _load_oltp_rows(oltp_env_file, template_rows)  # type: ignore[arg-type]
+    )
+    observed_years = {int(row[1]) for row in rows}
+    chronological = len(observed_years) >= 3 and {2024, 2025}.issubset(observed_years)
+
+    candidates: dict[tuple[str, str], list[tuple[str, int, str]]] = {}
+    excluded_shaped_pii = 0
+    for ticket_no, year, raw_text, family in rows:
+        split = _split_for_item(
+            ticket_no=str(ticket_no),
+            year=int(year),
+            seed=seed,
+            chronological=chronological,
+        )
+        if split is None:
+            continue
+        text = _normalized_text(str(raw_text))
+        if SHAPED_PII.search(text):
+            excluded_shaped_pii += 1
+            continue
+        stratum = FAMILY_TO_STRATUM.get(str(family), "s5")
+        candidates.setdefault((split, stratum), []).append(
+            (str(ticket_no), int(year), text)
+        )
+
+    selected: list[dict[str, object]] = []
+    for split in ("train", "validation", "test"):
+        for stratum in ("s1", "s2", "s3", "s4", "s5"):
+            target = unlabeled_per_split if stratum == "s5" else per_stratum_split
+            pool = candidates.get((split, stratum), [])
+            pool.sort(
+                key=lambda row: hashlib.sha256(
+                    f"{seed}\0{split}\0{stratum}\0{row[0]}".encode()
+                ).digest()
+            )
+            if len(pool) < target:
+                raise ValueError(
+                    f"insufficient {split}/{stratum} candidates: {len(pool)} < {target}"
+                )
+            for ticket_no, year, text in pool[:target]:
+                item_id = _identifier(ticket_no, salt=id_salt)
+                selected.append(
+                    {
+                        "item_id": item_id,
+                        "group_id": item_id,
+                        "redacted_text": text,
+                        "created_year": year,
+                        "split": split,
+                        "language": "unknown_pending_adjudication",
+                        "sampling_stratum": stratum,
+                    }
+                )
+
+    selected.sort(key=lambda row: (str(row["split"]), str(row["item_id"])))
+    rendered = "".join(
+        json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n" for row in selected
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(rendered, encoding="utf-8")
+    output_path.chmod(0o600)
+    fingerprint = "sha256:" + hashlib.sha256(rendered.encode()).hexdigest()
+    counts: dict[str, int] = {}
+    for row in selected:
+        key = f"{row['split']}/{row['sampling_stratum']}"
+        counts[key] = counts.get(key, 0) + 1
+    manifest = {
+        "schema_version": "actionability-adjudication-sample-v1",
+        "dataset_fingerprint": fingerprint,
+        "records": len(selected),
+        "counts": dict(sorted(counts.items())),
+        "parameters": {
+            "per_weak_stratum_split": per_stratum_split,
+            "unlabeled_per_split": unlabeled_per_split,
+            "seed": seed,
+            "split_policy": (
+                "chronological_2021_2023_train_2024_validation_2025_test"
+                if chronological
+                else "single_snapshot_hash_60_20_20_development_only"
+            ),
+            "ticket_identifier": "salted_sha256_not_reversible",
+            "shaped_pii_excluded": excluded_shaped_pii,
+            "adjudicator_blinding": "sampling strata are opaque s1-s5",
+        },
+        "sample_design": {
+            "sampling_scheme": "fixed quotas across opaque sampling strata",
+            "production_prevalence_representative": False,
+            "metric_interpretation": (
+                "accuracy, precision, PPV, and review workload measured on this "
+                "sample are composition-specific and are not production prevalence"
+            ),
+            "intended_use": "development model comparison and error analysis",
+        },
+        "selected_fields": [
+            "salted item/group id",
+            "grievance_redacted",
+            "created_year",
+            "split",
+            "opaque sampling stratum",
+        ],
+        "forbidden_fields": [
+            "ticket_no",
+            "raw grievance",
+            "officer remark",
+            "petitioner identifiers",
+            "office",
+        ],
+    }
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--complaints", type=Path)
+    parser.add_argument("--action-history", type=Path)
+    parser.add_argument("--oltp-env-file", type=Path)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--per-stratum-split", type=int, default=15)
+    parser.add_argument("--unlabeled-per-split", type=int, default=40)
+    parser.add_argument("--seed", default="actionability-gold-v1")
+    parser.add_argument("--id-salt-file", type=Path, required=True)
+    args = parser.parse_args()
+    build_sample(
+        args.complaints,
+        args.action_history,
+        args.oltp_env_file,
+        args.output,
+        args.manifest,
+        per_stratum_split=args.per_stratum_split,
+        unlabeled_per_split=args.unlabeled_per_split,
+        seed=args.seed,
+        id_salt=_private_salt(args.id_salt_file),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_actionability_adjudication.py
+++ b/tests/test_actionability_adjudication.py
@@ -1,0 +1,269 @@
+import json
+import stat
+
+from janasunani.evaluation.actionability import load_jsonl
+from janasunani.evaluation.adjudication import (
+    finalize_gold,
+    normalize_adjudication_provenance,
+    prepare_resolution,
+)
+
+
+def _write(path, rows):
+    path.write_text("".join(json.dumps(row) + "\n" for row in rows))
+
+
+def _sample_rows():
+    return [
+        {
+            "item_id": item_id,
+            "group_id": item_id,
+            "redacted_text": text,
+            "created_year": 2024,
+            "split": split,
+            "language": "unknown_pending_adjudication",
+            "sampling_stratum": "s5",
+        }
+        for item_id, text, split in (
+            ("a", "road is broken", "train"),
+            ("b", "hello", "validation"),
+            ("c", "need help", "test"),
+        )
+    ]
+
+
+def _judgment(item_id, label, *, uncertain=False):
+    return {
+        "item_id": item_id,
+        "label": label,
+        "confidence": 0.9,
+        "uncertain": uncertain,
+        "rationale_code": "unit_test",
+    }
+
+
+def test_prepare_and_finalize_frontier_gold(tmp_path):
+    sample = tmp_path / "sample.jsonl"
+    judge_a = tmp_path / "judge-a.jsonl"
+    judge_b = tmp_path / "judge-b.jsonl"
+    consensus = tmp_path / "consensus.jsonl"
+    resolver_input = tmp_path / "resolver-input.jsonl"
+    report_path = tmp_path / "report.json"
+    _write(sample, _sample_rows())
+    _write(
+        judge_a,
+        [
+            _judgment("a", "actionable"),
+            _judgment("b", "irrelevant"),
+            _judgment("c", "underspecified", uncertain=True),
+        ],
+    )
+    _write(
+        judge_b,
+        [
+            _judgment("a", "actionable"),
+            _judgment("b", "underspecified"),
+            _judgment("c", "underspecified"),
+        ],
+    )
+
+    report = prepare_resolution(
+        sample,
+        judge_a,
+        judge_b,
+        consensus_path=consensus,
+        resolver_input_path=resolver_input,
+        report_path=report_path,
+    )
+    assert report["records"] == 3
+    assert report["confident_consensus"] == 1
+    assert report["sent_to_resolver"] == 2
+    assert report["adjudication_provenance"]["judge_a_model"] == "unavailable"
+    assert report["sample_design"]["production_prevalence_representative"] is False
+    assert "redacted_text" not in report_path.read_text()
+    assert len(resolver_input.read_text().splitlines()) == 2
+
+    resolver = tmp_path / "resolver.jsonl"
+    _write(
+        resolver,
+        [
+            _judgment("b", "irrelevant"),
+            _judgment("c", "underspecified"),
+        ],
+    )
+    gold = tmp_path / "gold.jsonl"
+    manifest_path = tmp_path / "gold-manifest.json"
+    manifest = finalize_gold(
+        sample,
+        consensus,
+        resolver,
+        gold_path=gold,
+        manifest_path=manifest_path,
+    )
+    assert manifest["label_distribution"] == {
+        "actionable": 1,
+        "irrelevant": 1,
+        "underspecified": 1,
+    }
+    assert manifest["resolution"]["unresolved_excluded"] == 0
+    assert manifest["resolution"]["uncertain_resolver_labels_enter_gold"] is False
+    assert manifest["sample_design"]["sample_stratum_counts"] == {"s5": 3}
+    assert manifest["adjudication_provenance"]["resolver_model"] == "unavailable"
+    records = load_jsonl(gold)
+    assert len(records) == 3
+    assert stat.S_IMODE(gold.stat().st_mode) == 0o600
+    assert {record.label_source for record in records} == {"frontier_adjudicated"}
+    assert {record.sampling_stratum for record in records} == {"s5"}
+
+
+def test_uncertain_resolver_label_is_excluded_with_aggregate_counts(tmp_path):
+    sample = tmp_path / "sample.jsonl"
+    consensus = tmp_path / "consensus.jsonl"
+    resolver = tmp_path / "resolver.jsonl"
+    _write(sample, _sample_rows())
+    _write(consensus, [{"item_id": "a", "label": "actionable"}])
+    _write(
+        resolver,
+        [
+            _judgment("b", "irrelevant", uncertain=True),
+            _judgment("c", "underspecified"),
+        ],
+    )
+
+    gold = tmp_path / "gold.jsonl"
+    manifest = finalize_gold(
+        sample,
+        consensus,
+        resolver,
+        gold_path=gold,
+        manifest_path=tmp_path / "manifest.json",
+    )
+
+    assert manifest["records"] == 2
+    assert manifest["resolution"]["resolver_judgments_received"] == 2
+    assert manifest["resolution"]["confident_resolver_accepted"] == 1
+    assert manifest["resolution"]["unresolved_excluded"] == 1
+    assert manifest["resolution"]["unresolved_excluded_by_split"] == {
+        "validation": 1
+    }
+    assert '"item_id": "b"' not in gold.read_text()
+
+
+def test_adjudication_provenance_is_complete_and_hash_only():
+    provenance = normalize_adjudication_provenance(
+        {"prompt_sha256": "a" * 64, "rubric_version": "rubric-v1"}
+    )
+    assert provenance["prompt_sha256"] == "sha256:" + "a" * 64
+    assert provenance["judge_a_model"] == "unavailable"
+    assert set(provenance) == {
+        "protocol_version",
+        "rubric_version",
+        "prompt_sha256",
+        "judge_a_model",
+        "judge_b_model",
+        "resolver_model",
+        "inference_environment",
+        "egress_policy",
+        "retention_policy",
+    }
+
+    try:
+        normalize_adjudication_provenance({"prompt_sha256": "raw prompt text"})
+    except ValueError as exc:
+        assert "SHA-256" in str(exc)
+    else:
+        raise AssertionError("raw prompts must not enter aggregate provenance")
+
+
+def test_prepare_requires_exact_judge_coverage(tmp_path):
+    sample = tmp_path / "sample.jsonl"
+    judge_a = tmp_path / "judge-a.jsonl"
+    judge_b = tmp_path / "judge-b.jsonl"
+    _write(sample, _sample_rows())
+    _write(judge_a, [_judgment("a", "actionable")])
+    _write(judge_b, [_judgment("a", "actionable")])
+
+    try:
+        prepare_resolution(
+            sample,
+            judge_a,
+            judge_b,
+            consensus_path=tmp_path / "consensus.jsonl",
+            resolver_input_path=tmp_path / "resolver-input.jsonl",
+            report_path=tmp_path / "report.json",
+        )
+    except ValueError as exc:
+        assert "exactly the sample IDs" in str(exc)
+    else:
+        raise AssertionError("partial adjudication must fail closed")
+
+
+def test_finalize_accepts_empty_consensus_when_every_case_needs_resolution(tmp_path):
+    sample = tmp_path / "sample.jsonl"
+    consensus = tmp_path / "consensus.jsonl"
+    resolver = tmp_path / "resolver.jsonl"
+    _write(sample, _sample_rows())
+    consensus.write_text("")
+    _write(
+        resolver,
+        [
+            _judgment("a", "actionable"),
+            _judgment("b", "irrelevant"),
+            _judgment("c", "underspecified"),
+        ],
+    )
+
+    manifest = finalize_gold(
+        sample,
+        consensus,
+        resolver,
+        gold_path=tmp_path / "gold.jsonl",
+        manifest_path=tmp_path / "manifest.json",
+    )
+
+    assert manifest["records"] == 3
+    assert manifest["resolution"]["confident_consensus_accepted"] == 0
+
+
+def test_finalize_accepts_empty_resolver_when_every_case_is_consensus(tmp_path):
+    sample = tmp_path / "sample.jsonl"
+    consensus = tmp_path / "consensus.jsonl"
+    resolver = tmp_path / "resolver.jsonl"
+    _write(sample, _sample_rows())
+    _write(
+        consensus,
+        [
+            {"item_id": "a", "label": "actionable"},
+            {"item_id": "b", "label": "irrelevant"},
+            {"item_id": "c", "label": "underspecified"},
+        ],
+    )
+    resolver.write_text("")
+
+    manifest = finalize_gold(
+        sample,
+        consensus,
+        resolver,
+        gold_path=tmp_path / "gold.jsonl",
+        manifest_path=tmp_path / "manifest.json",
+    )
+
+    assert manifest["records"] == 3
+    assert manifest["resolution"]["resolver_judgments_received"] == 0
+
+
+def test_sample_rejects_invalid_year_and_sampling_stratum(tmp_path):
+    sample = tmp_path / "sample.jsonl"
+    rows = _sample_rows()
+    rows[0]["created_year"] = "2024"
+    rows[1]["sampling_stratum"] = ""
+    _write(sample, rows)
+
+    try:
+        from janasunani.evaluation.adjudication import load_sample
+
+        load_sample(sample)
+    except ValueError as exc:
+        assert "created_year" in str(exc) or "string field" in str(exc)
+    else:
+        raise AssertionError("invalid sample metadata must fail closed")

--- a/tests/test_actionability_adjudication_sample.py
+++ b/tests/test_actionability_adjudication_sample.py
@@ -1,0 +1,111 @@
+import json
+import stat
+
+import polars as pl
+
+from scripts.sample_actionability_adjudication import build_sample
+
+
+def _write_source(path):
+    remarks = {
+        "s1": "complaint details inadequate",
+        "s2": "no specific grievance",
+        "s3": "this is not within the purview of this grievance cell",
+        "s4": "can be considered only after a policy decision is made by the government",
+    }
+    complaints = []
+    actions = []
+    for year in (2021, 2024, 2025):
+        for stratum in ("s1", "s2", "s3", "s4", "s5"):
+            ticket = f"ticket-{year}-{stratum}"
+            complaints.append(
+                {
+                    "ticket_no": ticket,
+                    "created_year": year,
+                    "grievance_redacted": f"safe redacted complaint {year} {stratum}",
+                }
+            )
+            if stratum in remarks:
+                actions.append(
+                    {"ticket_no": ticket, "action_taken_remark": remarks[stratum]}
+                )
+    complaints.append(
+        {
+            "ticket_no": "excluded-phone",
+            "created_year": 2024,
+            "grievance_redacted": "please call 9876543210",
+        }
+    )
+    pl.DataFrame(complaints).write_parquet(path / "complaints.parquet")
+    pl.DataFrame(actions).write_parquet(path / "action_history.parquet")
+
+
+def test_build_sample_is_blinded_deterministic_and_redacted(tmp_path):
+    _write_source(tmp_path)
+    first = tmp_path / "sample.jsonl"
+    first_manifest = tmp_path / "manifest.json"
+    second = tmp_path / "sample-again.jsonl"
+    second_manifest = tmp_path / "manifest-again.json"
+    kwargs = {
+        "complaints_path": tmp_path / "complaints.parquet",
+        "action_history_path": tmp_path / "action_history.parquet",
+        "oltp_env_file": None,
+        "per_stratum_split": 1,
+        "unlabeled_per_split": 1,
+        "seed": "unit-test-seed",
+        "id_salt": "unit-test-private-salt-value-at-least-32",
+    }
+    build_sample(output_path=first, manifest_path=first_manifest, **kwargs)
+    build_sample(
+        output_path=second,
+        manifest_path=second_manifest,
+        **kwargs,
+    )
+
+    assert first.read_bytes() == second.read_bytes()
+    records = [json.loads(line) for line in first.read_text().splitlines()]
+    assert len(records) == 15
+    assert len({row["item_id"] for row in records}) == 15
+    assert {row["split"] for row in records} == {"train", "validation", "test"}
+    assert all(row["item_id"] == row["group_id"] for row in records)
+    assert all("ticket_no" not in row for row in records)
+    assert all("action_taken_remark" not in row for row in records)
+    assert all("9876543210" not in row["redacted_text"] for row in records)
+    assert stat.S_IMODE(first.stat().st_mode) == 0o600
+
+    manifest = json.loads(first_manifest.read_text())
+    assert manifest["records"] == 15
+    assert manifest["parameters"]["shaped_pii_excluded"] == 1
+    assert manifest["parameters"]["split_policy"].startswith("chronological_")
+    assert set(manifest["counts"].values()) == {1}
+    assert manifest["sample_design"] == {
+        "sampling_scheme": "fixed quotas across opaque sampling strata",
+        "production_prevalence_representative": False,
+        "metric_interpretation": (
+            "accuracy, precision, PPV, and review workload measured on this "
+            "sample are composition-specific and are not production prevalence"
+        ),
+        "intended_use": "development model comparison and error analysis",
+    }
+
+
+def test_build_sample_requires_one_source_mode(tmp_path):
+    _write_source(tmp_path)
+    output = tmp_path / "sample.jsonl"
+    manifest = tmp_path / "manifest.json"
+    try:
+        build_sample(
+            tmp_path / "complaints.parquet",
+            tmp_path / "action_history.parquet",
+            tmp_path / ".env",
+            output,
+            manifest,
+            per_stratum_split=1,
+            unlabeled_per_split=1,
+            seed="seed",
+            id_salt="salt-value-long-enough-for-test-only",
+        )
+    except ValueError as exc:
+        assert "choose either" in str(exc)
+    else:
+        raise AssertionError("mixed source modes must fail closed")

--- a/tests/test_benchmark_actionability_candidates.py
+++ b/tests/test_benchmark_actionability_candidates.py
@@ -1,0 +1,73 @@
+from types import SimpleNamespace
+
+from scripts import benchmark_actionability_candidates as benchmark
+
+
+class _Classifier:
+    classes_ = ("actionable", "review")
+
+    def predict_proba(self, texts):
+        return [[1.0, 0.0] for _ in texts]
+
+
+def test_report_metadata_is_stable_for_dvc(monkeypatch, tmp_path):
+    gold = tmp_path / "gold.jsonl"
+    gold.write_text("{}\n", encoding="utf-8")
+    records = [
+        SimpleNamespace(
+            split="validation",
+            label="actionable",
+            label_source="frontier_adjudicated",
+            redacted_text="example",
+        ),
+        SimpleNamespace(
+            split="test",
+            label="underspecified",
+            label_source="frontier_adjudicated",
+            redacted_text="example",
+        ),
+    ]
+    report = {
+        "validation": {
+            "review_recall": 1.0,
+            "review_precision": 1.0,
+            "accuracy": 1.0,
+        }
+    }
+    monkeypatch.setattr(benchmark, "load_jsonl", lambda _path: records)
+    monkeypatch.setattr(
+        benchmark,
+        "benchmark_binary_review",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            classifier=_Classifier(), report=report.copy()
+        ),
+    )
+    monkeypatch.setattr(
+        benchmark, "binary_discrimination_metrics", lambda *_args: {}
+    )
+    monkeypatch.setattr(
+        benchmark,
+        "sample_design_summary",
+        lambda _records: {"limitation": "development sample"},
+    )
+    monkeypatch.setattr(benchmark.importlib.metadata, "version", lambda _name: "1")
+
+    first = benchmark.build_report(
+        gold_path=gold,
+        encoder_specs=[],
+        c_values=[1.0],
+        min_review_precision=0.6,
+        max_actionable_review_rate=0.1,
+    )
+    second = benchmark.build_report(
+        gold_path=gold,
+        encoder_specs=[],
+        c_values=[1.0],
+        min_review_precision=0.6,
+        max_actionable_review_rate=0.1,
+    )
+
+    assert first == second
+    assert "created_at" not in first
+    assert "platform" not in first["software"]
+    assert first["gold"]["path"] == gold.as_posix()

--- a/tests/test_check_provenance_sidecars.py
+++ b/tests/test_check_provenance_sidecars.py
@@ -64,6 +64,64 @@ def test_the_real_shape_passes():
     assert check.check_payload(VALID) == []
 
 
+def test_actionability_sample_sidecar_is_metadata_only():
+    payload = {
+        "schema_version": "actionability-adjudication-sample-v1",
+        "dataset_fingerprint": "sha256:" + "a" * 64,
+        "counts": {"train/s1": 5, "validation/s5": 40, "test/s3": 5},
+        "forbidden_fields": ["ticket_no", "raw grievance"],
+        "parameters": {
+            "adjudicator_blinding": "opaque strata",
+            "per_weak_stratum_split": 5,
+            "seed": "fixed-seed",
+            "shaped_pii_excluded": 47,
+            "split_policy": "fixed hash split",
+            "ticket_identifier": "salted sha256",
+            "unlabeled_per_split": 40,
+        },
+        "records": 180,
+        "selected_fields": ["salted item id", "grievance_redacted"],
+    }
+    assert check.check_payload(payload) == []
+
+
+def test_sarvam_source_snapshot_sidecar_is_metadata_only():
+    payload = {
+        "schema_version": "janasunani.sarvam-source-snapshots/v1",
+        "claim_status": "cached provider evidence; not OCR accuracy",
+        "privacy": {
+            "contains_operational_ticket_and_document_identifiers": True,
+            "contains_provider_response_metadata": True,
+            "git_contains_row_level_bytes": False,
+            "storage": "private DVC remote",
+        },
+        "artifacts": {
+            "validation_5_page_scorecard.json": {
+                "sha256": "a" * 64,
+                "role": "machine-readable aggregate scorecard",
+            }
+        },
+        "limitations": ["No hand transcription exists."],
+    }
+    assert check.check_payload(payload) == []
+
+
+def test_nested_sidecar_schema_rejects_unexpected_fields():
+    payload = {
+        "schema_version": "actionability-adjudication-sample-v1",
+        "dataset_fingerprint": "sha256:" + "a" * 64,
+        "counts": {"train/s1": 5},
+        "forbidden_fields": [],
+        "parameters": {},
+        "records": 5,
+        "selected_fields": [],
+        "raw_text": CITIZEN_TEXT,
+    }
+    problems = check.check_payload(payload)
+    assert problems
+    assert all(CITIZEN_TEXT not in problem for problem in problems)
+
+
 class TestCounterKeysAreConstrained:
     """#95. The counter's keys were exempt from every rule because they are
     entity labels rather than a fixed key set, so a label-to-count map from a

--- a/tests/test_check_provenance_sidecars.py
+++ b/tests/test_check_provenance_sidecars.py
@@ -85,6 +85,77 @@ def test_actionability_sample_sidecar_is_metadata_only():
     assert check.check_payload(payload) == []
 
 
+def _frontier_payload():
+    return {
+        "schema_version": "janasunani.actionability-frontier-artifacts/v1",
+        "claim_status": "development evidence only",
+        "privacy": {
+            "source": "PII-redacted sample",
+            "contains_redacted_narratives": True,
+            "residual_pii_risk": True,
+            "git_contains_row_level_bytes": False,
+            "storage": "private DVC remote",
+        },
+        "sample": {
+            "records": 3,
+            "split_counts": {"train": 1, "validation": 1, "test": 1},
+            "sampling": "fixed sample",
+            "split_policy": "fixed hash split",
+            "sha256": "a" * 64,
+            "tracking_mode": "direct DVC input",
+            "tracking_reason": "private salt is not versioned",
+        },
+        "direct_inputs": {
+            name: {"role": "model output", "sha256": "b" * 64}
+            for name in ["judge_a.jsonl", "judge_b.jsonl", "resolver.jsonl", "resolver_backup.jsonl"]
+        },
+        "deterministic_stages": {
+            "actionability-adjudication-prepare": ["consensus.jsonl"],
+            "actionability-adjudication-finalize": ["gold.jsonl"],
+            "actionability-local-candidate-benchmark": ["scorecard.json"],
+        },
+        "canonical_reproducible_gold": {
+            "records": 3,
+            "sha256": "c" * 64,
+            "label_counts": {
+                "actionable": 2,
+                "underspecified": 1,
+                "irrelevant": 0,
+                "policy_blocked": 0,
+                "out_of_scope": 0,
+            },
+            "policy": "exclude uncertain rows",
+            "excluded_uncertain_resolver_rows": 1,
+        },
+        "preserved_historical_gold": {
+            "artifact": "historical.jsonl",
+            "manifest": "historical.manifest.json",
+            "records": 4,
+            "sha256": "d" * 64,
+            "status": "audit only",
+        },
+        "preserved_nonreproducible_reports": {
+            "historical_candidates_strict.json": "e" * 64,
+            "historical_candidates_sensitivity.json": "f" * 64,
+            "historical_candidates_high_catch.json": "1" * 64,
+            "historical_candidates_muril_minilm_high_catch.json": "2" * 64,
+        },
+        "limitations": ["No officer-confirmed labels."],
+    }
+
+
+def test_actionability_frontier_sidecar_is_metadata_only():
+    assert check.check_payload(_frontier_payload()) == []
+
+
+def test_actionability_frontier_rejects_unexpected_nested_fields_without_echoing():
+    payload = _frontier_payload()
+    payload["privacy"][CITIZEN_TEXT] = CITIZEN_TEXT
+    problems = check.check_payload(payload)
+    assert problems
+    assert all(CITIZEN_TEXT not in problem for problem in problems)
+
+
 def test_sarvam_source_snapshot_sidecar_is_metadata_only():
     payload = {
         "schema_version": "janasunani.sarvam-source-snapshots/v1",

--- a/tests/test_embedding_actionability.py
+++ b/tests/test_embedding_actionability.py
@@ -1,0 +1,172 @@
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from janasunani.evaluation.actionability import ActionabilityRecord
+from janasunani.evaluation.embedding_actionability import (
+    LocalEncoderSpec,
+    benchmark_frozen_encoder,
+    binary_discrimination_metrics,
+    resolve_cached_huggingface_snapshot,
+    resolve_local_model_dir,
+)
+from scripts.benchmark_actionability_candidates import (
+    _assert_aggregate_only,
+    _parse_named_path,
+)
+
+
+class FakeEncoder:
+    @property
+    def provenance(self):
+        return {
+            "name": "fake-multilingual",
+            "role": "multilingual_candidate",
+            "local_path": "/local/fake",
+            "revision": "deadbeef",
+            "artifact_fingerprint": "sha256:fake",
+            "frozen": True,
+            "local_files_only": True,
+        }
+
+    def encode(self, texts):
+        return np.asarray(
+            [
+                [
+                    float("review" in text),
+                    float("actionable" in text),
+                    (sum(map(ord, text)) % 17) / 17,
+                ]
+                for text in texts
+            ]
+        )
+
+
+def _records():
+    rows = []
+    for split, n in (("train", 16), ("validation", 8), ("test", 8)):
+        for index in range(n):
+            actionable = index % 2 == 0
+            label = "actionable" if actionable else "underspecified"
+            rows.append(
+                ActionabilityRecord(
+                    item_id=f"{split}-{index}",
+                    redacted_text=(
+                        f"actionable water request {index}"
+                        if actionable
+                        else f"review missing details {index}"
+                    ),
+                    label=label,
+                    group_id=f"{split}-{index}",
+                    language="Odia" if index % 3 == 0 else "English",
+                    split=split,
+                    label_source="frontier_adjudicated",
+                )
+            )
+    return rows
+
+
+def test_frozen_encoder_benchmark_is_aggregate_and_validation_selected():
+    records = _records()
+    benchmark = benchmark_frozen_encoder(
+        records,
+        FakeEncoder(),
+        c_values=(0.1, 1.0),
+        min_review_precision=0.0,
+        max_actionable_review_rate=1.0,
+    )
+
+    report = benchmark.report
+    assert report["encoder"]["frozen"] is True
+    assert report["encoder"]["local_files_only"] is True
+    assert report["selected_c"] in {0.1, 1.0}
+    assert report["split_counts"] == {"train": 16, "validation": 8, "test": 8}
+    assert len(report["test"]["accuracy_ci"]) == 2
+    assert set(report["test_by_language"]) == {"English", "Odia"}
+    serialized = json.dumps(report)
+    assert "actionable water request" not in serialized
+    assert "review missing details" not in serialized
+
+    flipped_test = [
+        ActionabilityRecord(
+            **{
+                **row.__dict__,
+                "label": (
+                    "underspecified"
+                    if row.split == "test" and row.label == "actionable"
+                    else (
+                        "actionable"
+                        if row.split == "test"
+                        else row.label
+                    )
+                ),
+            }
+        )
+        for row in records
+    ]
+    changed = benchmark_frozen_encoder(
+        flipped_test,
+        FakeEncoder(),
+        c_values=(0.1, 1.0),
+        min_review_precision=0.0,
+        max_actionable_review_rate=1.0,
+    )
+    assert changed.report["selected_c"] == report["selected_c"]
+    assert changed.review_threshold == report["review_threshold"]
+    assert changed.report["validation"] == report["validation"]
+
+
+def test_missing_local_model_fails_without_download(tmp_path):
+    missing = tmp_path / "missing-model"
+    with pytest.raises(FileNotFoundError, match="will not download"):
+        resolve_local_model_dir(missing)
+
+    with pytest.raises(FileNotFoundError, match="will not download"):
+        resolve_cached_huggingface_snapshot(
+            "google/muril-base-cased", cache_dir=tmp_path
+        )
+
+
+def test_encoder_output_must_be_aligned_and_finite():
+    class BrokenEncoder(FakeEncoder):
+        def encode(self, texts):
+            return np.full((len(texts) - 1, 2), np.nan)
+
+    with pytest.raises(ValueError, match="invalid train matrix shape"):
+        benchmark_frozen_encoder(_records(), BrokenEncoder(), c_values=(1.0,))
+
+
+def test_discrimination_metrics_validate_alignment():
+    test_records = [record for record in _records() if record.split == "test"]
+    metrics = binary_discrimination_metrics(
+        [0.1 if record.label == "actionable" else 0.9 for record in test_records],
+        test_records,
+    )
+    assert metrics == {
+        "roc_auc": 1.0,
+        "average_precision": 1.0,
+        "brier_score": pytest.approx(0.01),
+    }
+    with pytest.raises(ValueError, match="aligned non-empty"):
+        binary_discrimination_metrics([], test_records)
+
+
+def test_candidate_parser_and_aggregate_guard(tmp_path):
+    name, path = _parse_named_path(f"muril={tmp_path}")
+    assert name == "muril"
+    assert path == tmp_path
+    with pytest.raises(Exception, match="NAME=LOCAL_PATH"):
+        _parse_named_path("muril")
+    with pytest.raises(ValueError, match="forbidden text keys"):
+        _assert_aggregate_only({"nested": {"redacted_text": "secret"}})
+
+
+def test_encoder_spec_records_role_without_loading_model(tmp_path):
+    spec = LocalEncoderSpec(
+        name="muril",
+        model_path=Path(tmp_path),
+        role="multilingual_candidate",
+    )
+    assert spec.role == "multilingual_candidate"

--- a/tests/test_embedding_actionability.py
+++ b/tests/test_embedding_actionability.py
@@ -1,5 +1,7 @@
 import json
+import sys
 from pathlib import Path
+from types import ModuleType, SimpleNamespace
 
 import numpy as np
 import pytest
@@ -7,6 +9,7 @@ import pytest
 from janasunani.evaluation.actionability import ActionabilityRecord
 from janasunani.evaluation.embedding_actionability import (
     LocalEncoderSpec,
+    TransformersMeanPoolEncoder,
     benchmark_frozen_encoder,
     binary_discrimination_metrics,
     resolve_cached_huggingface_snapshot,
@@ -170,3 +173,51 @@ def test_encoder_spec_records_role_without_loading_model(tmp_path):
         role="multilingual_candidate",
     )
     assert spec.role == "multilingual_candidate"
+
+
+def test_encoder_provenance_keeps_portable_configured_path(monkeypatch):
+    import janasunani.evaluation.embedding_actionability as embedding
+
+    configured_path = Path("models/categorizer")
+    resolved_path = Path("/private/worktree/models/categorizer")
+    monkeypatch.setattr(
+        embedding, "resolve_local_model_dir", lambda _path: resolved_path
+    )
+    monkeypatch.setattr(
+        embedding, "directory_fingerprint", lambda _path: ("sha256:test", 1)
+    )
+
+    torch = ModuleType("torch")
+    torch.device = lambda value: value
+    transformers = ModuleType("transformers")
+
+    class _Model:
+        config = SimpleNamespace(model_type="bert", architectures=["BertModel"])
+
+        def to(self, _device):
+            return self
+
+        def eval(self):
+            return None
+
+        def parameters(self):
+            return []
+
+    transformers.AutoTokenizer = SimpleNamespace(
+        from_pretrained=lambda *_args, **_kwargs: object()
+    )
+    transformers.AutoModel = SimpleNamespace(
+        from_pretrained=lambda *_args, **_kwargs: _Model()
+    )
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    monkeypatch.setitem(sys.modules, "transformers", transformers)
+
+    encoder = TransformersMeanPoolEncoder(
+        LocalEncoderSpec(
+            name="muril",
+            model_path=configured_path,
+            role="multilingual_candidate",
+        )
+    )
+
+    assert encoder.provenance["local_path"] == "models/categorizer"


### PR DESCRIPTION
## Summary

- Reconcile two independent frontier judgments plus a resolver into privacy-screened development labels.
- Keep row-level redacted artifacts in DVC while tracking only aggregate, allowlisted provenance sidecars in Git.
- Benchmark local TF-IDF, frozen MuRIL, and cached MiniLM candidates on identical frozen splits without provider calls or downloads.
- Harden CI provenance-sidecar discovery and validation, including nested actionability manifests.

## Historical stack position

This is the next historical slice after #252:

- Base: `feat/actionability-evaluation`
- Head: `feat/actionability-adjudication`
- Exact head: `b021ee750d3a530215c9d036564ba49f168d5a1f`
- Slice commits: `f13afb4`, `2251167`, `a82664d`, merge `18f3ef0`, `c3b7676`, `fad47c5`, and `b021ee7`

The old “one Codex review after the whole stack” instruction is superseded. PRs #250–#252 completed exact-head review and were closed as already integrated. This head is also already contained in `feat/pipeline-quality-trunk` (0 commits unique here; 81 integration commits after it), so it will be reconciled only after its own exact-head gate is green.

## Verification on this exact slice

- Five targeted modules covering adjudication, sampling, candidate reports, provenance CI, and embedding candidates: **56 passed**.
- Ruff passed for all changed Python implementation, script, and test files.
- `git diff --check` passed.
- Historical pipeline, lint, and raw-data checks are green; the draft exemption must now be replaced by a real exact-head Codex verdict.

No file under `data/` was opened or reproduced during this review pass. The review covered code, tracked DVC pointers, workflow logic, and aggregate contracts only.

## Evidence and privacy boundaries

- “Gold” means frontier-adjudicated **development** supervision, not officer-confirmed truth.
- Uncertain resolver rows are excluded rather than forced into the development labels.
- Candidate selection is validation-only, test metrics are aggregate-only, and every candidate report is `release_eligible: false`.
- Models must be local and frozen; `local_files_only=True`, `trust_remote_code=False`, and offline environment flags prevent implicit egress/download.
- Git may contain only allowlisted aggregate provenance sidecars and `.dvc` pointers—not row-level narratives or predictions.

## Self-review points for exact review

- Verify consensus/resolver IDs and labels fail closed on malformed JSON runtime types.
- Verify every CI allowlist is exact enough that a nested sidecar cannot smuggle item-level values under an alternate key.
- Verify candidate provenance remains portable and does not record worktree-specific absolute paths.
- Verify checksummed lineage binds each aggregate report to the intended governed sample without implying source-owner confirmation.
