### PR TITLE
fix(ci): recognize structured Codex review commits

### DIFF
--- a/scripts/check_codex_review.py
+++ b/scripts/check_codex_review.py
@@ -3,8 +3,10 @@
 Codex in GitHub reports neither a check run nor a commit status, so there is
 nothing to mark required in branch protection. It leaves two signals instead:
 
-- If it has findings, it posts a review whose body carries
-  ``**Reviewed commit:** `<sha>` `` and one inline thread per finding.
+- If it has findings, GitHub records the reviewed commit in the review's
+  structured ``commit_id`` and Codex posts one inline thread per finding.
+  Older Codex review bodies also carried ``**Reviewed commit:** `<sha>` ``;
+  that text remains a compatibility fallback.
 - If it is clean, it posts nothing at all and reacts :+1:.
 
 This script reads both and decides whether the pull request satisfies the
@@ -51,6 +53,7 @@ API_ROOT = "https://api.github.com"
 CODEX_LOGINS = {"chatgpt-codex-connector", "chatgpt-codex-connector[bot]"}
 
 REVIEWED_COMMIT_RE = re.compile(r"Reviewed commit:\*\*\s*`([0-9a-f]{7,40})`")
+STRUCTURED_SHA_RE = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64})")
 
 # Out of review credits, Codex answers `@codex review` with a plain issue
 # comment and never looks at the diff. Without recognising it the check sits
@@ -174,10 +177,14 @@ def parse_timestamp(value: str) -> datetime:
 
 
 def reviewed_shas(reviews: Iterable[dict[str, Any]]) -> list[str]:
-    """Shas Codex says it reviewed, in the order the reviews were posted."""
+    """SHAs Codex reviewed, preferring GitHub's structured review field."""
     found: list[str] = []
     for review in reviews:
         if not is_codex((review.get("user") or {}).get("login")):
+            continue
+        commit_id = review.get("commit_id")
+        if isinstance(commit_id, str) and STRUCTURED_SHA_RE.fullmatch(commit_id):
+            found.append(commit_id)
             continue
         match = REVIEWED_COMMIT_RE.search(review.get("body") or "")
         if match:

--- a/tests/test_check_codex_review.py
+++ b/tests/test_check_codex_review.py
@@ -467,6 +467,46 @@ def test_reviewed_shas_ignores_non_codex_reviews():
     assert check.reviewed_shas(reviews) == ["f319c879a1"]
 
 
+def test_reviewed_shas_accepts_the_current_structured_commit_without_legacy_body_text():
+    reviews = [
+        {
+            "user": CODEX,
+            "body": "### Codex Review\n\nOne finding follows.",
+            "commit_id": HEAD,
+            "state": "COMMENTED",
+        }
+    ]
+    assert check.reviewed_shas(reviews) == [HEAD]
+
+
+def test_reviewed_shas_prefers_structured_commit_over_legacy_body_text():
+    reviews = [
+        {
+            "user": CODEX,
+            "body": CODEX_REVIEW_BODY.format(sha="deadbeef12"),
+            "commit_id": HEAD,
+            "state": "COMMENTED",
+        }
+    ]
+    assert check.reviewed_shas(reviews) == [HEAD]
+
+
+def test_reviewed_shas_rejects_an_abbreviated_structured_commit_id():
+    reviews = [
+        {
+            "user": CODEX,
+            "body": CODEX_REVIEW_BODY.format(sha=HEAD[:10]),
+            "commit_id": "deadbee",
+            "state": "COMMENTED",
+        }
+    ]
+    assert check.reviewed_shas(reviews) == [HEAD[:10]]
+
+
+def test_reviewed_shas_keeps_legacy_body_fallback():
+    assert check.reviewed_shas([codex_review("f319c879a1")]) == ["f319c879a1"]
+
+
 def test_reviewed_shas_keeps_posting_order():
     reviews = [codex_review("aaaaaaaaaa"), codex_review("bbbbbbbbbb")]
     assert check.reviewed_shas(reviews) == ["aaaaaaaaaa", "bbbbbbbbbb"]


### PR DESCRIPTION
## Summary

- recognize the current Codex review format through GitHub's structured `commit_id`
- require a full 40- or 64-character object ID from that authoritative field
- retain the legacy `Reviewed commit:` body parser for older reviews

## Why

Codex now posts findings without the legacy `Reviewed commit:` sentence. GitHub still records the exact reviewed commit in the review payload, but the gate ignored that structured field and falsely reported that reviewed PR heads had no Codex activity.

This remains fail-closed: only reviews authored by the recognized Codex identities count, an abbreviated structured ID is rejected, and unresolved Codex threads continue to fail the gate. The clean thumbs-up path and documented override are unchanged.

## Verification

- `python -m pytest tests/test_check_codex_review.py -q` — 43 passed
- `ruff check . --exclude data` — passed
- full offline suite — 1,466 passed, 22 skipped

The full suite used task-scoped caches with Hugging Face and Transformers forced offline so model initialization could not wait on network access.
