### PR TITLE
feat(evaluation): preserve cached Sarvam benchmark evidence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,6 +213,10 @@ data/output/*
 !data/interim/*.dvc
 !data/processed/*.dvc
 !data/external/*.dvc
+!data/external/sarvam_cached_v1/
+data/external/sarvam_cached_v1/*
+!data/external/sarvam_cached_v1/*.dvc
+!data/external/sarvam_cached_v1/provenance.json
 # Provenance sidecars for gold/draft artifacts: versions, checksums and span
 # counts only, written by scripts/rederive_pii_draft.py. They exist to be read
 # in review, so they belong in git. Never put citizen text in one.

--- a/data/external/sarvam_cached_v1/interrupted_300_page_audit.sqlite.dvc
+++ b/data/external/sarvam_cached_v1/interrupted_300_page_audit.sqlite.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 94053be2a95e04481b3bf24d84e55d08
+  size: 692224
+  hash: md5
+  path: interrupted_300_page_audit.sqlite

--- a/data/external/sarvam_cached_v1/provenance.json
+++ b/data/external/sarvam_cached_v1/provenance.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": "janasunani.sarvam-source-snapshots/v1",
+  "claim_status": "cached provider evidence; not OCR accuracy evidence and not a release gate",
+  "privacy": {
+    "contains_operational_ticket_and_document_identifiers": true,
+    "contains_provider_response_metadata": true,
+    "git_contains_row_level_bytes": false,
+    "storage": "private DVC remote"
+  },
+  "artifacts": {
+    "interrupted_300_page_audit.sqlite": {
+      "sha256": "247673d4d0e4a22b5ad88fa91af3e2e2711d3000e29c0e95299c2ac8faa36219",
+      "audit_events": 628,
+      "distinct_tickets": 15,
+      "distinct_documents": 65,
+      "role": "audit log for the paid run interrupted by credit exhaustion"
+    },
+    "validation_5_page_audit.sqlite": {
+      "sha256": "66d338c6bcddb8d67fc5c4fca0d11855b65a6c6411fcbf02c536d46a0d9f0ae2",
+      "audit_events": 46,
+      "distinct_tickets": 2,
+      "distinct_documents": 5,
+      "role": "audit log for the completed five-page validation run"
+    },
+    "validation_5_page_scorecard.json": {
+      "sha256": "c7c6f1214842d2532b4f12e549c91d701ec3df13a9b616f9a8eb57ed6767aeae",
+      "role": "machine-readable scorecard from the completed validation run"
+    },
+    "validation_5_page_scorecard.md": {
+      "sha256": "13e0283466a26edd129aa13707645bcec965d2637b1a5e8d8a89423c2f45a801",
+      "role": "human-readable scorecard from the completed validation run"
+    }
+  },
+  "limitations": [
+    "The original 300-page sample manifest and benchmark log were not recovered.",
+    "The paid run ended before it wrote a complete scorecard.",
+    "No hand transcription exists, so paired text divergence is not OCR accuracy.",
+    "Latency distributions and actual provider billing records were not recovered."
+  ]
+}

--- a/data/external/sarvam_cached_v1/validation_5_page_audit.sqlite.dvc
+++ b/data/external/sarvam_cached_v1/validation_5_page_audit.sqlite.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: fac83bd45ea7184251a808a4a557b0af
+  size: 61440
+  hash: md5
+  path: validation_5_page_audit.sqlite

--- a/data/external/sarvam_cached_v1/validation_5_page_scorecard.json.dvc
+++ b/data/external/sarvam_cached_v1/validation_5_page_scorecard.json.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 6bfa40f56aeff5f297ce8d507f3e7dd0
+  size: 4384
+  hash: md5
+  path: validation_5_page_scorecard.json

--- a/data/external/sarvam_cached_v1/validation_5_page_scorecard.md.dvc
+++ b/data/external/sarvam_cached_v1/validation_5_page_scorecard.md.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 7c87579ed225fa95f3be271fbedefb3e
+  size: 2593
+  hash: md5
+  path: validation_5_page_scorecard.md

--- a/docs/evidence/sarvam_cached_benchmark.json
+++ b/docs/evidence/sarvam_cached_benchmark.json
@@ -1,0 +1,82 @@
+{
+  "schema_version": "janasunani.sarvam-cached-evidence/v1",
+  "as_of": "2026-08-10",
+  "provider": "sarvam-hosted",
+  "model": "Sarvam Vision 1.5",
+  "slice": "Sambalpur/2024",
+  "extract_schema_version": "v1",
+  "normalizer_version": "1.0",
+  "credits_available_for_new_calls": false,
+  "reproducibility": {
+    "tracked_aggregate_only": false,
+    "source_artifacts_tracked": true,
+    "source_artifact_hashes_available": true,
+    "derivation_command_recorded": false,
+    "latency_distribution_available": false,
+    "claim_limit": "The aggregate and source snapshots are preserved, but the original sample manifest and derivation command were unavailable, so the aggregate cannot be independently reconstructed."
+  },
+  "runs": [
+    {
+      "run_id": "sarvam-validation-5-page",
+      "status": "completed",
+      "arm": "both",
+      "pages_submitted": 5,
+      "pages_paired_scored": 5,
+      "tickets": 2,
+      "provider_failures": 0,
+      "recorded_cost_rupees": 7.5,
+      "cost_basis": "list-price calculation; actual billing unavailable",
+      "actual_billing_available": false,
+      "normalized_exact_text_divergence": 1.0,
+      "pytesseract_normalized_characters": 4690,
+      "sarvam_normalized_characters": 5831,
+      "sarvam_to_pytesseract_character_ratio": 1.2433,
+      "source": "DVC-tracked data/external/sarvam_cached_v1/validation_5_page_scorecard.json",
+      "limitations": [
+        "No hand transcription; divergence is not OCR accuracy.",
+        "No reportable category accuracy or summary comparison.",
+        "Language is an en-IN request hint, not an observed language split.",
+        "Handwriting status is unknown."
+      ]
+    },
+    {
+      "run_id": "sarvam-300-page-interrupted",
+      "status": "interrupted_credit_exhaustion",
+      "arm": "both",
+      "sample_manifest_pages": 300,
+      "sample_manifest_tickets": 108,
+      "sample_manifest_categories": 31,
+      "sample_seed": 20260809,
+      "pages_attempted": 65,
+      "pages_paired_scored": 56,
+      "pages_excluded": 9,
+      "accepted_jobs": 127,
+      "accepted_digitise_jobs": 64,
+      "accepted_extract_jobs": 63,
+      "completed_jobs": 120,
+      "completed_digitise_jobs": 59,
+      "completed_extract_jobs": 61,
+      "provider_job_failures": 7,
+      "credit_exhaustion_http_402_submissions": 3,
+      "normalized_exact_text_divergence": 1.0,
+      "pytesseract_normalized_characters": 66171,
+      "sarvam_normalized_characters": 88306,
+      "sarvam_to_pytesseract_character_ratio": 1.3345,
+      "sarvam_longer_pages": 43,
+      "pytesseract_longer_pages": 13,
+      "estimated_list_price_accepted_jobs_rupees": 95.0,
+      "estimated_list_price_completed_jobs_rupees": 90.5,
+      "cost_basis": "list-price calculation; actual billing unavailable",
+      "actual_billing_available": false,
+      "source": "aggregate audit of the unavailable local sample manifest and benchmark log plus DVC-tracked data/external/sarvam_cached_v1/interrupted_300_page_audit.sqlite",
+      "limitations": [
+        "The original runner did not checkpoint a scorecard before HTTP 402.",
+        "No hand transcription; divergence and character length do not establish quality.",
+        "Failed pages are excluded from paired divergence and may be non-random.",
+        "The category-stratified sample is not handwriting- or language-stratified.",
+        "The original sample manifest contained ticket and object identifiers and was not recovered."
+      ]
+    }
+  ],
+  "reporting_rule": "Report coverage, failures, list-price cost estimates, and paired divergence only. Do not claim latency, actual billed cost, OCR accuracy, category superiority, or summary quality until the corresponding governed evidence exists."
+}

--- a/janasunani/evaluation/sarvam_cached.py
+++ b/janasunani/evaluation/sarvam_cached.py
@@ -279,7 +279,11 @@ def import_evidence(
             "provider_job_failure_rate": failures / accepted if accepted else 0.0,
         }
         cost = run.get("recorded_cost_rupees")
-        cost_kind = "recorded"
+        cost_kind = (
+            "actual_billing"
+            if run.get("actual_billing_available", False)
+            else "recorded_non_billing_amount"
+        )
         if cost is None:
             cost = run.get("estimated_list_price_accepted_jobs_rupees")
             cost_kind = "estimated_list_price_accepted_jobs"
@@ -295,9 +299,6 @@ def import_evidence(
             slice_id=str(payload["slice"]),
             ocr_engine="sarvam",
             sample_n=scored,
-            cost_per_doc_rupees=(
-                float(cost) / attempted if cost is not None and attempted else None
-            ),
             ocr_divergence_rate=float(run["normalized_exact_text_divergence"]),
             extra_params={
                 "cached_evidence_run_id": str(run["run_id"]),
@@ -312,6 +313,7 @@ def import_evidence(
                     run.get("actual_billing_available", False)
                 ).lower(),
                 "cost_evidence": cost_kind if cost is not None else "unavailable",
+                "cost_denominator": "attempted_page",
                 "cost_basis": str(run.get("cost_basis", "not recorded")),
                 "quality_claim_permitted": "false",
             },

--- a/janasunani/evaluation/sarvam_cached.py
+++ b/janasunani/evaluation/sarvam_cached.py
@@ -266,7 +266,7 @@ def import_evidence(
         attempted = int(run.get("pages_attempted", run.get("pages_submitted", 0)))
         scored = int(run["pages_paired_scored"])
         failures = int(run.get("provider_job_failures", run.get("provider_failures", 0)))
-        accepted = int(run.get("accepted_jobs", 0))
+        accepted = run.get("accepted_jobs")
         metrics = {
             "pages_attempted": float(attempted),
             "pages_paired_scored": float(scored),
@@ -278,8 +278,9 @@ def import_evidence(
                 run["sarvam_to_pytesseract_character_ratio"]
             ),
             "provider_job_failures": float(failures),
-            "provider_job_failure_rate": failures / accepted if accepted else 0.0,
         }
+        if accepted is not None and int(accepted) > 0:
+            metrics["provider_job_failure_rate"] = failures / int(accepted)
         cost = run.get("recorded_cost_rupees")
         cost_kind = (
             "actual_billing"

--- a/janasunani/evaluation/sarvam_cached.py
+++ b/janasunani/evaluation/sarvam_cached.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 from datetime import date
+import hashlib
 import json
 import math
 from pathlib import Path
@@ -104,7 +105,7 @@ def load_evidence(path: Path) -> Mapping[str, Any]:
     required_root = {
         "as_of", "provider", "model", "slice", "extract_schema_version",
         "normalizer_version", "credits_available_for_new_calls", "runs",
-        "reporting_rule",
+        "reporting_rule", "reproducibility",
     }
     missing_root = required_root - set(payload)
     if missing_root:
@@ -121,19 +122,18 @@ def load_evidence(path: Path) -> Mapping[str, Any]:
             raise ValueError(f"cached Sarvam evidence {field} must be a non-empty string")
     if not isinstance(payload["credits_available_for_new_calls"], bool):
         raise ValueError("credits_available_for_new_calls must be a boolean")
-    reproducibility = payload.get("reproducibility")
-    if reproducibility is not None:
-        if not isinstance(reproducibility, Mapping):
-            raise ValueError("reproducibility must be an object")
-        if set(reproducibility) != _REPRODUCIBILITY_FIELDS:
-            raise ValueError("reproducibility has an unexpected shape")
-        for field in _REPRODUCIBILITY_FIELDS - {"claim_limit"}:
-            if not isinstance(reproducibility[field], bool):
-                raise ValueError(f"reproducibility.{field} must be a boolean")
-        if not isinstance(reproducibility["claim_limit"], str) or not reproducibility[
-            "claim_limit"
-        ].strip():
-            raise ValueError("reproducibility.claim_limit must be a non-empty string")
+    reproducibility = payload["reproducibility"]
+    if not isinstance(reproducibility, Mapping):
+        raise ValueError("reproducibility must be an object")
+    if set(reproducibility) != _REPRODUCIBILITY_FIELDS:
+        raise ValueError("reproducibility has an unexpected shape")
+    for field in _REPRODUCIBILITY_FIELDS - {"claim_limit"}:
+        if not isinstance(reproducibility[field], bool):
+            raise ValueError(f"reproducibility.{field} must be a boolean")
+    if not isinstance(reproducibility["claim_limit"], str) or not reproducibility[
+        "claim_limit"
+    ].strip():
+        raise ValueError("reproducibility.claim_limit must be a non-empty string")
     runs = payload.get("runs")
     if not isinstance(runs, list) or not runs:
         raise ValueError("cached Sarvam evidence requires at least one run")
@@ -259,6 +259,8 @@ def import_evidence(
     artifact_uri: str | None = None,
 ) -> dict[str, str]:
     payload = load_evidence(path)
+    evidence_sha256 = hashlib.sha256(path.read_bytes()).hexdigest()
+    reproducibility = payload["reproducibility"]
     imported: dict[str, str] = {}
     for run in payload["runs"]:
         attempted = int(run.get("pages_attempted", run.get("pages_submitted", 0)))
@@ -316,6 +318,19 @@ def import_evidence(
                 "cost_denominator": "attempted_page",
                 "cost_basis": str(run.get("cost_basis", "not recorded")),
                 "quality_claim_permitted": "false",
+                "evidence_sha256": evidence_sha256,
+                "git_sha_role": "cached_evidence_import_code",
+                "source_run_git_sha": "unavailable",
+                "source_artifacts_tracked": str(
+                    reproducibility["source_artifacts_tracked"]
+                ).lower(),
+                "source_artifact_hashes_available": str(
+                    reproducibility["source_artifact_hashes_available"]
+                ).lower(),
+                "derivation_command_recorded": str(
+                    reproducibility["derivation_command_recorded"]
+                ).lower(),
+                "evidence_claim_limit": str(reproducibility["claim_limit"]),
             },
             extra_metrics=metrics,
             artifacts=[path],

--- a/janasunani/evaluation/sarvam_cached.py
+++ b/janasunani/evaluation/sarvam_cached.py
@@ -1,0 +1,342 @@
+"""Validate and import cached Sarvam aggregate evidence into MLflow.
+
+This command never calls Sarvam.  It converts the privacy-safe aggregate file
+under ``docs/evidence`` into comparable MLflow benchmark runs so the paid work
+already completed remains visible alongside local candidates.
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import date
+import json
+import math
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from janasunani.tracking.mlflow_utils import log_benchmark_run
+
+
+SCHEMA_VERSION = "janasunani.sarvam-cached-evidence/v1"
+DEFAULT_EVIDENCE = Path("docs/evidence/sarvam_cached_benchmark.json")
+_ROOT_FIELDS = {
+    "schema_version", "as_of", "provider", "model", "slice",
+    "extract_schema_version", "normalizer_version",
+    "credits_available_for_new_calls", "reproducibility", "runs", "reporting_rule",
+}
+_RUN_FIELDS = {
+    "run_id", "status", "arm", "pages_submitted", "pages_attempted",
+    "pages_paired_scored", "pages_excluded", "tickets", "provider_failures",
+    "accepted_jobs", "accepted_digitise_jobs", "accepted_extract_jobs",
+    "completed_jobs", "completed_digitise_jobs", "completed_extract_jobs",
+    "provider_job_failures", "credit_exhaustion_http_402_submissions",
+    "recorded_cost_rupees", "estimated_list_price_accepted_jobs_rupees",
+    "estimated_list_price_completed_jobs_rupees", "actual_billing_available",
+    "normalized_exact_text_divergence", "pytesseract_normalized_characters",
+    "sarvam_normalized_characters", "sarvam_to_pytesseract_character_ratio",
+    "sarvam_longer_pages", "pytesseract_longer_pages", "sample_manifest_pages",
+    "sample_manifest_tickets", "sample_manifest_categories", "sample_seed",
+    "cost_basis", "source", "limitations",
+}
+_REPRODUCIBILITY_FIELDS = {
+    "tracked_aggregate_only",
+    "source_artifacts_tracked",
+    "source_artifact_hashes_available",
+    "derivation_command_recorded",
+    "latency_distribution_available",
+    "claim_limit",
+}
+_COUNT_FIELDS = {
+    "pages_submitted",
+    "pages_attempted",
+    "pages_paired_scored",
+    "pages_excluded",
+    "tickets",
+    "provider_failures",
+    "accepted_jobs",
+    "accepted_digitise_jobs",
+    "accepted_extract_jobs",
+    "completed_jobs",
+    "completed_digitise_jobs",
+    "completed_extract_jobs",
+    "provider_job_failures",
+    "credit_exhaustion_http_402_submissions",
+    "pytesseract_normalized_characters",
+    "sarvam_normalized_characters",
+    "sarvam_longer_pages",
+    "pytesseract_longer_pages",
+    "sample_manifest_pages",
+    "sample_manifest_tickets",
+    "sample_manifest_categories",
+    "sample_seed",
+}
+_COST_FIELDS = {
+    "recorded_cost_rupees",
+    "estimated_list_price_accepted_jobs_rupees",
+    "estimated_list_price_completed_jobs_rupees",
+}
+
+
+def _nonnegative_int(value: object, *, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{field} must be a non-negative integer")
+    return value
+
+
+def _finite_number(value: object, *, field: str, minimum: float = 0.0) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{field} must be a finite number")
+    numeric = float(value)
+    if not math.isfinite(numeric) or numeric < minimum:
+        raise ValueError(f"{field} must be a finite number >= {minimum}")
+    return numeric
+
+
+def load_evidence(path: Path) -> Mapping[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, Mapping):
+        raise ValueError("cached Sarvam evidence root must be an object")
+    unknown_root = set(payload) - _ROOT_FIELDS
+    if unknown_root:
+        raise ValueError(f"cached Sarvam evidence has unknown fields: {sorted(unknown_root)}")
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError("unsupported cached Sarvam evidence schema")
+    required_root = {
+        "as_of", "provider", "model", "slice", "extract_schema_version",
+        "normalizer_version", "credits_available_for_new_calls", "runs",
+        "reporting_rule",
+    }
+    missing_root = required_root - set(payload)
+    if missing_root:
+        raise ValueError(f"cached Sarvam evidence is missing fields: {sorted(missing_root)}")
+    try:
+        date.fromisoformat(payload["as_of"])
+    except (TypeError, ValueError) as exc:
+        raise ValueError("cached Sarvam evidence as_of must be an ISO date") from exc
+    for field in (
+        "provider", "model", "slice", "extract_schema_version",
+        "normalizer_version", "reporting_rule",
+    ):
+        if not isinstance(payload[field], str) or not payload[field].strip():
+            raise ValueError(f"cached Sarvam evidence {field} must be a non-empty string")
+    if not isinstance(payload["credits_available_for_new_calls"], bool):
+        raise ValueError("credits_available_for_new_calls must be a boolean")
+    reproducibility = payload.get("reproducibility")
+    if reproducibility is not None:
+        if not isinstance(reproducibility, Mapping):
+            raise ValueError("reproducibility must be an object")
+        if set(reproducibility) != _REPRODUCIBILITY_FIELDS:
+            raise ValueError("reproducibility has an unexpected shape")
+        for field in _REPRODUCIBILITY_FIELDS - {"claim_limit"}:
+            if not isinstance(reproducibility[field], bool):
+                raise ValueError(f"reproducibility.{field} must be a boolean")
+        if not isinstance(reproducibility["claim_limit"], str) or not reproducibility[
+            "claim_limit"
+        ].strip():
+            raise ValueError("reproducibility.claim_limit must be a non-empty string")
+    runs = payload.get("runs")
+    if not isinstance(runs, list) or not runs:
+        raise ValueError("cached Sarvam evidence requires at least one run")
+    run_ids: set[str] = set()
+    for index, run in enumerate(runs):
+        if not isinstance(run, Mapping):
+            raise ValueError(f"cached Sarvam run {index} must be an object")
+        unknown_run = set(run) - _RUN_FIELDS
+        if unknown_run:
+            raise ValueError(
+                f"cached Sarvam run {index} has unknown fields: {sorted(unknown_run)}"
+            )
+        for field in ("run_id", "status", "arm", "pages_paired_scored"):
+            if run.get(field) in (None, ""):
+                raise ValueError(f"cached Sarvam run {index} is missing {field}")
+        run_id = run["run_id"]
+        if not isinstance(run_id, str) or not run_id.strip():
+            raise ValueError(f"cached Sarvam run {index} run_id must be a string")
+        if run_id in run_ids:
+            raise ValueError(f"cached Sarvam run {index} duplicates run_id {run_id!r}")
+        run_ids.add(run_id)
+        if not isinstance(run["status"], str) or run["status"] not in {
+            "completed", "interrupted_credit_exhaustion",
+        }:
+            raise ValueError(f"cached Sarvam run {index} has an invalid status")
+        if not isinstance(run["arm"], str) or run["arm"] not in {
+            "digitise", "extract", "both",
+        }:
+            raise ValueError(f"cached Sarvam run {index} has an invalid arm")
+        counts = {
+            field: _nonnegative_int(run[field], field=f"runs[{index}].{field}")
+            for field in _COUNT_FIELDS
+            if field in run
+        }
+        attempted = _nonnegative_int(
+            run.get("pages_attempted", run.get("pages_submitted", 0)),
+            field=f"runs[{index}].pages_attempted",
+        )
+        scored = _nonnegative_int(
+            run["pages_paired_scored"], field=f"runs[{index}].pages_paired_scored"
+        )
+        if scored > attempted:
+            raise ValueError(f"cached Sarvam run {index} scored more pages than attempted")
+        if "pages_excluded" in counts and counts["pages_excluded"] != attempted - scored:
+            raise ValueError(
+                f"cached Sarvam run {index} pages_excluded must equal attempted minus scored"
+            )
+        accepted = counts.get("accepted_jobs")
+        completed = counts.get("completed_jobs")
+        job_failures = counts.get("provider_job_failures")
+        if accepted is not None and completed is not None and completed > accepted:
+            raise ValueError(f"cached Sarvam run {index} completed more jobs than accepted")
+        if (
+            accepted is not None
+            and completed is not None
+            and job_failures is not None
+            and completed + job_failures != accepted
+        ):
+            raise ValueError(
+                f"cached Sarvam run {index} completed jobs plus failures must equal accepted jobs"
+            )
+        accepted_digitise = counts.get("accepted_digitise_jobs")
+        accepted_extract = counts.get("accepted_extract_jobs")
+        if (
+            accepted is not None
+            and accepted_digitise is not None
+            and accepted_extract is not None
+            and accepted_digitise + accepted_extract != accepted
+        ):
+            raise ValueError(
+                f"cached Sarvam run {index} accepted arm jobs must sum to accepted jobs"
+            )
+        completed_digitise = counts.get("completed_digitise_jobs")
+        completed_extract = counts.get("completed_extract_jobs")
+        if (
+            completed is not None
+            and completed_digitise is not None
+            and completed_extract is not None
+            and completed_digitise + completed_extract != completed
+        ):
+            raise ValueError(
+                f"cached Sarvam run {index} completed arm jobs must sum to completed jobs"
+            )
+        divergence = _finite_number(
+            run.get("normalized_exact_text_divergence"),
+            field=f"runs[{index}].normalized_exact_text_divergence",
+        )
+        if divergence > 1.0:
+            raise ValueError(f"cached Sarvam run {index} divergence must be in [0,1]")
+        _finite_number(
+            run.get("sarvam_to_pytesseract_character_ratio"),
+            field=f"runs[{index}].sarvam_to_pytesseract_character_ratio",
+        )
+        for field in _COST_FIELDS:
+            if field in run:
+                _finite_number(run[field], field=f"runs[{index}].{field}")
+        for field in ("source", "cost_basis"):
+            if field in run and (
+                not isinstance(run[field], str) or not run[field].strip()
+            ):
+                raise ValueError(f"runs[{index}].{field} must be a non-empty string")
+        if "limitations" in run and (
+            not isinstance(run["limitations"], list)
+            or not all(
+                isinstance(limitation, str) and limitation.strip()
+                for limitation in run["limitations"]
+            )
+        ):
+            raise ValueError(f"runs[{index}].limitations must be a list of strings")
+        if "actual_billing_available" in run and not isinstance(
+            run["actual_billing_available"], bool
+        ):
+            raise ValueError(
+                f"runs[{index}].actual_billing_available must be a boolean"
+            )
+    return payload
+
+
+def import_evidence(
+    path: Path,
+    *,
+    tracking_uri: str | None = None,
+    artifact_uri: str | None = None,
+) -> dict[str, str]:
+    payload = load_evidence(path)
+    imported: dict[str, str] = {}
+    for run in payload["runs"]:
+        attempted = int(run.get("pages_attempted", run.get("pages_submitted", 0)))
+        scored = int(run["pages_paired_scored"])
+        failures = int(run.get("provider_job_failures", run.get("provider_failures", 0)))
+        accepted = int(run.get("accepted_jobs", 0))
+        metrics = {
+            "pages_attempted": float(attempted),
+            "pages_paired_scored": float(scored),
+            "paired_page_coverage": scored / attempted if attempted else 0.0,
+            "normalized_exact_text_divergence": float(
+                run["normalized_exact_text_divergence"]
+            ),
+            "sarvam_to_pytesseract_character_ratio": float(
+                run["sarvam_to_pytesseract_character_ratio"]
+            ),
+            "provider_job_failures": float(failures),
+            "provider_job_failure_rate": failures / accepted if accepted else 0.0,
+        }
+        cost = run.get("recorded_cost_rupees")
+        cost_kind = "recorded"
+        if cost is None:
+            cost = run.get("estimated_list_price_accepted_jobs_rupees")
+            cost_kind = "estimated_list_price_accepted_jobs"
+        if cost is not None:
+            metrics["cost_per_attempted_page_rupees"] = (
+                float(cost) / attempted if attempted else 0.0
+            )
+            metrics["cost_total_rupees"] = float(cost)
+        imported[str(run["run_id"])] = log_benchmark_run(
+            pipeline_variant="sarvam_both" if run["arm"] == "both" else f"sarvam_{run['arm']}",
+            sarvam_arm=str(run["arm"]),
+            schema_version=str(payload["extract_schema_version"]),
+            slice_id=str(payload["slice"]),
+            ocr_engine="sarvam",
+            sample_n=scored,
+            cost_per_doc_rupees=(
+                float(cost) / attempted if cost is not None and attempted else None
+            ),
+            ocr_divergence_rate=float(run["normalized_exact_text_divergence"]),
+            extra_params={
+                "cached_evidence_run_id": str(run["run_id"]),
+                "evidence_status": str(run["status"]),
+                "provider": str(payload["provider"]),
+                "provider_model": str(payload["model"]),
+                "normalizer_version": str(payload["normalizer_version"]),
+                "credits_available_for_new_calls": str(
+                    payload["credits_available_for_new_calls"]
+                ).lower(),
+                "actual_billing_available": str(
+                    run.get("actual_billing_available", False)
+                ).lower(),
+                "cost_evidence": cost_kind if cost is not None else "unavailable",
+                "cost_basis": str(run.get("cost_basis", "not recorded")),
+                "quality_claim_permitted": "false",
+            },
+            extra_metrics=metrics,
+            artifacts=[path],
+            tracking_uri=tracking_uri,
+            artifact_uri=artifact_uri,
+        )
+    return imported
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--evidence", type=Path, default=DEFAULT_EVIDENCE)
+    parser.add_argument("--tracking-uri")
+    parser.add_argument("--artifact-uri")
+    args = parser.parse_args(argv)
+    imported = import_evidence(
+        args.evidence,
+        tracking_uri=args.tracking_uri,
+        artifact_uri=args.artifact_uri,
+    )
+    print(json.dumps(imported, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/janasunani/evaluation/sarvam_evaluate.py
+++ b/janasunani/evaluation/sarvam_evaluate.py
@@ -96,12 +96,14 @@ def discover_pages(input_dir: Path, limit: int | None) -> list[tuple[Path, int]]
 
 
 def _input_snapshot_id(pages: list[tuple[Path, int]]) -> str:
-    """Content-address the exact document bytes and requested page inventory.
+    """Content-address document bytes, pages, and ticket assignments.
 
-    Filenames can contain ticket identifiers and mtimes change when a governed
-    sample is copied. Neither belongs in the identity. Hash each source file's
-    bytes once, then bind that digest to every requested page number so changed
-    pixels cannot retain the same snapshot merely by preserving size/mtime.
+    Filenames can contain ticket identifiers, so never persist them or their
+    individual hashes. The ticket parsed from each filename nevertheless
+    determines the metadata join and must be part of the aggregate identity.
+    Hash each source file's bytes once, then bind its digest, requested page,
+    and an in-memory ticket digest into the final order-independent snapshot.
+    Mtimes and filename decorations outside the parsed ticket are irrelevant.
     """
 
     digest = hashlib.sha256()
@@ -117,7 +119,10 @@ def _input_snapshot_id(pages: list[tuple[Path, int]]) -> str:
                     source_digest.update(chunk)
             file_digest = source_digest.digest()
             file_digests[resolved] = file_digest
-        members.append(file_digest + b"\0" + str(number).encode("ascii"))
+        ticket_digest = hashlib.sha256(_ticket_of(path).encode("utf-8")).digest()
+        members.append(
+            file_digest + ticket_digest + b"\0" + str(number).encode("ascii")
+        )
     for value in sorted(members):
         digest.update(len(value).to_bytes(8, "big"))
         digest.update(value)

--- a/janasunani/evaluation/sarvam_evaluate.py
+++ b/janasunani/evaluation/sarvam_evaluate.py
@@ -25,9 +25,14 @@ version so ``benchmark_report`` can compare runs without re-reading pages.
 from __future__ import annotations
 
 import argparse
+from collections import Counter
+from datetime import UTC, datetime
+import hashlib
 import json
+import os
 import sys
 from pathlib import Path
+import tempfile
 from typing import Any
 
 from loguru import logger
@@ -50,6 +55,8 @@ PRICE_DIGITISE = 0.50
 PRICE_EXTRACT = 1.00
 PRICE_BOTH = 1.50
 IMAGE_SUFFIXES = {".png", ".jpg", ".jpeg", ".tiff", ".tif", ".bmp", ".gif"}
+PROGRESS_SCHEMA_VERSION = "janasunani.sarvam-progress/v1"
+PROGRESS_FILENAME = "sarvam_progress.json"
 
 
 def _price_for_arm(arm: str, n_pages: int) -> float:
@@ -86,6 +93,125 @@ def discover_pages(input_dir: Path, limit: int | None) -> list[tuple[Path, int]]
             if limit is not None and len(pages) >= limit:
                 return pages
     return pages
+
+
+def _input_snapshot_id(pages: list[tuple[Path, int]]) -> str:
+    """Content-address the exact document bytes and requested page inventory.
+
+    Filenames can contain ticket identifiers and mtimes change when a governed
+    sample is copied. Neither belongs in the identity. Hash each source file's
+    bytes once, then bind that digest to every requested page number so changed
+    pixels cannot retain the same snapshot merely by preserving size/mtime.
+    """
+
+    digest = hashlib.sha256()
+    file_digests: dict[Path, bytes] = {}
+    for path, number in pages:
+        resolved = path.resolve()
+        file_digest = file_digests.get(resolved)
+        if file_digest is None:
+            source_digest = hashlib.sha256()
+            with resolved.open("rb") as stream:
+                for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                    source_digest.update(chunk)
+            file_digest = source_digest.digest()
+            file_digests[resolved] = file_digest
+        value = file_digest + b"\0" + str(number).encode("ascii")
+        digest.update(len(value).to_bytes(8, "big"))
+        digest.update(value)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def _write_progress_checkpoint(
+    *,
+    out_dir: Path,
+    pages: list[tuple[Path, int]],
+    pages_processed: int,
+    records: list[PageRecord],
+    failures: list[dict[str, str]],
+    page_lengths: list[dict[str, object]],
+    arm: str,
+    schema_version: str,
+    slice_label: str,
+    dry_run: bool,
+    complete: bool,
+) -> Path:
+    """Atomically persist safe aggregate progress after every page.
+
+    The checkpoint intentionally excludes page IDs, ticket IDs, transcripts,
+    summaries, categories attached to a ticket, and provider response bodies.
+    Accepted provider jobs remain resumable through the separately governed
+    audit log; this file preserves what can be reported if credits or the
+    process stop before the final scorecard write.
+    """
+    from janasunani.evaluation.sarvam_scorecard import normalize_text
+
+    failure_arms = Counter(row["arm"] for row in failures)
+    failure_types = Counter(row["error"] for row in failures)
+    eligible_pairs = records if arm in {"digitise", "both"} else []
+    divergence_n = sum(
+        normalize_text(row.pytesseract_text) != normalize_text(row.sarvam_markdown)
+        for row in eligible_pairs
+    )
+    partial: dict[str, object] | None = None
+    if records:
+        report = build_scorecard(records, slice_label=slice_label, arm=arm).to_dict()
+        partial = {
+            key: report.get(key)
+            for key in (
+                "category", "transcription_accuracy", "transcription_divergence",
+                "by_handwritten", "by_language", "per_category", "summary_divergence",
+            )
+        }
+    payload = {
+        "schema_version": PROGRESS_SCHEMA_VERSION,
+        "updated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "complete": complete,
+        "input_snapshot_id": _input_snapshot_id(pages),
+        "arm": arm,
+        "extract_schema_version": schema_version,
+        "slice": slice_label,
+        "dry_run": dry_run,
+        "pages_discovered": len(pages),
+        "pages_processed": pages_processed,
+        "pages_scored": len(records),
+        "pages_excluded": max(0, pages_processed - len(records)),
+        "failure_events": len(failures),
+        "failures_by_arm": dict(sorted(failure_arms.items())),
+        "failures_by_error": dict(sorted(failure_types.items())),
+        "pytesseract_normalized_characters": sum(
+            int(row.get("pytesseract_chars", 0)) for row in page_lengths
+        ),
+        "sarvam_normalized_characters": sum(
+            int(row.get("sarvam_chars", 0)) for row in page_lengths
+        ),
+        "paired_exact_divergence_count": divergence_n,
+        "paired_exact_divergence_n": len(eligible_pairs),
+        "maximum_list_price_rupees": 0.0 if dry_run else _price_for_arm(arm, len(pages)),
+        "actual_billing_available": False,
+        "partial_scorecard": partial,
+        "privacy": {
+            "contains_page_or_ticket_ids": False,
+            "contains_text_or_provider_payloads": False,
+            "mode": "0600",
+        },
+    }
+    out_dir.mkdir(parents=True, exist_ok=True)
+    destination = out_dir / PROGRESS_FILENAME
+    fd, temporary_name = tempfile.mkstemp(prefix=".sarvam-progress-", dir=out_dir)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, 0o600)
+        os.replace(temporary, destination)
+    except Exception:
+        temporary.unlink(missing_ok=True)
+        raise
+    return destination
 
 
 def _load_metadata_join(
@@ -357,11 +483,12 @@ def main(argv: list[str] | None = None) -> int:
         )
 
     # pylint: disable=import-error
+    out_dir.mkdir(parents=True, exist_ok=True)
     records: list[PageRecord] = []
     failures: list[dict[str, str]] = []
     page_lengths: list[dict[str, object]] = []
 
-    for path, number in pages:
+    for processed, (path, number) in enumerate(pages, 1):
         page_id = f"{path.stem}:p{number}"
         ticket = _ticket_of(path)
 
@@ -479,6 +606,19 @@ def main(argv: list[str] | None = None) -> int:
                 if sarvam_summary:
                     print("---- sarvam_summary ----")
                     print(sarvam_summary)
+            _write_progress_checkpoint(
+                out_dir=out_dir,
+                pages=pages,
+                pages_processed=processed,
+                records=records,
+                failures=failures,
+                page_lengths=page_lengths,
+                arm=args.arm,
+                schema_version=args.schema_version,
+                slice_label=args.slice,
+                dry_run=args.dry_run,
+                complete=False,
+            )
             continue
 
         records.append(
@@ -518,6 +658,20 @@ def main(argv: list[str] | None = None) -> int:
                 print("---- sarvam_summary ----")
                 print(sarvam_summary)
 
+        _write_progress_checkpoint(
+            out_dir=out_dir,
+            pages=pages,
+            pages_processed=processed,
+            records=records,
+            failures=failures,
+            page_lengths=page_lengths,
+            arm=args.arm,
+            schema_version=args.schema_version,
+            slice_label=args.slice,
+            dry_run=args.dry_run,
+            complete=False,
+        )
+
     out_dir.mkdir(parents=True, exist_ok=True)
     # Pass arm + slice so scorecard correctly hides non-measured arms (digitise vs extract)
     # and renders the selected slice (not demo constant).
@@ -545,6 +699,19 @@ def main(argv: list[str] | None = None) -> int:
     destination = out_dir / "sarvam_scorecard.json"
     destination.write_text(json.dumps(payload, indent=2, default=str))
     logger.success(f"scorecard -> {destination}")
+    _write_progress_checkpoint(
+        out_dir=out_dir,
+        pages=pages,
+        pages_processed=len(pages),
+        records=records,
+        failures=failures,
+        page_lengths=page_lengths,
+        arm=args.arm,
+        schema_version=args.schema_version,
+        slice_label=args.slice,
+        dry_run=args.dry_run,
+        complete=True,
+    )
 
     # Also print markdown to stdout for pipeline visibility
     print(render_markdown(report))

--- a/janasunani/evaluation/sarvam_evaluate.py
+++ b/janasunani/evaluation/sarvam_evaluate.py
@@ -106,6 +106,7 @@ def _input_snapshot_id(pages: list[tuple[Path, int]]) -> str:
 
     digest = hashlib.sha256()
     file_digests: dict[Path, bytes] = {}
+    members: list[bytes] = []
     for path, number in pages:
         resolved = path.resolve()
         file_digest = file_digests.get(resolved)
@@ -116,7 +117,8 @@ def _input_snapshot_id(pages: list[tuple[Path, int]]) -> str:
                     source_digest.update(chunk)
             file_digest = source_digest.digest()
             file_digests[resolved] = file_digest
-        value = file_digest + b"\0" + str(number).encode("ascii")
+        members.append(file_digest + b"\0" + str(number).encode("ascii"))
+    for value in sorted(members):
         digest.update(len(value).to_bytes(8, "big"))
         digest.update(value)
     return f"sha256:{digest.hexdigest()}"

--- a/janasunani/evaluation/sarvam_evaluate.py
+++ b/janasunani/evaluation/sarvam_evaluate.py
@@ -125,7 +125,8 @@ def _input_snapshot_id(pages: list[tuple[Path, int]]) -> str:
 def _write_progress_checkpoint(
     *,
     out_dir: Path,
-    pages: list[tuple[Path, int]],
+    input_snapshot_id: str,
+    pages_discovered: int,
     pages_processed: int,
     records: list[PageRecord],
     failures: list[dict[str, str]],
@@ -167,12 +168,12 @@ def _write_progress_checkpoint(
         "schema_version": PROGRESS_SCHEMA_VERSION,
         "updated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
         "complete": complete,
-        "input_snapshot_id": _input_snapshot_id(pages),
+        "input_snapshot_id": input_snapshot_id,
         "arm": arm,
         "extract_schema_version": schema_version,
         "slice": slice_label,
         "dry_run": dry_run,
-        "pages_discovered": len(pages),
+        "pages_discovered": pages_discovered,
         "pages_processed": pages_processed,
         "pages_scored": len(records),
         "pages_excluded": max(0, pages_processed - len(records)),
@@ -187,7 +188,9 @@ def _write_progress_checkpoint(
         ),
         "paired_exact_divergence_count": divergence_n,
         "paired_exact_divergence_n": len(eligible_pairs),
-        "maximum_list_price_rupees": 0.0 if dry_run else _price_for_arm(arm, len(pages)),
+        "maximum_list_price_rupees": (
+            0.0 if dry_run else _price_for_arm(arm, pages_discovered)
+        ),
         "actual_billing_available": False,
         "partial_scorecard": partial,
         "privacy": {
@@ -409,6 +412,7 @@ def main(argv: list[str] | None = None) -> int:
     if not pages:
         logger.error(f"no documents found under {input_dir}")
         return 1
+    input_snapshot_id = _input_snapshot_id(pages)
 
     cost = _price_for_arm(args.arm, len(pages))
     logger.info(f"{len(pages)} page(s) across {len({p for p, _ in pages})} document(s) — arm={args.arm} schema={args.schema_version}")
@@ -608,7 +612,8 @@ def main(argv: list[str] | None = None) -> int:
                     print(sarvam_summary)
             _write_progress_checkpoint(
                 out_dir=out_dir,
-                pages=pages,
+                input_snapshot_id=input_snapshot_id,
+                pages_discovered=len(pages),
                 pages_processed=processed,
                 records=records,
                 failures=failures,
@@ -660,7 +665,8 @@ def main(argv: list[str] | None = None) -> int:
 
         _write_progress_checkpoint(
             out_dir=out_dir,
-            pages=pages,
+            input_snapshot_id=input_snapshot_id,
+            pages_discovered=len(pages),
             pages_processed=processed,
             records=records,
             failures=failures,
@@ -701,7 +707,8 @@ def main(argv: list[str] | None = None) -> int:
     logger.success(f"scorecard -> {destination}")
     _write_progress_checkpoint(
         out_dir=out_dir,
-        pages=pages,
+        input_snapshot_id=input_snapshot_id,
+        pages_discovered=len(pages),
         pages_processed=len(pages),
         records=records,
         failures=failures,

--- a/janasunani/evaluation/sarvam_evaluate.py
+++ b/janasunani/evaluation/sarvam_evaluate.py
@@ -161,16 +161,6 @@ def _write_progress_checkpoint(
         normalize_text(row.pytesseract_text) != normalize_text(row.sarvam_markdown)
         for row in eligible_pairs
     )
-    partial: dict[str, object] | None = None
-    if records:
-        report = build_scorecard(records, slice_label=slice_label, arm=arm).to_dict()
-        partial = {
-            key: report.get(key)
-            for key in (
-                "category", "transcription_accuracy", "transcription_divergence",
-                "by_handwritten", "by_language", "per_category", "summary_divergence",
-            )
-        }
     payload = {
         "schema_version": PROGRESS_SCHEMA_VERSION,
         "updated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
@@ -199,10 +189,10 @@ def _write_progress_checkpoint(
             0.0 if dry_run else _price_for_arm(arm, pages_discovered)
         ),
         "actual_billing_available": False,
-        "partial_scorecard": partial,
         "privacy": {
             "contains_page_or_ticket_ids": False,
             "contains_text_or_provider_payloads": False,
+            "contains_category_or_demographic_breakdowns": False,
             "mode": "0600",
         },
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,6 +162,7 @@ janasunani-evaluate-routing = "janasunani.evaluation.historical:main"
 janasunani-model-release = "janasunani.tracking.materialize:main"
 janasunani-evaluate-summary = "janasunani.evaluation.summary:main"
 janasunani-audit-actionability-labels = "janasunani.evaluation.weak_labels:main"
+janasunani-import-sarvam-evidence = "janasunani.evaluation.sarvam_cached:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/test_sarvam_cached.py
+++ b/tests/test_sarvam_cached.py
@@ -18,6 +18,14 @@ def _evidence(tmp_path):
                 "extract_schema_version": "v1",
                 "normalizer_version": "1.0",
                 "credits_available_for_new_calls": False,
+                "reproducibility": {
+                    "tracked_aggregate_only": True,
+                    "source_artifacts_tracked": False,
+                    "source_artifact_hashes_available": False,
+                    "derivation_command_recorded": False,
+                    "latency_distribution_available": False,
+                    "claim_limit": "Aggregate counts cannot reconstruct the source run.",
+                },
                 "reporting_rule": "Report aggregate coverage and divergence only.",
                 "runs": [
                     {
@@ -66,6 +74,10 @@ def test_cached_import_logs_aggregate_without_provider_call(tmp_path, monkeypatc
     )
     assert logged["extra_params"]["cost_denominator"] == "attempted_page"
     assert logged["extra_params"]["quality_claim_permitted"] == "false"
+    assert len(logged["extra_params"]["evidence_sha256"]) == 64
+    assert logged["extra_params"]["git_sha_role"] == "cached_evidence_import_code"
+    assert logged["extra_params"]["source_run_git_sha"] == "unavailable"
+    assert logged["extra_params"]["derivation_command_recorded"] == "false"
     assert logged["artifacts"]
 
 
@@ -116,6 +128,16 @@ def test_cached_import_rejects_unknown_schema(tmp_path):
     path.write_text(json.dumps(payload))
 
     with pytest.raises(ValueError, match="schema"):
+        sarvam_cached.load_evidence(path)
+
+
+def test_cached_import_requires_explicit_reproducibility_boundary(tmp_path):
+    path = _evidence(tmp_path)
+    payload = json.loads(path.read_text())
+    payload.pop("reproducibility")
+    path.write_text(json.dumps(payload))
+
+    with pytest.raises(ValueError, match="reproducibility"):
         sarvam_cached.load_evidence(path)
 
 

--- a/tests/test_sarvam_cached.py
+++ b/tests/test_sarvam_cached.py
@@ -81,6 +81,26 @@ def test_cached_import_logs_aggregate_without_provider_call(tmp_path, monkeypatc
     assert logged["artifacts"]
 
 
+def test_cached_import_omits_failure_rate_without_accepted_job_denominator(
+    tmp_path, monkeypatch
+):
+    path = _evidence(tmp_path)
+    payload = json.loads(path.read_text())
+    payload["runs"][0].pop("accepted_jobs")
+    path.write_text(json.dumps(payload))
+    calls = []
+    monkeypatch.setattr(
+        sarvam_cached,
+        "log_benchmark_run",
+        lambda **kwargs: calls.append(kwargs) or "run",
+    )
+
+    sarvam_cached.import_evidence(path)
+
+    assert calls[0]["extra_metrics"]["provider_job_failures"] == 7.0
+    assert "provider_job_failure_rate" not in calls[0]["extra_metrics"]
+
+
 def test_estimated_cost_never_implies_actual_billing(tmp_path, monkeypatch):
     path = _evidence(tmp_path)
     payload = json.loads(path.read_text())

--- a/tests/test_sarvam_cached.py
+++ b/tests/test_sarvam_cached.py
@@ -1,0 +1,157 @@
+import json
+
+import pytest
+
+from janasunani.evaluation import sarvam_cached
+
+
+def _evidence(tmp_path):
+    path = tmp_path / "sarvam.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": "janasunani.sarvam-cached-evidence/v1",
+                "as_of": "2026-08-10",
+                "provider": "sarvam-hosted",
+                "model": "Sarvam Vision 1.5",
+                "slice": "Sambalpur/2024",
+                "extract_schema_version": "v1",
+                "normalizer_version": "1.0",
+                "credits_available_for_new_calls": False,
+                "reporting_rule": "Report aggregate coverage and divergence only.",
+                "runs": [
+                    {
+                        "run_id": "interrupted",
+                        "status": "interrupted_credit_exhaustion",
+                        "arm": "both",
+                        "pages_attempted": 65,
+                        "pages_paired_scored": 56,
+                        "accepted_jobs": 127,
+                        "provider_job_failures": 7,
+                        "normalized_exact_text_divergence": 1.0,
+                        "sarvam_to_pytesseract_character_ratio": 1.3345,
+                        "estimated_list_price_accepted_jobs_rupees": 95.0,
+                        "actual_billing_available": False,
+                    }
+                ],
+            }
+        )
+    )
+    return path
+
+
+def test_cached_import_logs_aggregate_without_provider_call(tmp_path, monkeypatch):
+    calls = []
+
+    def fake_log(**kwargs):
+        calls.append(kwargs)
+        return "mlflow-run-1"
+
+    monkeypatch.setattr(sarvam_cached, "log_benchmark_run", fake_log)
+    result = sarvam_cached.import_evidence(_evidence(tmp_path))
+
+    assert result == {"interrupted": "mlflow-run-1"}
+    logged = calls[0]
+    assert logged["pipeline_variant"] == "sarvam_both"
+    assert logged["sample_n"] == 56
+    assert logged["cost_per_doc_rupees"] == pytest.approx(95 / 65)
+    assert logged["extra_metrics"]["paired_page_coverage"] == pytest.approx(56 / 65)
+    assert logged["extra_metrics"]["provider_job_failure_rate"] == pytest.approx(7 / 127)
+    assert logged["extra_metrics"]["cost_total_rupees"] == 95.0
+    assert logged["extra_params"]["cost_evidence"] == (
+        "estimated_list_price_accepted_jobs"
+    )
+    assert logged["extra_params"]["quality_claim_permitted"] == "false"
+    assert logged["artifacts"]
+
+
+def test_estimated_cost_never_implies_actual_billing(tmp_path, monkeypatch):
+    path = _evidence(tmp_path)
+    payload = json.loads(path.read_text())
+    payload["runs"][0].pop("actual_billing_available")
+    path.write_text(json.dumps(payload))
+    calls = []
+    monkeypatch.setattr(
+        sarvam_cached,
+        "log_benchmark_run",
+        lambda **kwargs: calls.append(kwargs) or "run",
+    )
+
+    sarvam_cached.import_evidence(path)
+
+    assert calls[0]["extra_params"]["actual_billing_available"] == "false"
+
+
+def test_cached_import_rejects_unknown_schema(tmp_path):
+    path = _evidence(tmp_path)
+    payload = json.loads(path.read_text())
+    payload["schema_version"] = "future"
+    path.write_text(json.dumps(payload))
+
+    with pytest.raises(ValueError, match="schema"):
+        sarvam_cached.load_evidence(path)
+
+
+def test_cached_import_rejects_unknown_fields_that_could_carry_narrative(tmp_path):
+    path = _evidence(tmp_path)
+    payload = json.loads(path.read_text())
+    payload["runs"][0]["raw_text"] = "must never be imported"
+    path.write_text(json.dumps(payload))
+
+    with pytest.raises(ValueError, match="unknown fields"):
+        sarvam_cached.load_evidence(path)
+
+
+def test_cached_import_accepts_declared_reproducibility_and_cost_basis(tmp_path):
+    path = _evidence(tmp_path)
+    payload = json.loads(path.read_text())
+    payload["reproducibility"] = {
+        "tracked_aggregate_only": True,
+        "source_artifacts_tracked": False,
+        "source_artifact_hashes_available": False,
+        "derivation_command_recorded": False,
+        "latency_distribution_available": False,
+        "claim_limit": "Aggregate counts cannot reconstruct the source run.",
+    }
+    payload["runs"][0]["cost_basis"] = "list-price estimate"
+    path.write_text(json.dumps(payload))
+
+    loaded = sarvam_cached.load_evidence(path)
+
+    assert loaded["runs"][0]["cost_basis"] == "list-price estimate"
+
+
+def test_cached_import_rejects_duplicate_run_ids_and_inconsistent_counts(tmp_path):
+    path = _evidence(tmp_path)
+    payload = json.loads(path.read_text())
+    payload["runs"].append(dict(payload["runs"][0]))
+    path.write_text(json.dumps(payload))
+    with pytest.raises(ValueError, match="duplicates run_id"):
+        sarvam_cached.load_evidence(path)
+
+    payload["runs"] = [payload["runs"][0]]
+    payload["runs"][0]["pages_excluded"] = 8
+    path.write_text(json.dumps(payload))
+    with pytest.raises(ValueError, match="pages_excluded"):
+        sarvam_cached.load_evidence(path)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("pages_paired_scored", 66, "more pages"),
+        ("pages_attempted", -1, "non-negative"),
+        ("normalized_exact_text_divergence", 1.1, "divergence"),
+        ("sarvam_to_pytesseract_character_ratio", float("nan"), "finite"),
+        ("estimated_list_price_accepted_jobs_rupees", True, "finite"),
+        ("status", ["completed"], "invalid status"),
+    ],
+)
+def test_cached_import_rejects_impossible_aggregate_metrics(tmp_path, field, value, message):
+    path = _evidence(tmp_path)
+    payload = json.loads(path.read_text())
+    payload["runs"][0][field] = value
+    path.write_text(json.dumps(payload))
+
+    with pytest.raises(ValueError, match=message):
+        sarvam_cached.load_evidence(path)

--- a/tests/test_sarvam_cached.py
+++ b/tests/test_sarvam_cached.py
@@ -54,13 +54,17 @@ def test_cached_import_logs_aggregate_without_provider_call(tmp_path, monkeypatc
     logged = calls[0]
     assert logged["pipeline_variant"] == "sarvam_both"
     assert logged["sample_n"] == 56
-    assert logged["cost_per_doc_rupees"] == pytest.approx(95 / 65)
+    assert "cost_per_doc_rupees" not in logged
+    assert logged["extra_metrics"]["cost_per_attempted_page_rupees"] == pytest.approx(
+        95 / 65
+    )
     assert logged["extra_metrics"]["paired_page_coverage"] == pytest.approx(56 / 65)
     assert logged["extra_metrics"]["provider_job_failure_rate"] == pytest.approx(7 / 127)
     assert logged["extra_metrics"]["cost_total_rupees"] == 95.0
     assert logged["extra_params"]["cost_evidence"] == (
         "estimated_list_price_accepted_jobs"
     )
+    assert logged["extra_params"]["cost_denominator"] == "attempted_page"
     assert logged["extra_params"]["quality_claim_permitted"] == "false"
     assert logged["artifacts"]
 
@@ -79,6 +83,29 @@ def test_estimated_cost_never_implies_actual_billing(tmp_path, monkeypatch):
 
     sarvam_cached.import_evidence(path)
 
+    assert calls[0]["extra_params"]["actual_billing_available"] == "false"
+
+
+def test_recorded_list_price_never_implies_actual_billing(tmp_path, monkeypatch):
+    path = _evidence(tmp_path)
+    payload = json.loads(path.read_text())
+    run = payload["runs"][0]
+    run.pop("estimated_list_price_accepted_jobs_rupees")
+    run["recorded_cost_rupees"] = 95.0
+    run["cost_basis"] = "list-price calculation; actual billing unavailable"
+    path.write_text(json.dumps(payload))
+    calls = []
+    monkeypatch.setattr(
+        sarvam_cached,
+        "log_benchmark_run",
+        lambda **kwargs: calls.append(kwargs) or "run",
+    )
+
+    sarvam_cached.import_evidence(path)
+
+    assert calls[0]["extra_params"]["cost_evidence"] == (
+        "recorded_non_billing_amount"
+    )
     assert calls[0]["extra_params"]["actual_billing_available"] == "false"
 
 

--- a/tests/test_sarvam_evaluate.py
+++ b/tests/test_sarvam_evaluate.py
@@ -349,6 +349,11 @@ def test_input_snapshot_is_content_addressed_not_filename_or_mtime(tmp_path: Pat
     assert _input_snapshot_id([(first, 1)]) != original
     assert _input_snapshot_id([(renamed, 2)]) != original
 
+    first.write_bytes(b"first-document")
+    renamed.write_bytes(b"second-document")
+    forward = _input_snapshot_id([(first, 1), (renamed, 1)])
+    assert _input_snapshot_id([(renamed, 1), (first, 1)]) == forward
+
 
 def test_evaluate_join_metadata_from_lake(tmp_path: Path):
     """--join-metadata should populate gold_category from lake complaints parquet."""

--- a/tests/test_sarvam_evaluate.py
+++ b/tests/test_sarvam_evaluate.py
@@ -327,16 +327,19 @@ def test_evaluate_hashes_the_input_snapshot_once_per_run(tmp_path: Path, monkeyp
     assert progress["input_snapshot_id"] == "sha256:" + "b" * 64
 
 
-def test_input_snapshot_is_content_addressed_not_filename_or_mtime(tmp_path: Path):
+def test_input_snapshot_binds_content_page_and_ticket_not_mtime(tmp_path: Path):
     from janasunani.evaluation.sarvam_evaluate import _input_snapshot_id
 
     first = tmp_path / "SECRET-TICKET_first.png"
-    renamed = tmp_path / "DIFFERENT-TICKET_copy.png"
+    renamed = tmp_path / "SECRET-TICKET_copy.png"
+    reassigned = tmp_path / "DIFFERENT-TICKET_copy.png"
     first.write_bytes(b"pixel-content-v1")
     renamed.write_bytes(first.read_bytes())
+    reassigned.write_bytes(first.read_bytes())
 
     original = _input_snapshot_id([(first, 1)])
     assert _input_snapshot_id([(renamed, 1)]) == original
+    assert _input_snapshot_id([(reassigned, 1)]) != original
 
     stat = first.stat()
     first.write_bytes(b"pixel-content-v2")

--- a/tests/test_sarvam_evaluate.py
+++ b/tests/test_sarvam_evaluate.py
@@ -216,8 +216,10 @@ def test_evaluate_dry_run_digitise_arm(tmp_path: Path):
     assert progress["complete"] is True
     assert progress["pages_processed"] == 2
     assert progress["pages_scored"] == 2
+    assert "partial_scorecard" not in progress
     assert progress["privacy"]["contains_page_or_ticket_ids"] is False
     assert progress["privacy"]["contains_text_or_provider_payloads"] is False
+    assert progress["privacy"]["contains_category_or_demographic_breakdowns"] is False
     assert progress_path.stat().st_mode & 0o777 == 0o600
     # markdown mentions arm/slice
     md = md_path.read_text()

--- a/tests/test_sarvam_evaluate.py
+++ b/tests/test_sarvam_evaluate.py
@@ -210,6 +210,15 @@ def test_evaluate_dry_run_digitise_arm(tmp_path: Path):
     assert data["schema_version"] == "v1"
     assert data["cost_rupees"] == 0.0  # dry-run
     assert "summary_divergence" in data
+    progress_path = out / "sarvam_progress.json"
+    progress = json.loads(progress_path.read_text())
+    assert progress["schema_version"] == "janasunani.sarvam-progress/v1"
+    assert progress["complete"] is True
+    assert progress["pages_processed"] == 2
+    assert progress["pages_scored"] == 2
+    assert progress["privacy"]["contains_page_or_ticket_ids"] is False
+    assert progress["privacy"]["contains_text_or_provider_payloads"] is False
+    assert progress_path.stat().st_mode & 0o777 == 0o600
     # markdown mentions arm/slice
     md = md_path.read_text()
     assert "Sarvam" in md
@@ -250,6 +259,70 @@ def test_evaluate_both_arm_cost(tmp_path: Path):
     assert _price_for_arm("digitise", 10) == pytest.approx(5.0)
     assert _price_for_arm("extract", 10) == pytest.approx(10.0)
     assert _price_for_arm("both", 10) == pytest.approx(15.0)
+
+
+def test_progress_checkpoint_contains_only_aggregates(tmp_path: Path):
+    from janasunani.evaluation.sarvam_evaluate import _write_progress_checkpoint
+    from janasunani.evaluation.sarvam_scorecard import PageRecord
+
+    page = tmp_path / "SECRET-TICKET_document.png"
+    page.write_bytes(b"pixels")
+    records = [
+        PageRecord(
+            ticket="SECRET-TICKET",
+            page_id="SECRET-TICKET:p1",
+            handwritten="printed",
+            language="English",
+            pytesseract_text="local grievance text",
+            sarvam_markdown="remote grievance text",
+        )
+    ]
+    destination = _write_progress_checkpoint(
+        out_dir=tmp_path / "out",
+        pages=[(page, 1)],
+        pages_processed=1,
+        records=records,
+        failures=[{"page_id": "SECRET-TICKET:p1", "error": "HTTP402", "arm": "extract"}],
+        page_lengths=[
+            {"page_id": "SECRET-TICKET:p1", "pytesseract_chars": 20, "sarvam_chars": 21}
+        ],
+        arm="both",
+        schema_version="v1",
+        slice_label="Sambalpur/2024",
+        dry_run=False,
+        complete=False,
+    )
+
+    encoded = destination.read_text()
+    assert "SECRET-TICKET" not in encoded
+    assert "grievance text" not in encoded
+    payload = json.loads(encoded)
+    assert payload["failure_events"] == 1
+    assert payload["failures_by_error"] == {"HTTP402": 1}
+    assert payload["paired_exact_divergence_count"] == 1
+
+
+def test_input_snapshot_is_content_addressed_not_filename_or_mtime(tmp_path: Path):
+    from janasunani.evaluation.sarvam_evaluate import _input_snapshot_id
+
+    first = tmp_path / "SECRET-TICKET_first.png"
+    renamed = tmp_path / "DIFFERENT-TICKET_copy.png"
+    first.write_bytes(b"pixel-content-v1")
+    renamed.write_bytes(first.read_bytes())
+
+    original = _input_snapshot_id([(first, 1)])
+    assert _input_snapshot_id([(renamed, 1)]) == original
+
+    stat = first.stat()
+    first.write_bytes(b"pixel-content-v2")
+    assert len(b"pixel-content-v1") == len(b"pixel-content-v2")
+    first.touch()
+    import os
+
+    os.utime(first, ns=(stat.st_atime_ns, stat.st_mtime_ns))
+
+    assert _input_snapshot_id([(first, 1)]) != original
+    assert _input_snapshot_id([(renamed, 2)]) != original
 
 
 def test_evaluate_join_metadata_from_lake(tmp_path: Path):

--- a/tests/test_sarvam_evaluate.py
+++ b/tests/test_sarvam_evaluate.py
@@ -279,7 +279,8 @@ def test_progress_checkpoint_contains_only_aggregates(tmp_path: Path):
     ]
     destination = _write_progress_checkpoint(
         out_dir=tmp_path / "out",
-        pages=[(page, 1)],
+        input_snapshot_id="sha256:" + "a" * 64,
+        pages_discovered=1,
         pages_processed=1,
         records=records,
         failures=[{"page_id": "SECRET-TICKET:p1", "error": "HTTP402", "arm": "extract"}],
@@ -300,6 +301,30 @@ def test_progress_checkpoint_contains_only_aggregates(tmp_path: Path):
     assert payload["failure_events"] == 1
     assert payload["failures_by_error"] == {"HTTP402": 1}
     assert payload["paired_exact_divergence_count"] == 1
+
+
+def test_evaluate_hashes_the_input_snapshot_once_per_run(tmp_path: Path, monkeypatch):
+    from janasunani.evaluation import sarvam_evaluate
+
+    inp = _make_dummy_input(tmp_path, n=3)
+    out = tmp_path / "out"
+    calls = []
+
+    def fake_snapshot(pages):
+        calls.append(list(pages))
+        return "sha256:" + "b" * 64
+
+    monkeypatch.setattr(sarvam_evaluate, "_input_snapshot_id", fake_snapshot)
+
+    rc = sarvam_evaluate.main(
+        ["--input", str(inp), "--out", str(out), "--arm", "digitise", "--dry-run"]
+    )
+
+    assert rc == 0
+    assert len(calls) == 1
+    assert len(calls[0]) == 3
+    progress = json.loads((out / "sarvam_progress.json").read_text())
+    assert progress["input_snapshot_id"] == "sha256:" + "b" * 64
 
 
 def test_input_snapshot_is_content_addressed_not_filename_or_mtime(tmp_path: Path):


### PR DESCRIPTION
## Summary

- preserve the completed five-page and interrupted 300-page Sarvam runs as governed benchmark evidence
- validate aggregate denominators, failures, costs, and explicit reproducibility limits before importing the evidence into MLflow
- checkpoint live evaluation progress using privacy-safe aggregates and a stable content-addressed input identity
- report coverage, list-price cost estimates, and paired divergence without claiming OCR accuracy, actual billing, or independently reproducible source results

No provider rerun or new credit spend occurs in this PR.

## Reconciled stack position

This is the next historical stack PR being reviewed after #257. PR #257 is closed as already integrated into `feat/pipeline-quality-trunk`; this PR retains `feat/actionability-serving` as its review base so its own diff remains bounded.

The remaining review order is:

1. #258 — cached Sarvam evidence
2. #262 — governed benchmark bundle
3. #259 — pipeline-quality evidence documentation
4. #260 — reproducible reports and briefs

After exact-head review succeeds, this historical PR will also be closed as already integrated rather than merged independently to `main`. The reconciled changes will reach `main` through the final integration PR.

## Corrections made during review

- `193fba5` labels cached costs per attempted page instead of passing a page denominator through a document-cost field
- `75112c3` hashes input bytes once per evaluation run rather than once per checkpoint
- `3785c29` requires and logs the cached evidence's reproducibility boundary, distinguishes list-price records from actual billing, and fingerprints the imported aggregate
- `13a8a7d` makes the input snapshot identity independent of discovery order while retaining content and page-number sensitivity

## Evidence and privacy boundary

The tracked metadata for the four protected source artifacts was inspected read-only at the pre-correction head. The `.dvc` files contain only object hashes, byte sizes, and artifact filenames. `provenance.json` states that operational identifiers and provider-response metadata remain in the private DVC artifacts and that row-level bytes are not stored in Git.

The source blobs were not pulled or read. Therefore their recorded SHA-256 values and aggregate counts are preserved metadata, not independently re-derived facts. The public aggregate records this limitation: the sample manifest and derivation command are unavailable, so the source run cannot be independently reconstructed.

## Verification

Run on exact head `13a8a7d9bf6888f48eb6513cdd7a02b7896b38b4`:

- focused Sarvam tests: **54 passed**
- full offline suite: **1,665 passed, 22 skipped**
- full Ruff check excluding protected `data/`: passed
- `git diff --check` against the review base, excluding protected `data/`: passed
- authorized metadata audit: no row-level bytes found in the five tracked metadata files; protected DVC blobs were not accessed

## Claim boundary

This evidence supports only coverage, failure counts, list-price cost estimates, and paired text divergence for the recorded development runs. It does not establish OCR accuracy, category superiority, summary quality, latency, actual provider billing, or production performance.
