### PR TITLE
fix(models): require approved local artifacts by default

### DIFF
--- a/janasunani/inference/serve.py
+++ b/janasunani/inference/serve.py
@@ -14,11 +14,6 @@ import sys
 # OpenMP initialization. This must run before any inference imports.
 if sys.platform == "darwin":
     os.environ.setdefault("OMP_NUM_THREADS", "1")
-    # The summarizer downloads facebook/bart-large-cnn from the HF hub on first
-    # run. The Rust `hf_xet` transfer backend can hang on a dispatch semaphore
-    # on macOS *after* the bytes land, wedging startup indefinitely. Fall back
-    # to plain HTTPS locally; the Linux CPU box (where Xet works) is untouched.
-    os.environ.setdefault("HF_HUB_DISABLE_XET", "1")
 
 from janasunani.inference.service import (  # noqa: E402
     build_processor,

--- a/janasunani/inference/service.py
+++ b/janasunani/inference/service.py
@@ -435,6 +435,26 @@ def _resolve_models_root(models_dir: str | Path | None) -> Path:
     return Path(configured_dir).expanduser() if configured_dir else MODELS_DIR
 
 
+def _resolved_model_dirs(root: Path) -> tuple[Path, Path, Path]:
+    """Resolve operator override -> pinned release -> DVC for live models."""
+
+    from janasunani.tracking.artifacts import resolve_artifact
+
+    unresolved = root / ".unresolved"
+    categorizer = resolve_artifact("categorizer", models_dir=root) or (
+        unresolved / "categorizer"
+    )
+    page_type = resolve_artifact("page_type_classifier", models_dir=root) or (
+        unresolved / "page_type_classifier"
+    )
+    if not (page_type / "config.json").is_file():
+        page_type = page_type / "vit_type_classifier"
+    summarizer = resolve_artifact("summarizer", models_dir=root) or (
+        unresolved / "summarizer"
+    )
+    return categorizer, page_type, summarizer
+
+
 def _required_model_files(root: Path) -> list[tuple[tuple[Path, ...], str]]:
     """The mandatory local model artifacts, as (candidate-paths, component).
 
@@ -456,8 +476,7 @@ def _required_model_files(root: Path) -> list[tuple[tuple[Path, ...], str]]:
     holds tokenizer *settings*, so a mirror with just the config still crashes
     in `AutoTokenizer.from_pretrained`.
     """
-    categorizer_dir = root / "categorizer"
-    page_type_dir = root / "page_type_classifier" / "vit_type_classifier"
+    categorizer_dir, page_type_dir, summarizer_dir = _resolved_model_dirs(root)
     return [
         ((categorizer_dir / "config.json",), "categorizer config"),
         (
@@ -490,6 +509,22 @@ def _required_model_files(root: Path) -> list[tuple[tuple[Path, ...], str]]:
             (page_type_dir / "preprocessor_config.json",),
             "page-type image processor",
         ),
+        ((summarizer_dir / "config.json",), "summarizer config"),
+        (
+            (
+                summarizer_dir / "model.safetensors",
+                summarizer_dir / "pytorch_model.bin",
+            ),
+            "summarizer weights",
+        ),
+        (
+            (
+                summarizer_dir / "tokenizer.json",
+                summarizer_dir / "vocab.json",
+            ),
+            "summarizer tokenizer",
+        ),
+        ((summarizer_dir / "merges.txt",), "summarizer merges"),
     ]
 
 
@@ -872,8 +907,7 @@ def build_processor(
     ``create_app`` already uses for its providers.
     """
     root = _resolve_models_root(models_dir)
-    categorizer_dir = root / "categorizer"
-    page_type_dir = root / "page_type_classifier" / "vit_type_classifier"
+    categorizer_dir, page_type_dir, summarizer_dir = _resolved_model_dirs(root)
 
     for candidates, component in _required_model_files(root):
         _require_model_artifact(candidates, component)
@@ -887,7 +921,7 @@ def build_processor(
 
     from janasunani.pipeline.stages.summarizer import Summarizer
 
-    summarizer = Summarizer()
+    summarizer = Summarizer(summarizer_dir)
 
     from janasunani.pipeline.stages.categorizer.model import GrievanceCategorizer
 

--- a/janasunani/pipeline/stages/categorizer/model.py
+++ b/janasunani/pipeline/stages/categorizer/model.py
@@ -17,16 +17,76 @@ from __future__ import annotations
 
 import pickle  # noqa: S403 — label encoder is a trusted local artifact
 from pathlib import Path
+
+from janasunani.tracking.artifacts import (
+    ALLOW_REMOTE_MODELS_ENV_VAR,
+    remote_models_allowed,
+)
 from loguru import logger
 
 # Max token length the model was trained with (MAX_LEN in the training script).
 MAX_LEN = 256
+LABEL_ENCODER_FILENAME = "label_encoder_ROS_wDOCS_english.pkl"
+
+
+def _nonempty_file(path: Path) -> bool:
+    try:
+        return path.is_file() and path.stat().st_size > 0
+    except OSError:
+        return False
+
+
+def require_complete_local_artifact(path: Path) -> Path:
+    """Validate all bytes required by the local Hugging Face loader."""
+
+    artifact = Path(path)
+    if not artifact.is_dir():
+        raise RuntimeError(f"local categorizer artifact is not a directory: {artifact}")
+    requirements = {
+        "config": (artifact / "config.json",),
+        "weights": (
+            artifact / "model.safetensors",
+            artifact / "pytorch_model.bin",
+        ),
+        "tokenizer": (
+            artifact / "tokenizer.json",
+            artifact / "vocab.txt",
+        ),
+        "label encoder": (artifact / LABEL_ENCODER_FILENAME,),
+    }
+    missing = [
+        name
+        for name, candidates in requirements.items()
+        if not any(_nonempty_file(candidate) for candidate in candidates)
+    ]
+    if missing:
+        raise RuntimeError(
+            "incomplete local categorizer artifact; missing non-empty "
+            + ", ".join(missing)
+        )
+    return artifact
+
+
+def resolve_model_source(model_dir: str | Path) -> tuple[str, bool, Path | None]:
+    """Resolve a complete local directory or an explicitly allowed repo ID."""
+
+    source = str(model_dir)
+    candidate = Path(source)
+    if candidate.exists():
+        artifact = require_complete_local_artifact(candidate)
+        return str(artifact), True, artifact / LABEL_ENCODER_FILENAME
+    if not remote_models_allowed():
+        raise RuntimeError(
+            "remote categorizer model IDs require explicit development opt-in via "
+            f"{ALLOW_REMOTE_MODELS_ENV_VAR}=1"
+        )
+    return source, False, None
 
 
 class GrievanceCategorizer:
     """Wraps the fine-tuned MuRIL classifier + its label encoder."""
 
-    def __init__(self, model_dir: str) -> None:
+    def __init__(self, model_dir: str | Path) -> None:
         import torch
         from huggingface_hub import hf_hub_download
         from transformers import (
@@ -44,29 +104,34 @@ class GrievanceCategorizer:
         else:
             self._device = "cuda"
 
-        # Label encoder: local dir (the DVC mirror) first; HF download only
-        # when model_dir is a repo id.
-        local = Path(model_dir) / "label_encoder_ROS_wDOCS_english.pkl"
-        if local.exists():
-            encoder_path = local
-        else:
+        source, local_only, encoder_path = resolve_model_source(model_dir)
+        if encoder_path is None:
             encoder_path = hf_hub_download(
-                repo_id=model_dir,
-                filename="label_encoder_ROS_wDOCS_english.pkl",
+                repo_id=source,
+                filename=LABEL_ENCODER_FILENAME,
+                local_files_only=False,
             )
 
         with open(encoder_path, "rb") as f:
             self._label_encoder = pickle.load(f)
 
-        # Load tokenizer + model directly from HF
-        self._tokenizer = AutoTokenizer.from_pretrained(model_dir)
+        self._tokenizer = AutoTokenizer.from_pretrained(
+            source,
+            local_files_only=local_only,
+            trust_remote_code=False,
+        )
 
         self._model = (
             AutoModelForSequenceClassification
-            .from_pretrained(model_dir)
+            .from_pretrained(
+                source,
+                local_files_only=local_only,
+                trust_remote_code=False,
+            )
             .to(self._device)
             .eval()
         )
+
     def predict(self, text: str) -> str:
         """Predict the grievance category for a piece of text.
 

--- a/janasunani/pipeline/stages/categorizer/stage.py
+++ b/janasunani/pipeline/stages/categorizer/stage.py
@@ -27,6 +27,7 @@ from ...config import PipelineConfig
 from ...db import connect
 from .ingest_grievances import ingest_grievances
 from .model import GrievanceCategorizer
+from janasunani.tracking.artifacts import remote_models_allowed, resolve_artifact
 from loguru import logger
 
 DB_BATCH_SIZE = 50
@@ -55,10 +56,18 @@ def run_categorizer(config: PipelineConfig) -> None:
 
     logger.info(f"categorizer: {len(work)} document(s) to categorize")
 
-    # Model provenance rule: prefer the DVC-mirrored copy under models/ —
-    # runtime must not depend on the (orphaned) student HF account.
-    local_dir = config.models_dir / "categorizer"
-    model_dir = str(local_dir) if (local_dir / "config.json").exists() else "jeseniapar/categorizer"
+    # Serving and batch both resolve operator override -> pinned release ->
+    # DVC mirror. The orphaned public account is development-only opt-in.
+    artifact = resolve_artifact("categorizer", models_dir=config.models_dir)
+    if artifact is not None:
+        model_dir = str(artifact)
+    elif remote_models_allowed():
+        model_dir = "jeseniapar/categorizer"
+    else:
+        raise RuntimeError(
+            "no local categorizer artifact resolved; materialize the approved "
+            "release or set JANASUNANI_ALLOW_REMOTE_MODELS=1 for development only"
+        )
 
     _run(
         db_path=config.db_path,

--- a/janasunani/pipeline/stages/format_classifier/__init__.py
+++ b/janasunani/pipeline/stages/format_classifier/__init__.py
@@ -10,9 +10,15 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from .model import FormatClassifier
-    from .stage import run_format_classifier
 
 __all__ = ["FormatClassifier", "run_format_classifier"]
+
+
+def run_format_classifier(config: Any) -> None:
+    """Run the stage without importing its optional dependencies at discovery time."""
+    from .stage import run_format_classifier as _run_format_classifier
+
+    _run_format_classifier(config)
 
 
 def __getattr__(name: str) -> Any:
@@ -20,8 +26,4 @@ def __getattr__(name: str) -> Any:
         from .model import FormatClassifier
 
         return FormatClassifier
-    if name == "run_format_classifier":
-        from .stage import run_format_classifier
-
-        return run_format_classifier
     raise AttributeError(name)

--- a/janasunani/pipeline/stages/format_classifier/__init__.py
+++ b/janasunani/pipeline/stages/format_classifier/__init__.py
@@ -1,10 +1,27 @@
-"""Format classifier stage.
+"""Format classifier stage with lazy heavy imports.
 
 Public surface:
   run_format_classifier — the entry point pipeline.py calls.
   FormatClassifier      — the model wrapper, if you want to use it standalone.
 """
-from .model import FormatClassifier
-from .stage import run_format_classifier
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .model import FormatClassifier
+    from .stage import run_format_classifier
 
 __all__ = ["FormatClassifier", "run_format_classifier"]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "FormatClassifier":
+        from .model import FormatClassifier
+
+        return FormatClassifier
+    if name == "run_format_classifier":
+        from .stage import run_format_classifier
+
+        return run_format_classifier
+    raise AttributeError(name)

--- a/janasunani/pipeline/stages/format_classifier/resolution.py
+++ b/janasunani/pipeline/stages/format_classifier/resolution.py
@@ -1,0 +1,34 @@
+"""Lightweight format-classifier artifact resolution.
+
+This module deliberately has no image or model imports so release-path checks
+can run in the light CI environment without OpenCV and the pipeline extras.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from janasunani.tracking.artifacts import resolve_artifact
+
+from ...config import PipelineConfig
+
+
+def resolve_model_path(config: PipelineConfig) -> Path:
+    artifact = resolve_artifact("format_classifier", models_dir=config.models_dir)
+    if artifact is None:
+        raise FileNotFoundError(
+            "no format-classifier artifact resolved from operator override, "
+            "active release, or DVC mirror"
+        )
+    if artifact.is_file():
+        if artifact.suffix.lower() != ".pkl":
+            raise ValueError("format-classifier artifact file must have .pkl suffix")
+        return artifact
+    candidates = sorted(artifact.glob("*.pkl"))
+    if len(candidates) != 1:
+        raise RuntimeError(
+            f"format-classifier directory {artifact} contains {len(candidates)} .pkl "
+            "files; pin one exact file with JANASUNANI_FORMAT_CLASSIFIER_ARTIFACT "
+            "or the active release manifest"
+        )
+    return candidates[0]

--- a/janasunani/pipeline/stages/format_classifier/stage.py
+++ b/janasunani/pipeline/stages/format_classifier/stage.py
@@ -28,6 +28,7 @@ from PIL import Image
 from ...config import PipelineConfig
 from ...db import connect
 from ...ticket import doc_id_from_relpath, ticket_from_relpath
+from janasunani.tracking.artifacts import resolve_artifact
 from .executors import Executor, auto_executor
 from .features import (
     configure_tesseract,
@@ -80,6 +81,27 @@ PAGE_ID_LENGTH = 16
 MODEL_NAME = "format_classifier_v3"
 
 
+def _resolve_model_path(config: PipelineConfig) -> Path:
+    artifact = resolve_artifact("format_classifier", models_dir=config.models_dir)
+    if artifact is None:
+        raise FileNotFoundError(
+            "no format-classifier artifact resolved from operator override, "
+            "active release, or DVC mirror"
+        )
+    if artifact.is_file():
+        if artifact.suffix.lower() != ".pkl":
+            raise ValueError("format-classifier artifact file must have .pkl suffix")
+        return artifact
+    candidates = sorted(artifact.glob("*.pkl"))
+    if len(candidates) != 1:
+        raise RuntimeError(
+            f"format-classifier directory {artifact} contains {len(candidates)} .pkl "
+            "files; pin one exact file with JANASUNANI_FORMAT_CLASSIFIER_ARTIFACT "
+            "or the active release manifest"
+        )
+    return candidates[0]
+
+
 # ---------------------------------------------------------------------------
 # Public entry point — called by pipeline.py
 # ---------------------------------------------------------------------------
@@ -90,17 +112,10 @@ def run_format_classifier(config: PipelineConfig) -> None:
     Reads input files from config.input_dir (or config.file_list if set),
     classifies each page, and writes results to config.db_path.
 
-    The trained model is loaded from the first .pkl file in
-    config.models_dir / "format_classifier".
+    The exact trained model is selected by operator override, immutable release
+    manifest, or an unambiguous one-file DVC mirror.
     """
-    model_dir = config.models_dir / "format_classifier"
-    candidates = sorted(model_dir.glob("*.pkl"))
-    if not candidates:
-        raise FileNotFoundError(
-            f"no .pkl model found in {model_dir}. "
-            "Place the trained format classifier there."
-        )
-    model_path = candidates[0]
+    model_path = _resolve_model_path(config)
 
     _run(
         db_path=config.db_path,

--- a/janasunani/pipeline/stages/format_classifier/stage.py
+++ b/janasunani/pipeline/stages/format_classifier/stage.py
@@ -28,7 +28,6 @@ from PIL import Image
 from ...config import PipelineConfig
 from ...db import connect
 from ...ticket import doc_id_from_relpath, ticket_from_relpath
-from janasunani.tracking.artifacts import resolve_artifact
 from .executors import Executor, auto_executor
 from .features import (
     configure_tesseract,
@@ -36,6 +35,7 @@ from .features import (
     suppress_stderr,
 )
 from .model import FormatClassifier
+from .resolution import resolve_model_path
 from loguru import logger
 
 # Avoid pdf2image's pixel-bomb DoS protection blocking large but legitimate
@@ -82,24 +82,8 @@ MODEL_NAME = "format_classifier_v3"
 
 
 def _resolve_model_path(config: PipelineConfig) -> Path:
-    artifact = resolve_artifact("format_classifier", models_dir=config.models_dir)
-    if artifact is None:
-        raise FileNotFoundError(
-            "no format-classifier artifact resolved from operator override, "
-            "active release, or DVC mirror"
-        )
-    if artifact.is_file():
-        if artifact.suffix.lower() != ".pkl":
-            raise ValueError("format-classifier artifact file must have .pkl suffix")
-        return artifact
-    candidates = sorted(artifact.glob("*.pkl"))
-    if len(candidates) != 1:
-        raise RuntimeError(
-            f"format-classifier directory {artifact} contains {len(candidates)} .pkl "
-            "files; pin one exact file with JANASUNANI_FORMAT_CLASSIFIER_ARTIFACT "
-            "or the active release manifest"
-        )
-    return candidates[0]
+    """Backward-compatible private seam; use resolution.resolve_model_path."""
+    return resolve_model_path(config)
 
 
 # ---------------------------------------------------------------------------

--- a/janasunani/pipeline/stages/ocr_extraction/deepseek_backend.py
+++ b/janasunani/pipeline/stages/ocr_extraction/deepseek_backend.py
@@ -1,14 +1,13 @@
 """DeepSeek-OCR backend.
 
-Loads `deepseek-ai/DeepSeek-OCR` from HuggingFace and runs inference
+Loads a pinned local DeepSeek-OCR artifact and runs inference
 via `model.infer()`. Requires CUDA — fails fast at model load time
 if a GPU isn't available, with a clear message pointing to pytesseract
 as the CPU alternative.
 
-The model itself is multi-gigabyte and takes a noticeable time to load
-(and download on first run). For that reason this module never auto-
-loads the model — the caller must explicitly call `load_model()` only
-when there's work to do.
+The model itself is multi-gigabyte and takes a noticeable time to load. This
+module never auto-loads it, and a mutable public Hugging Face ID is accepted
+only with the explicit development-only remote-model opt-in.
 """
 from __future__ import annotations
 
@@ -17,6 +16,7 @@ from tempfile import NamedTemporaryFile
 from typing import Any
 
 from PIL import Image
+from janasunani.tracking.artifacts import remote_models_allowed, resolve_artifact
 
 # Default model ID. Override by passing a different name to load_model().
 DEFAULT_MODEL_NAME = "deepseek-ai/DeepSeek-OCR"
@@ -26,12 +26,35 @@ DEFAULT_MODEL_NAME = "deepseek-ai/DeepSeek-OCR"
 DEFAULT_PROMPT = "<image>\nFree OCR. Oriya or English."
 
 
-def load_model(model_name: str = DEFAULT_MODEL_NAME) -> tuple[Any, Any]:
+def _resolve_model_source(model_name: str | None = None) -> tuple[str, bool]:
+    if model_name is not None:
+        candidate = Path(model_name)
+        if candidate.exists():
+            return str(candidate), True
+        if remote_models_allowed():
+            return model_name, False
+        raise RuntimeError(
+            "remote DeepSeek model IDs require JANASUNANI_ALLOW_REMOTE_MODELS=1"
+        )
+    artifact = resolve_artifact("deepseek_ocr")
+    if artifact is not None:
+        return str(artifact), True
+    if remote_models_allowed():
+        return DEFAULT_MODEL_NAME, False
+    raise RuntimeError(
+        "no local DeepSeek OCR artifact resolved; materialize the approved release "
+        "or set JANASUNANI_ALLOW_REMOTE_MODELS=1 for development only"
+    )
+
+
+def load_model(model_name: str | None = None) -> tuple[Any, Any]:
     """Load the DeepSeek-OCR tokenizer and model. Returns (tokenizer, model).
 
     Raises a clear error if CUDA isn't available, since this model is
     GPU-only in practice (the original code calls .cuda() unconditionally).
     """
+    source, local_only = _resolve_model_source(model_name)
+
     # Import torch/transformers lazily so importing this module doesn't
     # fail on systems without those deps installed.
     import torch
@@ -46,18 +69,24 @@ def load_model(model_name: str = DEFAULT_MODEL_NAME) -> tuple[Any, Any]:
     # The original code preferred LlamaTokenizer and fell back to AutoTokenizer.
     # Keep that order.
     try:
-        tokenizer = LlamaTokenizer.from_pretrained(model_name, trust_remote_code=True)
+        tokenizer = LlamaTokenizer.from_pretrained(
+            source, trust_remote_code=True, local_files_only=local_only
+        )
     except Exception:
         tokenizer = AutoTokenizer.from_pretrained(
-            model_name, trust_remote_code=True, use_fast=False
+            source,
+            trust_remote_code=True,
+            use_fast=False,
+            local_files_only=local_only,
         )
 
     model = AutoModel.from_pretrained(
-        model_name,
+        source,
         attn_implementation="eager",
         trust_remote_code=True,
         use_safetensors=True,
         torch_dtype=torch.bfloat16,
+        local_files_only=local_only,
     )
     model = model.to("cuda").eval()
 

--- a/janasunani/pipeline/stages/page_type_classifier.py
+++ b/janasunani/pipeline/stages/page_type_classifier.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 
 from janasunani.pipeline.config import PipelineConfig
 from janasunani.pipeline.db import connect
+from janasunani.tracking.artifacts import remote_models_allowed, resolve_artifact
 from loguru import logger
 
 
@@ -45,14 +46,31 @@ PAGE_TYPE_CLASS_BY_LABEL = {
 
 
 def _resolve_model_id(config: PipelineConfig) -> str:
-    """Model provenance rule: the DVC-mirrored copy under models/ wins;
-    the orphaned-org HF repo is only a fallback. Explicit config overrides."""
+    """Resolve a pinned local artifact; public IDs are development-only."""
     if config.page_type_model_id:
-        return config.page_type_model_id
-    local = config.models_dir / "page_type_classifier" / "vit_type_classifier"
-    if (local / "config.json").exists():
-        return str(local)
-    return "DPIC-Pipeline/vit_type_classifier"
+        explicit = Path(config.page_type_model_id)
+        if explicit.exists() or remote_models_allowed():
+            return config.page_type_model_id
+        raise RuntimeError(
+            "remote page-type model IDs require JANASUNANI_ALLOW_REMOTE_MODELS=1"
+        )
+    artifact = resolve_artifact(
+        "page_type_classifier", models_dir=config.models_dir
+    )
+    if artifact is not None:
+        local = (
+            artifact
+            if (artifact / "config.json").is_file()
+            else artifact / "vit_type_classifier"
+        )
+        if (local / "config.json").is_file():
+            return str(local)
+    if remote_models_allowed():
+        return "DPIC-Pipeline/vit_type_classifier"
+    raise RuntimeError(
+        "no local page-type artifact resolved; materialize the approved release "
+        "or set JANASUNANI_ALLOW_REMOTE_MODELS=1 for development only"
+    )
 
 
 def run_page_type_classifier(config: PipelineConfig) -> None:

--- a/janasunani/pipeline/stages/summarizer.py
+++ b/janasunani/pipeline/stages/summarizer.py
@@ -1,8 +1,13 @@
 import os
 from dataclasses import dataclass
+from pathlib import Path
 
 from janasunani.pipeline.config import PipelineConfig
 from janasunani.pipeline.db import connect
+from janasunani.tracking.artifacts import (
+    ALLOW_REMOTE_MODELS_ENV_VAR,
+    remote_models_allowed,
+)
 from loguru import logger
 
 
@@ -31,11 +36,11 @@ def run_summarizer(config: PipelineConfig) -> None:
         logger.info("summarizer: nothing to do")
         return
 
-    tokenizer, model, torch, device = _load_model()
+    tokenizer, model, torch, device = _load_model(models_dir=config.models_dir)
     total_completed = 0
     logger.info(
         "summarizer: "
-        f"model={MODEL_NAME} device={device} "
+        f"model=local-release-or-dvc device={device} "
         f"target_page_type_class={TARGET_PAGE_TYPE_CLASS} "
         f"batch_size={DEFAULT_BATCH_SIZE}"
     )
@@ -131,14 +136,49 @@ def _fetch_documents_to_summarize(
     return output
 
 
-def _load_model():
+def _remote_models_allowed() -> bool:
+    return remote_models_allowed()
+
+
+def _resolve_model_source(*, models_dir=None) -> tuple[str, bool]:
+    """Return a local artifact by default; remote HF is explicit dev mode."""
+
+    from janasunani.tracking.artifacts import resolve_artifact
+
+    artifact = resolve_artifact(
+        "summarizer", models_dir=Path(models_dir) if models_dir is not None else None
+    )
+    if artifact is not None:
+        return str(artifact), True
+    if _remote_models_allowed():
+        return MODEL_NAME, False
+    raise RuntimeError(
+        "no local summarizer artifact resolved; materialize the approved release "
+        f"or set {ALLOW_REMOTE_MODELS_ENV_VAR}=1 for development only"
+    )
+
+
+def _load_model(model_name_or_path=None, *, models_dir=None):
     import torch
     from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
 
     device = "cuda" if torch.cuda.is_available() else "cpu"
-    hf_token = os.getenv("HF_TOKEN")
-    tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME, token=hf_token)
-    model = AutoModelForSeq2SeqLM.from_pretrained(MODEL_NAME, token=hf_token).to(device)
+    if model_name_or_path is None:
+        source, local_only = _resolve_model_source(models_dir=models_dir)
+    else:
+        source = str(model_name_or_path)
+        local_only = Path(source).exists()
+        if not local_only and not _remote_models_allowed():
+            raise RuntimeError(
+                "remote summarizer model IDs require explicit development opt-in"
+            )
+    hf_token = None if local_only else os.getenv("HF_TOKEN")
+    tokenizer = AutoTokenizer.from_pretrained(
+        source, token=hf_token, local_files_only=local_only
+    )
+    model = AutoModelForSeq2SeqLM.from_pretrained(
+        source, token=hf_token, local_files_only=local_only
+    ).to(device)
     model.eval()
     return tokenizer, model, torch, device
 
@@ -170,8 +210,12 @@ class Summarizer:
     inference processor) that summarize one document at a time.
     """
 
-    def __init__(self) -> None:
-        self._tokenizer, self._model, self._torch, self._device = _load_model()
+    def __init__(self, model_name_or_path=None) -> None:
+        if model_name_or_path is None:
+            loaded = _load_model()
+        else:
+            loaded = _load_model(model_name_or_path)
+        self._tokenizer, self._model, self._torch, self._device = loaded
 
     def summarize(self, text: str) -> str:
         """Summarize a single piece of text using the warm model handles."""

--- a/janasunani/tracking/artifacts.py
+++ b/janasunani/tracking/artifacts.py
@@ -1,17 +1,17 @@
 """Resolve a trained-model artifact to a path, or to nothing at all.
 
-``mlflow_utils`` in this package is registration-side only: it logs artifacts
-and creates model versions, and nothing in it resolves an alias back to
-something loadable. So a learned router or scorer has no way to find its own
-weights. This module is that missing half, deliberately kept to the smallest
-thing that works.
+``mlflow_utils`` in this package is registration-side only. Registry aliases
+are materialized into an immutable release before deploy; serving resolves
+only operator overrides, that pinned local release, or the DVC mirror. This
+module is deliberately kept free of registry and network clients.
 
 Resolution order, first hit wins:
 
 1. ``JANASUNANI_<NAME>_ARTIFACT`` — an explicit operator override.
-2. ``<models_dir>/<name>`` — the DVC-mirrored convention the rest of the repo
+2. The active, immutable local release manifest.
+3. ``<models_dir>/<name>`` — the DVC-mirrored convention the rest of the repo
    already uses for the categorizer and page-type models.
-3. ``None``.
+4. ``None``.
 
 **Never raises.** The degradation contract is copied from
 ``janasunani.routing.crosswalk.load_crosswalk``: a missing *or structurally
@@ -19,22 +19,31 @@ unusable* artifact returns ``None`` and the caller falls through to whatever
 it was doing before. A model that cannot be found must not be able to take
 the demo down, and an operator typo in a path must not either.
 
-Registry resolution (``models:/name@champion``) is deliberately absent. It
-would put a network call on the startup path of a box that has to come up in
-front of an audience, and there is no read side in ``mlflow_utils`` to build
-on. The seam is named below so the day it lands there is one place to put it.
+Registry aliases are resolved before deploy into the release manifest.  This
+module never imports MLflow and never makes a network call.
 """
 
 from __future__ import annotations
 
 import os
 from pathlib import Path
+import re
 
 from loguru import logger
 
-#: Set to route resolution through a model registry instead of the filesystem.
-REGISTRY_ENV_VAR = "JANASUNANI_MODEL_REGISTRY"
 
+ALLOW_REMOTE_MODELS_ENV_VAR = "JANASUNANI_ALLOW_REMOTE_MODELS"
+_ARTIFACT_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$")
+
+
+def remote_models_allowed() -> bool:
+    """Whether mutable public model IDs are allowed for development only."""
+
+    return os.getenv(ALLOW_REMOTE_MODELS_ENV_VAR, "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }
 
 def _env_var_for(name: str) -> str:
     return f"JANASUNANI_{name.upper().replace('-', '_')}_ARTIFACT"
@@ -73,6 +82,9 @@ def resolve_artifact(name: str, *, models_dir: Path | None = None) -> Path | Non
     or an override pointing somewhere unreadable.
     """
     try:
+        if not isinstance(name, str) or _ARTIFACT_NAME.fullmatch(name) is None:
+            logger.warning("invalid artifact name {!r}; treating it as absent", name)
+            return None
         override = os.environ.get(_env_var_for(name))
         if override:
             candidate = Path(override)
@@ -84,10 +96,11 @@ def resolve_artifact(name: str, *, models_dir: Path | None = None) -> Path | Non
                 override,
             )
 
-        if os.environ.get(REGISTRY_ENV_VAR):
-            resolved = _resolve_via_registry(name)
-            if resolved is not None:
-                return resolved
+        from janasunani.tracking.release import resolve_manifest_artifact
+
+        resolved = resolve_manifest_artifact(name)
+        if resolved is not None:
+            return resolved
 
         candidate = _models_dir(models_dir) / name
         if _usable(candidate):
@@ -96,16 +109,3 @@ def resolve_artifact(name: str, *, models_dir: Path | None = None) -> Path | Non
     except Exception:  # pragma: no cover — the contract is "never raises"
         logger.warning("artifact resolution for {!r} failed; treating it as absent", name)
         return None
-
-
-def _resolve_via_registry(name: str) -> Path | None:
-    """Resolve through a model registry alias. Not implemented before 14 Aug.
-
-    Returns ``None`` rather than raising so that setting the env var early is
-    harmless: resolution simply falls through to the filesystem.
-    """
-    logger.warning(
-        "{} is set but registry resolution is not implemented; falling back to the filesystem",
-        REGISTRY_ENV_VAR,
-    )
-    return None

--- a/tests/test_inference_live_builder.py
+++ b/tests/test_inference_live_builder.py
@@ -65,6 +65,14 @@ def _write_dummy_model_artifacts(root: Path) -> None:
     (page_type_dir / "config.json").write_text("{}")
     (page_type_dir / "model.safetensors").write_bytes(b"")
     (page_type_dir / "preprocessor_config.json").write_text("{}")
+    summarizer_dir = root / "summarizer"
+    summarizer_dir.mkdir(parents=True)
+    (summarizer_dir / "config.json").write_text("{}")
+    (summarizer_dir / "model.safetensors").write_bytes(b"")
+    (summarizer_dir / "tokenizer.json").write_text("{}")
+    (summarizer_dir / "merges.txt").write_text("#version: 0.2")
+
+
 def test_preflight_reports_immutable_release_versions_without_hosted_endpoint(
     tmp_path, monkeypatch
 ):

--- a/tests/test_local_model_resolution.py
+++ b/tests/test_local_model_resolution.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+import pytest
+
+from janasunani.pipeline.stages.ocr_extraction.deepseek_backend import (
+    DEFAULT_MODEL_NAME,
+    _resolve_model_source as resolve_deepseek_source,
+)
+from janasunani.tracking.artifacts import ALLOW_REMOTE_MODELS_ENV_VAR
+
+
+def test_deepseek_requires_local_artifact_by_default(tmp_path, monkeypatch):
+    monkeypatch.setenv("JANASUNANI_MODELS_DIR", str(tmp_path / "missing"))
+    monkeypatch.delenv("JANASUNANI_DEEPSEEK_OCR_ARTIFACT", raising=False)
+    monkeypatch.delenv(ALLOW_REMOTE_MODELS_ENV_VAR, raising=False)
+
+    with pytest.raises(RuntimeError, match="no local DeepSeek OCR artifact"):
+        resolve_deepseek_source()
+
+
+def test_deepseek_resolves_local_override_without_network(tmp_path, monkeypatch):
+    artifact = tmp_path / "deepseek"
+    artifact.mkdir()
+    (artifact / "config.json").write_text("{}")
+    monkeypatch.setenv("JANASUNANI_DEEPSEEK_OCR_ARTIFACT", str(artifact))
+    monkeypatch.delenv(ALLOW_REMOTE_MODELS_ENV_VAR, raising=False)
+
+    assert resolve_deepseek_source() == (str(artifact), True)
+
+
+def test_deepseek_public_id_is_explicit_development_mode(tmp_path, monkeypatch):
+    monkeypatch.setenv("JANASUNANI_MODELS_DIR", str(tmp_path / "missing"))
+    monkeypatch.delenv("JANASUNANI_DEEPSEEK_OCR_ARTIFACT", raising=False)
+    monkeypatch.setenv(ALLOW_REMOTE_MODELS_ENV_VAR, "true")
+
+    assert resolve_deepseek_source() == (DEFAULT_MODEL_NAME, False)
+
+
+def test_deepseek_explicit_local_path_is_local(tmp_path, monkeypatch):
+    artifact = Path(tmp_path / "deepseek")
+    artifact.mkdir()
+    monkeypatch.delenv(ALLOW_REMOTE_MODELS_ENV_VAR, raising=False)
+
+    assert resolve_deepseek_source(str(artifact)) == (str(artifact), True)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -24,11 +24,23 @@ FORMAT_MODEL = directories.MODELS / "format_classifier" / "page_split_v3.0_doc_s
 
 def test_format_classifier_resolution_import_does_not_require_opencv(monkeypatch):
     monkeypatch.setitem(sys.modules, "cv2", None)
-    sys.modules.pop("janasunani.pipeline.stages.format_classifier.resolution", None)
+    monkeypatch.delitem(
+        sys.modules, "janasunani.pipeline.stages.format_classifier.resolution", raising=False
+    )
     module = importlib.import_module(
         "janasunani.pipeline.stages.format_classifier.resolution"
     )
     assert callable(module.resolve_model_path)
+
+
+def test_format_classifier_entrypoint_export_does_not_require_opencv(monkeypatch):
+    monkeypatch.setitem(sys.modules, "cv2", None)
+    monkeypatch.delitem(
+        sys.modules, "janasunani.pipeline.stages.format_classifier", raising=False
+    )
+    module = importlib.import_module("janasunani.pipeline.stages.format_classifier")
+    assert callable(module.run_format_classifier)
+    assert hasattr(module, "run_format_classifier")
 
 
 def test_init_db_creates_schema_and_is_idempotent(tmp_path):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -55,14 +55,18 @@ def test_doc_id_unique_across_nested_dirs_and_stable_for_flat_files():
     assert doc_id_from_relpath("CMO2021_complaint_y.jpeg") == "CMO2021_complaint_y"
 
 
-def test_page_type_model_resolves_to_dvc_mirror(tmp_path):
-    # Provenance rule: the mirrored local copy wins; HF repo only as fallback;
-    # explicit config overrides everything.
+def test_page_type_model_resolves_to_dvc_mirror(tmp_path, monkeypatch):
+    # Provenance rule: local copy wins; remote IDs require explicit dev opt-in.
     from janasunani.pipeline.stages.page_type_classifier import _resolve_model_id
 
     local = tmp_path / "page_type_classifier" / "vit_type_classifier"
     cfg = PipelineConfig(input_dir=tmp_path, db_path=tmp_path / "p.db", models_dir=tmp_path)
-    assert _resolve_model_id(cfg) == "DPIC-Pipeline/vit_type_classifier"  # no mirror
+    monkeypatch.delenv("JANASUNANI_ALLOW_REMOTE_MODELS", raising=False)
+    with pytest.raises(RuntimeError, match="no local page-type artifact"):
+        _resolve_model_id(cfg)
+    monkeypatch.setenv("JANASUNANI_ALLOW_REMOTE_MODELS", "1")
+    assert _resolve_model_id(cfg) == "DPIC-Pipeline/vit_type_classifier"
+    monkeypatch.delenv("JANASUNANI_ALLOW_REMOTE_MODELS")
     local.mkdir(parents=True)
     (local / "config.json").write_text("{}")
     assert _resolve_model_id(cfg) == str(local)  # mirror present
@@ -70,7 +74,31 @@ def test_page_type_model_resolves_to_dvc_mirror(tmp_path):
         input_dir=tmp_path, db_path=tmp_path / "p.db", models_dir=tmp_path,
         page_type_model_id="explicit/override",
     )
+    monkeypatch.setenv("JANASUNANI_ALLOW_REMOTE_MODELS", "1")
     assert _resolve_model_id(cfg2) == "explicit/override"
+
+
+def test_format_classifier_requires_an_unambiguous_pinned_artifact(
+    tmp_path, monkeypatch
+):
+    from janasunani.pipeline.stages.format_classifier.stage import _resolve_model_path
+
+    model_dir = tmp_path / "format_classifier"
+    model_dir.mkdir()
+    cfg = PipelineConfig(input_dir=tmp_path, db_path=tmp_path / "p.db", models_dir=tmp_path)
+    with pytest.raises(FileNotFoundError, match="no format-classifier artifact"):
+        _resolve_model_path(cfg)
+
+    first = model_dir / "first.pkl"
+    first.write_bytes(b"first")
+    assert _resolve_model_path(cfg) == first
+
+    (model_dir / "second.pkl").write_bytes(b"second")
+    with pytest.raises(RuntimeError, match="contains 2 .pkl"):
+        _resolve_model_path(cfg)
+
+    monkeypatch.setenv("JANASUNANI_FORMAT_CLASSIFIER_ARTIFACT", str(first))
+    assert _resolve_model_path(cfg) == first
 
 
 def test_partial_json_reingest_preserves_existing_grievances(tmp_path):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -6,8 +6,10 @@ generated fixture image and skips where the tesseract binary or the DVC-pulled
 format-classifier pickle is missing (e.g. CI).
 """
 
+import importlib
 import shutil
 import sqlite3
+import sys
 
 import pytest
 
@@ -18,6 +20,15 @@ from janasunani.pipeline.db import connect, initialize_database
 from janasunani.pipeline.pipeline import STAGE_ORDER, run_pipeline
 
 FORMAT_MODEL = directories.MODELS / "format_classifier" / "page_split_v3.0_doc_split.pkl"
+
+
+def test_format_classifier_resolution_import_does_not_require_opencv(monkeypatch):
+    monkeypatch.setitem(sys.modules, "cv2", None)
+    sys.modules.pop("janasunani.pipeline.stages.format_classifier.resolution", None)
+    module = importlib.import_module(
+        "janasunani.pipeline.stages.format_classifier.resolution"
+    )
+    assert callable(module.resolve_model_path)
 
 
 def test_init_db_creates_schema_and_is_idempotent(tmp_path):
@@ -81,24 +92,24 @@ def test_page_type_model_resolves_to_dvc_mirror(tmp_path, monkeypatch):
 def test_format_classifier_requires_an_unambiguous_pinned_artifact(
     tmp_path, monkeypatch
 ):
-    from janasunani.pipeline.stages.format_classifier.stage import _resolve_model_path
+    from janasunani.pipeline.stages.format_classifier.resolution import resolve_model_path
 
     model_dir = tmp_path / "format_classifier"
     model_dir.mkdir()
     cfg = PipelineConfig(input_dir=tmp_path, db_path=tmp_path / "p.db", models_dir=tmp_path)
     with pytest.raises(FileNotFoundError, match="no format-classifier artifact"):
-        _resolve_model_path(cfg)
+        resolve_model_path(cfg)
 
     first = model_dir / "first.pkl"
     first.write_bytes(b"first")
-    assert _resolve_model_path(cfg) == first
+    assert resolve_model_path(cfg) == first
 
     (model_dir / "second.pkl").write_bytes(b"second")
     with pytest.raises(RuntimeError, match="contains 2 .pkl"):
-        _resolve_model_path(cfg)
+        resolve_model_path(cfg)
 
     monkeypatch.setenv("JANASUNANI_FORMAT_CLASSIFIER_ARTIFACT", str(first))
-    assert _resolve_model_path(cfg) == first
+    assert resolve_model_path(cfg) == first
 
 
 def test_partial_json_reingest_preserves_existing_grievances(tmp_path):

--- a/tests/test_summarizer_wrapper.py
+++ b/tests/test_summarizer_wrapper.py
@@ -6,8 +6,33 @@ Summarizer class logic: loading once, threading cached handles, and the
 short-input guard.
 """
 
+import pytest
+
 from janasunani.pipeline.stages import summarizer as summarizer_module
-from janasunani.pipeline.stages.summarizer import MIN_SUMMARY_LENGTH, Summarizer
+from janasunani.pipeline.stages.summarizer import (
+    ALLOW_REMOTE_MODELS_ENV_VAR,
+    MIN_SUMMARY_LENGTH,
+    MODEL_NAME,
+    Summarizer,
+    _resolve_model_source,
+)
+
+
+def test_summarizer_requires_local_artifact_by_default(tmp_path, monkeypatch):
+    monkeypatch.setenv("JANASUNANI_MODELS_DIR", str(tmp_path / "missing"))
+    monkeypatch.delenv("JANASUNANI_SUMMARIZER_ARTIFACT", raising=False)
+    monkeypatch.delenv(ALLOW_REMOTE_MODELS_ENV_VAR, raising=False)
+
+    with pytest.raises(RuntimeError, match="no local summarizer artifact"):
+        _resolve_model_source()
+
+
+def test_summarizer_remote_model_is_explicit_development_mode(tmp_path, monkeypatch):
+    monkeypatch.setenv("JANASUNANI_MODELS_DIR", str(tmp_path / "missing"))
+    monkeypatch.delenv("JANASUNANI_SUMMARIZER_ARTIFACT", raising=False)
+    monkeypatch.setenv(ALLOW_REMOTE_MODELS_ENV_VAR, "1")
+
+    assert _resolve_model_source() == (MODEL_NAME, False)
 
 
 def test_summarize_loads_model_once_and_threads_cached_handles(monkeypatch):

--- a/tests/test_tracking_artifacts.py
+++ b/tests/test_tracking_artifacts.py
@@ -1,0 +1,88 @@
+from janasunani.tracking.artifacts import resolve_artifact
+from janasunani.tracking.release import (
+    RELEASE_MANIFEST_ENV_VAR,
+    ModelRelease,
+    artifact_sha256,
+    new_manifest,
+    write_manifest,
+)
+
+
+def _manifest(tmp_path, artifact):
+    release_dir = tmp_path / "release-1"
+    release_dir.mkdir()
+    copied = release_dir / "model.bin"
+    copied.write_bytes(artifact.read_bytes())
+    model = ModelRelease(
+        name="spam_scorer",
+        provider="local_sklearn",
+        trust_tier="local",
+        version="2",
+        artifact_path="model.bin",
+        artifact_sha256=artifact_sha256(copied),
+    )
+    path = release_dir / "release-manifest.json"
+    write_manifest(
+        path,
+        new_manifest(
+            release_id="release-1", git_sha="a" * 40, models={"spam_scorer": model}
+        ),
+    )
+    return path, copied
+
+
+def test_resolution_order_override_then_manifest_then_dvc(tmp_path, monkeypatch):
+    source = tmp_path / "source.bin"
+    source.write_bytes(b"manifest")
+    manifest, manifest_artifact = _manifest(tmp_path, source)
+    models = tmp_path / "models"
+    dvc = models / "spam_scorer"
+    dvc.mkdir(parents=True)
+    (dvc / "model.bin").write_bytes(b"dvc")
+    override = tmp_path / "override.bin"
+    override.write_bytes(b"override")
+    monkeypatch.setenv(RELEASE_MANIFEST_ENV_VAR, str(manifest))
+    monkeypatch.setenv("JANASUNANI_SPAM_SCORER_ARTIFACT", str(override))
+
+    assert resolve_artifact("spam_scorer", models_dir=models) == override
+    monkeypatch.delenv("JANASUNANI_SPAM_SCORER_ARTIFACT")
+    assert resolve_artifact("spam_scorer", models_dir=models) == manifest_artifact
+    monkeypatch.delenv(RELEASE_MANIFEST_ENV_VAR)
+    assert resolve_artifact("spam_scorer", models_dir=models) == dvc
+
+
+def test_resolution_degrades_when_manifest_is_invalid(tmp_path, monkeypatch):
+    models = tmp_path / "models"
+    fallback = models / "spam_scorer"
+    fallback.mkdir(parents=True)
+    (fallback / "model.bin").write_bytes(b"dvc")
+    broken = tmp_path / "broken.json"
+    broken.write_text("not json")
+    monkeypatch.setenv(RELEASE_MANIFEST_ENV_VAR, str(broken))
+
+    assert resolve_artifact("spam_scorer", models_dir=models) is None
+
+
+def test_runtime_resolver_does_not_import_mlflow():
+    import ast
+    import inspect
+    from janasunani.tracking import artifacts, release
+
+    for module in (artifacts, release):
+        tree = ast.parse(inspect.getsource(module))
+        imported = {
+            alias.name
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.Import, ast.ImportFrom))
+            for alias in node.names
+        }
+        assert not any(name == "mlflow" or name.startswith("mlflow.") for name in imported)
+
+
+def test_artifact_name_cannot_escape_the_models_directory(tmp_path):
+    outside = tmp_path / "outside"
+    outside.write_bytes(b"model")
+    models = tmp_path / "models"
+    models.mkdir()
+
+    assert resolve_artifact("../outside", models_dir=models) is None


### PR DESCRIPTION
## Summary

- resolve live and batch model artifacts in operator-override → active immutable release → governed DVC order
- make local models the default and permit mutable public model IDs only behind an explicit development opt-in
- validate required categorizer, page-type, and summarizer files before live warm-up
- keep artifact resolution free of MLflow and other startup network calls
- defer optional format-classifier imports so lightweight resolution and CI do not require the heavy runtime stack

## Reconciliation status

This historical stack slice is already an ancestor of `feat/pipeline-quality-trunk`; it will not be merged independently into `main`. After this exact-head review is complete, the PR will be closed as already integrated. Final integration to `main` remains a separate PR and requires explicit maintainer approval.

- Review base: `feat/model-release-control-plane`
- Exact head under review: `00b52903f99d6d7dc56c07e2b573c45d0d86a380`
- Primary commits: `8c893d2`, `048d0aa`, `00b5290`
- Successor: PR #257

## Safety boundary

- An invalid active manifest fails closed instead of silently falling through to older DVC bytes.
- Operator overrides remain explicit recovery controls; unusable overrides are logged and skipped.
- Remote Hugging Face identifiers require `JANASUNANI_ALLOW_REMOTE_MODELS=1` and are development-only.
- The runtime resolver imports no MLflow client and performs no registry/network resolution.
- No model release is activated by this PR.

The reconciled integration branch also contains `d9d54a9`, a bounded self-review fix requiring every startup/preflight model file to be non-empty. This closes a false-green case where a zero-byte weight or tokenizer file passed the existence-only readiness check and failed later inside the real loader.

It also contains `70cfa7f`, which rejects symlinked artifact roots for operator overrides and DVC fallbacks, aligning those paths with the immutable-release symlink policy.

## Verification

Exact slice:

- 71 targeted tests passed, 1 optional-dependency test skipped
- Ruff passed on all changed Python and test files
- `git diff --check` passed

Downstream self-review fix:

- 56 live-resolution/preflight tests passed
- Ruff and `git diff --check` passed

No citizen data files were opened during this review pass.

## Review protocol

This PR is ready for an exact-head Codex review. Every finding will be verified, answered individually with evidence, fixed on the reconciled integration branch when valid, and resolved before the `codex-review` gate is accepted.
