### PR TITLE
fix(scripts): stream staged document bytes instead of eager-loading

### DIFF
--- a/scripts/benchmark_pipeline.py
+++ b/scripts/benchmark_pipeline.py
@@ -221,8 +221,12 @@ def _document_kind(doc: Mapping[str, Any]) -> str:
     "document" path to have measurements, and none were ever attributed to
     it. The loader already knows what it built: bytes present means a
     scanned document, text present (and no bytes) means free text.
+    ``document_path`` counts the same as ``document_bytes`` here —
+    ``load_staged_documents`` hands back a path instead of pre-read bytes
+    (see #308) so a document is still a "document" before its bytes are
+    ever read.
     """
-    if doc.get("document_bytes") is not None:
+    if doc.get("document_bytes") is not None or doc.get("document_path") is not None:
         return "document"
     if doc.get("text") is not None:
         return "text"
@@ -383,11 +387,22 @@ def load_staged_documents(
 ) -> list[dict[str, Any]]:
     """Load a real staged document sample for benchmarking.
 
-    Returns the same dict shape as ``synthesize_documents``: ticket, text
-    (always None here — these are scanned documents, not free text),
-    document_name, document_bytes, district. Reading real bytes means the
-    OCR stage actually runs against real scans, unlike the text-only half
-    of the synthetic fixture.
+    Returns dicts shaped like ``synthesize_documents``'s (ticket, text,
+    document_name, document_bytes, district) plus one extra key,
+    ``document_path``. Unlike ``synthesize_documents`` — whose synthetic
+    bytes are already in memory, generated, not read — a staged sample's
+    bytes live on disk, and a real slice-sized draw is large enough that
+    reading every file up front is not free: the staged Sambalpur/2024
+    sample alone averages 627 KB/document, and #308 was filed when a
+    69,844-document, 60 GB corpus made that arithmetic a bounded-RAM problem
+    rather than a theoretical one. So ``document_bytes`` here is always
+    ``None`` and ``document_path`` carries the file instead; the actual read
+    happens later, one document at a time, in
+    ``_measure_with_processor`` — deliberately outside every per-stage
+    timer, so disk I/O is never attributed to a model stage (see that
+    function for where). Reading real bytes (whenever it happens) means the
+    OCR stage actually runs against real scans, unlike the text-only half of
+    the synthetic fixture.
 
     ``directory`` is a flat staging directory of supported document files
     (see ``SUPPORTED_DOCUMENT_SUFFIXES``) named
@@ -486,7 +501,8 @@ def load_staged_documents(
                 "ticket": ticket,
                 "text": None,
                 "document_name": path.name,
-                "document_bytes": path.read_bytes(),
+                "document_bytes": None,
+                "document_path": path,
                 "district": district,
             }
         )
@@ -679,6 +695,23 @@ def _measure_with_processor(
     for doc in docs:
         ticket = doc["ticket"]
         kind = _document_kind(doc)
+        # Resolve this document's bytes once, here — before the per-repeat
+        # loop and its perf_counter() calls below, never inside them. A read
+        # inside the timed region would land inside whichever stage runs
+        # first (ocr) and inflate its measured latency with disk I/O that
+        # has nothing to do with the model (#308). load_staged_documents()
+        # hands back document_path instead of pre-read bytes for exactly
+        # this reason: reading here, one document at a time, keeps at most
+        # one document's bytes resident rather than the whole staged
+        # sample. Read once and reuse for every repeat of this document
+        # (not re-read per repeat) — still outside the timer either way,
+        # but no reason to hit disk more than once for the same file. The
+        # fake path (processor is None) never touches document bytes, so
+        # the read is skipped entirely there.
+        document_bytes = doc.get("document_bytes")
+        document_path = doc.get("document_path")
+        if document_bytes is None and document_path is not None and processor is not None:
+            document_bytes = Path(document_path).read_bytes()
         for r in range(repeats):
             attempts += 1
             is_warm = discard_warm and r == 0
@@ -697,7 +730,7 @@ def _measure_with_processor(
                         ticket_no=ticket,
                         text=doc.get("text"),
                         document_name=doc.get("document_name"),
-                        document_bytes=doc.get("document_bytes"),
+                        document_bytes=document_bytes,
                         district=doc.get("district"),
                     )
                 except Exception as exc:  # noqa: BLE001

--- a/scripts/benchmark_pipeline.py
+++ b/scripts/benchmark_pipeline.py
@@ -703,6 +703,105 @@ def _get_git_sha() -> str | None:
     return None
 
 
+def _probe_tesseract() -> tuple[str, list[str] | str]:
+    """Best-effort (version, sorted available languages) for tesseract.
+
+    Resolves the binary exactly as the real OCR stage does —
+    ``pytesseract_backend._configure_tesseract()``, which checks
+    ``TESSERACT_CMD``/PATH/the bundled ``~/.local/tesseract`` install in that
+    order — not a naive PATH lookup, so a box using the bundled install is
+    reported accurately. Never raises: returns ``("unavailable",
+    "unavailable")`` if tesseract, or even the ``pipeline-core`` extra
+    itself, is unavailable. The two probes are independent (a broken version
+    call must not blank out a working language list, or vice versa).
+    """
+    version: str = "unavailable"
+    langs: list[str] | str = "unavailable"
+    try:
+        import pytesseract
+        from janasunani.pipeline.stages.ocr_extraction.pytesseract_backend import (
+            _configure_tesseract,
+        )
+
+        _configure_tesseract()
+        try:
+            version = str(pytesseract.get_tesseract_version())
+        except Exception:
+            pass
+        try:
+            langs = sorted(pytesseract.get_languages(config=""))
+        except Exception:
+            pass
+    except Exception:
+        pass
+    return version, langs
+
+
+def _probe_poppler_version() -> str:
+    """Best-effort poppler/pdftoppm version banner.
+
+    Resolves the binary exactly as ``page_renderer`` does —
+    ``page_renderer.POPPLER_PATH`` (the bundled ``~/.local/poppler`` install,
+    falling back to ``/usr/bin``, falling back to plain PATH) — the same
+    value ``render_page`` passes to ``pdf2image``. Never raises: returns
+    ``"unavailable"`` if pdftoppm cannot be run at all (missing binary,
+    ``pipeline-core`` extra absent, etc).
+    """
+    try:
+        from janasunani.pipeline.stages.ocr_extraction import page_renderer
+
+        pdftoppm_cmd = (
+            str(Path(page_renderer.POPPLER_PATH) / "pdftoppm")
+            if page_renderer.POPPLER_PATH
+            else "pdftoppm"
+        )
+        result = subprocess.run(
+            [pdftoppm_cmd, "-v"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        # pdftoppm prints its version banner ("pdftoppm version X.YY.Z") to
+        # stderr regardless of exit code; take the first line either stream
+        # produced rather than trusting the exit code.
+        banner = (result.stderr or result.stdout or "").strip().splitlines()
+        if banner:
+            return banner[0].strip()
+    except Exception:
+        pass
+    return "unavailable"
+
+
+def _probe_ocr_toolchain() -> dict[str, Any]:
+    """Best-effort provenance for the OCR toolchain this run would use.
+
+    Two artifacts from the same corpus, produced by different tesseract
+    versions (a laptop's 5.5.1 vs. a freshly-provisioned box's 5.3.4), or by
+    one machine silently missing the Odia (`ori`) traineddata, must not be
+    indistinguishable in ``benchmark_context`` — a missing language pack is a
+    null-scored-as-zero: OCR quietly degrades with no error and no trace in
+    the artifact.
+
+    Never raises (composes ``_probe_tesseract``/``_probe_poppler_version``,
+    both independently defensive). A machine with no tesseract/poppler
+    installed, or missing the ``pipeline-core`` extra entirely (e.g. plain
+    CI), must not crash the harness on import or on the synthetic
+    (``--fake``) path — this is called unconditionally for every run. Each
+    field is the real value or the literal string ``"unavailable"``: never
+    omitted, so an absent key is never mistaken for "not recorded" when it
+    means "checked and absent". This is an environment probe, not a
+    measurement — called outside ``run_benchmark``/``_measure_with_processor``
+    entirely, nowhere near a stage timer.
+    """
+    tesseract_version, tesseract_langs = _probe_tesseract()
+    return {
+        "tesseract_version": tesseract_version,
+        "tesseract_langs": tesseract_langs,
+        "poppler_version": _probe_poppler_version(),
+    }
+
+
 def _measure_with_processor(
     variant: str,
     docs: list[dict[str, Any]],
@@ -1346,6 +1445,25 @@ def main(argv: list[str] | None = None) -> int:
                 startup["seconds"] = time.perf_counter() - started
             return warmed["processor"]
 
+    # Probed once — the OCR toolchain does not vary per variant within a
+    # single process — and merged into every variant's benchmark_context
+    # below (additive keys, both the real-document and synthetic paths) so
+    # two artifacts from different machines are distinguishable by tesseract
+    # version and available language packs, not just by host_label.
+    # _probe_ocr_toolchain() is already internally defensive (never raises),
+    # but this call site adds an outer belt-and-suspenders catch: an
+    # environment probe must never be the reason the harness — including the
+    # synthetic/--fake path, which has no OCR dependency of its own — fails
+    # to run at all.
+    try:
+        ocr_toolchain = _probe_ocr_toolchain()
+    except Exception:
+        ocr_toolchain = {
+            "tesseract_version": "unavailable",
+            "tesseract_langs": "unavailable",
+            "poppler_version": "unavailable",
+        }
+
     results: dict[str, dict[str, Any]] = {}
     for variant in variants:
         try:
@@ -1386,6 +1504,7 @@ def main(argv: list[str] | None = None) -> int:
                 "sample_slice": sample_slice,
                 "sample_document_count": len(loaded_docs),
                 "sample_digest": sample_digest,
+                **ocr_toolchain,
             }
         else:
             result["benchmark_context"] = {
@@ -1393,6 +1512,7 @@ def main(argv: list[str] | None = None) -> int:
                 "model_release_id": args.model_release_id,
                 "fixture": "deterministic synthetic grievances without citizen data",
                 "execution": "sequential single-process execution",
+                **ocr_toolchain,
             }
         results[variant] = result
         e2e = result["stages"][E2E_KEY]

--- a/scripts/benchmark_pipeline.py
+++ b/scripts/benchmark_pipeline.py
@@ -354,8 +354,47 @@ def _staged_document_paths(directory: Path) -> list[Path]:
     )
 
 
+class StaleDocumentBytesError(RuntimeError):
+    """A staged document's bytes changed after the sample was fingerprinted.
+
+    ``main()`` fingerprints the staged sample (``sample_digest`` /
+    ``_document_sample_file_hashes``) once, before the run starts.
+    ``_measure_with_processor`` then reads each document's actual bytes
+    lazily — one document at a time, potentially much later for a large
+    corpus (see #308) — to keep memory bounded. That gap is a real window: a
+    file rewritten mid-run (e.g. a corpus still hydrating from Box while the
+    benchmark is already running against it) is read with content the
+    published ``sample_digest`` never claimed. Raised eagerly, outside the
+    per-attempt failure tracking in ``_measure_with_processor`` — a silently
+    wrong provenance digest on a publishable artifact is exactly the defect
+    this guards against, not a processing failure to count and continue
+    past.
+    """
+
+
+def _document_sample_file_hashes(directory: Path) -> dict[str, str]:
+    """SHA-256 hex digest of each staged document's current bytes, by name.
+
+    Reads every file once, the same work ``_document_sample_digest`` already
+    folds into its aggregate digest — exposed per-file so a caller can
+    fingerprint the sample up front and later verify individual documents
+    against that snapshot at the point they are actually read (see
+    ``StaleDocumentBytesError`` and ``run_benchmark``'s
+    ``expected_file_hashes``), without a second full pass over the
+    directory. Bytes are hashed and discarded one file at a time — nothing
+    beyond one file's bytes is ever resident, same as the eager-read fix in
+    #308.
+    """
+    return {
+        path.name: hashlib.sha256(path.read_bytes()).hexdigest()
+        for path in _staged_document_paths(directory)
+    }
+
+
 def _document_sample_digest(
-    directory: Path, manifest: Mapping[str, Any] | None
+    directory: Path,
+    manifest: Mapping[str, Any] | None,
+    file_hashes: Mapping[str, str] | None = None,
 ) -> str:
     """Stable digest identifying the on-disk sample, for provenance.
 
@@ -371,13 +410,20 @@ def _document_sample_digest(
     the manifest never claimed. Hashing filename + content per file (not
     the full path) keeps the re-stage stability the manifest-only version
     had, while an equal-count substitution now moves the digest.
+
+    ``file_hashes``, when given, must be ``_document_sample_file_hashes``'s
+    output for the same ``directory`` — reused so a caller that also wants
+    the per-file map (e.g. ``main()``, to pass as ``run_benchmark``'s
+    ``expected_file_hashes``) reads each file once, not twice.
     """
+    if file_hashes is None:
+        file_hashes = _document_sample_file_hashes(directory)
     hasher = hashlib.sha256()
     if manifest is not None:
         hasher.update(json.dumps(manifest, sort_keys=True).encode("utf-8"))
-    for path in _staged_document_paths(directory):
-        hasher.update(path.name.encode("utf-8"))
-        hasher.update(hashlib.sha256(path.read_bytes()).digest())
+    for name in sorted(file_hashes):
+        hasher.update(name.encode("utf-8"))
+        hasher.update(bytes.fromhex(file_hashes[name]))
     return hasher.hexdigest()
 
 
@@ -664,6 +710,7 @@ def _measure_with_processor(
     discard_warm: bool,
     processor_factory: Callable[[str], Any] | None,
     sleep_fake: bool = False,
+    expected_file_hashes: Mapping[str, str] | None = None,
 ) -> dict[str, Any]:
     """Run processor over docs repeats times, collect per-stage wall seconds.
 
@@ -676,6 +723,17 @@ def _measure_with_processor(
     method with the same signature as ``PipelineGrievanceProcessor.process``.
     The factory is called once per variant (models warmed once). If it is
     None, fake timings are used (no real processor).
+
+    ``expected_file_hashes`` (filename -> sha256 hex, from
+    ``_document_sample_file_hashes``) is the fingerprint taken before this
+    run started. When given, every document read from ``document_path``
+    below is re-hashed and checked against it, raising
+    ``StaleDocumentBytesError`` on any mismatch — closing the window between
+    that snapshot and this function's lazy, one-document-at-a-time read
+    (#308) during which a file could be rewritten out from under the run,
+    e.g. by a corpus still hydrating from Box. ``None`` (the default) skips
+    the check, which is correct for synthetic docs and any caller that never
+    took a snapshot to check against.
     """
     per_stage_times: dict[str, list[float]] = {k: [] for k in ALL_KEYS}
     per_stage_tickets: dict[str, list[str]] = {k: [] for k in ALL_KEYS}
@@ -711,7 +769,27 @@ def _measure_with_processor(
         document_bytes = doc.get("document_bytes")
         document_path = doc.get("document_path")
         if document_bytes is None and document_path is not None and processor is not None:
-            document_bytes = Path(document_path).read_bytes()
+            resolved_path = Path(document_path)
+            document_bytes = resolved_path.read_bytes()
+            if expected_file_hashes is not None:
+                # Verification stays here too — after the read, still before
+                # the per-repeat timer loop below. One sha256 over bytes
+                # already in memory is cheap next to OCR, and it must never
+                # be silently skipped: a document missing from the snapshot
+                # (staged after fingerprinting) is exactly as stale as one
+                # whose hash no longer matches.
+                actual_hash = hashlib.sha256(document_bytes).hexdigest()
+                expected_hash = expected_file_hashes.get(resolved_path.name)
+                if expected_hash is None or actual_hash != expected_hash:
+                    raise StaleDocumentBytesError(
+                        f"{resolved_path.name} does not match the "
+                        "sample_digest snapshot taken before this run "
+                        f"started (expected sha256 {expected_hash!r}, got "
+                        f"{actual_hash!r}). The file changed on disk between "
+                        "fingerprinting and being read — e.g. a corpus still "
+                        "hydrating from Box. Re-stage the sample (or wait "
+                        "for hydration to finish) before benchmarking it."
+                    )
         for r in range(repeats):
             attempts += 1
             is_warm = discard_warm and r == 0
@@ -818,6 +896,7 @@ def run_benchmark(
     seed: int = 42,
     sleep_fake: bool = False,
     is_fake: bool | None = None,
+    expected_file_hashes: Mapping[str, str] | None = None,
 ) -> dict[str, Any]:
     """Run one benchmark variant and return structured results.
 
@@ -834,6 +913,11 @@ def run_benchmark(
             is non-zero for manual checks; default False for fast tests.
         is_fake: whether this result is synthetic fake timing (non-publishable).
             If None, inferred from processor_factory is None.
+        expected_file_hashes: filename -> sha256 hex fingerprint taken before
+            this run started (see ``_document_sample_file_hashes``). Passed
+            straight to ``_measure_with_processor``, which raises
+            ``StaleDocumentBytesError`` if a document's bytes no longer match
+            when actually read. ``None`` (the default) skips the check.
 
     Returns dict with keys variant, n_docs, repeats, warm_discarded,
     git_sha, timestamp, stages (per-stage stats), is_fake_timing, etc.
@@ -862,6 +946,7 @@ def run_benchmark(
         discard_warm=discard_warm,
         processor_factory=processor_factory,
         sleep_fake=sleep_fake,
+        expected_file_hashes=expected_file_hashes,
     )
     per_stage_times: dict[str, list[float]] = raw["times"]  # type: ignore[assignment]
     per_stage_tickets: dict[str, list[str]] = raw["tickets"]  # type: ignore[assignment]
@@ -1175,6 +1260,7 @@ def main(argv: list[str] | None = None) -> int:
     sample_manifest: dict[str, Any] | None = None
     sample_slice: str | None = None
     sample_digest: str | None = None
+    sample_file_hashes: dict[str, str] | None = None
     if args.documents_dir is not None:
         if args.n_docs is not None or args.n_image_docs is not None:
             parser.error(
@@ -1196,7 +1282,15 @@ def main(argv: list[str] | None = None) -> int:
             or (sample_manifest or {}).get("slice")
             or "unspecified"
         )
-        sample_digest = _document_sample_digest(args.documents_dir, sample_manifest)
+        # Fingerprint the sample once, here, before the run reads anything —
+        # sample_file_hashes is threaded into run_benchmark below so each
+        # document's later, lazy read (#308) is checked against this exact
+        # snapshot rather than trusted blind. file_hashes= reuses that same
+        # read for sample_digest instead of a second pass over the directory.
+        sample_file_hashes = _document_sample_file_hashes(args.documents_dir)
+        sample_digest = _document_sample_digest(
+            args.documents_dir, sample_manifest, file_hashes=sample_file_hashes
+        )
     else:
         n_docs = DEFAULT_N_TEXT if args.n_docs is None else args.n_docs
         n_image_docs = DEFAULT_N_IMAGE if args.n_image_docs is None else args.n_image_docs
@@ -1254,18 +1348,26 @@ def main(argv: list[str] | None = None) -> int:
 
     results: dict[str, dict[str, Any]] = {}
     for variant in variants:
-        result = run_benchmark(
-            variant=variant,
-            n_text=0 if loaded_docs is not None else args.n_docs,
-            n_image=0 if loaded_docs is not None else args.n_image_docs,
-            docs=loaded_docs,
-            repeats=args.repeats,
-            discard_warm=discard_warm,
-            seed=args.seed,
-            sleep_fake=args.sleep_fake,
-            processor_factory=processor_factory,
-            is_fake=is_fake,
-        )
+        try:
+            result = run_benchmark(
+                variant=variant,
+                n_text=0 if loaded_docs is not None else args.n_docs,
+                n_image=0 if loaded_docs is not None else args.n_image_docs,
+                docs=loaded_docs,
+                repeats=args.repeats,
+                discard_warm=discard_warm,
+                seed=args.seed,
+                sleep_fake=args.sleep_fake,
+                processor_factory=processor_factory,
+                is_fake=is_fake,
+                expected_file_hashes=sample_file_hashes,
+            )
+        except StaleDocumentBytesError as exc:
+            # A staged document changed under us mid-run (e.g. a corpus
+            # still hydrating from Box) — fail loudly with the filename
+            # rather than publish a sample_digest that no longer describes
+            # what was actually measured.
+            parser.error(str(exc))
         result["processor_startup_seconds"] = startup.get("seconds")
         if loaded_docs is not None:
             # Real-document path: this is the actual defect being fixed —

--- a/scripts/benchmark_pipeline.py
+++ b/scripts/benchmark_pipeline.py
@@ -372,7 +372,30 @@ class StaleDocumentBytesError(RuntimeError):
     """
 
 
-def _document_sample_file_hashes(directory: Path) -> dict[str, str]:
+class SampleFingerprintDriftError(RuntimeError):
+    """The fingerprinted file set differs from the documents actually loaded.
+
+    ``load_staged_documents`` and ``_document_sample_file_hashes`` each list
+    ``directory`` independently by default (two separate ``iterdir()``
+    calls). A file staged between those two scans — the same live-hydration
+    scenario ``StaleDocumentBytesError`` guards against, just at the
+    directory-listing level instead of a single file's bytes — could end up
+    fingerprinted into ``sample_digest`` without ever being loaded (and
+    therefore never benchmarked or verified), or loaded without ever being
+    fingerprinted. Either way the published digest would describe a file set
+    the run never actually measured. ``main()`` closes the race at the
+    source: it derives the file list to fingerprint from ``loaded_docs``'
+    own ``document_path`` entries (a single directory scan, inside
+    ``load_staged_documents``) rather than a second, independent scan. This
+    error is the cheap, explicit insurance on top of that — checked, not
+    assumed — for any caller (present or future) that fingerprints from an
+    independently-scanned file list instead.
+    """
+
+
+def _document_sample_file_hashes(
+    directory: Path, files: list[Path] | None = None
+) -> dict[str, str]:
     """SHA-256 hex digest of each staged document's current bytes, by name.
 
     Reads every file once, the same work ``_document_sample_digest`` already
@@ -384,11 +407,50 @@ def _document_sample_file_hashes(directory: Path) -> dict[str, str]:
     directory. Bytes are hashed and discarded one file at a time — nothing
     beyond one file's bytes is ever resident, same as the eager-read fix in
     #308.
+
+    ``files``, when given, is hashed as-is instead of scanning ``directory``
+    independently. ``main()`` passes the ``document_path`` values from
+    ``load_staged_documents``'s own return, so the fingerprint covers
+    exactly the documents that were actually loaded (see
+    ``SampleFingerprintDriftError``) rather than whatever a second,
+    independent directory listing happens to see — a real difference while a
+    staging directory is actively being hydrated. The default (``None``)
+    scans fresh, which is correct for a standalone call with no
+    already-loaded document list to reuse.
     """
+    if files is None:
+        files = _staged_document_paths(directory)
     return {
-        path.name: hashlib.sha256(path.read_bytes()).hexdigest()
-        for path in _staged_document_paths(directory)
+        path.name: hashlib.sha256(path.read_bytes()).hexdigest() for path in files
     }
+
+
+def _check_fingerprint_matches_loaded_documents(
+    loaded_docs: list[dict[str, Any]],
+    file_hashes: Mapping[str, str],
+) -> None:
+    """Raise ``SampleFingerprintDriftError`` if the two file sets disagree.
+
+    Cheap insurance on top of ``main()`` deriving ``_document_sample_file_hashes``'s
+    ``files=`` from ``loaded_docs`` itself: an explicit, fast check rather
+    than trusting that derivation silently. ``loaded_docs`` is what
+    ``run_benchmark`` will actually iterate and measure; ``file_hashes``'
+    keys are what ``sample_digest`` claims to describe. They must name
+    exactly the same documents.
+    """
+    loaded_names = {doc["document_name"] for doc in loaded_docs}
+    hashed_names = set(file_hashes)
+    if loaded_names != hashed_names:
+        only_hashed = sorted(hashed_names - loaded_names)
+        only_loaded = sorted(loaded_names - hashed_names)
+        raise SampleFingerprintDriftError(
+            "sample_digest's file set does not match the documents loaded "
+            f"for benchmarking (fingerprinted but never loaded, so never "
+            f"measured: {only_hashed}; loaded but never fingerprinted: "
+            f"{only_loaded}). The staged directory likely changed between "
+            "listing and fingerprinting — re-run once staging/hydration has "
+            "settled."
+        )
 
 
 def _document_sample_digest(
@@ -479,6 +541,15 @@ def load_staged_documents(
     still works from the directory's filenames alone, just without a
     district, the cross-check, or protection against the hierarchical-
     ticket collision above.
+
+    ``main()`` fingerprints this same directory afterward
+    (``_document_sample_file_hashes``) for ``sample_digest``, from the
+    ``document_path`` this function already put in each returned dict —
+    not a second, independent directory scan. Two independent scans of a
+    staging directory that is actively being hydrated can each see a
+    different file set (see ``SampleFingerprintDriftError``); deriving the
+    fingerprint's file list from what was actually loaded here closes that
+    race at the source instead of trusting two scans to agree.
 
     Raises:
         FileNotFoundError: ``directory`` does not exist or is not a
@@ -1386,7 +1457,26 @@ def main(argv: list[str] | None = None) -> int:
         # document's later, lazy read (#308) is checked against this exact
         # snapshot rather than trusted blind. file_hashes= reuses that same
         # read for sample_digest instead of a second pass over the directory.
-        sample_file_hashes = _document_sample_file_hashes(args.documents_dir)
+        #
+        # The file list to hash comes from loaded_docs' own document_path
+        # entries, not a fresh directory scan: load_staged_documents() above
+        # already scanned the directory once. A second, independent scan
+        # here (the original shape) can see a different file set while a
+        # staging directory is actively being hydrated -- a file staged in
+        # between could be fingerprinted into sample_digest without ever
+        # being loaded (and therefore never benchmarked or verified), or the
+        # reverse. Reusing the already-loaded paths closes that race at the
+        # source; _check_fingerprint_matches_loaded_documents below is the
+        # cheap, explicit check on top, in case a future change reintroduces
+        # an independent scan somewhere in this path.
+        staged_files = [doc["document_path"] for doc in loaded_docs]
+        sample_file_hashes = _document_sample_file_hashes(
+            args.documents_dir, files=staged_files
+        )
+        try:
+            _check_fingerprint_matches_loaded_documents(loaded_docs, sample_file_hashes)
+        except SampleFingerprintDriftError as exc:
+            parser.error(str(exc))
         sample_digest = _document_sample_digest(
             args.documents_dir, sample_manifest, file_hashes=sample_file_hashes
         )

--- a/tests/test_benchmark_pipeline.py
+++ b/tests/test_benchmark_pipeline.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tracemalloc
@@ -1085,8 +1086,20 @@ def test_probe_ocr_toolchain_populates_real_values_when_installed():
     # must report real values: two machines with different tesseract
     # versions or a missing Odia (ori) pack must be distinguishable from
     # this output, which is the entire point of #315's follow-up.
+    #
+    # The importorskips gate on the Python wrappers; the assertions below
+    # need the system binaries those wrappers shell out to. They are
+    # separately installable, so `pip install pytesseract` on a host with no
+    # `tesseract` on PATH satisfies the import and still probes
+    # "unavailable" — correct behaviour that used to fail this test, and so
+    # the repo's required test command, on a legitimate environment. Gate on
+    # what is actually asserted.
     pytest.importorskip("pytesseract")
     pytest.importorskip("pdf2image")
+    if shutil.which("tesseract") is None:
+        pytest.skip("tesseract binary not on PATH; _probe_tesseract has its own test")
+    if shutil.which("pdftoppm") is None:
+        pytest.skip("poppler (pdftoppm) not on PATH; _probe_poppler_version has its own test")
 
     toolchain = bench_mod._probe_ocr_toolchain()
 

--- a/tests/test_benchmark_pipeline.py
+++ b/tests/test_benchmark_pipeline.py
@@ -24,7 +24,9 @@ from scripts.benchmark_pipeline import (
     STAGES,
     SUPPORTED_DOCUMENT_SUFFIXES,
     VALID_VARIANTS,
+    SampleFingerprintDriftError,
     StaleDocumentBytesError,
+    _check_fingerprint_matches_loaded_documents,
     _clustered_se,
     _document_kind,
     _document_sample_digest,
@@ -592,6 +594,158 @@ def test_cli_documents_dir_stale_document_bytes_fails_loudly(tmp_path, monkeypat
     assert "sample_digest snapshot" in err
 
 
+# ---------------------------------------------------------------------------
+# #315 Codex follow-up round 2 — fingerprint file set must match what was
+# actually loaded (a file added/removed between two independent directory
+# scans could be fingerprinted without being benchmarked, or vice versa)
+# ---------------------------------------------------------------------------
+
+
+def test_check_fingerprint_matches_loaded_documents_passes_when_sets_agree():
+    loaded_docs = [
+        {"document_name": "a.pdf"},
+        {"document_name": "b.pdf"},
+    ]
+    file_hashes = {"a.pdf": "hash-a", "b.pdf": "hash-b"}
+    # Must not raise.
+    _check_fingerprint_matches_loaded_documents(loaded_docs, file_hashes)
+
+
+def test_check_fingerprint_matches_loaded_documents_raises_on_extra_hash():
+    # A file fingerprinted but never loaded is the dangerous direction:
+    # sample_digest would cover bytes nothing in the run ever measured.
+    loaded_docs = [{"document_name": "a.pdf"}]
+    file_hashes = {"a.pdf": "hash-a", "stowaway.pdf": "hash-b"}
+
+    with pytest.raises(SampleFingerprintDriftError, match="stowaway.pdf"):
+        _check_fingerprint_matches_loaded_documents(loaded_docs, file_hashes)
+
+
+def test_check_fingerprint_matches_loaded_documents_raises_on_missing_hash():
+    loaded_docs = [{"document_name": "a.pdf"}, {"document_name": "b.pdf"}]
+    file_hashes = {"a.pdf": "hash-a"}
+
+    with pytest.raises(SampleFingerprintDriftError, match="b.pdf"):
+        _check_fingerprint_matches_loaded_documents(loaded_docs, file_hashes)
+
+
+def test_fingerprint_race_between_independent_scans_is_real_and_caught(tmp_path):
+    # Reproduces the actual race Codex found: load_staged_documents() and
+    # _document_sample_file_hashes() each independently list the directory
+    # by default (two directory.iterdir() calls, not one). A file staged in
+    # between -- e.g. a corpus still hydrating into this directory -- lands
+    # in the second scan's hashes without ever having been loaded. This is
+    # exactly what main() no longer does (it derives the hash target list
+    # from loaded_docs' own document_path, not a second scan -- see the
+    # tests below), but the two independently-scanning functions still
+    # exist on their own and the mismatch they can produce must be caught,
+    # not silently published.
+    _stage_document(tmp_path, "CMO20241020862")
+    loaded_docs = load_staged_documents(tmp_path)  # scan #1
+
+    # Simulate a file landing mid-hydration, after scan #1.
+    _stage_document(tmp_path, "CMO2024483790", suffix=".jpeg")
+
+    file_hashes = _document_sample_file_hashes(tmp_path)  # independent scan #2
+    assert "CMO2024483790_complaint_20250715_234307.jpeg" in file_hashes  # premise: the race is real
+
+    with pytest.raises(
+        SampleFingerprintDriftError, match="CMO2024483790_complaint_20250715_234307.jpeg"
+    ):
+        _check_fingerprint_matches_loaded_documents(loaded_docs, file_hashes)
+
+
+def test_document_sample_file_hashes_with_explicit_files_ignores_later_directory_changes(
+    tmp_path,
+):
+    # This is the actual fix: an explicit files= snapshot is hashed as-is,
+    # so a file appearing after the snapshot was taken cannot silently
+    # enter the fingerprint no matter when _document_sample_file_hashes
+    # happens to run relative to the directory changing.
+    _stage_document(tmp_path, "CMO20241020862")
+    files = bench_mod._staged_document_paths(tmp_path)
+
+    _stage_document(tmp_path, "CMO2024483790", suffix=".jpeg")  # lands after the snapshot
+
+    hashes = _document_sample_file_hashes(tmp_path, files=files)
+    assert set(hashes) == {"CMO20241020862_complaint_20250715_234307.pdf"}
+
+
+def test_cli_documents_dir_fingerprint_derives_from_loaded_documents_not_a_rescan(tmp_path):
+    # Integration-level regression guard for the actual fix in main(): the
+    # file list handed to _document_sample_file_hashes comes from
+    # loaded_docs' own document_path values, not a fresh directory scan. A
+    # file staged after load_staged_documents() has already run (simulated
+    # here by writing it right after staging the first two, before main()
+    # runs at all -- main() only ever sees the directory once) must not
+    # appear in sample_digest's file set unless it was actually loaded.
+    # (The full race -- a file appearing *during* main()'s own run, between
+    # its load and fingerprint steps -- can no longer happen by
+    # construction, which is exactly what this test is standing in for:
+    # there is only one directory scan for main() to race against itself.)
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    _stage_document(staging, "CMO20241020862")
+    _stage_document(staging, "CMO2024483790", suffix=".jpeg")
+    out = tmp_path / "latency.json"
+
+    rc = bench_mod.main(
+        [
+            "--fake",
+            "--documents-dir",
+            str(staging),
+            "--repeats",
+            "2",
+            "--output",
+            str(out),
+        ]
+    )
+    assert rc == 0
+    data = json.loads(out.read_text())
+    assert data["n_docs"] == 2
+    assert data["benchmark_context"]["sample_digest"]
+
+
+def test_cli_documents_dir_fingerprint_drift_fails_loudly(tmp_path, monkeypatch, capsys):
+    # CLI wiring: main() must convert a SampleFingerprintDriftError raised
+    # by the insurance check into a loud, non-zero-exit CLI failure, not a
+    # silently-written latency.json whose sample_digest overclaims what was
+    # measured. The detection logic itself is exercised for real above;
+    # this test is only about main()'s try/except around the call.
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    _stage_document(staging, "CMO20241020862")
+    out = tmp_path / "latency.json"
+
+    def fake_check(*_args, **_kwargs):
+        raise SampleFingerprintDriftError(
+            "sample_digest's file set does not match the documents loaded "
+            "for benchmarking (fingerprinted but never loaded, so never "
+            "measured: ['stowaway.pdf']; loaded but never fingerprinted: [])"
+        )
+
+    monkeypatch.setattr(
+        bench_mod, "_check_fingerprint_matches_loaded_documents", fake_check
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        bench_mod.main(
+            [
+                "--fake",
+                "--documents-dir",
+                str(staging),
+                "--repeats",
+                "2",
+                "--output",
+                str(out),
+            ]
+        )
+    assert exc.value.code == 2
+    assert not out.exists()
+    err = capsys.readouterr().err
+    assert "stowaway.pdf" in err
+
+
 def test_run_benchmark_over_loaded_real_documents(tmp_path):
     # No processor_factory here, so this exercises the fake timing path,
     # which never touches document_bytes/document_path — docs from
@@ -922,11 +1076,18 @@ def test_cli_synthetic_path_benchmark_context_fixture_is_unchanged(tmp_path):
 
 
 def test_probe_ocr_toolchain_populates_real_values_when_installed():
-    # Real code path, no mocking of pytesseract/poppler: the pipeline-core
-    # test gate (tests/README.md) requires tesseract and poppler installed
-    # locally, so this must report real values, not "unavailable"
-    # placeholders. Two machines with different tesseract versions or a
-    # missing Odia (ori) pack must be distinguishable from this output.
+    # Real code path, no mocking of pytesseract/poppler. Base CI
+    # (pipeline.yml) deliberately runs `uv sync --all-groups --extra
+    # serving` without pipeline-core, so pytesseract/pdf2image are not
+    # importable there and this test must skip rather than assert on
+    # "unavailable" — that path has its own test below. Locally, with
+    # pipeline-core installed (tests/README.md's gate requirement), this
+    # must report real values: two machines with different tesseract
+    # versions or a missing Odia (ori) pack must be distinguishable from
+    # this output, which is the entire point of #315's follow-up.
+    pytest.importorskip("pytesseract")
+    pytest.importorskip("pdf2image")
+
     toolchain = bench_mod._probe_ocr_toolchain()
 
     assert set(toolchain) == {"tesseract_version", "tesseract_langs", "poppler_version"}
@@ -940,10 +1101,19 @@ def test_probe_ocr_toolchain_populates_real_values_when_installed():
 
 
 def test_probe_ocr_toolchain_records_unavailable_when_tesseract_probe_fails(monkeypatch):
-    # Simulate a box where tesseract cannot be located/configured (e.g. no
-    # binary installed at all). The probe must not raise, must not silently
-    # omit the keys, and must not let a tesseract failure take poppler's
+    # Simulate a box where tesseract is importable but misbehaves at runtime
+    # (as opposed to not being installed at all, which base CI already
+    # exercises for real — see test_probe_ocr_toolchain_composes_independent_
+    # tesseract_and_poppler_probes, which asserts nothing about availability
+    # and so passes either way). monkeypatch.setattr's string-path form has
+    # to import pytesseract_backend to resolve the target, and that module
+    # does `import pytesseract` at module scope, so this needs pytesseract
+    # importable too — skip in base CI rather than error out on the mock
+    # setup itself. The probe must not raise, must not silently omit the
+    # keys, and must not let a tesseract failure take poppler's
     # (independently probed) result down with it.
+    pytest.importorskip("pytesseract")
+
     def boom():
         raise RuntimeError("tesseract not installed on this box")
 

--- a/tests/test_benchmark_pipeline.py
+++ b/tests/test_benchmark_pipeline.py
@@ -902,8 +902,119 @@ def test_cli_synthetic_path_benchmark_context_fixture_is_unchanged(tmp_path):
     ctx = data["benchmark_context"]
     assert ctx["fixture"] == "deterministic synthetic grievances without citizen data"
     assert ctx["execution"] == "sequential single-process execution"
-    # No document-sample keys leak onto the synthetic path.
-    assert set(ctx) == {"host_label", "model_release_id", "fixture", "execution"}
+    # No document-sample keys leak onto the synthetic path. The OCR
+    # toolchain keys (#315 follow-up) are additive and present on every
+    # path, including synthetic — see test_cli_synthetic_path_records_ocr_toolchain.
+    assert set(ctx) == {
+        "host_label",
+        "model_release_id",
+        "fixture",
+        "execution",
+        "tesseract_version",
+        "tesseract_langs",
+        "poppler_version",
+    }
+
+
+# ---------------------------------------------------------------------------
+# #315 Codex follow-up — OCR toolchain provenance in benchmark_context
+# ---------------------------------------------------------------------------
+
+
+def test_probe_ocr_toolchain_populates_real_values_when_installed():
+    # Real code path, no mocking of pytesseract/poppler: the pipeline-core
+    # test gate (tests/README.md) requires tesseract and poppler installed
+    # locally, so this must report real values, not "unavailable"
+    # placeholders. Two machines with different tesseract versions or a
+    # missing Odia (ori) pack must be distinguishable from this output.
+    toolchain = bench_mod._probe_ocr_toolchain()
+
+    assert set(toolchain) == {"tesseract_version", "tesseract_langs", "poppler_version"}
+    assert toolchain["tesseract_version"] != "unavailable"
+    assert toolchain["tesseract_version"][0].isdigit()
+    assert isinstance(toolchain["tesseract_langs"], list)
+    assert toolchain["tesseract_langs"] == sorted(toolchain["tesseract_langs"])
+    assert "eng" in toolchain["tesseract_langs"]
+    assert toolchain["poppler_version"] != "unavailable"
+    assert "pdftoppm" in toolchain["poppler_version"].lower()
+
+
+def test_probe_ocr_toolchain_records_unavailable_when_tesseract_probe_fails(monkeypatch):
+    # Simulate a box where tesseract cannot be located/configured (e.g. no
+    # binary installed at all). The probe must not raise, must not silently
+    # omit the keys, and must not let a tesseract failure take poppler's
+    # (independently probed) result down with it.
+    def boom():
+        raise RuntimeError("tesseract not installed on this box")
+
+    monkeypatch.setattr(
+        "janasunani.pipeline.stages.ocr_extraction.pytesseract_backend._configure_tesseract",
+        boom,
+    )
+
+    toolchain = bench_mod._probe_ocr_toolchain()
+
+    assert toolchain["tesseract_version"] == "unavailable"
+    assert toolchain["tesseract_langs"] == "unavailable"
+    assert toolchain["poppler_version"] != "unavailable"  # unaffected
+
+
+def test_probe_ocr_toolchain_composes_independent_tesseract_and_poppler_probes():
+    # _probe_ocr_toolchain() itself has no per-field try/except — it trusts
+    # _probe_tesseract()/_probe_poppler_version() to each be defensive on
+    # their own (tested directly above/below). What it must get right is
+    # composition: both fields present, independently sourced.
+    toolchain = bench_mod._probe_ocr_toolchain()
+    tesseract_version, tesseract_langs = bench_mod._probe_tesseract()
+    assert toolchain["tesseract_version"] == tesseract_version
+    assert toolchain["tesseract_langs"] == tesseract_langs
+    assert toolchain["poppler_version"] == bench_mod._probe_poppler_version()
+
+
+def test_probe_poppler_version_never_raises_when_subprocess_fails(monkeypatch):
+    # One level lower than the test above: exercises _probe_poppler_version
+    # itself (not the composite _probe_ocr_toolchain) against the exact
+    # failure it is written to catch — subprocess.run raising because
+    # pdftoppm isn't installed.
+    def boom(*_args, **_kwargs):
+        raise FileNotFoundError("pdftoppm not found")
+
+    monkeypatch.setattr(bench_mod.subprocess, "run", boom)
+
+    assert bench_mod._probe_poppler_version() == "unavailable"
+
+
+def test_cli_synthetic_path_records_ocr_toolchain(tmp_path):
+    out = tmp_path / "latency.json"
+    rc = bench_mod.main(
+        ["--fake", "--n-docs", "2", "--repeats", "2", "--output", str(out)]
+    )
+    assert rc == 0
+    ctx = json.loads(out.read_text())["benchmark_context"]
+    for key in ("tesseract_version", "tesseract_langs", "poppler_version"):
+        assert key in ctx
+
+
+def test_cli_harness_still_runs_when_ocr_toolchain_probe_itself_raises(tmp_path, monkeypatch):
+    # Belt-and-suspenders: even if _probe_ocr_toolchain's own internal
+    # defensiveness were ever broken by a future change, main()'s outer
+    # catch must still keep the synthetic (--fake) path — which has no OCR
+    # dependency of its own — running to completion rather than crashing on
+    # an environment probe.
+    def boom():
+        raise RuntimeError("unexpected probe failure")
+
+    monkeypatch.setattr(bench_mod, "_probe_ocr_toolchain", boom)
+
+    out = tmp_path / "latency.json"
+    rc = bench_mod.main(
+        ["--fake", "--n-docs", "2", "--repeats", "2", "--output", str(out)]
+    )
+    assert rc == 0
+    ctx = json.loads(out.read_text())["benchmark_context"]
+    assert ctx["tesseract_version"] == "unavailable"
+    assert ctx["tesseract_langs"] == "unavailable"
+    assert ctx["poppler_version"] == "unavailable"
 
 
 def test_run_benchmark_standard_variant_basic():

--- a/tests/test_benchmark_pipeline.py
+++ b/tests/test_benchmark_pipeline.py
@@ -7,6 +7,7 @@ for the four variants standard / sarvam_digitise / sarvam_extract / sarvam_both.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import subprocess
@@ -23,9 +24,11 @@ from scripts.benchmark_pipeline import (
     STAGES,
     SUPPORTED_DOCUMENT_SUFFIXES,
     VALID_VARIANTS,
+    StaleDocumentBytesError,
     _clustered_se,
     _document_kind,
     _document_sample_digest,
+    _document_sample_file_hashes,
     _fake_process,
     _percentile,
     _single_page_text_pdf,
@@ -410,6 +413,183 @@ def test_document_sample_digest_stable_across_restage_to_new_path(tmp_path):
     }
 
     assert _document_sample_digest(dir1, manifest) == _document_sample_digest(dir2, manifest)
+
+
+# ---------------------------------------------------------------------------
+# #315 Codex follow-up — bind sample_digest to the bytes actually benchmarked
+# ---------------------------------------------------------------------------
+
+
+def test_document_sample_file_hashes_matches_per_file_digest_inputs(tmp_path):
+    _stage_document(tmp_path, "CMO20241020862")
+    _stage_document(tmp_path, "CMO2024483790", suffix=".jpeg")
+
+    hashes = _document_sample_file_hashes(tmp_path)
+
+    names = {d.name for d in tmp_path.iterdir() if d.suffix.lower() in SUPPORTED_DOCUMENT_SUFFIXES}
+    assert set(hashes) == names
+    for name, digest in hashes.items():
+        expected = hashlib.sha256((tmp_path / name).read_bytes()).hexdigest()
+        assert digest == expected
+    # _document_sample_digest(..., file_hashes=hashes) must be reusable
+    # without a second read — same result as computing it fresh.
+    assert _document_sample_digest(tmp_path, None, file_hashes=hashes) == _document_sample_digest(
+        tmp_path, None
+    )
+
+
+def test_run_benchmark_detects_document_mutated_after_fingerprint(tmp_path):
+    # This is the actual race #308's lazy read opened: sample_digest is
+    # fingerprinted once, before the run starts; _measure_with_processor then
+    # reads each document lazily, potentially much later. Stage a directory,
+    # fingerprint it (as main() does before run_benchmark starts), mutate one
+    # file on disk exactly like a corpus still hydrating from Box would, and
+    # confirm the run refuses to silently benchmark content the fingerprint
+    # never saw.
+    mutated_path = _stage_document(tmp_path, "CMO20241020862")
+    _stage_document(tmp_path, "CMO2024483790", suffix=".jpeg")
+    file_hashes = _document_sample_file_hashes(tmp_path)
+    docs = load_staged_documents(tmp_path)
+
+    # Simulate the mid-run rewrite: different bytes land on disk after the
+    # fingerprint but before run_benchmark's lazy read.
+    mutated_path.write_bytes(_single_page_text_pdf("A completely different scan"))
+
+    with pytest.raises(StaleDocumentBytesError, match=mutated_path.name):
+        run_benchmark(
+            variant="standard",
+            docs=docs,
+            repeats=1,
+            discard_warm=False,
+            processor_factory=lambda _variant: type(
+                "Processor",
+                (),
+                {
+                    "_timing_sink": None,
+                    "process": lambda self, **kwargs: self._timing_sink(
+                        {"redact": 0.1, "e2e": 0.2, "ok": 1.0}
+                    ),
+                },
+            )(),
+            expected_file_hashes=file_hashes,
+        )
+
+
+def test_run_benchmark_missing_from_fingerprint_also_fails_loudly(tmp_path):
+    # A file staged after the fingerprint was taken is exactly as stale as
+    # one whose content changed — both mean the run is about to measure
+    # bytes the published sample_digest never claimed. Must not be treated
+    # as "no opinion, so allow it".
+    file_hashes = _document_sample_file_hashes(tmp_path)  # empty snapshot
+    _stage_document(tmp_path, "CMO20241020862")
+    docs = load_staged_documents(tmp_path)
+
+    with pytest.raises(StaleDocumentBytesError, match="CMO20241020862"):
+        run_benchmark(
+            variant="standard",
+            docs=docs,
+            repeats=1,
+            discard_warm=False,
+            processor_factory=lambda _variant: type(
+                "Processor",
+                (),
+                {
+                    "_timing_sink": None,
+                    "process": lambda self, **kwargs: self._timing_sink(
+                        {"redact": 0.1, "e2e": 0.2, "ok": 1.0}
+                    ),
+                },
+            )(),
+            expected_file_hashes=file_hashes,
+        )
+
+
+def test_run_benchmark_happy_path_with_matching_fingerprint_still_passes(tmp_path):
+    # The verification must not get in its own way when nothing changed —
+    # this is the common case (no hydration race) and must behave exactly
+    # like passing no expected_file_hashes at all.
+    _stage_document(tmp_path, "CMO20241020862")
+    _stage_document(tmp_path, "CMO2024483790", suffix=".jpeg")
+    file_hashes = _document_sample_file_hashes(tmp_path)
+    docs = load_staged_documents(tmp_path)
+
+    result = run_benchmark(
+        variant="standard",
+        docs=docs,
+        repeats=2,
+        discard_warm=False,
+        processor_factory=lambda _variant: type(
+            "Processor",
+            (),
+            {
+                "_timing_sink": None,
+                "process": lambda self, **kwargs: self._timing_sink(
+                    {"redact": 0.1, "e2e": 0.2, "ok": 1.0}
+                ),
+            },
+        )(),
+        expected_file_hashes=file_hashes,
+    )
+    assert result["n_docs"] == 2
+    assert result["failed_attempts"] == 0
+    assert result["stages"]["e2e"]["n"] == 4
+
+
+def test_run_benchmark_fake_path_skips_fingerprint_check(tmp_path):
+    # The fake timing path never reads document bytes at all (see #308's
+    # fake-path test), so it must not fail even when expected_file_hashes is
+    # stale — there is nothing to verify because nothing gets read.
+    mutated_path = _stage_document(tmp_path, "CMO20241020862")
+    file_hashes = _document_sample_file_hashes(tmp_path)
+    docs = load_staged_documents(tmp_path)
+    mutated_path.write_bytes(_single_page_text_pdf("A completely different scan"))
+
+    result = run_benchmark(
+        variant="standard",
+        docs=docs,
+        repeats=2,
+        discard_warm=False,
+        expected_file_hashes=file_hashes,  # no processor_factory -> fake path
+    )
+    assert result["n_docs"] == 1
+
+
+def test_cli_documents_dir_stale_document_bytes_fails_loudly(tmp_path, monkeypatch, capsys):
+    # CLI wiring: main() must convert a StaleDocumentBytesError raised deep
+    # inside run_benchmark into a loud, non-zero-exit CLI failure that names
+    # the file, not a silently-written latency.json. run_benchmark itself is
+    # stubbed here — the detection logic is exercised for real above; this
+    # test is only about main()'s try/except around the call.
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    _stage_document(staging, "CMO20241020862")
+    out = tmp_path / "latency.json"
+
+    def fake_run_benchmark(*_args, **_kwargs):
+        raise StaleDocumentBytesError(
+            "CMO20241020862_complaint_20250715_234307.pdf does not match "
+            "the sample_digest snapshot taken before this run started"
+        )
+
+    monkeypatch.setattr(bench_mod, "run_benchmark", fake_run_benchmark)
+
+    with pytest.raises(SystemExit) as exc:
+        bench_mod.main(
+            [
+                "--fake",
+                "--documents-dir",
+                str(staging),
+                "--repeats",
+                "2",
+                "--output",
+                str(out),
+            ]
+        )
+    assert exc.value.code == 2
+    assert not out.exists()
+    err = capsys.readouterr().err
+    assert "CMO20241020862_complaint_20250715_234307.pdf" in err
+    assert "sample_digest snapshot" in err
 
 
 def test_run_benchmark_over_loaded_real_documents(tmp_path):

--- a/tests/test_benchmark_pipeline.py
+++ b/tests/test_benchmark_pipeline.py
@@ -11,6 +11,7 @@ import json
 import os
 import subprocess
 import sys
+import tracemalloc
 from pathlib import Path
 
 import pytest
@@ -178,12 +179,16 @@ def test_load_staged_documents_without_manifest(tmp_path):
     tickets = {d["ticket"] for d in docs}
     assert tickets == {"CMO20241020862", "CMO2024483790"}
     for doc in docs:
-        # Same shape as synthesize_documents(): ticket, text, document_name,
-        # document_bytes, district.
+        # Same shape as synthesize_documents() (ticket, text, document_name,
+        # document_bytes, district) plus document_path. Bytes are not read
+        # here (#308) — document_bytes stays None and document_path carries
+        # the file; _measure_with_processor reads it lazily, one document at
+        # a time, outside every stage timer.
         assert doc["text"] is None
         assert doc["document_name"]
-        assert isinstance(doc["document_bytes"], bytes)
-        assert len(doc["document_bytes"]) > 0
+        assert doc["document_bytes"] is None
+        assert doc["document_path"].is_file()
+        assert len(doc["document_path"].read_bytes()) > 0
         # No manifest present, so district falls back to a stable label
         # rather than crashing or silently using None.
         assert doc["district"] == "unspecified"
@@ -408,8 +413,10 @@ def test_document_sample_digest_stable_across_restage_to_new_path(tmp_path):
 
 
 def test_run_benchmark_over_loaded_real_documents(tmp_path):
-    # The measurement loop needs no change: docs from load_staged_documents
-    # flow through run_benchmark exactly like any other custom doc list.
+    # No processor_factory here, so this exercises the fake timing path,
+    # which never touches document_bytes/document_path — docs from
+    # load_staged_documents flow through run_benchmark exactly like any
+    # other custom doc list.
     _stage_document(tmp_path, "CMO20241020862")
     _stage_document(tmp_path, "CMO2024483790", suffix=".jpeg")
     docs = load_staged_documents(tmp_path)
@@ -418,6 +425,121 @@ def test_run_benchmark_over_loaded_real_documents(tmp_path):
     assert result["n_docs"] == 2
     assert result["stages"]["e2e"]["n"] == 4
     assert {"CMO20241020862", "CMO2024483790"} == set(result["_raw"]["tickets"]["e2e"])
+
+
+# ---------------------------------------------------------------------------
+# #308 — streaming: only one document's bytes resident/read at a time
+# ---------------------------------------------------------------------------
+
+
+def test_load_staged_documents_streams_bytes_bounded_memory(tmp_path):
+    """load_staged_documents() used to call path.read_bytes() for every
+    staged file and hold the whole list before run_benchmark started, so an
+    n-document sample cost roughly n * average_document_size resident on top
+    of the loaded models — ~630 MB for the 627 KB/doc Sambalpur/2024 sample
+    at n=1,000, ~44 GB for the 69,844-document corpus this harness is about
+    to run over (see #308). It now hands back a document_path per document,
+    and the real bytes are read lazily by _measure_with_processor, one
+    document at a time. Build documents large enough that eager loading
+    would clearly show up in peak traced memory, and confirm streaming keeps
+    the peak near a single document's size instead of scaling with n.
+    """
+    n_docs = 8
+    doc_size = 3_000_000  # ~3 MB filler; deterministic, no citizen data
+    filler = b"%PDF-1.4\n" + (b"A" * doc_size)
+    for i in range(n_docs):
+        path = tmp_path / f"CMO2024{i:07d}_complaint_20250715_234307.pdf"
+        path.write_bytes(filler)
+
+    docs = load_staged_documents(tmp_path)
+    assert len(docs) == n_docs
+    # Nothing has been read yet — the loader only records paths.
+    assert all(doc["document_bytes"] is None for doc in docs)
+    assert all(doc["document_path"] is not None for doc in docs)
+
+    class Processor:
+        _timing_sink = None
+
+        def process(self, **kwargs):
+            document_bytes = kwargs["document_bytes"]
+            assert document_bytes is not None
+            assert len(document_bytes) == len(filler)
+            self._timing_sink({"redact": 0.001, "e2e": 0.002, "ok": 1.0})
+
+    tracemalloc.start()
+    try:
+        run_benchmark(
+            variant="standard",
+            docs=docs,
+            repeats=1,
+            discard_warm=False,
+            processor_factory=lambda _variant: Processor(),
+        )
+        _current, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+
+    # Eager loading (the bug) would resident roughly n_docs * doc_size here
+    # (~24 MB for 8 x 3 MB). Streaming should keep the traced peak within a
+    # small multiple of one document, not scale with the sample size.
+    assert peak < doc_size * 3, (
+        f"peak traced memory {peak} bytes suggests more than one document's "
+        f"bytes were resident at once (n_docs={n_docs}, doc_size={doc_size})"
+    )
+
+
+def test_measure_with_processor_reads_each_document_once_not_per_repeat(tmp_path, monkeypatch):
+    # Bounded reads, not just bounded memory: a document's bytes must be
+    # read once and reused across its repeats, not re-read from disk every
+    # repeat (which would still be correct memory-wise but wasteful I/O).
+    _stage_document(tmp_path, "CMO20241020862")
+    _stage_document(tmp_path, "CMO2024483790", suffix=".jpeg")
+    docs = load_staged_documents(tmp_path)
+
+    read_calls: list[Path] = []
+    original_read_bytes = Path.read_bytes
+
+    def counting_read_bytes(self):
+        read_calls.append(self)
+        return original_read_bytes(self)
+
+    monkeypatch.setattr(Path, "read_bytes", counting_read_bytes)
+
+    class Processor:
+        _timing_sink = None
+
+        def process(self, **kwargs):
+            self._timing_sink({"redact": 0.001, "e2e": 0.002, "ok": 1.0})
+
+    run_benchmark(
+        variant="standard",
+        docs=docs,
+        repeats=3,
+        discard_warm=False,
+        processor_factory=lambda _variant: Processor(),
+    )
+
+    # 2 documents x 3 repeats: without the fix this would be up to 6 reads
+    # from inside the loop (or reads already done eagerly by the loader).
+    # Reading once per document and reusing it across repeats caps this at 2.
+    assert len(read_calls) == 2
+    assert {p.name for p in read_calls} == {d["document_path"].name for d in docs}
+
+
+def test_run_benchmark_fake_path_never_reads_staged_bytes(tmp_path, monkeypatch):
+    # The fake timing path (no processor_factory) never calls process(), so
+    # it has no use for document bytes at all; the lazy read must not fire
+    # just because a real staged sample happens to be on disk.
+    _stage_document(tmp_path, "CMO20241020862")
+    docs = load_staged_documents(tmp_path)
+
+    def failing_read_bytes(self):
+        raise AssertionError(f"fake timing path must not read {self}")
+
+    monkeypatch.setattr(Path, "read_bytes", failing_read_bytes)
+
+    result = run_benchmark(variant="standard", docs=docs, repeats=2, discard_warm=False)
+    assert result["n_docs"] == 1
 
 
 def test_document_kind_reads_the_doc_not_the_ticket_string():


### PR DESCRIPTION
## Summary

- `load_staged_documents()` called `path.read_bytes()` for every staged document and held the whole list resident before `run_benchmark` started. At 627 KB/document (staged Sambalpur/2024 sample) that's ~630 MB for a 1,000-document draw; the 69,844-document/60 GB corpus this harness is about to run over would be ~44 GB — unworkable on a bounded-RAM box.
- The loader now hands back a `document_path` per document (`document_bytes: None`) instead of pre-read bytes. `_measure_with_processor()` resolves the real bytes lazily, one document at a time, immediately before that document's per-repeat measurement loop — before any `time.perf_counter()` call, never inside one — so the read is never attributed to the `ocr` stage.
- The read happens once per document (reused across its `repeats`, not re-read per repeat) and only on the real-processor path; the fake timing path never touches document bytes at all, so pointing `--fake` at a staged sample triggers zero disk reads.
- `_document_sample_digest()` (the P1 fix from #307 that hashes manifest + file bytes for `sample_digest`) is untouched — it already reads one file at a time inside its own loop and was never the source of the eager-loading problem, so no regression there.

## On the timing-semantics constraint

The issue calls out the real difficulty: moving the read inside the per-document loop must not land it inside a stage timer. I read `run_benchmark`'s structure first — `_measure_with_processor` builds the processor once, then loops `for doc in docs: for r in range(repeats):`, starting `time.perf_counter()` immediately before `processor.process(...)` on the real-processor path. That gave a clean separation: resolve `document_bytes` right after entering the `for doc` loop, strictly before the `for r in range(repeats)` loop and its timers. No timing semantics changed — same stages, same measured window. This was a clean case, not one where I had to compromise the numbers' meaning.

## Requirements checklist

- [x] Only one document's bytes resident at a time — verified with a `tracemalloc`-based test (8 x ~3 MB documents; peak traced memory stays within a small multiple of one document instead of scaling toward ~24 MB).
- [x] Reads are bounded, not just memory — a `Path.read_bytes()` call-count test confirms exactly 2 reads for 2 documents x 3 repeats (not 6), and a separate test confirms the fake path performs zero reads even when pointed at a real staged sample.
- [x] `synthesize_documents()` unchanged — synthetic bytes are generated in memory, never touch `document_path`/disk, no data dependency.
- [x] `benchmark_context` unchanged apart from additive keys — the only additive keys are the OCR-toolchain ones described below; nothing existing was renamed/removed.
- [x] `sample_digest` still hashes manifest + file bytes — `_document_sample_digest()` untouched (see the digest-binding fix below for the one gap Codex found in this area).
- [x] Real-code-path tests over a small fixture directory under `tests/`, demonstrating bounded memory/reads rather than just shape.

## Follow-up 1: bind `sample_digest` to the bytes actually benchmarked (Codex P2)

Codex flagged, and the coordinator verified independently before asking me to fix it: `main()` fingerprints `sample_digest` once via `_document_sample_digest()` before `run_benchmark` starts, but the lazy read above happens later, one document at a time, inside `_measure_with_processor`. A file rewritten in that window — e.g. a corpus still hydrating from Box while the benchmark is already running against it, which is literally what we're doing right now with the 69,844-document corpus — would be measured with content the published digest never described.

Fix:
- `_document_sample_file_hashes(directory)` exposes the per-file sha256 map `_document_sample_digest()` already computed internally (`file_hashes=` param reuses it instead of a second full read).
- `main()` takes the fingerprint once, up front, and threads it into `run_benchmark(..., expected_file_hashes=...)`.
- `_measure_with_processor()` re-hashes each document immediately after its lazy read — still before the per-repeat `time.perf_counter()` loop, so the check sits outside every stage timer exactly like the read itself does — and raises `StaleDocumentBytesError`, naming the file, on any mismatch or on a file missing from the snapshot entirely. Not caught by the per-attempt `failures_by_error` tracking: a wrong provenance digest on a publishable artifact is the defect itself, not a processing failure to count and move past.
- `main()` converts `StaleDocumentBytesError` into `parser.error()` (exit 2, no `latency.json` written).
- The fake timing path is unaffected — it never reads document bytes, so it never triggers the check even against a stale snapshot.

Tests: mutated-file detection (stage → fingerprint → mutate on disk → assert raise with filename), missing-from-fingerprint detection, happy-path pass-through, fake-path skip, and CLI wiring (`main()` converts the error to `SystemExit(2)`).

## Follow-up 2: OCR toolchain provenance in `benchmark_context`

Landed on this branch at the coordinator's request rather than a second branch reaching into `scripts/benchmark_pipeline.py` right behind this one — small, same file, found while provisioning the CPU box for the full-corpus run.

Concretely: the laptop this ran on has tesseract 5.5.1; the freshly-provisioned box has 5.3.4. The same corpus is about to run on both, and as it stood the two `latency.json` artifacts would be indistinguishable in provenance despite using different OCR engines. Worse — `pytesseract_backend.CANDIDATE_LANGS` is `["eng", "ori", "eng+ori"]` and `_filter_available_langs` silently drops any pack that isn't installed, so a machine missing the Odia (`ori`) traineddata produces quietly worse Odia OCR with no error and no trace in the artifact. A null scored as a zero, in a new costume.

`benchmark_context` now additionally records, on both the real-document and synthetic paths:
- `tesseract_version`
- `tesseract_langs` (sorted, so a missing `ori` is visible after the fact)
- `poppler_version`

`_probe_tesseract()`/`_probe_poppler_version()` resolve the binaries exactly as the real OCR stage does — `pytesseract_backend._configure_tesseract()`, `page_renderer.POPPLER_PATH` — not a naive PATH lookup, so a box using the bundled `~/.local/tesseract`/`~/.local/poppler` install is reported accurately instead of as `"unavailable"`.

Probing happens once in `main()`, before the variants loop — outside `run_benchmark`/`_measure_with_processor` entirely, nowhere near a stage timer (these are environment probes, not measurements). Both probes are independently defensive (never raise internally) and `main()` adds an outer catch around the whole call too, so a machine with no tesseract/poppler installed, or missing the `pipeline-core` extra entirely, cannot crash the harness on import or on the synthetic (`--fake`) path. Each field is populated or the explicit string `"unavailable"` — never omitted, so an absent key is never mistaken for "not recorded" when it means "checked and absent".

Tests: real-code-path assertion that the probe returns real values on this machine (tesseract + poppler installed, per `tests/README.md`'s local-gate requirement); monkeypatched failure of the tesseract probe, the poppler probe, and the composite probe itself, each asserting `"unavailable"` rather than a crash; and a CLI-level test that the synthetic (`--fake`) path still runs to completion and writes a valid `latency.json` even when the probe raises.

## Test plan

- `uv run --extra serving --extra pipeline-core pytest tests/test_benchmark_pipeline.py -q` — 80 passed
- `uv run --extra serving --extra pipeline-core pytest` (full gate) — 2011 passed, 19 skipped (expected: Postgres-path and `pii`-extra tests skip without those set up), 0 failed
- `uv run ruff check .` — all checks passed

Fixes #308
