### PR TITLE
fix(makefile): run the infra targets without resolving the project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -796,8 +796,15 @@ box-paths:
 #   make infra ARGS="--no-ssh"
 CPU_BOX_SSH    ?= ubuntu@52.66.116.80
 
+# --no-project on the infra targets is deliberate. Both scripts are pure
+# stdlib plus the aws CLI, so they need none of the project's dependencies --
+# and resolving them is exactly what breaks these targets when you need them
+# most. On 2026-08-25 `make ssh` failed with a timeout fetching the spaCy model
+# wheel from GitHub: the box was up, the security group was the only thing
+# wrong, and the one tool that fixes that could not start. Reaching an
+# unreachable box must not depend on the ML dependency tree resolving.
 infra:
-	@uv run python scripts/infra_status.py --host "$(CPU_BOX_SSH)" \
+	@uv run --no-project python scripts/infra_status.py --host "$(CPU_BOX_SSH)" \
 	  $(if $(SITE),--site "$(SITE)") $(if $(SG_ID),--sg-id "$(SG_ID)") $(ARGS)
 
 # Open tcp/22 to your current IP if it is not already permitted, then SSH in.
@@ -813,7 +820,7 @@ infra:
 #
 # PRUNE is opt-in: a stale-looking /32 may be a colleague who is connected.
 ssh:
-	@uv run python scripts/box_ssh.py --host "$(CPU_BOX_SSH)" \
+	@uv run --no-project python scripts/box_ssh.py --host "$(CPU_BOX_SSH)" \
 	  $(if $(CHECK),--check) $(if $(PRUNE),--prune) $(ARGS)
 
 status:


### PR DESCRIPTION
Recovering SSH to the CPU box required the ML dependency tree to resolve. It should not.

## What happened

`make ssh` failed with a timeout fetching the spaCy model wheel from GitHub. The box was up and healthy. The only thing actually wrong was that the security group still pinned `tcp/22` to a previous ISP lease — exactly the condition `scripts/box_ssh.py` exists to detect and repair.

So the one tool that could restore access could not start, and the symptom (no ICMP, closed port) was indistinguishable from the instance being down. That is the failure mode the script's own docstring warns about, reached by a route the script could not defend against.

## The fix

`make ssh` and `make infra` went through `uv run python`, which resolves the entire project first. Neither script needs it:

- `scripts/box_ssh.py` imports `argparse`, `ipaddress`, `json`, `os`, `shutil`, `subprocess`, `sys`, `urllib.request`
- `scripts/infra_status.py` imports `argparse`, `ipaddress`, `json`, `shutil`, `subprocess`, `sys`, `dataclasses`, `datetime`, `typing`

All standard library, plus the `aws` CLI on PATH. `--no-project` keeps uv's managed Python and skips project resolution.

## Verification

- `make ssh CHECK=1` correctly reported the stale allowlist against the current IP, and touched nothing.
- `make ssh` then opened the rule and connected.
- `make infra ARGS="--no-ssh"` ran its checks and reported cleanly.
- No behaviour change to either script.

## Note

The stale rule this uncovered has since been reconciled in terraform, so the security group now carries only the current maintainer IP rather than accumulating a second `/32`.