### PR TITLE
feat(routing): add historical incidence benchmark and serving

### DIFF
--- a/janasunani/evaluation/historical.py
+++ b/janasunani/evaluation/historical.py
@@ -1,0 +1,266 @@
+"""Governed historical scorecards over structured lake fields.
+
+This module deliberately exposes aggregate-only loaders.  Routing evaluation
+needs category, subcategory, district, department, and time; it never needs
+complaint text.  The SQL therefore names every selected column and turns the
+1.37M-row lake into weighted feature cells before Python sees it.
+
+The resulting benchmark measures historical incidence (where cases were
+sent), not the quality of the destination or the eventual outcome.  Years are
+held out chronologically: 2021--2023 train, 2024 validation, and 2025 test by
+default.  Because the current full lake has no full-corpus dedup-group join,
+the report says so explicitly rather than claiming duplicate-group isolation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Sequence
+
+from janasunani.evaluation.routing import (
+    RouteRecord,
+    RoutingBenchmark,
+    benchmark_incidence_router,
+)
+
+
+UNINFORMATIVE_CATEGORIES = frozenset({"general", "miscellaneous"})
+
+
+@dataclass(frozen=True)
+class HistoricalRouteData:
+    records: tuple[RouteRecord, ...]
+    diagnostics: dict[str, object]
+
+
+def _split_for_year(
+    year: int,
+    *,
+    train_from: int,
+    train_through: int,
+    validation_year: int,
+    test_year: int,
+) -> str | None:
+    if train_from <= year <= train_through:
+        return "train"
+    if year == validation_year:
+        return "validation"
+    if year == test_year:
+        return "test"
+    return None
+
+
+def _cell_id(values: Sequence[str]) -> str:
+    payload = "\0".join(values).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()[:24]
+
+
+def _route_cell_sql(*, use_subcategory: bool) -> str:
+    subcategory = (
+        "coalesce(nullif(trim(subcategory), ''), '') AS subcategory,"
+        if use_subcategory
+        else "'' AS subcategory,"
+    )
+    group_subcategory = ", subcategory" if use_subcategory else ""
+    return f"""
+SELECT
+    created_year,
+    trim(category) AS category,
+    {subcategory}
+    coalesce(nullif(trim(district), ''), '') AS district,
+    trim(dept) AS department,
+    count(*)::BIGINT AS cases
+FROM read_parquet(?)
+WHERE created_year IS NOT NULL
+  AND category IS NOT NULL AND trim(category) <> ''
+  AND dept IS NOT NULL AND trim(dept) <> ''
+GROUP BY created_year, category, district, dept{group_subcategory}
+ORDER BY created_year, category, subcategory, district, department
+""".strip()
+
+
+def load_route_cells(
+    complaints_path: Path,
+    *,
+    train_from: int = 2021,
+    train_through: int = 2023,
+    validation_year: int = 2024,
+    test_year: int = 2025,
+    use_subcategory: bool = False,
+    informative_categories_only: bool = False,
+) -> HistoricalRouteData:
+    """Load weighted route cells without selecting grievance text."""
+
+    if not complaints_path.is_file():
+        raise FileNotFoundError(complaints_path)
+    if not train_from <= train_through < validation_year < test_year:
+        raise ValueError(
+            "years must satisfy train_from <= train_through < validation < test"
+        )
+
+    import duckdb
+
+    connection = duckdb.connect(":memory:")
+    try:
+        rows = connection.execute(
+            _route_cell_sql(use_subcategory=use_subcategory),
+            [str(complaints_path)],
+        ).fetchall()
+    finally:
+        connection.close()
+
+    records: list[RouteRecord] = []
+    excluded = {
+        "outside_split_years": 0,
+        "uninformative_category": 0,
+    }
+    split_cases = {"train": 0, "validation": 0, "test": 0}
+    split_cells = {"train": 0, "validation": 0, "test": 0}
+    for year, category, subcategory, district, department, cases in rows:
+        split = _split_for_year(
+            int(year),
+            train_from=train_from,
+            train_through=train_through,
+            validation_year=validation_year,
+            test_year=test_year,
+        )
+        if split is None:
+            excluded["outside_split_years"] += int(cases)
+            continue
+        if (
+            informative_categories_only
+            and category.strip().lower() in UNINFORMATIVE_CATEGORIES
+        ):
+            excluded["uninformative_category"] += int(cases)
+            continue
+        values = (
+            split,
+            str(year),
+            category,
+            subcategory,
+            district,
+            department,
+        )
+        identifier = _cell_id(values)
+        records.append(
+            RouteRecord(
+                item_id=identifier,
+                group_id=identifier,
+                observed_on=date(int(year), 1, 1),
+                category=category,
+                subcategory=subcategory or None,
+                district=district or None,
+                department=department,
+                split=split,
+                language="unknown_not_available_without_text",
+                weight=int(cases),
+            )
+        )
+        split_cases[split] += int(cases)
+        split_cells[split] += 1
+
+    diagnostics: dict[str, object] = {
+        "source": str(complaints_path),
+        "selected_columns": [
+            "created_year",
+            "category",
+            "subcategory" if use_subcategory else None,
+            "district",
+            "dept",
+        ],
+        "split_years": {
+            "train_from": train_from,
+            "train_through": train_through,
+            "validation": validation_year,
+            "test": test_year,
+        },
+        "split_cases": split_cases,
+        "split_feature_cells": split_cells,
+        "excluded_cases": excluded,
+        "informative_categories_only": informative_categories_only,
+        "dedup_group_isolation": "unavailable_full_corpus",
+        "language_slices": "unavailable_without_governed_redacted_text",
+    }
+    return HistoricalRouteData(records=tuple(records), diagnostics=diagnostics)
+
+
+def benchmark_historical_routing(
+    complaints_path: Path,
+    *,
+    use_subcategory: bool = False,
+    informative_categories_only: bool = False,
+    alpha_values: Sequence[float] = (3.0, 10.0, 30.0, 100.0),
+    artifact_dir: Path | None = None,
+) -> RoutingBenchmark:
+    data = load_route_cells(
+        complaints_path,
+        use_subcategory=use_subcategory,
+        informative_categories_only=informative_categories_only,
+    )
+    benchmark = benchmark_incidence_router(
+        data.records,
+        alpha_values=alpha_values,
+        history_year_values=(None, 1, 2),
+        use_subcategory=use_subcategory,
+        artifact_dir=artifact_dir,
+    )
+    benchmark.report["historical_data"] = data.diagnostics
+    benchmark.report["limitations"].extend(
+        [
+            "full-corpus dedup groups are unavailable, so leakage control is chronological but not campaign-grouped",
+            "language is not present in structured complaints and is not inferred from raw grievance text",
+        ]
+    )
+    return benchmark
+
+
+def _parse_alpha_values(value: str) -> tuple[float, ...]:
+    try:
+        values = tuple(float(item.strip()) for item in value.split(","))
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("--alpha-values must be comma-separated numbers") from exc
+    if not values:
+        raise argparse.ArgumentTypeError("--alpha-values cannot be empty")
+    return values
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Evaluate local historical-incidence routing on structured fields"
+    )
+    parser.add_argument("--complaints", type=Path, required=True)
+    parser.add_argument("--use-subcategory", action="store_true")
+    parser.add_argument("--informative-categories-only", action="store_true")
+    parser.add_argument(
+        "--alpha-values", type=_parse_alpha_values, default=(3.0, 10.0, 30.0, 100.0)
+    )
+    parser.add_argument("--output", type=Path)
+    parser.add_argument(
+        "--artifact-dir",
+        type=Path,
+        help="Explicitly publish an immutable, aggregate-only serving artifact",
+    )
+    args = parser.parse_args()
+
+    result = benchmark_historical_routing(
+        args.complaints,
+        use_subcategory=args.use_subcategory,
+        informative_categories_only=args.informative_categories_only,
+        alpha_values=args.alpha_values,
+        artifact_dir=args.artifact_dir,
+    ).report
+    rendered = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/janasunani/evaluation/routing.py
+++ b/janasunani/evaluation/routing.py
@@ -1,0 +1,972 @@
+"""Leakage-safe evaluation for local incidence-based routing.
+
+This evaluates where cases were historically sent.  It must not be described
+as outcome optimization: disposal time and citizen benefit are absent by
+construction because they are confounded by case difficulty and office
+selection.  The model here is a cheap empirical-Bayes backoff over the live
+features (category and district), with an optional secondary benchmark for
+subcategory when a future classifier supplies it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+import tempfile
+from typing import Iterable, Mapping, Sequence
+
+from janasunani.evaluation.classification import (
+    ScoredExample,
+    assert_group_disjoint,
+    classification_metrics,
+    metrics_by_language,
+)
+
+
+INCIDENCE_ARTIFACT_SCHEMA_VERSION = "routing-incidence-v2"
+INCIDENCE_ARTIFACT_FILENAME = "routing_incidence.json"
+INCIDENCE_ARTIFACT_MIN_SUPPORT = 3
+INCIDENCE_ARTIFACT_MAX_BYTES = 50 * 1024 * 1024
+INCIDENCE_SERVING_MIN_SUPPORT = 10
+INCIDENCE_SERVING_MIN_CONCENTRATION = 0.50
+INCIDENCE_SERVING_MIN_MARGIN = 0.10
+
+_ARTIFACT_TOP_LEVEL_KEYS = {
+    "schema_version",
+    "kind",
+    "objective",
+    "outcome_optimized",
+    "parameters",
+    "departments",
+    "counts",
+    "privacy",
+    "checksum",
+}
+_COUNT_ENTRY_KEYS = {"department", "count"}
+_TABLE_ROW_KEYS = {
+    "category": {"category", "counts"},
+    "category_district": {"category", "district", "counts"},
+    "subcategory": {"category", "subcategory", "counts"},
+    "full": {"category", "subcategory", "district", "counts"},
+}
+
+
+@dataclass(frozen=True)
+class RouteRecord:
+    item_id: str
+    group_id: str
+    observed_on: date
+    category: str
+    department: str
+    split: str
+    district: str | None = None
+    subcategory: str | None = None
+    language: str = "unknown"
+    weight: int = 1
+
+
+@dataclass(frozen=True)
+class IncidencePrediction:
+    """One aggregate prediction and the historical cell supporting it."""
+
+    probabilities: dict[str, float]
+    support: int
+    concentration: float
+    width: str
+
+
+def _norm(value: str | None) -> str:
+    return " ".join((value or "").strip().lower().split())
+
+
+def validate_route_records(records: Sequence[RouteRecord]) -> None:
+    if not records:
+        raise ValueError("routing benchmark is empty")
+    ids = [record.item_id for record in records]
+    if len(ids) != len(set(ids)):
+        raise ValueError("item_id values must be unique")
+    if {record.split for record in records} != {"train", "validation", "test"}:
+        raise ValueError("routing benchmark requires train, validation, and test")
+    for record in records:
+        if record.split not in {"train", "validation", "test"}:
+            raise ValueError(f"invalid split {record.split!r}")
+        if not record.item_id or not record.group_id:
+            raise ValueError("item_id and group_id must be non-empty")
+        if not _norm(record.category) or not _norm(record.department):
+            raise ValueError("category and department must be non-empty")
+        if not record.language:
+            raise ValueError("language must be non-empty")
+        if (
+            isinstance(record.weight, bool)
+            or not isinstance(record.weight, int)
+            or record.weight < 1
+        ):
+            raise ValueError("weight must be a positive integer")
+    assert_group_disjoint((record.group_id, record.split) for record in records)
+
+    train_dates = [record.observed_on for record in records if record.split == "train"]
+    validation_dates = [
+        record.observed_on for record in records if record.split == "validation"
+    ]
+    test_dates = [record.observed_on for record in records if record.split == "test"]
+    if max(train_dates) >= min(validation_dates):
+        raise ValueError("training must end before validation begins")
+    if max(validation_dates) >= min(test_dates):
+        raise ValueError("validation must end before test begins")
+
+
+class IncidenceRouter:
+    """Smoothed hierarchical distributions over historical destinations."""
+
+    def __init__(
+        self,
+        *,
+        alpha: float,
+        use_subcategory: bool = False,
+        serving_min_support: int = INCIDENCE_SERVING_MIN_SUPPORT,
+        serving_min_concentration: float = INCIDENCE_SERVING_MIN_CONCENTRATION,
+        serving_min_margin: float = INCIDENCE_SERVING_MIN_MARGIN,
+    ) -> None:
+        if not math.isfinite(alpha) or alpha <= 0.0:
+            raise ValueError("alpha must be positive and finite")
+        if (
+            isinstance(serving_min_support, bool)
+            or not isinstance(serving_min_support, int)
+            or serving_min_support < INCIDENCE_ARTIFACT_MIN_SUPPORT
+        ):
+            raise ValueError(
+                "serving_min_support must be an integer at least the privacy floor"
+            )
+        for value, name in (
+            (serving_min_concentration, "serving_min_concentration"),
+            (serving_min_margin, "serving_min_margin"),
+        ):
+            if (
+                isinstance(value, bool)
+                or not isinstance(value, (int, float))
+                or not math.isfinite(value)
+                or not 0.0 <= value <= 1.0
+            ):
+                raise ValueError(f"{name} must be finite and in [0, 1]")
+        self.alpha = alpha
+        self.use_subcategory = use_subcategory
+        self.serving_min_support = serving_min_support
+        self.serving_min_concentration = float(serving_min_concentration)
+        self.serving_min_margin = float(serving_min_margin)
+        self.departments: tuple[str, ...] = ()
+        self._global: Counter[str] = Counter()
+        self._category: dict[str, Counter[str]] = defaultdict(Counter)
+        self._category_district: dict[tuple[str, str], Counter[str]] = defaultdict(Counter)
+        self._subcategory: dict[tuple[str, str], Counter[str]] = defaultdict(Counter)
+        self._full: dict[tuple[str, str, str], Counter[str]] = defaultdict(Counter)
+
+    def fit(self, records: Sequence[RouteRecord]) -> "IncidenceRouter":
+        if not records:
+            raise ValueError("at least one training record is required")
+        global_counts: Counter[str] = Counter()
+        category_counts: dict[str, Counter[str]] = defaultdict(Counter)
+        category_district_counts: dict[tuple[str, str], Counter[str]] = defaultdict(
+            Counter
+        )
+        subcategory_counts: dict[tuple[str, str], Counter[str]] = defaultdict(Counter)
+        full_counts: dict[tuple[str, str, str], Counter[str]] = defaultdict(Counter)
+        for record in records:
+            category = _norm(record.category)
+            subcategory = _norm(record.subcategory)
+            district = _norm(record.district)
+            department = record.department.strip()
+            if not category or not department:
+                raise ValueError("category and department must be non-empty")
+            if (
+                isinstance(record.weight, bool)
+                or not isinstance(record.weight, int)
+                or record.weight < 1
+            ):
+                raise ValueError("weight must be a positive integer")
+            global_counts[department] += record.weight
+            category_counts[category][department] += record.weight
+            if district:
+                category_district_counts[(category, district)][department] += record.weight
+            if subcategory:
+                subcategory_counts[(category, subcategory)][department] += record.weight
+            if subcategory and district:
+                full_counts[(category, subcategory, district)][department] += record.weight
+        self._global = global_counts
+        self._category = category_counts
+        self._category_district = category_district_counts
+        self._subcategory = subcategory_counts
+        self._full = full_counts
+        self.departments = tuple(sorted(global_counts))
+        return self
+
+    def _update(
+        self, prior: Mapping[str, float], counts: Mapping[str, int]
+    ) -> dict[str, float]:
+        support = sum(counts.values())
+        if support == 0:
+            return dict(prior)
+        denominator = support + self.alpha
+        return {
+            department: (
+                counts.get(department, 0) + self.alpha * prior[department]
+            )
+            / denominator
+            for department in self.departments
+        }
+
+    def predict_proba(
+        self,
+        *,
+        category: str,
+        district: str | None = None,
+        subcategory: str | None = None,
+    ) -> dict[str, float]:
+        if not self.departments:
+            raise RuntimeError("router must be fitted before prediction")
+        total = sum(self._global.values())
+        probability = {
+            department: self._global[department] / total
+            for department in self.departments
+        }
+        category_key = _norm(category)
+        district_key = _norm(district)
+        subcategory_key = _norm(subcategory)
+        probability = self._update(probability, self._category.get(category_key, {}))
+        if district_key:
+            probability = self._update(
+                probability,
+                self._category_district.get((category_key, district_key), {}),
+            )
+        if self.use_subcategory and subcategory_key:
+            probability = self._update(
+                probability,
+                self._subcategory.get((category_key, subcategory_key), {}),
+            )
+            if district_key:
+                probability = self._update(
+                    probability,
+                    self._full.get(
+                        (category_key, subcategory_key, district_key), {}
+                    ),
+                )
+        return probability
+
+    def predict_with_evidence(
+        self,
+        *,
+        category: str,
+        district: str | None = None,
+        subcategory: str | None = None,
+    ) -> IncidencePrediction | None:
+        """Predict only when a category aggregate exists, with honest evidence.
+
+        ``predict_proba`` retains global backoff for evaluation. Serving is
+        stricter: an unseen category has no comparable-case cell, so this
+        method returns ``None`` and the provider falls through to the governed
+        crosswalk/rules ladder. The evidence describes the deepest aggregate
+        cell that actually updated the posterior, never the global prior.
+        """
+
+        probabilities = self.predict_proba(
+            category=category,
+            district=district,
+            subcategory=subcategory,
+        )
+        category_key = _norm(category)
+        district_key = _norm(district)
+        subcategory_key = _norm(subcategory)
+        category_counts = self._category.get(category_key)
+        if not category_counts:
+            return None
+        matches: list[tuple[str, Mapping[str, int]]] = [
+            ("category", category_counts)
+        ]
+        if district_key:
+            district_counts = self._category_district.get(
+                (category_key, district_key)
+            )
+            if district_counts:
+                matches.append(("category+district", district_counts))
+        if self.use_subcategory and subcategory_key:
+            subcategory_counts = self._subcategory.get(
+                (category_key, subcategory_key)
+            )
+            if subcategory_counts:
+                matches.append(("category+subcategory", subcategory_counts))
+            if district_key:
+                full_counts = self._full.get(
+                    (category_key, subcategory_key, district_key)
+                )
+                if full_counts:
+                    matches.append(
+                        ("category+subcategory+district", full_counts)
+                    )
+
+        predicted = max(probabilities, key=probabilities.get)
+        ranked_probabilities = sorted(probabilities.values(), reverse=True)
+        probability_margin = ranked_probabilities[0] - (
+            ranked_probabilities[1] if len(ranked_probabilities) > 1 else 0.0
+        )
+        if probability_margin < self.serving_min_margin:
+            return None
+        # Do not let a sparse deeper cell alter the posterior and then cite a
+        # broader, better-supported cell as its evidence. The deepest cell that
+        # actually updated the posterior must itself clear every serving gate;
+        # otherwise the provider falls back.
+        width, counts = matches[-1]
+        if (
+            sum(counts.values()) < self.serving_min_support
+            or counts.get(predicted, 0) == 0
+        ):
+            return None
+        support = sum(counts.values())
+        concentration = counts[predicted] / support
+        if concentration < self.serving_min_concentration:
+            return None
+        return IncidencePrediction(
+            probabilities=probabilities,
+            support=support,
+            concentration=concentration,
+            width=width,
+        )
+
+
+def _canonical_json_bytes(payload: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _artifact_checksum(payload_without_checksum: Mapping[str, object]) -> str:
+    return "sha256:" + hashlib.sha256(
+        _canonical_json_bytes(payload_without_checksum)
+    ).hexdigest()
+
+
+def _artifact_file(path: Path) -> Path:
+    return path if path.suffix.lower() == ".json" else path / INCIDENCE_ARTIFACT_FILENAME
+
+
+def _counter_entries(counts: Mapping[str, int]) -> list[dict[str, object]]:
+    return [
+        {"department": department, "count": int(count)}
+        for department, count in sorted(counts.items())
+        if count > 0
+    ]
+
+
+def _table_rows(
+    table: Mapping[object, Mapping[str, int]],
+    fields: Sequence[str],
+) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for raw_key, counts in table.items():
+        if sum(counts.values()) < INCIDENCE_ARTIFACT_MIN_SUPPORT:
+            continue
+        key = raw_key if isinstance(raw_key, tuple) else (raw_key,)
+        row = {field: value for field, value in zip(fields, key, strict=True)}
+        row["counts"] = _counter_entries(counts)
+        rows.append(row)
+    return sorted(rows, key=lambda row: tuple(str(row[field]) for field in fields))
+
+
+def incidence_router_artifact(router: IncidenceRouter) -> dict[str, object]:
+    """Return the checksummed, aggregate-only serving artifact for ``router``.
+
+    Only normalized taxonomy/district labels and counts are serialized. Route
+    record IDs, group IDs, dates, language, and grievance text have no field in
+    this schema. Keys with fewer than three historical cases are suppressed.
+    """
+
+    if not router.departments or not router._global:
+        raise ValueError("router must be fitted before it can be serialized")
+    payload: dict[str, object] = {
+        "schema_version": INCIDENCE_ARTIFACT_SCHEMA_VERSION,
+        "kind": "routing_incidence",
+        "objective": "historical_incidence_only",
+        "outcome_optimized": False,
+        "parameters": {
+            "alpha": router.alpha,
+            "use_subcategory": router.use_subcategory,
+            "serving_min_support": router.serving_min_support,
+            "serving_min_concentration": router.serving_min_concentration,
+            "serving_min_margin": router.serving_min_margin,
+        },
+        "departments": list(router.departments),
+        "counts": {
+            "global": _counter_entries(router._global),
+            "category": _table_rows(router._category, ("category",)),
+            "category_district": _table_rows(
+                router._category_district, ("category", "district")
+            ),
+            "subcategory": (
+                _table_rows(router._subcategory, ("category", "subcategory"))
+                if router.use_subcategory
+                else []
+            ),
+            "full": (
+                _table_rows(
+                    router._full,
+                    ("category", "subcategory", "district"),
+                )
+                if router.use_subcategory
+                else []
+            ),
+        },
+        "privacy": {
+            "contains_citizen_text_or_identifiers": False,
+            "minimum_key_support": INCIDENCE_ARTIFACT_MIN_SUPPORT,
+        },
+    }
+    payload["checksum"] = _artifact_checksum(payload)
+    # Validate the artifact through the same path serving will use before any
+    # bytes reach disk. This catches accidental schema drift at build time.
+    _router_from_artifact(payload)
+    return payload
+
+
+def save_incidence_router(router: IncidenceRouter, path: Path) -> Path:
+    """Atomically write one immutable governed artifact and return its file."""
+
+    artifact = _artifact_file(Path(path))
+    payload = incidence_router_artifact(router)
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    if artifact.exists():
+        raise FileExistsError(artifact)
+    fd, temporary_name = tempfile.mkstemp(
+        prefix=f".{artifact.name}.", dir=artifact.parent
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=False, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        # Hard-link publication is atomic and fails if another process has
+        # already published this immutable artifact path; os.replace would
+        # silently overwrite that release in the race between exists() and
+        # publication.
+        os.link(temporary, artifact)
+        temporary.unlink()
+    except Exception:
+        temporary.unlink(missing_ok=True)
+        raise
+    return artifact
+
+
+def _valid_label(value: object, *, normalized: bool) -> bool:
+    if not isinstance(value, str) or not value or len(value) > 160:
+        return False
+    if value != value.strip() or any(ord(character) < 32 for character in value):
+        return False
+    return not normalized or value == _norm(value)
+
+
+def _parse_counter(
+    value: object,
+    *,
+    departments: set[str],
+    require_all_departments: bool = False,
+) -> Counter[str]:
+    if not isinstance(value, list) or not value:
+        raise ValueError("counts must be a non-empty list")
+    counter: Counter[str] = Counter()
+    for entry in value:
+        if not isinstance(entry, dict) or set(entry) != _COUNT_ENTRY_KEYS:
+            raise ValueError("invalid count entry")
+        department = entry["department"]
+        count = entry["count"]
+        if department not in departments or department in counter:
+            raise ValueError("unknown or duplicate department")
+        if isinstance(count, bool) or not isinstance(count, int) or count < 1:
+            raise ValueError("count must be a positive integer")
+        counter[department] = count
+    if require_all_departments and set(counter) != departments:
+        raise ValueError("global counts must cover every department")
+    return counter
+
+
+def _parse_table(
+    value: object,
+    *,
+    name: str,
+    fields: Sequence[str],
+    departments: set[str],
+) -> dict[object, Counter[str]]:
+    if not isinstance(value, list):
+        raise ValueError(f"{name} must be a list")
+    table: dict[object, Counter[str]] = {}
+    for row in value:
+        if not isinstance(row, dict) or set(row) != _TABLE_ROW_KEYS[name]:
+            raise ValueError(f"invalid {name} row")
+        labels = tuple(row[field] for field in fields)
+        if not all(_valid_label(label, normalized=True) for label in labels):
+            raise ValueError(f"invalid {name} key")
+        key: object = labels[0] if len(labels) == 1 else labels
+        if key in table:
+            raise ValueError(f"duplicate {name} key")
+        counter = _parse_counter(row["counts"], departments=departments)
+        if sum(counter.values()) < INCIDENCE_ARTIFACT_MIN_SUPPORT:
+            raise ValueError(f"{name} row is below the privacy support floor")
+        table[key] = counter
+    return table
+
+
+def _router_from_artifact(payload: object) -> IncidenceRouter:
+    if not isinstance(payload, dict) or set(payload) != _ARTIFACT_TOP_LEVEL_KEYS:
+        raise ValueError("invalid incidence artifact top-level schema")
+    if payload["schema_version"] != INCIDENCE_ARTIFACT_SCHEMA_VERSION:
+        raise ValueError("unsupported incidence artifact schema")
+    if payload["kind"] != "routing_incidence":
+        raise ValueError("invalid incidence artifact kind")
+    if payload["objective"] != "historical_incidence_only":
+        raise ValueError("invalid incidence objective")
+    if payload["outcome_optimized"] is not False:
+        raise ValueError("incidence artifact must declare outcome_optimized=false")
+
+    checksum = payload["checksum"]
+    if not isinstance(checksum, str) or not checksum.startswith("sha256:"):
+        raise ValueError("invalid incidence artifact checksum")
+    unsigned = dict(payload)
+    unsigned.pop("checksum")
+    if checksum != _artifact_checksum(unsigned):
+        raise ValueError("incidence artifact checksum mismatch")
+
+    parameters = payload["parameters"]
+    if not isinstance(parameters, dict) or set(parameters) != {
+        "alpha",
+        "use_subcategory",
+        "serving_min_support",
+        "serving_min_concentration",
+        "serving_min_margin",
+    }:
+        raise ValueError("invalid incidence parameters")
+    alpha = parameters["alpha"]
+    use_subcategory = parameters["use_subcategory"]
+    serving_min_support = parameters["serving_min_support"]
+    serving_min_concentration = parameters["serving_min_concentration"]
+    serving_min_margin = parameters["serving_min_margin"]
+    if isinstance(alpha, bool) or not isinstance(alpha, (int, float)):
+        raise ValueError("alpha must be numeric")
+    if not math.isfinite(float(alpha)) or float(alpha) <= 0.0:
+        raise ValueError("alpha must be positive and finite")
+    if not isinstance(use_subcategory, bool):
+        raise ValueError("use_subcategory must be boolean")
+
+    raw_departments = payload["departments"]
+    if not isinstance(raw_departments, list) or not raw_departments:
+        raise ValueError("departments must be a non-empty list")
+    if not all(_valid_label(value, normalized=False) for value in raw_departments):
+        raise ValueError("invalid department label")
+    if raw_departments != sorted(set(raw_departments)):
+        raise ValueError("departments must be unique and sorted")
+    departments = set(raw_departments)
+
+    privacy = payload["privacy"]
+    if privacy != {
+        "contains_citizen_text_or_identifiers": False,
+        "minimum_key_support": INCIDENCE_ARTIFACT_MIN_SUPPORT,
+    }:
+        raise ValueError("invalid incidence privacy declaration")
+    counts = payload["counts"]
+    if not isinstance(counts, dict) or set(counts) != {
+        "global",
+        "category",
+        "category_district",
+        "subcategory",
+        "full",
+    }:
+        raise ValueError("invalid incidence counts schema")
+
+    global_counts = _parse_counter(
+        counts["global"],
+        departments=departments,
+        require_all_departments=True,
+    )
+    category = _parse_table(
+        counts["category"],
+        name="category",
+        fields=("category",),
+        departments=departments,
+    )
+    if not category:
+        raise ValueError("incidence artifact has no supported category cells")
+    category_district = _parse_table(
+        counts["category_district"],
+        name="category_district",
+        fields=("category", "district"),
+        departments=departments,
+    )
+    subcategory = _parse_table(
+        counts["subcategory"],
+        name="subcategory",
+        fields=("category", "subcategory"),
+        departments=departments,
+    )
+    full = _parse_table(
+        counts["full"],
+        name="full",
+        fields=("category", "subcategory", "district"),
+        departments=departments,
+    )
+    if not use_subcategory and (subcategory or full):
+        raise ValueError("non-subcategory artifact contains unreachable tables")
+
+    router = IncidenceRouter(
+        alpha=float(alpha),
+        use_subcategory=use_subcategory,
+        serving_min_support=serving_min_support,
+        serving_min_concentration=serving_min_concentration,
+        serving_min_margin=serving_min_margin,
+    )
+    router.departments = tuple(raw_departments)
+    router._global = global_counts
+    router._category = defaultdict(Counter, category)
+    router._category_district = defaultdict(Counter, category_district)
+    router._subcategory = defaultdict(Counter, subcategory)
+    router._full = defaultdict(Counter, full)
+    return router
+
+
+def load_incidence_router(path: Path) -> IncidenceRouter | None:
+    """Load a checksummed artifact without raising or making network calls."""
+
+    try:
+        artifact = _artifact_file(Path(path))
+        if not artifact.is_file():
+            return None
+        if artifact.stat().st_size <= 0 or artifact.stat().st_size > INCIDENCE_ARTIFACT_MAX_BYTES:
+            return None
+
+        def reject_constant(value: str) -> object:
+            raise ValueError(f"invalid JSON constant {value}")
+
+        payload = json.loads(
+            artifact.read_text(encoding="utf-8"),
+            parse_constant=reject_constant,
+        )
+        return _router_from_artifact(payload)
+    except (OSError, UnicodeError, ValueError, TypeError, json.JSONDecodeError):
+        return None
+
+
+def _score(
+    router: IncidenceRouter,
+    records: Sequence[RouteRecord],
+    *,
+    expected_labels: Sequence[str] | None = None,
+) -> list[ScoredExample]:
+    departments = set(router.departments)
+    unseen = sorted({record.department for record in records}.difference(departments))
+    labels = (
+        tuple(expected_labels)
+        if expected_labels is not None
+        else tuple(sorted(departments.union(unseen)))
+    )
+    examples: list[ScoredExample] = []
+    for record in records:
+        probability = router.predict_proba(
+            category=record.category,
+            district=record.district,
+            subcategory=record.subcategory,
+        )
+        complete = {label: probability.get(label, 0.0) for label in labels}
+        examples.append(
+            ScoredExample(
+                item_id=record.item_id,
+                gold_label=record.department,
+                probabilities=complete,
+                group_id=record.group_id,
+                language=record.language,
+                weight=record.weight,
+            )
+        )
+    return examples
+
+
+def _suppress_non_cluster_robust_intervals(
+    metrics: Mapping[str, object],
+) -> dict[str, object]:
+    """Remove weighted Wilson bounds that assume independent complaints.
+
+    Historical routing inputs are aggregate cells whose integer weights expand
+    correlated complaints. Point metrics remain useful historical-agreement
+    summaries, but treating every weighted complaint as an independent trial
+    produces falsely narrow intervals. Keep the field names visible with
+    ``None`` so downstream reports cannot silently mistake absence for a parser
+    failure, and state what must replace them.
+    """
+
+    result = dict(metrics)
+    result["accuracy_interval"] = None
+    result["selective_accuracy_interval"] = None
+    result["interval_status"] = (
+        "suppressed_not_cluster_robust_for_weighted_route_cells"
+    )
+    result["interval_requirement"] = (
+        "district_time_or_campaign_block_uncertainty_required"
+    )
+    return result
+
+
+def _hard_backoff_score(
+    train: Sequence[RouteRecord],
+    records: Sequence[RouteRecord],
+    *,
+    expected_labels: Sequence[str] | None = None,
+) -> list[ScoredExample]:
+    """Unsmooth category+district -> category -> global incidence baseline."""
+
+    global_counts: Counter[str] = Counter()
+    by_category: dict[str, Counter[str]] = defaultdict(Counter)
+    by_district: dict[tuple[str, str], Counter[str]] = defaultdict(Counter)
+    for record in train:
+        category = _norm(record.category)
+        global_counts[record.department] += record.weight
+        by_category[category][record.department] += record.weight
+        if _norm(record.district):
+            by_district[(category, _norm(record.district))][record.department] += record.weight
+    labels = (
+        tuple(expected_labels)
+        if expected_labels is not None
+        else tuple(
+            sorted(set(global_counts).union(record.department for record in records))
+        )
+    )
+    examples = []
+    for record in records:
+        counts = (
+            by_district.get((_norm(record.category), _norm(record.district)))
+            or by_category.get(_norm(record.category))
+            or global_counts
+        )
+        total = sum(counts.values())
+        probability = {
+            label: counts.get(label, 0) / total
+            for label in labels
+        }
+        examples.append(
+            ScoredExample(
+                item_id=record.item_id,
+                gold_label=record.department,
+                probabilities=probability,
+                group_id=record.group_id,
+                language=record.language,
+                weight=record.weight,
+            )
+        )
+    return examples
+
+
+@dataclass
+class RoutingBenchmark:
+    router: IncidenceRouter
+    report: dict[str, object]
+
+
+def benchmark_incidence_router(
+    records: Sequence[RouteRecord],
+    *,
+    alpha_values: Sequence[float] = (3.0, 10.0, 30.0, 100.0),
+    history_year_values: Sequence[int | None] = (None,),
+    use_subcategory: bool = False,
+    serving_min_support: int = INCIDENCE_SERVING_MIN_SUPPORT,
+    serving_min_concentration: float = INCIDENCE_SERVING_MIN_CONCENTRATION,
+    serving_min_margin: float = INCIDENCE_SERVING_MIN_MARGIN,
+    artifact_dir: Path | None = None,
+) -> RoutingBenchmark:
+    """Select smoothing on chronological validation, then score test once."""
+
+    validate_route_records(records)
+    if not alpha_values or any(
+        not math.isfinite(alpha) or alpha <= 0.0 for alpha in alpha_values
+    ):
+        raise ValueError("alpha_values must contain positive finite values")
+    if not history_year_values or any(
+        value is not None
+        and (isinstance(value, bool) or not isinstance(value, int) or value < 1)
+        for value in history_year_values
+    ):
+        raise ValueError("history_year_values must contain positive integers or None")
+    train = [record for record in records if record.split == "train"]
+    validation = [record for record in records if record.split == "validation"]
+    test = [record for record in records if record.split == "test"]
+    expected_labels = tuple(
+        sorted({record.department for record in (*train, *validation, *test)})
+    )
+
+    def recent(rows: Sequence[RouteRecord], years: int | None) -> list[RouteRecord]:
+        if years is None:
+            return list(rows)
+        latest = max(record.observed_on.year for record in rows)
+        first = latest - years + 1
+        return [record for record in rows if record.observed_on.year >= first]
+
+    candidates: list[
+        tuple[float, int | None, IncidenceRouter, dict[str, object], int]
+    ] = []
+    for history_years in history_year_values:
+        candidate_train = recent(train, history_years)
+        for alpha in alpha_values:
+            router = IncidenceRouter(
+                alpha=alpha,
+                use_subcategory=use_subcategory,
+                serving_min_support=serving_min_support,
+                serving_min_concentration=serving_min_concentration,
+                serving_min_margin=serving_min_margin,
+            ).fit(candidate_train)
+            metrics = _suppress_non_cluster_robust_intervals(
+                classification_metrics(
+                    _score(router, validation, expected_labels=expected_labels),
+                    expected_labels=expected_labels,
+                    top_k=(1, 3, 5),
+                )
+            )
+            candidates.append(
+                (
+                    alpha,
+                    history_years,
+                    router,
+                    metrics,
+                    sum(record.weight for record in candidate_train),
+                )
+            )
+    alpha, history_years, _, validation_metrics, validation_fit_cases = max(
+        candidates,
+        key=lambda row: (
+            float(row[3]["accuracy"]),
+            float(row[3]["top_k_accuracy"]["3"]),
+            -float(row[3]["log_loss"]),
+            -row[0],
+        ),
+    )
+
+    # Hyperparameters are chosen on validation, then the final candidate is
+    # refitted on all pre-test history.  The untouched test period is still
+    # scored exactly once; withholding validation from the final fit would
+    # make the deployed historical lookup needlessly stale.
+    pre_test = recent([*train, *validation], history_years)
+    fitted_router = IncidenceRouter(
+        alpha=alpha,
+        use_subcategory=use_subcategory,
+        serving_min_support=serving_min_support,
+        serving_min_concentration=serving_min_concentration,
+        serving_min_margin=serving_min_margin,
+    ).fit(pre_test)
+    # Score the exact privacy-suppressed shape serving will load, rather than
+    # the richer in-memory counters used during fitting. This round trip is
+    # deliberately in-memory; publishing remains explicit and immutable below.
+    router = _router_from_artifact(incidence_router_artifact(fitted_router))
+    test_examples = _score(router, test, expected_labels=expected_labels)
+    test_metrics = _suppress_non_cluster_robust_intervals(
+        classification_metrics(
+            test_examples,
+            expected_labels=expected_labels,
+            top_k=(1, 3, 5),
+        )
+    )
+    hard_metrics = _suppress_non_cluster_robust_intervals(
+        classification_metrics(
+            _hard_backoff_score(pre_test, test, expected_labels=expected_labels),
+            expected_labels=expected_labels,
+            top_k=(1, 3, 5),
+        )
+    )
+    unseen = sorted(
+        {record.department for record in (*validation, *test)}
+        .difference(router.departments)
+    )
+    serving_eligible = sum(
+        record.weight
+        for record in test
+        if router.predict_with_evidence(
+            category=record.category,
+            district=record.district,
+            subcategory=record.subcategory,
+        )
+        is not None
+    )
+    test_cases = sum(record.weight for record in test)
+    report: dict[str, object] = {
+        "objective": "historical_incidence_only",
+        "outcome_optimized": False,
+        "live_feature_shape": (
+            "category+subcategory+district"
+            if use_subcategory
+            else "category+district"
+        ),
+        "selected_alpha": alpha,
+        "selected_history_years": history_years,
+        "validation_fit_cases": validation_fit_cases,
+        "final_fit_cases": sum(record.weight for record in pre_test),
+        "final_fit": "train_plus_validation_before_untouched_test",
+        "evaluation_router": "serialized_reloaded_privacy_suppressed_artifact",
+        "serving_gates": {
+            "minimum_support": router.serving_min_support,
+            "minimum_concentration": router.serving_min_concentration,
+            "minimum_top1_margin": router.serving_min_margin,
+            "eligible_test_cases": serving_eligible,
+            "eligible_test_coverage": serving_eligible / test_cases,
+            "fallback_test_cases": test_cases - serving_eligible,
+        },
+        "split_counts": {
+            "train": sum(record.weight for record in train),
+            "validation": sum(record.weight for record in validation),
+            "test": sum(record.weight for record in test),
+        },
+        "validation": validation_metrics,
+        "test": test_metrics,
+        "test_by_language": {
+            language: _suppress_non_cluster_robust_intervals(metrics)
+            for language, metrics in metrics_by_language(
+                test_examples,
+                expected_labels=expected_labels,
+                top_k=(1, 3, 5),
+            ).items()
+        },
+        "hard_backoff_test": hard_metrics,
+        "unseen_departments": unseen,
+        "candidate_validation": [
+            {
+                "alpha": candidate_alpha,
+                "history_years": candidate_history_years,
+                "accuracy": metrics["accuracy"],
+                "top3_accuracy": metrics["top_k_accuracy"]["3"],
+                "log_loss": metrics["log_loss"],
+            }
+            for candidate_alpha, candidate_history_years, _, metrics, _ in candidates
+        ],
+        "limitations": [
+            "predicts where similar cases were sent, not where they resolve best",
+            "chronological holdout measures drift but does not remove policy bias",
+            "subcategory benchmark is non-live until the classifier supplies it",
+            "weighted Wilson intervals are suppressed because aggregate route cells are not independent trials",
+        ],
+    }
+    if artifact_dir is not None:
+        artifact_path = save_incidence_router(router, artifact_dir)
+        artifact_payload = incidence_router_artifact(router)
+        report["serving_artifact"] = {
+            "path": str(artifact_path),
+            "schema_version": INCIDENCE_ARTIFACT_SCHEMA_VERSION,
+            "checksum": artifact_payload["checksum"],
+            "contains_citizen_text_or_identifiers": False,
+            "outcome_optimized": False,
+        }
+    return RoutingBenchmark(router=router, report=report)
+
+
+def temporal_split_counts(records: Iterable[RouteRecord]) -> dict[str, int]:
+    """Small helper for manifest diagnostics without selecting any text."""
+
+    return dict(sorted(Counter(record.split for record in records).items()))

--- a/janasunani/routing/provider.py
+++ b/janasunani/routing/provider.py
@@ -41,7 +41,13 @@ ROUTER_DEFAULT = "crosswalk"
 #: reproduce the pre-#33 behaviour and to isolate the crosswalk in a comparison.
 ROUTER_RULES = "rules"
 
-SUPPORTED_ROUTERS = (ROUTER_DEFAULT, ROUTER_RULES)
+#: Checksummed aggregate-only empirical-Bayes artifact. This predicts
+#: historical destination incidence, never disposal quality or citizen benefit.
+ROUTER_INCIDENCE = "incidence"
+
+ROUTING_INCIDENCE_ARTIFACT_NAME = "routing_incidence"
+
+SUPPORTED_ROUTERS = (ROUTER_DEFAULT, ROUTER_RULES, ROUTER_INCIDENCE)
 
 
 class RoutingProvider(Protocol):
@@ -65,6 +71,76 @@ class RoutingProvider(Protocol):
     ) -> RoutingResult: ...
 
 
+class IncidenceRoutingProvider:
+    """Serve a governed local incidence artifact with a safe fallback ladder."""
+
+    def __init__(self, router, fallback: RoutingProvider) -> None:
+        self._router = router
+        self._fallback = fallback
+
+    def route(
+        self,
+        *,
+        category: str,
+        subcategory: Optional[str] = None,
+        district: Optional[str] = None,
+    ) -> RoutingResult:
+        try:
+            prediction = self._router.predict_with_evidence(
+                category=category,
+                subcategory=subcategory,
+                district=district,
+            )
+            if prediction is not None:
+                department = max(
+                    prediction.probabilities,
+                    key=prediction.probabilities.get,
+                )
+                district_name = " ".join((district or "State").split())
+                from janasunani.serving.schemas import EmpiricalRoutingEvidence
+
+                return RoutingResult(
+                    dept=department,
+                    office=f"{department}, {district_name}",
+                    confidence=min(0.95, prediction.probabilities[department]),
+                    method="learned",
+                    empirical_evidence=EmpiricalRoutingEvidence(
+                        support=prediction.support,
+                        concentration=prediction.concentration,
+                        width=prediction.width,
+                    ),
+                )
+        except Exception:
+            logger.warning(
+                "incidence routing failed for an aggregate lookup; using the "
+                "crosswalk/rules fallback"
+            )
+        return self._fallback.route(
+            category=category,
+            subcategory=subcategory,
+            district=district,
+        )
+
+
+def _load_incidence_provider() -> IncidenceRoutingProvider | None:
+    """Resolve and load the local artifact; never contact MLflow or a registry."""
+
+    try:
+        from janasunani.evaluation.routing import load_incidence_router
+        from janasunani.routing.rules import DEFAULT_ROUTER
+        from janasunani.tracking.artifacts import resolve_artifact
+
+        artifact = resolve_artifact(ROUTING_INCIDENCE_ARTIFACT_NAME)
+        if artifact is None:
+            return None
+        router = load_incidence_router(artifact)
+        if router is None:
+            return None
+        return IncidenceRoutingProvider(router, DEFAULT_ROUTER)
+    except Exception:
+        return None
+
+
 def router_from_env(value: str | None = None) -> RoutingProvider:
     """Select a router by environment, degrading to the default on anything odd.
 
@@ -85,6 +161,17 @@ def router_from_env(value: str | None = None) -> RoutingProvider:
         except (OSError, RuntimeError, ValueError):
             logger.warning("{}={} could not be constructed; using the default router", ROUTER_ENV_VAR, configured)
             return RuleRouter()
+    if configured == ROUTER_INCIDENCE:
+        provider = _load_incidence_provider()
+        if provider is not None:
+            return provider
+        logger.warning(
+            "{}={} has no valid local {} artifact; using the default router",
+            ROUTER_ENV_VAR,
+            configured,
+            ROUTING_INCIDENCE_ARTIFACT_NAME,
+        )
+        return DEFAULT_ROUTER
     logger.warning(
         "{}={!r} is not one of {}; using the default router",
         ROUTER_ENV_VAR,
@@ -151,6 +238,43 @@ def router_status() -> tuple[str, bool, str]:
             True,
             "crosswalk disabled by configuration; first rung is the ORTPSA mapping tables",
         )
+
+    if configured == ROUTER_INCIDENCE:
+        try:
+            from janasunani.evaluation.routing import (
+                INCIDENCE_ARTIFACT_SCHEMA_VERSION,
+                load_incidence_router,
+            )
+            from janasunani.tracking.artifacts import resolve_artifact
+
+            artifact = resolve_artifact(ROUTING_INCIDENCE_ARTIFACT_NAME)
+            if artifact is None:
+                return (
+                    ROUTER_DEFAULT,
+                    False,
+                    "incidence router requested but no local routing_incidence "
+                    "artifact resolved; using the crosswalk/rules fallback",
+                )
+            if load_incidence_router(artifact) is None:
+                return (
+                    ROUTER_DEFAULT,
+                    False,
+                    "incidence router artifact is unreadable, corrupt, or invalid; "
+                    "using the crosswalk/rules fallback",
+                )
+            return (
+                ROUTER_INCIDENCE,
+                True,
+                f"checksummed {INCIDENCE_ARTIFACT_SCHEMA_VERSION} artifact loaded "
+                "locally; objective is historical incidence, not outcome optimization",
+            )
+        except Exception as exc:
+            return (
+                ROUTER_DEFAULT,
+                False,
+                f"incidence router could not be loaded ({exc}); using the "
+                "crosswalk/rules fallback",
+            )
 
     if configured not in SUPPORTED_ROUTERS:
         return (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,7 @@ janasunani-spam-scorecard = "janasunani.evaluation.spam_scorecard:main"
 janasunani-evaluate-benchmark = "janasunani.evaluation.benchmark_report:main"
 janasunani-evaluate-sarvam = "janasunani.evaluation.sarvam_evaluate:main"
 janasunani-build-sarvam-sample = "janasunani.evaluation.sarvam_sample_builder:main"
+janasunani-evaluate-routing = "janasunani.evaluation.historical:main"
 janasunani-evaluate-summary = "janasunani.evaluation.summary:main"
 janasunani-audit-actionability-labels = "janasunani.evaluation.weak_labels:main"
 

--- a/tests/test_historical_evaluation.py
+++ b/tests/test_historical_evaluation.py
@@ -1,0 +1,103 @@
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from janasunani.evaluation.historical import (
+    _route_cell_sql,
+    benchmark_historical_routing,
+    load_route_cells,
+)
+from janasunani.evaluation.routing import load_incidence_router
+
+
+def complaints(path: Path) -> Path:
+    rows = []
+    for year, split_count in ((2023, 30), (2024, 12), (2025, 12)):
+        for index in range(split_count):
+            housing = index % 3 != 0
+            rows.append(
+                {
+                    "created_year": year,
+                    "category": "Housing" if housing else "General",
+                    "subcategory": "PMAY" if housing else None,
+                    "district": "Sambalpur",
+                    "dept": "Housing Department" if housing else "General Department",
+                    "grievance": "raw text must never be selected",
+                }
+            )
+    rows.append(
+        {
+            "created_year": 2020,
+            "category": "Legacy",
+            "subcategory": None,
+            "district": "Sambalpur",
+            "dept": "Legacy Department",
+            "grievance": "must remain outside the declared training window",
+        }
+    )
+    target = path / "complaints.parquet"
+    pl.DataFrame(rows).write_parquet(target)
+    return target
+
+
+def test_sql_names_only_structured_fields():
+    sql = _route_cell_sql(use_subcategory=True).lower()
+
+    assert "grievance" not in sql
+    assert "select *" not in sql
+    assert "subcategory" in sql
+
+
+def test_loader_aggregates_cases_and_holds_out_years(tmp_path):
+    data = load_route_cells(complaints(tmp_path), use_subcategory=True)
+
+    assert sum(record.weight for record in data.records) == 54
+    assert data.diagnostics["split_cases"] == {
+        "train": 30,
+        "validation": 12,
+        "test": 12,
+    }
+    assert len(data.records) == 6
+    assert {record.observed_on.year for record in data.records} == {2023, 2024, 2025}
+    assert data.diagnostics["dedup_group_isolation"] == "unavailable_full_corpus"
+    assert data.diagnostics["excluded_cases"]["outside_split_years"] == 1
+
+
+def test_informative_scope_excludes_general_but_reports_it(tmp_path):
+    data = load_route_cells(
+        complaints(tmp_path), informative_categories_only=True
+    )
+
+    assert sum(record.weight for record in data.records) == 36
+    assert data.diagnostics["excluded_cases"]["uninformative_category"] == 18
+
+
+def test_historical_benchmark_is_weighted_and_not_outcome_optimized(tmp_path):
+    result = benchmark_historical_routing(
+        complaints(tmp_path), alpha_values=(3.0,)
+    ).report
+
+    assert result["test"]["n"] == 12
+    assert result["test"]["accuracy"] == pytest.approx(1.0)
+    assert result["test"]["accuracy_interval"] is None
+    assert result["test"]["interval_status"] == (
+        "suppressed_not_cluster_robust_for_weighted_route_cells"
+    )
+    assert result["outcome_optimized"] is False
+    assert result["historical_data"]["split_feature_cells"]["train"] == 2
+
+
+def test_historical_benchmark_publishes_artifact_only_when_explicit(tmp_path):
+    artifact_dir = tmp_path / "release"
+    result = benchmark_historical_routing(
+        complaints(tmp_path), alpha_values=(3.0,), artifact_dir=artifact_dir
+    ).report
+
+    assert result["serving_artifact"]["outcome_optimized"] is False
+    assert load_incidence_router(artifact_dir) is not None
+
+
+def test_loader_rejects_missing_file(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        load_route_cells(tmp_path / "missing.parquet")

--- a/tests/test_routing_evaluation.py
+++ b/tests/test_routing_evaluation.py
@@ -1,0 +1,450 @@
+import hashlib
+import json
+from datetime import date
+
+import pytest
+
+from janasunani.evaluation.routing import (
+    INCIDENCE_ARTIFACT_FILENAME,
+    INCIDENCE_ARTIFACT_SCHEMA_VERSION,
+    IncidenceRouter,
+    RouteRecord,
+    benchmark_incidence_router,
+    load_incidence_router,
+    save_incidence_router,
+    validate_route_records,
+)
+
+
+def route(
+    item_id,
+    when,
+    category,
+    department,
+    split,
+    *,
+    district="Sambalpur",
+    subcategory=None,
+    language="English",
+    group=None,
+    weight=1,
+):
+    return RouteRecord(
+        item_id=item_id,
+        group_id=group or item_id,
+        observed_on=when,
+        category=category,
+        subcategory=subcategory,
+        district=district,
+        department=department,
+        split=split,
+        language=language,
+        weight=weight,
+    )
+
+
+def dataset():
+    rows = []
+    departments = {
+        "Water": "Water Department",
+        "Pension": "Social Security",
+        "Road": "Works Department",
+    }
+    for category, department in departments.items():
+        for i in range(20):
+            rows.append(
+                route(
+                    f"train-{category}-{i}",
+                    date(2023, 1, 1),
+                    category,
+                    department if i < 16 else "General Administration",
+                    "train",
+                    district="Sambalpur" if i % 2 else "Cuttack",
+                    subcategory=f"{category} issue",
+                )
+            )
+        for i in range(4):
+            rows.append(
+                route(
+                    f"validation-{category}-{i}",
+                    date(2024, 1, 1),
+                    category,
+                    department,
+                    "validation",
+                    district="Sambalpur",
+                    subcategory=f"{category} issue",
+                )
+            )
+        for i in range(4):
+            rows.append(
+                route(
+                    f"test-{category}-{i}",
+                    date(2025, 1, 1),
+                    category,
+                    department,
+                    "test",
+                    district="Sambalpur",
+                    subcategory=f"{category} issue",
+                    language="Odia" if i % 2 else "English",
+                )
+            )
+    return rows
+
+
+def test_temporal_and_group_leakage_are_hard_failures():
+    rows = dataset()
+    rows[0] = route(
+        rows[0].item_id,
+        date(2024, 6, 1),
+        rows[0].category,
+        rows[0].department,
+        "train",
+    )
+    with pytest.raises(ValueError, match="training must end"):
+        validate_route_records(rows)
+
+    rows = dataset()
+    rows[-1] = route(
+        rows[-1].item_id,
+        rows[-1].observed_on,
+        rows[-1].category,
+        rows[-1].department,
+        "test",
+        group=rows[0].group_id,
+    )
+    with pytest.raises(ValueError, match="leaks"):
+        validate_route_records(rows)
+
+
+def test_smoothed_router_returns_complete_probabilities_and_backoff():
+    train = [record for record in dataset() if record.split == "train"]
+    router = IncidenceRouter(alpha=10.0).fit(train)
+
+    known = router.predict_proba(category="Water", district="Sambalpur")
+    unseen = router.predict_proba(category="Astronomy", district="Unknown")
+
+    assert set(known) == set(router.departments)
+    assert sum(known.values()) == pytest.approx(1.0)
+    assert max(known, key=known.get) == "Water Department"
+    assert sum(unseen.values()) == pytest.approx(1.0)
+    assert unseen == {
+        department: router._global[department] / sum(router._global.values())
+        for department in router.departments
+    }
+
+
+def test_refit_replaces_prior_counts_instead_of_accumulating():
+    training = [record for record in dataset() if record.split == "train"]
+    router = IncidenceRouter(alpha=10.0).fit(training)
+    first_total = sum(router._global.values())
+
+    router.fit(training[:5])
+
+    assert first_total == 60
+    assert sum(router._global.values()) == 5
+
+
+def test_serving_prediction_requires_support_concentration_and_margin():
+    ambiguous = [
+        route(
+            f"ambiguous-{index}",
+            date(2023, 1, 1),
+            "Water",
+            department,
+            "train",
+        )
+        for index, department in enumerate(("A", "B", "C", "D"))
+    ]
+    router = IncidenceRouter(alpha=10.0, serving_min_support=3).fit(ambiguous)
+    assert router.predict_with_evidence(category="Water") is None
+
+    concentrated = [
+        route(
+            f"concentrated-{index}",
+            date(2023, 1, 1),
+            "Water",
+            "A" if index < 8 else "B",
+            "train",
+        )
+        for index in range(10)
+    ]
+    gated = IncidenceRouter(
+        alpha=10.0,
+        serving_min_support=10,
+        serving_min_concentration=0.75,
+        serving_min_margin=0.20,
+    ).fit(concentrated)
+    prediction = gated.predict_with_evidence(category="Water")
+    assert prediction is not None
+    assert prediction.support == 10
+    assert prediction.concentration == 0.8
+
+    sparse_district = [
+        route(
+            f"broad-{index}",
+            date(2023, 1, 1),
+            "Water",
+            "A",
+            "train",
+            district="Cuttack",
+        )
+        for index in range(20)
+    ] + [
+        route(
+            f"sparse-{index}",
+            date(2023, 1, 1),
+            "Water",
+            "B",
+            "train",
+            district="Sambalpur",
+        )
+        for index in range(3)
+    ]
+    sparse = IncidenceRouter(alpha=1.0, serving_min_support=10).fit(
+        sparse_district
+    )
+    assert (
+        sparse.predict_with_evidence(category="Water", district="Sambalpur")
+        is None
+    )
+
+
+def test_subcategory_is_an_explicit_non_live_candidate():
+    train = [record for record in dataset() if record.split == "train"]
+    live = IncidenceRouter(alpha=3.0, use_subcategory=False).fit(train)
+    future = IncidenceRouter(alpha=3.0, use_subcategory=True).fit(train)
+
+    live_probability = live.predict_proba(
+        category="Water", district="Sambalpur", subcategory="Water issue"
+    )
+    future_probability = future.predict_proba(
+        category="Water", district="Sambalpur", subcategory="Water issue"
+    )
+
+    assert live_probability != future_probability
+
+
+def test_benchmark_selects_on_validation_and_reports_honest_objective():
+    benchmark = benchmark_incidence_router(
+        dataset(), alpha_values=(1.0, 10.0, 100.0)
+    )
+    report = benchmark.report
+
+    assert report["objective"] == "historical_incidence_only"
+    assert report["outcome_optimized"] is False
+    assert report["live_feature_shape"] == "category+district"
+    assert report["split_counts"] == {"train": 60, "validation": 12, "test": 12}
+    assert report["selected_alpha"] in {1.0, 10.0, 100.0}
+    assert report["final_fit"] == "train_plus_validation_before_untouched_test"
+    assert report["evaluation_router"] == (
+        "serialized_reloaded_privacy_suppressed_artifact"
+    )
+    assert report["serving_gates"] == {
+        "minimum_support": 10,
+        "minimum_concentration": 0.5,
+        "minimum_top1_margin": 0.1,
+        "eligible_test_cases": 12,
+        "eligible_test_coverage": 1.0,
+        "fallback_test_cases": 0,
+    }
+    assert report["test"]["n"] == 12
+    assert report["test"]["top_k_accuracy"]["3"] == 1.0
+    assert report["test"]["accuracy_interval"] is None
+    assert report["test"]["interval_requirement"] == (
+        "district_time_or_campaign_block_uncertainty_required"
+    )
+    assert set(report["test_by_language"]) == {"English", "Odia"}
+    assert all(
+        metrics["accuracy_interval"] is None
+        for metrics in report["test_by_language"].values()
+    )
+    assert len(report["candidate_validation"]) == 3
+    assert "not where they resolve best" in report["limitations"][0]
+
+
+def test_unknown_future_department_counts_as_failure_instead_of_disappearing():
+    rows = dataset()
+    rows.append(
+        route(
+            "test-new-dept",
+            date(2025, 1, 1),
+            "Water",
+            "New Department",
+            "test",
+        )
+    )
+    benchmark = benchmark_incidence_router(rows, alpha_values=(10.0,))
+
+    assert benchmark.report["unseen_departments"] == ["New Department"]
+    assert benchmark.report["test"]["accuracy"] < 1.0
+
+
+def test_weighted_route_cells_count_underlying_cases():
+    rows = dataset()
+    rows[0] = route(
+        "train-0",
+        date(2023, 1, 1),
+        "Water",
+        "Water Department",
+        "train",
+        weight=10,
+    )
+    result = benchmark_incidence_router(rows, alpha_values=(3.0,))
+
+    assert result.report["split_counts"]["train"] == 69
+
+
+def test_history_window_is_selected_on_validation_then_rolls_forward():
+    result = benchmark_incidence_router(
+        dataset(),
+        alpha_values=(3.0,),
+        history_year_values=(None, 1),
+    )
+
+    assert result.report["selected_history_years"] in {None, 1}
+    assert len(result.report["candidate_validation"]) == 2
+    assert result.report["final_fit_cases"] == 72
+
+
+def test_incidence_artifact_round_trip_is_aggregate_only_and_checksummed(tmp_path):
+    training = [record for record in dataset() if record.split == "train"]
+    router = IncidenceRouter(alpha=10.0).fit(training)
+
+    artifact = save_incidence_router(router, tmp_path / "release")
+    payload = json.loads(artifact.read_text())
+    loaded = load_incidence_router(artifact)
+
+    assert artifact.name == INCIDENCE_ARTIFACT_FILENAME
+    assert payload["schema_version"] == INCIDENCE_ARTIFACT_SCHEMA_VERSION
+    assert payload["objective"] == "historical_incidence_only"
+    assert payload["outcome_optimized"] is False
+    assert payload["privacy"] == {
+        "contains_citizen_text_or_identifiers": False,
+        "minimum_key_support": 3,
+    }
+    serialized = artifact.read_text()
+    for forbidden in (
+        "item_id",
+        "group_id",
+        "observed_on",
+        "language",
+        "train-Water-0",
+    ):
+        assert forbidden not in serialized
+    assert loaded is not None
+    assert loaded.serving_min_support == 10
+    assert loaded.serving_min_concentration == 0.5
+    assert loaded.serving_min_margin == 0.1
+    assert loaded.predict_proba(
+        category="Water", district="Sambalpur"
+    ) == pytest.approx(
+        router.predict_proba(category="Water", district="Sambalpur")
+    )
+
+
+def test_incidence_artifact_rejects_checksum_and_schema_tampering(tmp_path):
+    training = [record for record in dataset() if record.split == "train"]
+    artifact = save_incidence_router(
+        IncidenceRouter(alpha=10.0).fit(training), tmp_path / "second"
+    )
+    payload = json.loads(artifact.read_text())
+    payload["parameters"]["alpha"] = 999.0
+    artifact.write_text(json.dumps(payload))
+    assert load_incidence_router(artifact) is None
+
+    artifact = save_incidence_router(
+        IncidenceRouter(alpha=10.0).fit(training), tmp_path
+    )
+    payload = json.loads(artifact.read_text())
+    payload["unexpected"] = "field"
+    # Re-signing must not make an expanded schema acceptable. The strict
+    # top-level field allowlist is a separate control from integrity.
+    unsigned = dict(payload)
+    unsigned.pop("checksum")
+    canonical = json.dumps(
+        unsigned, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+    ).encode()
+    payload["checksum"] = "sha256:" + hashlib.sha256(canonical).hexdigest()
+    artifact.write_text(json.dumps(payload))
+    assert load_incidence_router(artifact) is None
+
+
+def test_benchmark_can_publish_an_explicit_serving_artifact(tmp_path):
+    benchmark = benchmark_incidence_router(
+        dataset(), alpha_values=(10.0,), artifact_dir=tmp_path / "release"
+    )
+
+    manifest = benchmark.report["serving_artifact"]
+    assert manifest["outcome_optimized"] is False
+    assert manifest["contains_citizen_text_or_identifiers"] is False
+    loaded = load_incidence_router(tmp_path / "release")
+    assert loaded is not None
+    assert loaded.predict_proba(
+        category="Water", district="Sambalpur"
+    ) == pytest.approx(
+        benchmark.router.predict_proba(category="Water", district="Sambalpur")
+    )
+
+
+def test_benchmark_scores_the_privacy_suppressed_reloaded_router():
+    rows = [
+        route(
+            f"train-common-{index}",
+            date(2023, 1, 1),
+            "Common",
+            "Department A",
+            "train",
+            district=None,
+        )
+        for index in range(4)
+    ]
+    rows.extend(
+        [
+            route(
+                "train-sparse",
+                date(2023, 1, 1),
+                "Sparse",
+                "Department B",
+                "train",
+                district=None,
+            ),
+            route(
+                "validation-sparse",
+                date(2024, 1, 1),
+                "Sparse",
+                "Department B",
+                "validation",
+                district=None,
+            ),
+            route(
+                "test-sparse",
+                date(2025, 1, 1),
+                "Sparse",
+                "Department B",
+                "test",
+                district=None,
+            ),
+        ]
+    )
+
+    benchmark = benchmark_incidence_router(rows, alpha_values=(0.1,))
+
+    # The two-case Sparse cell is below the artifact's privacy floor. A richer
+    # in-memory fit would predict Department B, but the serialized/reloaded
+    # router must back off to its Department A global majority and be scored as
+    # wrong on the untouched test case.
+    assert max(
+        benchmark.router.predict_proba(category="Sparse"),
+        key=benchmark.router.predict_proba(category="Sparse").get,
+    ) == "Department A"
+    assert benchmark.report["test"]["accuracy"] == 0.0
+
+
+def test_incidence_artifact_is_immutable(tmp_path):
+    training = [record for record in dataset() if record.split == "train"]
+    router = IncidenceRouter(alpha=10.0).fit(training)
+    destination = tmp_path / "release"
+    save_incidence_router(router, destination)
+
+    with pytest.raises(FileExistsError):
+        save_incidence_router(router, destination)

--- a/tests/test_routing_incidence_provider.py
+++ b/tests/test_routing_incidence_provider.py
@@ -1,0 +1,179 @@
+import json
+from datetime import date
+
+import pytest
+
+from janasunani.evaluation.routing import (
+    IncidenceRouter,
+    RouteRecord,
+    load_incidence_router,
+    save_incidence_router,
+)
+from janasunani.routing.provider import (
+    ROUTER_DEFAULT,
+    ROUTER_ENV_VAR,
+    ROUTER_INCIDENCE,
+    IncidenceRoutingProvider,
+    router_from_env,
+    router_status,
+)
+from janasunani.routing.rules import RuleRouter
+
+
+def _artifact(tmp_path):
+    rows = [
+        RouteRecord(
+            item_id=f"aggregate-source-{index}",
+            group_id=f"aggregate-source-{index}",
+            observed_on=date(2024, 1, 1),
+            category="Housing",
+            district="Sambalpur",
+            department="Housing Department",
+            split="train",
+        )
+        for index in range(4)
+    ]
+    router = IncidenceRouter(alpha=10.0, serving_min_support=3).fit(rows)
+    return save_incidence_router(router, tmp_path / "release")
+
+
+def test_incidence_provider_returns_support_and_concentration(tmp_path, monkeypatch):
+    artifact = _artifact(tmp_path)
+    monkeypatch.setenv("JANASUNANI_ROUTING_INCIDENCE_ARTIFACT", str(artifact))
+
+    provider = router_from_env(ROUTER_INCIDENCE)
+    result = provider.route(category="Housing", district="Sambalpur")
+
+    assert isinstance(provider, IncidenceRoutingProvider)
+    assert result.method == "learned"
+    assert result.dept == "Housing Department"
+    assert result.empirical_evidence is not None
+    assert result.empirical_evidence.support == 4
+    assert result.empirical_evidence.concentration == 1.0
+    assert result.empirical_evidence.width == "category+district"
+
+
+def test_incidence_provider_uses_existing_fallback_for_unseen_category(
+    tmp_path, monkeypatch
+):
+    artifact = _artifact(tmp_path)
+    monkeypatch.setenv("JANASUNANI_ROUTING_INCIDENCE_ARTIFACT", str(artifact))
+
+    result = router_from_env(ROUTER_INCIDENCE).route(
+        category="Unseen category", district="Sambalpur"
+    )
+
+    assert result.method != "learned"
+    assert result.empirical_evidence is None
+
+
+def test_incidence_provider_abstains_on_an_ambiguous_supported_cell(tmp_path):
+    rows = [
+        RouteRecord(
+            item_id=f"ambiguous-{index}",
+            group_id=f"ambiguous-{index}",
+            observed_on=date(2024, 1, 1),
+            category="Housing",
+            district="Sambalpur",
+            department=department,
+            split="train",
+        )
+        for index, department in enumerate(("A", "B", "C", "D"))
+    ]
+    artifact = save_incidence_router(
+        IncidenceRouter(alpha=10.0, serving_min_support=3).fit(rows),
+        tmp_path / "ambiguous",
+    )
+    loaded = load_incidence_router(artifact)
+    assert loaded is not None
+    result = IncidenceRoutingProvider(loaded, RuleRouter()).route(
+        category="Housing", district="Sambalpur"
+    )
+
+    assert result.method != "learned"
+    assert result.empirical_evidence is None
+
+
+def test_incidence_provider_abstains_below_the_configured_support_gate(tmp_path):
+    rows = [
+        RouteRecord(
+            item_id=f"small-{index}",
+            group_id=f"small-{index}",
+            observed_on=date(2024, 1, 1),
+            category="Housing",
+            district="Sambalpur",
+            department="Housing Department",
+            split="train",
+        )
+        for index in range(4)
+    ]
+    artifact = save_incidence_router(
+        IncidenceRouter(alpha=10.0, serving_min_support=5).fit(rows),
+        tmp_path / "small",
+    )
+    loaded = load_incidence_router(artifact)
+    assert loaded is not None
+    result = IncidenceRoutingProvider(loaded, RuleRouter()).route(
+        category="Housing", district="Sambalpur"
+    )
+
+    assert result.method != "learned"
+    assert result.empirical_evidence is None
+
+
+def test_missing_incidence_artifact_is_an_explicit_safe_fallback(monkeypatch):
+    monkeypatch.setenv(ROUTER_ENV_VAR, ROUTER_INCIDENCE)
+    monkeypatch.setenv(
+        "JANASUNANI_ROUTING_INCIDENCE_ARTIFACT", "/definitely/not/present"
+    )
+    monkeypatch.setenv("JANASUNANI_MODELS_DIR", "/also/not/present")
+
+    provider = router_from_env()
+    name, ok, detail = router_status()
+
+    assert provider.route(category="Housing").method in {
+        "learned",
+        "rules",
+        "fallback",
+    }
+    assert name == ROUTER_DEFAULT
+    assert ok is False
+    assert "no local routing_incidence artifact" in detail
+
+
+def test_invalid_incidence_artifact_is_not_served(tmp_path, monkeypatch):
+    artifact = _artifact(tmp_path)
+    payload = json.loads(artifact.read_text())
+    payload["outcome_optimized"] = True
+    artifact.write_text(json.dumps(payload))
+    monkeypatch.setenv(ROUTER_ENV_VAR, ROUTER_INCIDENCE)
+    monkeypatch.setenv("JANASUNANI_ROUTING_INCIDENCE_ARTIFACT", str(artifact))
+
+    provider = router_from_env()
+    name, ok, detail = router_status()
+
+    assert not isinstance(provider, IncidenceRoutingProvider)
+    assert name == ROUTER_DEFAULT
+    assert ok is False
+    assert "corrupt, or invalid" in detail
+
+
+def test_fallback_failure_is_not_retried_or_misattributed():
+    class AbstainingRouter:
+        def predict_with_evidence(self, **_kwargs):
+            return None
+
+    class FailingFallback:
+        calls = 0
+
+        def route(self, **_kwargs):
+            self.calls += 1
+            raise RuntimeError("fallback unavailable")
+
+    fallback = FailingFallback()
+    provider = IncidenceRoutingProvider(AbstainingRouter(), fallback)
+
+    with pytest.raises(RuntimeError, match="fallback unavailable"):
+        provider.route(category="Housing")
+
+    assert fallback.calls == 1


### PR DESCRIPTION
## Summary

- Benchmark a chronological, aggregate-only empirical-Bayes model of the department recorded in the complaints lake.
- Select smoothing/history-window hyperparameters on validation, refit on pre-test history, and score an untouched test year.
- Serialize a checksummed, privacy-suppressed incidence artifact with minimum support, concentration, and margin gates.
- Keep the incidence provider opt-in and fail back to the existing crosswalk/rules ladder.

## Historical stack position

This is the next historical slice after #253:

- Base: `feat/actionability-adjudication`
- Head: `feat/routing-incidence`
- Exact head: `fdf8f8dfdc95546cd5371341e619e1a3c2bd5464`
- Primary feature commits: `e8136d6` and `b69a939`, followed by four ancestor synchronization merges

PRs #250–#253 have completed exact-head review and were closed as already integrated. This head is also contained in `feat/pipeline-quality-trunk` (0 commits unique here; 77 integration commits after it). It will be reconciled only after its own Codex findings are addressed and exact-head gate is green.

## Verification on this exact slice

- Historical loader, routing evaluation, and incidence-provider modules: **27 passed**.
- Ruff passed for all six changed implementation/test files.
- `git diff --check` passed.
- Historical pipeline, lint, and raw-data checks are green; the draft exemption must be replaced by a real exact-head Codex verdict.

No file under `data/` was opened or reproduced during this review pass.

## Unconfirmed source-field semantics

The source-system owner is unavailable. We therefore do **not** have confirmation that `complaints.dept` is immutable initial assignment, current/final department, or another snapshot convention. This PR must be read narrowly as agreement with the department value recorded in the lake snapshot.

In particular, it does **not** establish:

- de jure assignment intent (the jointly selected department-and-complete-chain treatment);
- de facto handling (the nodes actually reached in action history);
- the correct authority, best route, outcome improvement, or citizen benefit;
- compatibility with the joint department-and-chain action used by the causal routing model.

The implementation is opt-in rather than the default router, but the exact review should verify whether an unconfirmed field is sufficiently governed even for optional serving.

## Evidence and safety boundaries

- Objective is `historical_incidence_only`; `outcome_optimized` is always false.
- Weighted-cell Wilson intervals are suppressed because complaint independence is not available.
- Sparse/ambiguous cells abstain and use the existing governed fallback.
- Artifacts contain aggregate counts only and suppress keys below the privacy floor.
- A checksum or schema failure disables the incidence provider rather than making a network call or returning an unvalidated route.

## Self-review points for exact review

- Verify the language “historically sent” is not stronger than the unconfirmed `dept` snapshot supports.
- Verify optional serving cannot be mistaken for policy correctness or for the joint department-and-chain treatment.
- Verify suppressed aggregate cells cannot influence a served posterior while citing a broader cell as evidence.
- Verify all numeric artifact parameters reject booleans, non-finite values, and malformed JSON.
