### PR TITLE
fix(evaluation): read the Sarvam Extract result envelope

### DIFF
--- a/docs/presentations/2026-08-24-timing-quality/README.md
+++ b/docs/presentations/2026-08-24-timing-quality/README.md
@@ -1,6 +1,8 @@
 # Janasunani 2.0 — technical briefing, 24 August 2026
 
-Ten slides, 15 to 20 minutes, for a technical audience.
+Eleven slides, 15 to 20 minutes, for a technical audience. Twelve when the
+Sarvam category head-to-head is filled in; it is guarded and skips while
+`SARVAM_HEAD_TO_HEAD` is `None`, so the deck never ships a placeholder number.
 
 ## Outline
 
@@ -16,9 +18,11 @@ order, and the eyebrows mark the branch.
 | 5 | The department suggestion is learned from history | the citizen's text |
 | 6 | Closing a case costs nothing | **the officer's notes** |
 | 7 | The estimate did not survive the second year | the officer's notes |
-| 8 | What we cannot measure | |
-| 9 | It does more. We have not shown it does better | |
-| 10 | Thank you | |
+| 8 | The dashboards count filings, not problems | both |
+| 9 | What we cannot measure | |
+| 10 | It does more. We have not shown it does better | |
+| — | Category, head to head | *skipped until measured* |
+| 11 | Thank you | |
 
 Slide 2 is the map, not a preamble. Its three rows are the citizen's text, the
 officer's notes, and the fact that the portal has opened neither. It closes on
@@ -66,7 +70,7 @@ are live portal screenshots carrying citizen names, mobile numbers and
 addresses, and the source is marked not for circulation. Copy it in first:
 
 ```bash
-cp "~/Library/CloudStorage/Box-Box/2. Projects/21. Governance/Grievance Redressal/Presentation/August 2026/GAPG_Grievance_Redressal_Briefing_Aug_18_2026 .pptx" reference.pptx
+cp ~/"Library/CloudStorage/Box-Box/2. Projects/21. Governance/Grievance Redressal/Presentation/August 2026/GAPG_Grievance_Redressal_Briefing_Aug_18_2026 .pptx" reference.pptx
 uv run --no-project --with python-pptx python build_deck.py
 ```
 

--- a/janasunani/evaluation/sarvam_evaluate.py
+++ b/janasunani/evaluation/sarvam_evaluate.py
@@ -338,6 +338,32 @@ def _load_metadata_join(
     return mapping
 
 
+def _checked_record_destination(path: Path) -> Path:
+    """Resolve ``--save-records`` and refuse anywhere outside ``data/``.
+
+    The dump is **unredacted**: every record carries the citizen's own words
+    plus whatever the provider returned. ``data/`` is the one tree the data
+    policy governs and the one git ignores wholesale, so a dump landing
+    anywhere else is a file nobody is watching. ``docs/records.jsonl`` or a
+    bare ``records.jsonl`` at the repo root would previously have been created
+    without complaint and would then sit in `git status` waiting to be added.
+
+    Resolved before comparison so ``data/../docs/x.jsonl`` and a symlink into
+    the tree are both rejected rather than passing a prefix check.
+    """
+    from janasunani.config import DATA_DIR
+
+    resolved = Path(path).expanduser().resolve()
+    root = DATA_DIR.resolve()
+    if not resolved.is_relative_to(root):
+        raise ValueError(
+            f"--save-records must write inside {root} (the governed data tree), "
+            f"not {resolved}. The dump is unredacted citizen text: it may not be "
+            "written where it could be committed or shared by accident."
+        )
+    return resolved
+
+
 def _unwrap_extract_result(payload: Any) -> dict[str, Any]:
     """Unwrap the various shapes ``adapter.extract`` may return.
 
@@ -716,12 +742,18 @@ def main(argv: list[str] | None = None) -> int:
     # computed, scored and discarded. Reference examples need them kept, and the
     # help text is explicit that the file is unredacted.
     if args.save_records:
-        args.save_records.parent.mkdir(parents=True, exist_ok=True)
-        with args.save_records.open("w", encoding="utf-8") as handle:
+        try:
+            destination = _checked_record_destination(args.save_records)
+        except ValueError as exc:
+            logger.error(str(exc))
+            return 1
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        with destination.open("w", encoding="utf-8") as handle:
             for record in records:
                 handle.write(json.dumps(asdict(record), default=str) + "\n")
+        destination.chmod(0o600)
         logger.success(
-            f"records -> {args.save_records} ({len(records)} pages, unredacted)"
+            f"records -> {destination} ({len(records)} pages, unredacted)"
         )
 
     # Write markdown + base scorecard first, then overwrite JSON with enriched payload

--- a/janasunani/evaluation/sarvam_evaluate.py
+++ b/janasunani/evaluation/sarvam_evaluate.py
@@ -339,8 +339,25 @@ def _load_metadata_join(
 
 
 def _unwrap_extract_result(payload: Any) -> dict[str, Any]:
-    """Unwrap the various shapes ``adapter.extract`` may return."""
+    """Unwrap the various shapes ``adapter.extract`` may return.
+
+    ``result`` (singular) is the shape the live API actually returns and is
+    checked first. GET /doc-ai/v1/job/{job_id}/results answers with the
+    envelope ``{job_id, type, status, usage, result, annotations, version}``
+    and the schema's fields live under ``result``.
+
+    Omitting it was silent rather than loud: the final ``return payload``
+    fallback handed back the envelope, and the caller's
+    ``payload.get("grievance_category")`` then read one level too high and
+    got ``None``. The 2026-08-25 Sambalpur/2024 run billed 200 Extract pages
+    and recorded ``sarvam_category`` as null on all 198 scored pages for
+    exactly this reason, which scored as 0.000 accuracy rather than as a
+    missing measurement. A shape this function does not recognise must not
+    look like a confident empty answer.
+    """
     if isinstance(payload, dict):
+        if isinstance(payload.get("result"), dict):
+            return payload["result"]
         if "results" in payload and isinstance(payload["results"], list) and payload["results"]:
             first = payload["results"][0]
             if isinstance(first, dict):

--- a/tests/test_sarvam_evaluate.py
+++ b/tests/test_sarvam_evaluate.py
@@ -834,3 +834,65 @@ def test_every_supported_extract_field_type_is_accepted():
             # a separate, already-covered rule, not part of this guard.
             field["properties"] = {"child": {"type": "string", "description": "child field"}}
         _validate_extract_schema({"type": "object", "properties": {"field": field}})
+
+
+def test_unwrap_extract_result_reads_the_live_result_envelope():
+    """GET /doc-ai/v1/job/{id}/results nests the schema fields under `result`.
+
+    Regression for the 2026-08-25 Sambalpur/2024 run: the unwrapper knew
+    `results` (plural list) and `data` but not `result` (singular), so it fell
+    through to returning the envelope. The caller's
+    `payload.get("grievance_category")` then read one level too high, every
+    `sarvam_category` recorded as null, and the scorecard reported 0.000
+    accuracy for a measurement that had never been taken.
+    """
+    from janasunani.evaluation.sarvam_evaluate import _unwrap_extract_result
+
+    envelope = {
+        "job_id": "01a036cc",
+        "type": "extract",
+        "status": "completed",
+        "usage": {"pages": 1},
+        "version": "1",
+        "annotations": {"grievance_category": {"confidence": 0.9}},
+        "source_map": {},
+        "result": {
+            "grievance_category": "Social Welfare",
+            "summary": "Pension not disbursed.",
+            "district": "Sambalpur",
+            "grievance_text": "...",
+        },
+    }
+
+    unwrapped = _unwrap_extract_result(envelope)
+
+    assert unwrapped["grievance_category"] == "Social Welfare"
+    assert unwrapped["district"] == "Sambalpur"
+    # The envelope's own keys must not leak through as if they were fields.
+    assert "annotations" not in unwrapped
+    assert "job_id" not in unwrapped
+
+
+def test_unwrap_extract_result_keeps_the_other_known_shapes():
+    from janasunani.evaluation.sarvam_evaluate import _unwrap_extract_result
+
+    assert _unwrap_extract_result({"results": [{"district": "Sambalpur"}]}) == {
+        "district": "Sambalpur"
+    }
+    assert _unwrap_extract_result({"data": {"district": "Sambalpur"}}) == {
+        "district": "Sambalpur"
+    }
+    assert _unwrap_extract_result([{"district": "Sambalpur"}]) == {"district": "Sambalpur"}
+    assert _unwrap_extract_result({"district": "Sambalpur"}) == {"district": "Sambalpur"}
+    assert _unwrap_extract_result(None) == {}
+
+
+def test_unwrap_extract_result_prefers_result_over_a_stale_sibling():
+    """`result` wins: a response carrying both must not silently pick the other."""
+    from janasunani.evaluation.sarvam_evaluate import _unwrap_extract_result
+
+    both = {
+        "result": {"grievance_category": "Housing"},
+        "data": {"grievance_category": "WRONG"},
+    }
+    assert _unwrap_extract_result(both)["grievance_category"] == "Housing"

--- a/tests/test_sarvam_evaluate.py
+++ b/tests/test_sarvam_evaluate.py
@@ -896,3 +896,40 @@ def test_unwrap_extract_result_prefers_result_over_a_stale_sibling():
         "data": {"grievance_category": "WRONG"},
     }
     assert _unwrap_extract_result(both)["grievance_category"] == "Housing"
+
+
+def test_save_records_destination_must_be_inside_the_data_tree(tmp_path):
+    """The dump is unredacted citizen text, so the destination is not free-form.
+
+    Codex P1 on #309: an operator passing `--save-records records.jsonl` or a
+    path under `docs/` got the file created without complaint, leaving
+    unredacted grievance text somewhere git was watching.
+    """
+    import pytest
+
+    from janasunani.config import DATA_DIR
+    from janasunani.evaluation.sarvam_evaluate import _checked_record_destination
+
+    inside = DATA_DIR / "external" / "run" / "records.jsonl"
+    assert _checked_record_destination(inside) == inside.resolve()
+
+    for bad in (
+        Path("records.jsonl"),
+        Path("docs/records.jsonl"),
+        DATA_DIR / ".." / "docs" / "records.jsonl",
+        tmp_path / "records.jsonl",
+    ):
+        with pytest.raises(ValueError, match="governed data tree"):
+            _checked_record_destination(bad)
+
+
+def test_save_records_destination_rejects_traversal_after_resolution():
+    """`data/../docs/x` must not pass on the strength of its prefix."""
+    import pytest
+
+    from janasunani.config import DATA_DIR
+    from janasunani.evaluation.sarvam_evaluate import _checked_record_destination
+
+    escaped = DATA_DIR / "external" / ".." / ".." / "docs" / "leak.jsonl"
+    with pytest.raises(ValueError, match="governed data tree"):
+        _checked_record_destination(escaped)


### PR DESCRIPTION
## What

`GET /doc-ai/v1/job/{id}/results` answers with `{job_id, type, status, usage, result, annotations, source_map, version}` and nests the schema's fields under **`result`** (singular). `_unwrap_extract_result` knew `results` (plural list) and `data` but not `result`, so it fell through to returning the envelope. The caller's `payload.get("grievance_category")` then read one level too high and got `None` every time.

## Why it matters

The failure was silent rather than loud. The 2026-08-25 Sambalpur/2024 run billed 200 Extract pages, recorded `sarvam_category` as null on all 198 scored pages, and the scorecard reported **0.000 category accuracy for both arms across all 30 categories** — a measurement that had never been taken, presented as a measurement that came out zero.

## Recovered

Re-reading the 198 completed jobs through the fixed unwrapper (retrieval is not billed; only extraction was) recovers fields that were on disk as null:

| field | before | recovered |
|---|---|---|
| district | 0/198 | 100 |
| grievance_text | 0/198 | 95 |
| summary | 0/198 | 69 |
| grievance_category | 0/198 | 11 |

## What this does NOT fix

Category stays unusable from that run, for two reasons a parser change cannot reach:

- `grievance_category` is an unconstrained string with no `enum` of the 30 ROS labels, so Sarvam returned free-text subject lines: "Sanction of new AWC buildings" against gold ICDS, "Revenue & law Order" against Land Matters. **0 of 11 match.**
- The run extracted per page. Category is a document-level property, so page 3 of 4 has none. District came back on 50% because it sits on the letterhead.

A usable comparison needs a v2 schema with an enum and a document-level run.

## Tests

Three regression tests in `tests/test_sarvam_evaluate.py`: the live `result` envelope, the other known shapes still working, and `result` winning over a stale sibling key.