### PR TITLE
feat(tracking): add model release control plane

### DIFF
--- a/deploy/model-release.example.json
+++ b/deploy/model-release.example.json
@@ -1,0 +1,141 @@
+{
+  "release_id": "replace-with-reviewed-release-id",
+  "git_sha": "replace-with-full-git-sha",
+  "models": {
+    "format_classifier": {
+      "registry_name": "janasunani-format-classifier",
+      "alias": "production",
+      "provider": "local_xgboost",
+      "trust_tier": "local",
+      "artifact_sha256": "replace-with-approved-sha256",
+      "parameters": {
+        "feature_contract": "format-classifier-v3"
+      },
+      "input_schema_version": "page-image/v1",
+      "output_schema_version": "page-format/v1",
+      "benchmark_run_id": "replace-with-governed-run-id",
+      "dataset_id": "replace-with-dataset-fingerprint",
+      "gold_id": "replace-with-gold-set-id"
+    },
+    "page_type_classifier": {
+      "registry_name": "janasunani-page-type-classifier",
+      "alias": "production",
+      "provider": "local_transformers",
+      "trust_tier": "local",
+      "artifact_sha256": "replace-with-approved-sha256",
+      "parameters": {
+        "target_grievance_class": 1,
+        "local_files_only": true
+      },
+      "input_schema_version": "page-image/v1",
+      "output_schema_version": "page-type/v1",
+      "benchmark_run_id": "replace-with-governed-run-id",
+      "dataset_id": "replace-with-dataset-fingerprint",
+      "gold_id": "replace-with-gold-set-id"
+    },
+    "actionability": {
+      "registry_name": "janasunani-actionability",
+      "alias": "production",
+      "provider": "local_sklearn",
+      "trust_tier": "local",
+      "artifact_sha256": "replace-with-approved-sha256",
+      "parameters": {
+        "taxonomy_version": "actionability-v1",
+        "review_threshold": 0.7
+      },
+      "input_schema_version": "redacted-text/v1",
+      "output_schema_version": "actionability-v1",
+      "benchmark_run_id": "replace-with-governed-run-id",
+      "dataset_id": "replace-with-dataset-fingerprint",
+      "gold_id": "replace-with-gold-set-id"
+    },
+    "routing_incidence": {
+      "registry_name": "janasunani-routing-incidence",
+      "alias": "production",
+      "provider": "local_empirical_bayes",
+      "trust_tier": "local",
+      "artifact_sha256": "replace-with-approved-sha256",
+      "parameters": {
+        "alpha": 100.0,
+        "history_years": 1,
+        "use_subcategory": false,
+        "outcome_optimized": false
+      },
+      "input_schema_version": "category-district/v1",
+      "output_schema_version": "routing-result/v1",
+      "benchmark_run_id": "replace-with-governed-run-id",
+      "dataset_id": "replace-with-dataset-fingerprint"
+    },
+    "categorizer": {
+      "registry_name": "janasunani-categorizer",
+      "alias": "production",
+      "provider": "local_transformers",
+      "trust_tier": "local",
+      "artifact_sha256": "replace-with-approved-sha256",
+      "parameters": {
+        "language_gate": "english-compatible",
+        "local_files_only": true
+      },
+      "input_schema_version": "redacted-text/v1",
+      "output_schema_version": "category/v1",
+      "benchmark_run_id": "replace-with-governed-run-id",
+      "dataset_id": "replace-with-dataset-fingerprint",
+      "gold_id": "replace-with-gold-set-id"
+    },
+    "summarizer": {
+      "registry_name": "janasunani-summarizer",
+      "alias": "production",
+      "provider": "local_transformers",
+      "trust_tier": "local",
+      "artifact_sha256": "replace-with-approved-sha256",
+      "parameters": {
+        "max_input_tokens": 1024,
+        "min_output_tokens": 20,
+        "max_output_tokens": 100,
+        "num_beams": 4,
+        "local_files_only": true
+      },
+      "input_schema_version": "redacted-text/v1",
+      "output_schema_version": "summary/v1",
+      "benchmark_run_id": "replace-with-governed-run-id",
+      "dataset_id": "replace-with-dataset-fingerprint",
+      "gold_id": "replace-with-gold-set-id"
+    },
+    "deepseek_ocr": {
+      "registry_name": "janasunani-deepseek-ocr",
+      "alias": "candidate",
+      "provider": "local_transformers",
+      "trust_tier": "experimental",
+      "artifact_sha256": "replace-with-approved-sha256",
+      "parameters": {
+        "attn_implementation": "eager",
+        "base_size": 1024,
+        "image_size": 640,
+        "crop_mode": true,
+        "repetition_penalty": 1.2,
+        "no_repeat_ngram_size": 3,
+        "temperature": 0.7,
+        "local_files_only": true
+      },
+      "input_schema_version": "page-image/v1",
+      "output_schema_version": "ocr-text/v1",
+      "benchmark_run_id": "replace-with-governed-run-id",
+      "dataset_id": "replace-with-dataset-fingerprint",
+      "gold_id": "replace-with-transcription-gold-id"
+    },
+    "sarvam_digitise": {
+      "provider": "sarvam",
+      "trust_tier": "authorized_hosted",
+      "version": "replace-with-observed-provider-model-id",
+      "endpoint": "sarvam-digitise",
+      "parameters": {
+        "submission_rate_per_minute": 10,
+        "poll_seconds": 5,
+        "attempts": 3
+      },
+      "input_schema_version": "provider-request/v1",
+      "output_schema_version": "sarvam-digitise/v1",
+      "benchmark_run_id": "replace-with-cached-evidence-run-id"
+    }
+  }
+}

--- a/janasunani/inference/service.py
+++ b/janasunani/inference/service.py
@@ -615,6 +615,50 @@ def _triage_check() -> DependencyCheck:
     return DependencyCheck(f"triage ({name})", ok, detail, required=False)
 
 
+def _model_release_check() -> DependencyCheck:
+    """Expose the active immutable model release without revealing endpoints.
+
+    Serving never resolves MLflow aliases here. This check only reads the
+    local active pointer/manifest, validates every pinned local artifact, and
+    reports immutable versions plus short checksums for operator visibility.
+    """
+    try:
+        from janasunani.tracking.release import (
+            active_manifest_path,
+            load_manifest,
+            resolve_manifest_artifact,
+        )
+
+        path = active_manifest_path()
+        if path is None:
+            return DependencyCheck(
+                "model release",
+                False,
+                "no active immutable release manifest; using operator/DVC resolution",
+                required=False,
+            )
+        manifest = load_manifest(path)
+        versions = []
+        for name in sorted(manifest.models):
+            model = manifest.models[name]
+            if model.artifact_path is not None:
+                resolve_manifest_artifact(name, manifest_path=path)
+                identity = f"sha256:{model.artifact_sha256[:12]}"
+            else:
+                identity = "authorized-hosted"
+            versions.append(f"{name}@{model.version} ({identity})")
+    except Exception as exc:  # pragma: no cover - defensive; never raise
+        return DependencyCheck(
+            "model release", False, f"invalid active release: {exc}", required=False
+        )
+    return DependencyCheck(
+        "model release",
+        True,
+        f"release_id={manifest.release_id}; " + ", ".join(versions),
+        required=False,
+    )
+
+
 # The exact columns janasunani/serving/history.py's LakeHistory.search()
 # selects. Duplicated here (not imported) rather than sharing a constant with
 # janasunani.serving.history: preflight lives in this module specifically so
@@ -800,6 +844,7 @@ def preflight(models_dir: str | Path | None = None) -> list[DependencyCheck]:
     # OLTP_DB_URL is explicitly set: it opens a real, timeout-bounded
     # connection (_OLTP_PROBE_TIMEOUT_S) rather than just checking presence.
     checks.append(_routing_mappings_check())
+    checks.append(_model_release_check())
     checks.append(_router_check())
     checks.append(_triage_check())
     checks.append(_lake_check())

--- a/janasunani/tracking/materialize.py
+++ b/janasunani/tracking/materialize.py
@@ -1,0 +1,311 @@
+"""Materialize approved MLflow aliases into a local immutable release.
+
+This command is the only registry read path.  It is run before deployment;
+request-serving code reads only :mod:`janasunani.tracking.release`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import tempfile
+from typing import Any, Callable, Mapping, Sequence
+
+from janasunani.tracking.mlflow_utils import DVC_HASH_TAG, DVC_PATH_TAG
+from janasunani.tracking.release import (
+    ModelRelease,
+    ReleaseManifestError,
+    activate_manifest,
+    artifact_sha256,
+    new_manifest,
+    validate_release_identifier,
+    write_manifest,
+)
+
+
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+_GIT_SHA = re.compile(r"^[0-9a-f]{40}(?:[0-9a-f]{24})?$")
+_DVC_HASH = re.compile(r"^(?:(?:md5|sha256):)?(?:[0-9a-f]{32}|[0-9a-f]{64})(?:\.dir)?$")
+_LOCAL_MODEL_FIELDS = frozenset(
+    {
+        "registry_name",
+        "alias",
+        "provider",
+        "trust_tier",
+        "artifact_sha256",
+        "parameters",
+        "input_schema_version",
+        "output_schema_version",
+        "benchmark_run_id",
+        "dataset_id",
+        "gold_id",
+    }
+)
+
+
+def materialize_release(
+    *,
+    spec: Mapping[str, Any],
+    release_root: Path,
+    tracking_uri: str | None = None,
+    activate: bool = False,
+    client: Any | None = None,
+    downloader: Callable[..., str] | None = None,
+) -> Path:
+    """Resolve all aliases, verify provenance, and publish one release.
+
+    ``client`` and ``downloader`` are injectable for tests.  Production imports
+    MLflow lazily here, never from the runtime resolver.
+    """
+    release_id, git_sha, models = _parse_spec(spec)
+    release_root = release_root.resolve()
+    release_root.mkdir(parents=True, exist_ok=True)
+    final_dir = release_root / release_id
+    if final_dir.exists():
+        raise FileExistsError(final_dir)
+
+    if client is None or downloader is None:
+        import mlflow
+        from mlflow.tracking import MlflowClient
+
+        if tracking_uri:
+            mlflow.set_tracking_uri(tracking_uri)
+        if client is None:
+            client = MlflowClient(tracking_uri=tracking_uri)
+        if downloader is None:
+            downloader = mlflow.artifacts.download_artifacts
+
+    staging = Path(tempfile.mkdtemp(prefix=f".{release_id}.", dir=release_root))
+    releases: dict[str, ModelRelease] = {}
+    reserved_final_dir = False
+    try:
+        for name, config in models.items():
+            if config.get("endpoint"):
+                releases[name] = _hosted_release(name, config)
+                continue
+            releases[name] = _materialize_registry_model(
+                name=name,
+                config=config,
+                staging=staging,
+                client=client,
+                downloader=downloader,
+            )
+        manifest = new_manifest(release_id=release_id, git_sha=git_sha, models=releases)
+        write_manifest(staging / "release-manifest.json", manifest)
+        final_dir.mkdir()
+        reserved_final_dir = True
+        for item in staging.iterdir():
+            os.replace(item, final_dir / item.name)
+        staging.rmdir()
+    except Exception:
+        shutil.rmtree(staging, ignore_errors=True)
+        if reserved_final_dir:
+            shutil.rmtree(final_dir, ignore_errors=True)
+        raise
+
+    manifest_path = final_dir / "release-manifest.json"
+    if activate:
+        activate_manifest(manifest_path, root=release_root)
+    return manifest_path
+
+
+def _parse_spec(
+    spec: Mapping[str, Any],
+) -> tuple[str, str, Mapping[str, Mapping[str, Any]]]:
+    allowed = {"release_id", "git_sha", "models"}
+    unknown = set(spec) - allowed
+    if unknown:
+        raise ReleaseManifestError(f"unknown materialization fields: {sorted(unknown)}")
+    release_id = spec.get("release_id")
+    git_sha = spec.get("git_sha") or _git_sha()
+    models = spec.get("models")
+    release_id = validate_release_identifier(release_id, field="release_id")
+    if not isinstance(git_sha, str) or _GIT_SHA.fullmatch(git_sha) is None:
+        raise ReleaseManifestError(
+            "git_sha must be a full 40- or 64-character SHA"
+        )
+    if not isinstance(models, Mapping) or not models:
+        raise ReleaseManifestError("models must be a non-empty object")
+    for name, config in models.items():
+        if not isinstance(name, str) or not isinstance(config, Mapping):
+            raise ReleaseManifestError("each model spec must be a named object")
+        validate_release_identifier(name, field="model name")
+        if config.get("endpoint"):
+            ModelRelease.from_dict(name, config)
+        else:
+            unknown = set(config) - _LOCAL_MODEL_FIELDS
+            if unknown:
+                raise ReleaseManifestError(
+                    f"model {name!r} has unknown materialization fields: "
+                    f"{sorted(unknown)}"
+                )
+            _validate_local_spec(name, config)
+    return release_id, git_sha, models
+
+
+def _concrete_identifier(value: object, *, model: str, field: str) -> str:
+    if (
+        not isinstance(value, str)
+        or not value.strip()
+        or value.strip().lower().startswith("replace-with")
+    ):
+        raise ReleaseManifestError(f"model {model!r} must pin a concrete {field}")
+    return value.strip()
+
+
+def _validate_local_spec(name: str, config: Mapping[str, Any]) -> None:
+    expected = config.get("artifact_sha256")
+    if not isinstance(expected, str) or _SHA256.fullmatch(expected) is None:
+        raise ReleaseManifestError(
+            f"model {name!r} must pin an approved artifact_sha256 before download"
+        )
+    _concrete_identifier(
+        config.get("benchmark_run_id"), model=name, field="benchmark_run_id"
+    )
+    _concrete_identifier(config.get("dataset_id"), model=name, field="dataset_id")
+    _concrete_identifier(config.get("alias"), model=name, field="alias")
+    _concrete_identifier(
+        config.get("registry_name") or name, model=name, field="registry_name"
+    )
+    trust_tier = config.get("trust_tier") or "local"
+    if trust_tier not in {"local", "experimental"}:
+        raise ReleaseManifestError(
+            f"local model {name!r} has invalid trust_tier {trust_tier!r}"
+        )
+    parameters = config.get("parameters")
+    if parameters is not None and not isinstance(parameters, Mapping):
+        raise ReleaseManifestError(f"model {name!r} parameters must be an object")
+
+
+def _materialize_registry_model(
+    *,
+    name: str,
+    config: Mapping[str, Any],
+    staging: Path,
+    client: Any,
+    downloader: Callable[..., str],
+) -> ModelRelease:
+    registry_name = str(config.get("registry_name") or name)
+    alias = config.get("alias")
+    if not isinstance(alias, str) or not alias:
+        raise ReleaseManifestError(f"model {name!r} must request a registry alias")
+    version = client.get_model_version_by_alias(registry_name, alias)
+    tags = dict(getattr(version, "tags", {}) or {})
+    dvc_path = tags.get(DVC_PATH_TAG)
+    dvc_hash = tags.get(DVC_HASH_TAG)
+    if not dvc_path or not dvc_hash:
+        raise ReleaseManifestError(
+            f"model {name!r} version {version.version} lacks DVC provenance tags"
+        )
+    dvc_relative = Path(str(dvc_path))
+    if dvc_relative.is_absolute() or ".." in dvc_relative.parts:
+        raise ReleaseManifestError(
+            f"model {name!r} has unsafe DVC provenance path {dvc_path!r}"
+        )
+    if _DVC_HASH.fullmatch(str(dvc_hash)) is None:
+        raise ReleaseManifestError(
+            f"model {name!r} has invalid DVC provenance hash {dvc_hash!r}"
+        )
+    source = getattr(version, "source", None)
+    if not source:
+        raise ReleaseManifestError(
+            f"model {name!r} version {version.version} has no source"
+        )
+    destination = staging / "artifacts" / name
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    downloaded = Path(downloader(artifact_uri=source, dst_path=destination.parent))
+    try:
+        downloaded.resolve().relative_to(destination.parent.resolve())
+    except ValueError as exc:
+        raise ReleaseManifestError(
+            f"model {name!r} download escaped its staging directory"
+        ) from exc
+    if downloaded.resolve() != destination.resolve():
+        if destination.exists():
+            raise ReleaseManifestError(
+                f"download destination already exists: {destination}"
+            )
+        shutil.move(downloaded, destination)
+    digest = artifact_sha256(destination)
+    expected = config["artifact_sha256"]
+    if expected != digest:
+        raise ReleaseManifestError(
+            f"model {name!r} downloaded checksum {digest} does not match approved {expected}"
+        )
+    return ModelRelease(
+        name=name,
+        provider=str(config.get("provider") or "local"),
+        trust_tier=str(config.get("trust_tier") or "local"),
+        version=str(version.version),
+        artifact_path=f"artifacts/{name}",
+        artifact_sha256=digest,
+        alias=alias,
+        parameters=config.get("parameters"),
+        input_schema_version=config.get("input_schema_version"),
+        output_schema_version=config.get("output_schema_version"),
+        dvc_path=dvc_path,
+        dvc_hash=dvc_hash,
+        benchmark_run_id=config.get("benchmark_run_id") or tags.get("benchmark.run_id"),
+        dataset_id=config.get("dataset_id") or tags.get("dataset.id"),
+        gold_id=config.get("gold_id") or tags.get("gold.id"),
+    )
+
+
+def _hosted_release(name: str, config: Mapping[str, Any]) -> ModelRelease:
+    version = config.get("version")
+    if not isinstance(version, str) or not version:
+        raise ReleaseManifestError(f"hosted model {name!r} must pin observed version")
+    return ModelRelease.from_dict(name, dict(config))
+
+
+def _git_sha() -> str | None:
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"], capture_output=True, text=True, check=False
+    )
+    return result.stdout.strip() if result.returncode == 0 else None
+
+
+def _load_spec(path: Path) -> Mapping[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, Mapping):
+        raise ReleaseManifestError("materialization spec root must be an object")
+    return payload
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    materialize = subparsers.add_parser("materialize")
+    materialize.add_argument("--spec", type=Path, required=True)
+    materialize.add_argument(
+        "--release-root", type=Path, default=Path("models/releases")
+    )
+    materialize.add_argument("--tracking-uri")
+    materialize.add_argument("--activate", action="store_true")
+    activation = subparsers.add_parser("activate")
+    activation.add_argument("manifest", type=Path)
+    activation.add_argument(
+        "--release-root", type=Path, default=Path("models/releases")
+    )
+    args = parser.parse_args(argv)
+    if args.command == "materialize":
+        path = materialize_release(
+            spec=_load_spec(args.spec),
+            release_root=args.release_root,
+            tracking_uri=args.tracking_uri,
+            activate=args.activate,
+        )
+        print(path)
+        return 0
+    activate_manifest(args.manifest, root=args.release_root)
+    print(args.manifest)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/janasunani/tracking/mlflow_utils.py
+++ b/janasunani/tracking/mlflow_utils.py
@@ -8,9 +8,11 @@ let operators resolve the exact mirrored artifact.
 from __future__ import annotations
 
 from dataclasses import dataclass
+import hashlib
 import math
 import os
 from pathlib import Path
+import re
 from typing import Mapping, Optional
 
 import mlflow
@@ -22,6 +24,14 @@ from janasunani.config import settings
 
 DVC_PATH_TAG = "dvc.path"
 DVC_HASH_TAG = "dvc.hash"
+
+_GOVERNED_EVALUATION_EXPERIMENT_DEFAULT = "janasunani-governed-evaluation"
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+_FINGERPRINT_RE = re.compile(
+    r"^[a-z0-9][a-z0-9._+-]*:[0-9a-f]{32,128}(?:\.dir)?$"
+)
+_GIT_SHA_RE = re.compile(r"^[0-9a-f]{40}(?:[0-9a-f]{24})?$")
+_SHA256_RE = re.compile(r"^(?:sha256:)?[0-9a-f]{64}$")
 
 
 @dataclass(frozen=True)
@@ -174,6 +184,156 @@ def _create_model_version(
     for key, value in tags.items():
         client.set_model_version_tag(name, model_version.version, key, value)
     return model_version.version
+
+
+def _require_identifier(value: str, *, field: str) -> str:
+    if not isinstance(value, str) or _IDENTIFIER_RE.fullmatch(value) is None:
+        raise ValueError(
+            f"{field} must be a non-empty identifier containing only letters, "
+            "numbers, dot, underscore, or hyphen"
+        )
+    return value
+
+
+def _require_fingerprint(value: str, *, field: str) -> str:
+    if not isinstance(value, str) or _FINGERPRINT_RE.fullmatch(value) is None:
+        raise ValueError(
+            f"{field} must be an algorithm-prefixed hexadecimal fingerprint"
+        )
+    return value
+
+
+def _parameter_value(value: object, *, key: str) -> str:
+    """Serialize one governed hyperparameter without losing its value.
+
+    Evaluation parameters are deliberately scalar.  Nested structures are
+    report artifacts, not MLflow parameters: accepting them here risks MLflow
+    truncating a JSON blob while the run still appears fully specified.
+    """
+
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, str):
+        return value
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float) and math.isfinite(value):
+        return repr(value)
+    raise ValueError(
+        f"parameter {key!r} must be a scalar string, number, boolean, or None"
+    )
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def log_evaluation_run(
+    *,
+    task: str,
+    dataset_fingerprint: str,
+    split_fingerprint: str,
+    code_sha: str,
+    dependency_lock_sha: str,
+    report_schema: str,
+    report_version: str,
+    parameters: Mapping[str, object],
+    metrics: Mapping[str, float],
+    report_path: Path | str,
+    experiment_name: str = _GOVERNED_EVALUATION_EXPERIMENT_DEFAULT,
+    tracking_uri: str | None = None,
+    artifact_uri: str | None = None,
+) -> str:
+    """Log one reproducible, governed evaluation run.
+
+    Unlike :func:`log_benchmark_run`, this helper refuses incomplete
+    provenance.  Every value needed to distinguish the data, split, code,
+    dependency environment, report contract, and model parameterization is an
+    immutable MLflow parameter.  The non-empty report is logged alongside its
+    SHA-256 digest so a later promotion can prove which report it reviewed.
+
+    Validation completes before MLflow is configured or an experiment/run is
+    created.  Callers therefore cannot leave a plausible-looking partial run
+    merely by omitting a fingerprint or passing an invalid metric.
+    """
+
+    task = _require_identifier(task, field="task")
+    dataset_fingerprint = _require_fingerprint(
+        dataset_fingerprint, field="dataset_fingerprint"
+    )
+    split_fingerprint = _require_fingerprint(
+        split_fingerprint, field="split_fingerprint"
+    )
+    if not isinstance(code_sha, str) or _GIT_SHA_RE.fullmatch(code_sha) is None:
+        raise ValueError("code_sha must be a full 40- or 64-character Git SHA")
+    if (
+        not isinstance(dependency_lock_sha, str)
+        or _SHA256_RE.fullmatch(dependency_lock_sha) is None
+    ):
+        raise ValueError("dependency_lock_sha must be a SHA-256 digest")
+    report_schema = _require_identifier(report_schema, field="report_schema")
+    report_version = _require_identifier(report_version, field="report_version")
+    experiment_name = _require_identifier(experiment_name, field="experiment_name")
+
+    if not isinstance(parameters, Mapping) or not parameters:
+        raise ValueError("parameters must contain the full evaluation parameterization")
+    parameter_values: dict[str, str] = {}
+    for key, value in parameters.items():
+        clean_key = _require_identifier(key, field="parameter name")
+        parameter_values[f"parameter.{clean_key}"] = _parameter_value(
+            value, key=clean_key
+        )
+
+    if not isinstance(metrics, Mapping) or not metrics:
+        raise ValueError("metrics must contain at least one evaluation metric")
+    metric_values: dict[str, float] = {}
+    for key, value in metrics.items():
+        clean_key = _require_identifier(key, field="metric name")
+        try:
+            metric_value = float(value)
+        except (TypeError, ValueError, OverflowError):
+            metric_value = math.nan
+        if isinstance(value, bool) or not math.isfinite(metric_value):
+            raise ValueError(f"metric {clean_key!r} must be a finite number")
+        metric_values[clean_key] = metric_value
+
+    try:
+        report = Path(report_path)
+    except TypeError as exc:
+        raise ValueError("report_path must name an existing file") from exc
+    if not report.is_file():
+        raise ValueError("report_path must name an existing file")
+    try:
+        if report.stat().st_size <= 0:
+            raise ValueError("report_path must not be empty")
+        report_sha256 = _sha256(report)
+    except OSError as exc:
+        raise ValueError("report_path could not be read") from exc
+
+    provenance = {
+        "evaluation.task": task,
+        "dataset.fingerprint": dataset_fingerprint,
+        "split.fingerprint": split_fingerprint,
+        "code.sha": code_sha,
+        "dependency_lock.sha256": dependency_lock_sha.removeprefix("sha256:"),
+        "report.schema": report_schema,
+        "report.version": report_version,
+        "report.sha256": report_sha256,
+    }
+    experiment_id = ensure_experiment(
+        experiment_name, tracking_uri=tracking_uri, artifact_uri=artifact_uri
+    )
+    with mlflow.start_run(experiment_id=experiment_id) as run:
+        mlflow.log_params({**provenance, **parameter_values})
+        mlflow.log_metrics(metric_values)
+        mlflow.log_artifact(report.as_posix(), artifact_path="report")
+        return run.info.run_id
 
 
 # ---------------------------------------------------------------------------

--- a/janasunani/tracking/release.py
+++ b/janasunani/tracking/release.py
@@ -1,0 +1,399 @@
+"""Immutable, local-only model release manifests.
+
+MLflow aliases are intentionally resolved by the deployment control plane, not
+by a serving process.  The serving side consumes this manifest and verifies the
+bytes it is about to load.  That makes an alias promotion reviewable and keeps a
+moving registry or a network outage out of the request path.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import tempfile
+from typing import Any, Mapping
+
+
+SCHEMA_VERSION = "janasunani.release/v1"
+RELEASE_MANIFEST_ENV_VAR = "JANASUNANI_RELEASE_MANIFEST"
+RELEASE_ROOT_ENV_VAR = "JANASUNANI_RELEASE_ROOT"
+ACTIVE_POINTER = "active.json"
+_RELEASE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+_GIT_SHA = re.compile(r"^[0-9a-f]{40}(?:[0-9a-f]{24})?$")
+_TRUST_TIERS = frozenset({"local", "authorized_hosted", "experimental"})
+
+
+class ReleaseManifestError(ValueError):
+    """The manifest or the artifact it pins is invalid."""
+
+
+def validate_release_identifier(value: object, *, field: str) -> str:
+    """Return a filesystem-safe release identifier or raise.
+
+    Materialization uses this before any download or filesystem mutation; the
+    manifest parser uses the same rule when reading an existing release.
+    """
+
+    if not isinstance(value, str) or _RELEASE_ID.fullmatch(value) is None:
+        raise ReleaseManifestError(f"invalid {field} {value!r}")
+    return value
+
+
+def artifact_sha256(path: Path) -> str:
+    """Return a stable digest for one file or an entire artifact directory.
+
+    Directory hashes include relative POSIX paths, file sizes, and file bytes.
+    Symlinks are rejected so an artifact cannot escape its pinned directory
+    after validation.
+    """
+    path = Path(path)
+    if path.is_symlink():
+        raise ReleaseManifestError(f"artifact is a symlink: {path}")
+    path = path.resolve()
+    if path.is_file():
+        return _file_sha256(path)
+    if not path.is_dir():
+        raise ReleaseManifestError(f"artifact is not a file or directory: {path}")
+
+    digest = hashlib.sha256()
+    files: list[Path] = []
+    for item in path.rglob("*"):
+        # Check every node before filtering for files. A symlink to a directory
+        # is not ``is_file()``, and filtering first silently excluded exactly
+        # the kind of link that can escape a checksummed artifact tree.
+        if item.is_symlink():
+            raise ReleaseManifestError(f"artifact contains a symlink: {item}")
+        if item.is_file():
+            files.append(item)
+    files.sort()
+    if not files:
+        raise ReleaseManifestError(f"artifact directory is empty: {path}")
+    for item in files:
+        relative = item.relative_to(path).as_posix().encode("utf-8")
+        digest.update(len(relative).to_bytes(8, "big"))
+        digest.update(relative)
+        digest.update(item.stat().st_size.to_bytes(8, "big"))
+        with item.open("rb") as handle:
+            for block in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(block)
+    return digest.hexdigest()
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+@dataclass(frozen=True)
+class ModelRelease:
+    """One immutable model/provider choice in a release."""
+
+    name: str
+    provider: str
+    trust_tier: str
+    version: str
+    artifact_path: str | None = None
+    artifact_sha256: str | None = None
+    alias: str | None = None
+    endpoint: str | None = None
+    parameters: Mapping[str, Any] | None = None
+    input_schema_version: str | None = None
+    output_schema_version: str | None = None
+    dvc_path: str | None = None
+    dvc_hash: str | None = None
+    benchmark_run_id: str | None = None
+    dataset_id: str | None = None
+    gold_id: str | None = None
+
+    @classmethod
+    def from_dict(cls, name: str, payload: Mapping[str, Any]) -> ModelRelease:
+        allowed = {
+            "provider",
+            "trust_tier",
+            "version",
+            "artifact_path",
+            "artifact_sha256",
+            "alias",
+            "endpoint",
+            "parameters",
+            "input_schema_version",
+            "output_schema_version",
+            "dvc_path",
+            "dvc_hash",
+            "benchmark_run_id",
+            "dataset_id",
+            "gold_id",
+        }
+        unknown = set(payload) - allowed
+        if unknown:
+            raise ReleaseManifestError(
+                f"model {name!r} has unknown fields: {sorted(unknown)}"
+            )
+        required = ("provider", "trust_tier", "version")
+        missing = [field for field in required if not payload.get(field)]
+        if missing:
+            raise ReleaseManifestError(f"model {name!r} is missing {missing}")
+        trust_tier = str(payload["trust_tier"])
+        if trust_tier not in _TRUST_TIERS:
+            raise ReleaseManifestError(
+                f"model {name!r} has unsupported trust_tier {trust_tier!r}"
+            )
+        artifact_path = payload.get("artifact_path")
+        endpoint = payload.get("endpoint")
+        artifact_digest = payload.get("artifact_sha256")
+        if bool(artifact_path) == bool(endpoint):
+            raise ReleaseManifestError(
+                f"model {name!r} must pin exactly one of artifact_path or endpoint"
+            )
+        if artifact_path and not artifact_digest:
+            raise ReleaseManifestError(
+                f"model {name!r} with artifact_path must pin artifact_sha256"
+            )
+        if artifact_digest is not None and (
+            not isinstance(artifact_digest, str)
+            or _SHA256.fullmatch(artifact_digest) is None
+        ):
+            raise ReleaseManifestError(
+                f"model {name!r} artifact_sha256 must be 64 lowercase hex characters"
+            )
+        if endpoint and trust_tier != "authorized_hosted":
+            raise ReleaseManifestError(
+                f"hosted model {name!r} must use trust_tier='authorized_hosted'"
+            )
+        parameters = payload.get("parameters")
+        if parameters is not None and not isinstance(parameters, Mapping):
+            raise ReleaseManifestError(f"model {name!r} parameters must be an object")
+        return cls(name=name, **dict(payload))
+
+    def as_dict(self) -> dict[str, Any]:
+        payload = {
+            field: getattr(self, field)
+            for field in (
+                "provider",
+                "trust_tier",
+                "version",
+                "artifact_path",
+                "artifact_sha256",
+                "alias",
+                "endpoint",
+                "parameters",
+                "input_schema_version",
+                "output_schema_version",
+                "dvc_path",
+                "dvc_hash",
+                "benchmark_run_id",
+                "dataset_id",
+                "gold_id",
+            )
+            if getattr(self, field) is not None
+        }
+        return payload
+
+
+@dataclass(frozen=True)
+class ReleaseManifest:
+    release_id: str
+    created_at: str
+    git_sha: str
+    models: Mapping[str, ModelRelease]
+    schema_version: str = SCHEMA_VERSION
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> ReleaseManifest:
+        allowed = {"schema_version", "release_id", "created_at", "git_sha", "models"}
+        unknown = set(payload) - allowed
+        if unknown:
+            raise ReleaseManifestError(f"unknown manifest fields: {sorted(unknown)}")
+        if payload.get("schema_version") != SCHEMA_VERSION:
+            raise ReleaseManifestError(
+                f"unsupported schema_version {payload.get('schema_version')!r}"
+            )
+        release_id = validate_release_identifier(
+            payload.get("release_id"), field="release_id"
+        )
+        created_at = str(payload.get("created_at", ""))
+        try:
+            parsed = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise ReleaseManifestError("created_at must be ISO-8601") from exc
+        if parsed.tzinfo is None:
+            raise ReleaseManifestError("created_at must include a timezone")
+        git_sha = str(payload.get("git_sha", ""))
+        if _GIT_SHA.fullmatch(git_sha) is None:
+            raise ReleaseManifestError("git_sha must be a full 40- or 64-character SHA")
+        model_payload = payload.get("models")
+        if not isinstance(model_payload, Mapping) or not model_payload:
+            raise ReleaseManifestError("models must be a non-empty object")
+        models: dict[str, ModelRelease] = {}
+        for name, model in model_payload.items():
+            validate_release_identifier(name, field="model name")
+            if not isinstance(model, Mapping):
+                raise ReleaseManifestError(f"model {name!r} must be an object")
+            models[name] = ModelRelease.from_dict(name, model)
+        return cls(
+            release_id=release_id,
+            created_at=created_at,
+            git_sha=git_sha,
+            models=models,
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "release_id": self.release_id,
+            "created_at": self.created_at,
+            "git_sha": self.git_sha,
+            "models": {
+                name: self.models[name].as_dict() for name in sorted(self.models)
+            },
+        }
+
+
+def load_manifest(path: Path) -> ReleaseManifest:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ReleaseManifestError(
+            f"cannot read release manifest {path}: {exc}"
+        ) from exc
+    if not isinstance(payload, Mapping):
+        raise ReleaseManifestError("release manifest root must be an object")
+    return ReleaseManifest.from_dict(payload)
+
+
+def write_manifest(path: Path, manifest: ReleaseManifest) -> None:
+    """Atomically write a validated manifest; never overwrite a release."""
+    validated = ReleaseManifest.from_dict(manifest.as_dict())
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        raise FileExistsError(path)
+    encoded = json.dumps(validated.as_dict(), indent=2, sort_keys=True) + "\n"
+    fd, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.link(temporary, path)
+        Path(temporary).unlink()
+    except Exception:
+        Path(temporary).unlink(missing_ok=True)
+        raise
+
+
+def release_root(root: Path | None = None) -> Path:
+    if root is not None:
+        return root
+    return Path(os.environ.get(RELEASE_ROOT_ENV_VAR, "models/releases"))
+
+
+def active_manifest_path(root: Path | None = None) -> Path | None:
+    explicit = os.environ.get(RELEASE_MANIFEST_ENV_VAR)
+    if explicit:
+        return Path(explicit)
+    base = release_root(root)
+    pointer = base / ACTIVE_POINTER
+    try:
+        payload = json.loads(pointer.read_text(encoding="utf-8"))
+        relative = payload["manifest"]
+    except (OSError, json.JSONDecodeError, KeyError, TypeError):
+        return None
+    if not isinstance(relative, str) or Path(relative).is_absolute():
+        return None
+    candidate = (base / relative).resolve()
+    try:
+        candidate.relative_to(base.resolve())
+    except ValueError:
+        return None
+    return candidate if candidate.is_file() else None
+
+
+def activate_manifest(path: Path, *, root: Path | None = None) -> None:
+    """Atomically point serving at an already validated immutable manifest."""
+    manifest = load_manifest(path)
+    base = release_root(root).resolve()
+    resolved = path.resolve()
+    try:
+        relative = resolved.relative_to(base)
+    except ValueError as exc:
+        raise ReleaseManifestError("manifest must live under the release root") from exc
+    _validate_local_models(manifest, resolved)
+    base.mkdir(parents=True, exist_ok=True)
+    payload = (
+        json.dumps(
+            {"release_id": manifest.release_id, "manifest": relative.as_posix()},
+            sort_keys=True,
+        )
+        + "\n"
+    )
+    fd, temporary = tempfile.mkstemp(prefix=".active.", dir=base)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, base / ACTIVE_POINTER)
+    except Exception:
+        Path(temporary).unlink(missing_ok=True)
+        raise
+
+
+def resolve_manifest_artifact(
+    name: str, *, manifest_path: Path | None = None, root: Path | None = None
+) -> Path | None:
+    path = manifest_path or active_manifest_path(root)
+    if path is None:
+        return None
+    manifest = load_manifest(path)
+    model = manifest.models.get(name)
+    if model is None or model.artifact_path is None:
+        return None
+    artifact = _artifact_path(path, model.artifact_path)
+    if artifact_sha256(artifact) != model.artifact_sha256:
+        raise ReleaseManifestError(f"artifact checksum mismatch for model {name!r}")
+    return artifact
+
+
+def _artifact_path(manifest_path: Path, value: str) -> Path:
+    relative = Path(value)
+    if relative.is_absolute():
+        raise ReleaseManifestError("artifact_path must be relative to its manifest")
+    candidate = manifest_path.parent / relative
+    resolved = candidate.resolve()
+    try:
+        resolved.relative_to(manifest_path.parent.resolve())
+    except ValueError as exc:
+        raise ReleaseManifestError(
+            "artifact_path escapes its release directory"
+        ) from exc
+    return candidate
+
+
+def _validate_local_models(manifest: ReleaseManifest, manifest_path: Path) -> None:
+    for name, model in manifest.models.items():
+        if model.artifact_path is None:
+            continue
+        artifact = _artifact_path(manifest_path, model.artifact_path)
+        if artifact_sha256(artifact) != model.artifact_sha256:
+            raise ReleaseManifestError(f"artifact checksum mismatch for model {name!r}")
+
+
+def new_manifest(
+    *, release_id: str, git_sha: str, models: Mapping[str, ModelRelease]
+) -> ReleaseManifest:
+    now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    return ReleaseManifest(
+        release_id=release_id,
+        created_at=now,
+        git_sha=git_sha,
+        models=models,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,7 @@ janasunani-evaluate-benchmark = "janasunani.evaluation.benchmark_report:main"
 janasunani-evaluate-sarvam = "janasunani.evaluation.sarvam_evaluate:main"
 janasunani-build-sarvam-sample = "janasunani.evaluation.sarvam_sample_builder:main"
 janasunani-evaluate-routing = "janasunani.evaluation.historical:main"
+janasunani-model-release = "janasunani.tracking.materialize:main"
 janasunani-evaluate-summary = "janasunani.evaluation.summary:main"
 janasunani-audit-actionability-labels = "janasunani.evaluation.weak_labels:main"
 

--- a/tests/test_inference_live_builder.py
+++ b/tests/test_inference_live_builder.py
@@ -28,6 +28,13 @@ from janasunani.inference.service import (  # noqa: E402
 )
 from janasunani.pipeline.stages.ocr_extraction import page_renderer  # noqa: E402
 from janasunani.serving.api import create_app  # noqa: E402
+from janasunani.tracking.release import (  # noqa: E402
+    RELEASE_MANIFEST_ENV_VAR,
+    ModelRelease,
+    artifact_sha256,
+    new_manifest,
+    write_manifest,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -58,6 +65,78 @@ def _write_dummy_model_artifacts(root: Path) -> None:
     (page_type_dir / "config.json").write_text("{}")
     (page_type_dir / "model.safetensors").write_bytes(b"")
     (page_type_dir / "preprocessor_config.json").write_text("{}")
+def test_preflight_reports_immutable_release_versions_without_hosted_endpoint(
+    tmp_path, monkeypatch
+):
+    release_dir = tmp_path / "release-1"
+    artifact = release_dir / "artifacts" / "actionability"
+    artifact.mkdir(parents=True)
+    (artifact / "model.joblib").write_bytes(b"weights")
+    manifest = new_manifest(
+        release_id="release-1",
+        git_sha="a" * 40,
+        models={
+            "actionability": ModelRelease(
+                name="actionability",
+                provider="local_sklearn",
+                trust_tier="local",
+                version="12",
+                artifact_path="artifacts/actionability",
+                artifact_sha256=artifact_sha256(artifact),
+            ),
+            "sarvam_digitise": ModelRelease(
+                name="sarvam_digitise",
+                provider="sarvam",
+                trust_tier="authorized_hosted",
+                version="observed-2026-08-01",
+                endpoint="https://secret-provider.example/jobs",
+            ),
+        },
+    )
+    manifest_path = release_dir / "release-manifest.json"
+    write_manifest(manifest_path, manifest)
+    monkeypatch.setenv(RELEASE_MANIFEST_ENV_VAR, str(manifest_path))
+
+    release_check = next(check for check in preflight(tmp_path) if check.name == "model release")
+
+    assert release_check.ok is True
+    assert "release_id=release-1" in release_check.detail
+    assert "actionability@12" in release_check.detail
+    assert "sarvam_digitise@observed-2026-08-01" in release_check.detail
+    assert "secret-provider" not in release_check.detail
+
+
+def test_preflight_reports_checksum_drift_in_active_release(tmp_path, monkeypatch):
+    release_dir = tmp_path / "release-1"
+    artifact = release_dir / "artifacts" / "actionability"
+    artifact.mkdir(parents=True)
+    model_file = artifact / "model.joblib"
+    model_file.write_bytes(b"weights")
+    manifest_path = release_dir / "release-manifest.json"
+    write_manifest(
+        manifest_path,
+        new_manifest(
+            release_id="release-1",
+            git_sha="a" * 40,
+            models={
+                "actionability": ModelRelease(
+                    name="actionability",
+                    provider="local_sklearn",
+                    trust_tier="local",
+                    version="12",
+                    artifact_path="artifacts/actionability",
+                    artifact_sha256=artifact_sha256(artifact),
+                )
+            },
+        ),
+    )
+    model_file.write_bytes(b"drifted")
+    monkeypatch.setenv(RELEASE_MANIFEST_ENV_VAR, str(manifest_path))
+
+    release_check = next(check for check in preflight(tmp_path) if check.name == "model release")
+
+    assert release_check.ok is False
+    assert "checksum mismatch" in release_check.detail
 
 
 def test_build_processor_fails_closed_when_local_models_are_missing(tmp_path):

--- a/tests/test_mlflow_utils.py
+++ b/tests/test_mlflow_utils.py
@@ -1,3 +1,4 @@
+import hashlib
 from uuid import uuid4
 
 import pytest
@@ -8,6 +9,7 @@ from janasunani.tracking.mlflow_utils import (
     DVC_PATH_TAG,
     ensure_experiment,
     log_benchmark_run,
+    log_evaluation_run,
     log_model_artifact,
 )
 
@@ -132,6 +134,146 @@ def test_log_model_artifact_dvc_tags_survive_clobbering_extra_tags(tmp_path):
     version = client.get_model_version(model_name, logged.model_version)
     assert version.tags[DVC_PATH_TAG] == "models/categorizer"
     assert version.tags[DVC_HASH_TAG] == "abc123"
+
+
+# ---------------------------------------------------------------------------
+# Governed evaluation runs
+# ---------------------------------------------------------------------------
+
+
+def _governed_evaluation_args(tmp_path):
+    report = tmp_path / "evaluation.json"
+    report.write_text('{"accuracy": 0.75}\n', encoding="utf-8")
+    return {
+        "task": "actionability",
+        "dataset_fingerprint": f"sha256:{'a' * 64}",
+        "split_fingerprint": f"sha256:{'b' * 64}",
+        "code_sha": "c" * 40,
+        "dependency_lock_sha": f"sha256:{'d' * 64}",
+        "report_schema": "classification-report",
+        "report_version": "1.0",
+        "parameters": {
+            "model_family": "tfidf-logreg",
+            "c": 2.0,
+            "class_weight_balanced": True,
+            "max_features": None,
+        },
+        "metrics": {"macro_f1": 0.72, "accuracy": 0.75},
+        "report_path": report,
+    }
+
+
+def test_log_evaluation_run_records_required_provenance_and_report(tmp_path):
+    tracking_uri = (tmp_path / "mlruns").as_uri()
+    artifact_uri = (tmp_path / "artifacts").as_uri()
+    arguments = _governed_evaluation_args(tmp_path)
+
+    run_id = log_evaluation_run(
+        **arguments,
+        experiment_name="governed-test",
+        tracking_uri=tracking_uri,
+        artifact_uri=artifact_uri,
+    )
+
+    client = MlflowClient(tracking_uri=tracking_uri)
+    run = client.get_run(run_id)
+    params = run.data.params
+    assert params["evaluation.task"] == "actionability"
+    assert params["dataset.fingerprint"] == f"sha256:{'a' * 64}"
+    assert params["split.fingerprint"] == f"sha256:{'b' * 64}"
+    assert params["code.sha"] == "c" * 40
+    assert params["dependency_lock.sha256"] == "d" * 64
+    assert params["report.schema"] == "classification-report"
+    assert params["report.version"] == "1.0"
+    assert params["report.sha256"] == hashlib.sha256(
+        arguments["report_path"].read_bytes()
+    ).hexdigest()
+    assert params["parameter.model_family"] == "tfidf-logreg"
+    assert params["parameter.c"] == "2.0"
+    assert params["parameter.class_weight_balanced"] == "true"
+    assert params["parameter.max_features"] == "null"
+    assert run.data.metrics["macro_f1"] == pytest.approx(0.72)
+    assert run.data.metrics["accuracy"] == pytest.approx(0.75)
+    assert {item.path for item in client.list_artifacts(run_id, "report")} == {
+        "report/evaluation.json"
+    }
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("task", "", "task"),
+        ("dataset_fingerprint", "", "dataset_fingerprint"),
+        ("split_fingerprint", "not-a-digest", "split_fingerprint"),
+        ("code_sha", "abc1234", "code_sha"),
+        ("dependency_lock_sha", "f" * 40, "dependency_lock_sha"),
+        ("report_schema", "", "report_schema"),
+        ("report_version", "version with spaces", "report_version"),
+    ],
+)
+def test_log_evaluation_run_rejects_missing_or_invalid_provenance(
+    tmp_path, field, value, message
+):
+    arguments = _governed_evaluation_args(tmp_path)
+    arguments[field] = value
+
+    with pytest.raises(ValueError, match=message):
+        log_evaluation_run(**arguments, tracking_uri=(tmp_path / "mlruns").as_uri())
+
+    # Validation is complete before MLflow creates a local experiment/run.
+    assert not (tmp_path / "mlruns").exists()
+
+
+@pytest.mark.parametrize(
+    ("parameters", "message"),
+    [
+        ({}, "parameters"),
+        ({"nested": {"c": 1}}, "scalar"),
+        ({"bad value": 1}, "parameter name"),
+        ({"c": float("nan")}, "scalar"),
+    ],
+)
+def test_log_evaluation_run_rejects_incomplete_or_lossy_parameters(
+    tmp_path, parameters, message
+):
+    arguments = _governed_evaluation_args(tmp_path)
+    arguments["parameters"] = parameters
+
+    with pytest.raises(ValueError, match=message):
+        log_evaluation_run(**arguments, tracking_uri=(tmp_path / "mlruns").as_uri())
+
+
+@pytest.mark.parametrize(
+    ("metrics", "message"),
+    [
+        ({}, "metrics"),
+        ({"accuracy": float("inf")}, "finite"),
+        ({"accuracy": True}, "finite"),
+        ({"bad metric": 0.5}, "metric name"),
+    ],
+)
+def test_log_evaluation_run_rejects_missing_or_invalid_metrics(
+    tmp_path, metrics, message
+):
+    arguments = _governed_evaluation_args(tmp_path)
+    arguments["metrics"] = metrics
+
+    with pytest.raises(ValueError, match=message):
+        log_evaluation_run(**arguments, tracking_uri=(tmp_path / "mlruns").as_uri())
+
+
+@pytest.mark.parametrize("kind", ["missing", "empty", "directory"])
+def test_log_evaluation_run_requires_a_nonempty_report_file(tmp_path, kind):
+    arguments = _governed_evaluation_args(tmp_path)
+    report = tmp_path / f"{kind}-report.json"
+    if kind == "empty":
+        report.touch()
+    elif kind == "directory":
+        report.mkdir()
+    arguments["report_path"] = report
+
+    with pytest.raises(ValueError, match="report_path"):
+        log_evaluation_run(**arguments, tracking_uri=(tmp_path / "mlruns").as_uri())
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_model_materialize.py
+++ b/tests/test_model_materialize.py
@@ -1,0 +1,223 @@
+from types import SimpleNamespace
+
+import pytest
+
+from janasunani.tracking.materialize import materialize_release
+from janasunani.tracking.release import (
+    ReleaseManifestError,
+    active_manifest_path,
+    load_manifest,
+)
+
+
+APPROVED_ARTIFACT_SHA256 = (
+    "542c971fe8899506c71941c54893b529eca20fa6c0b76e2d0a448a2d45665592"
+)
+
+
+class FakeClient:
+    def __init__(self, *, tags=None):
+        self.tags = (
+            {"dvc.path": "models/actionability", "dvc.hash": "a" * 32 + ".dir"}
+            if tags is None
+            else tags
+        )
+        self.calls = []
+
+    def get_model_version_by_alias(self, name, alias):
+        self.calls.append((name, alias))
+        return SimpleNamespace(
+            version="12", source="fake:/actionability", tags=self.tags
+        )
+
+
+def _spec():
+    return {
+        "release_id": "release-12",
+        "git_sha": "a" * 40,
+        "models": {
+            "actionability": {
+                "registry_name": "janasunani-actionability",
+                "alias": "production",
+                "provider": "local_sklearn",
+                "trust_tier": "local",
+                "artifact_sha256": APPROVED_ARTIFACT_SHA256,
+                "parameters": {"review_threshold": 0.7},
+                "benchmark_run_id": "bench-1",
+                "dataset_id": "redacted-v1",
+                "gold_id": "gold-v1",
+            },
+            "sarvam_digitise": {
+                "provider": "sarvam",
+                "trust_tier": "authorized_hosted",
+                "version": "observed-2026-08-01",
+                "endpoint": "sarvam-digitise",
+                "parameters": {"mode": "accurate"},
+                "benchmark_run_id": "sarvam-cached-1",
+            },
+        },
+    }
+
+
+def _downloader(*, artifact_uri, dst_path):
+    assert artifact_uri == "fake:/actionability"
+    target = dst_path / "downloaded-model"
+    target.mkdir()
+    (target / "model.joblib").write_bytes(b"weights")
+    return str(target)
+
+
+def test_materialize_pins_alias_to_version_and_can_activate(tmp_path):
+    client = FakeClient()
+
+    path = materialize_release(
+        spec=_spec(),
+        release_root=tmp_path,
+        activate=True,
+        client=client,
+        downloader=_downloader,
+    )
+
+    manifest = load_manifest(path)
+    actionability = manifest.models["actionability"]
+    assert client.calls == [("janasunani-actionability", "production")]
+    assert actionability.alias == "production"
+    assert actionability.version == "12"
+    assert actionability.dvc_path == "models/actionability"
+    assert actionability.artifact_sha256
+    assert manifest.models["sarvam_digitise"].endpoint == "sarvam-digitise"
+    assert active_manifest_path(tmp_path) == path
+
+
+def test_materialize_rejects_registry_version_without_dvc_provenance(tmp_path):
+    client = FakeClient(tags={})
+
+    with pytest.raises(ReleaseManifestError, match="DVC provenance"):
+        materialize_release(
+            spec=_spec(), release_root=tmp_path, client=client, downloader=_downloader
+        )
+
+    assert not (tmp_path / "release-12").exists()
+
+
+def test_materialize_checks_approved_download_digest(tmp_path):
+    spec = _spec()
+    spec["models"]["actionability"]["artifact_sha256"] = "0" * 64
+
+    with pytest.raises(ReleaseManifestError, match="approved"):
+        materialize_release(
+            spec=spec,
+            release_root=tmp_path,
+            client=FakeClient(),
+            downloader=_downloader,
+        )
+
+    assert not (tmp_path / "release-12").exists()
+
+
+def test_materialize_requires_approved_digest_before_registry_access(tmp_path):
+    spec = _spec()
+    del spec["models"]["actionability"]["artifact_sha256"]
+    client = FakeClient()
+
+    with pytest.raises(ReleaseManifestError, match="approved artifact_sha256"):
+        materialize_release(
+            spec=spec, release_root=tmp_path, client=client, downloader=_downloader
+        )
+
+    assert client.calls == []
+
+
+def test_materialize_rejects_model_path_traversal_before_any_write(tmp_path):
+    spec = _spec()
+    model = spec["models"].pop("actionability")
+    model["registry_name"] = "janasunani-actionability"
+    spec["models"]["../../escaped"] = model
+    client = FakeClient()
+
+    with pytest.raises(ReleaseManifestError, match="invalid model name"):
+        materialize_release(
+            spec=spec, release_root=tmp_path, client=client, downloader=_downloader
+        )
+
+    assert client.calls == []
+    assert not (tmp_path / "escaped").exists()
+
+
+def test_materialize_rejects_malformed_dvc_provenance(tmp_path):
+    client = FakeClient(tags={"dvc.path": "../outside", "dvc.hash": "not-a-hash"})
+
+    with pytest.raises(ReleaseManifestError, match="unsafe DVC provenance path"):
+        materialize_release(
+            spec=_spec(), release_root=tmp_path, client=client, downloader=_downloader
+        )
+
+    assert not (tmp_path / "release-12").exists()
+
+
+def test_materialize_never_overwrites_an_existing_release(tmp_path):
+    materialize_release(
+        spec=_spec(), release_root=tmp_path, client=FakeClient(), downloader=_downloader
+    )
+
+    with pytest.raises(FileExistsError):
+        materialize_release(
+            spec=_spec(),
+            release_root=tmp_path,
+            client=FakeClient(),
+            downloader=_downloader,
+        )
+
+
+def test_materialize_rejects_invalid_git_sha_before_registry_or_write(tmp_path):
+    spec = _spec()
+    spec["git_sha"] = "abc123"
+    client = FakeClient()
+    release_root = tmp_path / "releases"
+
+    with pytest.raises(ReleaseManifestError, match="full 40- or 64-character"):
+        materialize_release(
+            spec=spec,
+            release_root=release_root,
+            client=client,
+            downloader=_downloader,
+        )
+
+    assert client.calls == []
+    assert not release_root.exists()
+
+
+def test_materialize_never_moves_a_download_from_outside_staging(tmp_path):
+    outside = tmp_path / "outside-download"
+    outside.mkdir()
+    (outside / "model.joblib").write_bytes(b"weights")
+
+    def outside_downloader(**_kwargs):
+        return str(outside)
+
+    with pytest.raises(ReleaseManifestError, match="escaped its staging"):
+        materialize_release(
+            spec=_spec(),
+            release_root=tmp_path / "releases",
+            client=FakeClient(),
+            downloader=outside_downloader,
+        )
+
+    assert outside.is_dir()
+    assert not (tmp_path / "releases" / "release-12").exists()
+
+
+def test_materialize_validates_hosted_shape_before_creating_release_root(tmp_path):
+    spec = _spec()
+    spec["models"]["sarvam_digitise"]["unexpected"] = "value"
+    release_root = tmp_path / "releases"
+
+    with pytest.raises(ReleaseManifestError, match="unknown fields"):
+        materialize_release(
+            spec=spec,
+            release_root=release_root,
+            client=FakeClient(),
+            downloader=_downloader,
+        )
+
+    assert not release_root.exists()

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -1,0 +1,230 @@
+import json
+
+import pytest
+
+from janasunani.tracking.release import (
+    ACTIVE_POINTER,
+    RELEASE_MANIFEST_ENV_VAR,
+    ModelRelease,
+    ReleaseManifest,
+    ReleaseManifestError,
+    activate_manifest,
+    active_manifest_path,
+    artifact_sha256,
+    load_manifest,
+    new_manifest,
+    resolve_manifest_artifact,
+    write_manifest,
+)
+
+
+def _local_model(path, *, version="7"):
+    return ModelRelease(
+        name="actionability",
+        provider="local_sklearn",
+        trust_tier="local",
+        version=version,
+        artifact_path="artifacts/actionability",
+        artifact_sha256=artifact_sha256(path),
+        alias="production",
+        parameters={"threshold": 0.7},
+        dvc_path="models/actionability",
+        dvc_hash="dvc123",
+        benchmark_run_id="run123",
+        dataset_id="redacted-gold-v1",
+        gold_id="actionability-gold-v1",
+    )
+
+
+def _release(tmp_path, *, release_id="release-1"):
+    release_dir = tmp_path / release_id
+    artifact = release_dir / "artifacts" / "actionability"
+    artifact.mkdir(parents=True)
+    (artifact / "model.joblib").write_bytes(b"weights")
+    manifest = new_manifest(
+        release_id=release_id,
+        git_sha="a" * 40,
+        models={"actionability": _local_model(artifact)},
+    )
+    path = release_dir / "release-manifest.json"
+    write_manifest(path, manifest)
+    return path, artifact
+
+
+def test_manifest_round_trip_and_activation(tmp_path, monkeypatch):
+    path, artifact = _release(tmp_path)
+
+    activate_manifest(path, root=tmp_path)
+
+    assert active_manifest_path(tmp_path) == path
+    assert resolve_manifest_artifact("actionability", root=tmp_path) == artifact
+    assert load_manifest(path).models["actionability"].version == "7"
+
+
+def test_activation_is_atomic_and_supports_explicit_rollback(tmp_path):
+    first, _ = _release(tmp_path, release_id="release-1")
+    second, _ = _release(tmp_path, release_id="release-2")
+
+    activate_manifest(first, root=tmp_path)
+    activate_manifest(second, root=tmp_path)
+    assert (
+        json.loads((tmp_path / ACTIVE_POINTER).read_text())["release_id"] == "release-2"
+    )
+
+    activate_manifest(first, root=tmp_path)
+    assert (
+        json.loads((tmp_path / ACTIVE_POINTER).read_text())["release_id"] == "release-1"
+    )
+
+
+def test_manifest_checksum_drift_fails_closed(tmp_path):
+    path, artifact = _release(tmp_path)
+    (artifact / "model.joblib").write_bytes(b"changed")
+
+    with pytest.raises(ReleaseManifestError, match="checksum"):
+        resolve_manifest_artifact("actionability", manifest_path=path)
+    with pytest.raises(ReleaseManifestError, match="checksum"):
+        activate_manifest(path, root=tmp_path)
+
+
+def test_artifact_hash_rejects_symlinked_directory(tmp_path):
+    artifact = tmp_path / "artifact"
+    artifact.mkdir()
+    (artifact / "model.bin").write_bytes(b"weights")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "remote-code.py").write_text("raise RuntimeError('unchecked')")
+    (artifact / "code").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ReleaseManifestError, match="contains a symlink"):
+        artifact_sha256(artifact)
+
+
+def test_artifact_hash_rejects_symlinked_root(tmp_path):
+    artifact = tmp_path / "artifact"
+    artifact.mkdir()
+    (artifact / "model.bin").write_bytes(b"weights")
+    linked = tmp_path / "linked"
+    linked.symlink_to(artifact, target_is_directory=True)
+
+    with pytest.raises(ReleaseManifestError, match="artifact is a symlink"):
+        artifact_sha256(linked)
+
+
+def test_manifest_rejects_path_traversal(tmp_path):
+    payload = {
+        "schema_version": "janasunani.release/v1",
+        "release_id": "release-1",
+        "created_at": "2026-08-10T10:00:00Z",
+        "git_sha": "a" * 40,
+        "models": {
+            "actionability": {
+                "provider": "local_sklearn",
+                "trust_tier": "local",
+                "version": "1",
+                "artifact_path": "../escape",
+                "artifact_sha256": "0" * 64,
+            }
+        },
+    }
+    path = tmp_path / "release-manifest.json"
+    path.write_text(json.dumps(payload))
+
+    with pytest.raises(ReleaseManifestError, match="escapes"):
+        resolve_manifest_artifact("actionability", manifest_path=path)
+
+
+def test_hosted_model_requires_authorized_trust_tier():
+    payload = {
+        "schema_version": "janasunani.release/v1",
+        "release_id": "release-1",
+        "created_at": "2026-08-10T10:00:00Z",
+        "git_sha": "a" * 40,
+        "models": {
+            "sarvam_digitise": {
+                "provider": "sarvam",
+                "trust_tier": "experimental",
+                "version": "observed-model-id",
+                "endpoint": "sarvam-digitise",
+            }
+        },
+    }
+
+    with pytest.raises(ReleaseManifestError, match="authorized_hosted"):
+        ReleaseManifest.from_dict(payload)
+
+
+def test_manifest_rejects_malformed_artifact_digest():
+    payload = {
+        "schema_version": "janasunani.release/v1",
+        "release_id": "release-1",
+        "created_at": "2026-08-10T10:00:00Z",
+        "git_sha": "a" * 40,
+        "models": {
+            "actionability": {
+                "provider": "local_sklearn",
+                "trust_tier": "local",
+                "version": "1",
+                "artifact_path": "artifacts/actionability",
+                "artifact_sha256": "not-a-checksum",
+            }
+        },
+    }
+
+    with pytest.raises(ReleaseManifestError, match="64 lowercase hex"):
+        ReleaseManifest.from_dict(payload)
+
+
+def test_explicit_manifest_env_overrides_active_pointer(tmp_path, monkeypatch):
+    first, _ = _release(tmp_path, release_id="release-1")
+    second, _ = _release(tmp_path, release_id="release-2")
+    activate_manifest(first, root=tmp_path)
+    monkeypatch.setenv(RELEASE_MANIFEST_ENV_VAR, str(second))
+
+    assert active_manifest_path(tmp_path) == second
+
+
+def test_write_manifest_never_overwrites_an_immutable_release(tmp_path):
+    path, _ = _release(tmp_path)
+    manifest = load_manifest(path)
+
+    with pytest.raises(FileExistsError):
+        write_manifest(path, manifest)
+
+
+def test_manifest_requires_a_full_git_sha(tmp_path):
+    path, _ = _release(tmp_path)
+    payload = json.loads(path.read_text())
+    payload["git_sha"] = "abc123"
+
+    with pytest.raises(ReleaseManifestError, match="full 40- or 64-character"):
+        ReleaseManifest.from_dict(payload)
+
+
+def test_manifest_resolution_rejects_symlinked_artifact_root(tmp_path):
+    release_dir = tmp_path / "release-1"
+    real_artifact = release_dir / "real-artifact"
+    real_artifact.mkdir(parents=True)
+    (real_artifact / "model.bin").write_bytes(b"weights")
+    linked_artifact = release_dir / "artifacts" / "actionability"
+    linked_artifact.parent.mkdir()
+    linked_artifact.symlink_to(real_artifact, target_is_directory=True)
+    manifest = new_manifest(
+        release_id="release-1",
+        git_sha="a" * 40,
+        models={
+            "actionability": ModelRelease(
+                name="actionability",
+                provider="local",
+                trust_tier="local",
+                version="1",
+                artifact_path="artifacts/actionability",
+                artifact_sha256=artifact_sha256(real_artifact),
+            )
+        },
+    )
+    manifest_path = release_dir / "release-manifest.json"
+    write_manifest(manifest_path, manifest)
+
+    with pytest.raises(ReleaseManifestError, match="artifact is a symlink"):
+        resolve_manifest_artifact("actionability", manifest_path=manifest_path)


### PR DESCRIPTION
## Summary

- add immutable, checksummed model release manifests and atomic activation/rollback
- resolve reviewed MLflow aliases only in the deployment control plane, never in request-serving code
- require approved artifact digests and DVC provenance before local materialization
- expose the active immutable release and pinned versions in preflight without revealing hosted endpoints

## Reconciliation status

This historical stack slice is already an ancestor of `feat/pipeline-quality-trunk`; it will not be merged independently into `main`. After this exact-head review is complete, the PR will be closed as already integrated. Final integration to `main` remains a separate PR and requires explicit maintainer approval.

- Review base: `feat/routing-incidence`
- Exact head under review: `43e5e10548978842a97e9ed11006f774f8f962e0`
- Primary commits: `844232a`, `5bc04bc`
- Successor: PR #256

## Routing evidence boundary

The routing-incidence artifact must not be treated as a correct-authority or outcome model. The source-system owner is unavailable, so the lifecycle semantics of `complaints.dept` remain unconfirmed. It is only a recorded department snapshot—not the joint department-and-chain assignment intent and not the de facto route traversed in action history.

The reconciled integration branch contains two bounded self-review fixes relevant to this slice:

- `2209227` changes the example routing release from `production`/`local` to `candidate`/`experimental`, pins the v3 snapshot-agreement semantics, and records that correct-authority adjudication and serving approval are absent.
- `ad6ec4e` rejects registry DVC provenance outside governed model mirrors under `models/` and rejects non-canonical paths.

No release is activated by this PR. Materialization and activation remain explicit operator actions.

## Verification

Exact slice:

- 98 targeted release/materialization/MLflow/live-builder tests passed
- Ruff passed on all changed Python and test files
- `git diff --check` passed

Downstream self-review fixes:

- 24 release/materialization tests passed
- Ruff and `git diff --check` passed
- `deploy/model-release.example.json` parses successfully

No citizen data files were opened during this review pass.

## Review protocol

This PR is ready for an exact-head Codex review. Every finding will be verified, answered individually with evidence, fixed on the reconciled integration branch when valid, and resolved before the `codex-review` gate is accepted.
