### PR TITLE
feat(ci): reject terraform plan archives and unvetted data/ blobs by content

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -4,7 +4,9 @@ set -eu
 # Block local-only state and secret files before they enter Git history.
 # Keep this in sync with .github/workflows/data-check.yml.
 bad_files="$(
-  git diff --cached --name-only --diff-filter=ACMR |
+  # ACMRT, not ACMR: replacing a tracked file with a symlink stages as a
+  # type change (T), which ACMR does not select.
+  git diff --cached --name-only --diff-filter=ACMRT |
     grep -E '(^|/)(terraform\.tfstate(\..*)?|terraform\.tfvars|.*\.auto\.tfvars|.*\.tfplan|\.env|.*\.pem|id_rsa|id_ed25519)$' |
     grep -Ev '(^|/)\.env\.example$|(^|/)terraform\.tfvars\.example$' || true
 )"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -29,41 +29,13 @@ fi
 # direction for a check whose job is to stop secrets entering history.
 python3 "$(git rev-parse --show-toplevel)/scripts/check_no_terraform_plans.py" --staged
 
-# Provenance sidecars, against the schema rather than against JSON syntax.
-# `scripts/check_provenance_sidecars.py` is the owner of that schema -- an
-# allowlist of keys with a 200-character scalar cap -- and CI already runs it.
-# Without this the hook only knew the file parsed, so citizen text staged as
-# valid JSON at an allowlisted name was committed and rejected only after the
-# push.
+# Provenance sidecars are checked by the same call. `--staged` validates every
+# blob the data allowlist exempts -- markers, DVC pointers and sidecars -- and
+# hands sidecar payloads to `check_provenance_sidecars.check_payload`, the
+# module that owns that schema and that CI already runs.
 #
-# The staged blob is checked, not the worktree file: those differ once a file
-# is staged and then edited, and the blob is what gets committed.
-root="$(git rev-parse --show-toplevel)"
-staged_sidecars="$(
-  git diff --cached --name-only -z --diff-filter=ACMR -- \
-    'data/external/provenance.json' \
-    'data/external/**/provenance.json' \
-    'data/external/*.provenance.json' \
-    'data/external/**/*.provenance.json' |
-    tr '\0' '\n'
-)"
-if [ -n "$staged_sidecars" ]; then
-  tmpdir="$(mktemp -d)"
-  trap 'rm -rf "$tmpdir"' EXIT
-  copies=""
-  printf '%s\n' "$staged_sidecars" | while IFS= read -r path; do
-    [ -n "$path" ] || continue
-    mkdir -p "$tmpdir/$(dirname "$path")"
-    git cat-file blob ":$path" > "$tmpdir/$path"
-  done
-  # Run from inside the temp tree and pass relative paths, so a rejection
-  # names `data/external/...` as the author sees it rather than a temp path.
-  # NUL-delimited through xargs rather than an unquoted variable: a sidecar
-  # path containing a space or a glob character would otherwise be split into
-  # several arguments and the real file never checked.
-  (
-    cd "$tmpdir" || exit 1
-    find . -type f -print0 |
-      xargs -0 python3 "$root/scripts/check_provenance_sidecars.py"
-  )
-fi
+# Deliberately one Python call rather than a shell pipeline assembling paths.
+# The previous version copied staged blobs in `sh` and could not carry a
+# filename containing a newline through `tr`, which failed by checking nothing
+# and passing. Python reads the NUL-delimited list itself, so no filename can
+# be split.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -5,7 +5,7 @@ set -eu
 # Keep this in sync with .github/workflows/data-check.yml.
 bad_files="$(
   git diff --cached --name-only --diff-filter=ACMR |
-    grep -E '(^|/)(terraform\.tfstate(\..*)?|terraform\.tfvars|.*\.auto\.tfvars|\.env|.*\.pem|id_rsa|id_ed25519)$' |
+    grep -E '(^|/)(terraform\.tfstate(\..*)?|terraform\.tfvars|.*\.auto\.tfvars|.*\.tfplan|\.env|.*\.pem|id_rsa|id_ed25519)$' |
     grep -Ev '(^|/)\.env\.example$|(^|/)terraform\.tfvars\.example$' || true
 )"
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -16,3 +16,15 @@ if [ -n "$bad_files" ]; then
   echo "Keep Terraform state, tfvars, env files, and private keys local." >&2
   exit 1
 fi
+
+# Terraform plan archives, by content rather than by name. The filename check
+# above cannot catch these: `terraform plan -out=` takes any name, and the
+# documented example (`-out=tfplan`) has no suffix at all. Without this the
+# only content scan lives in CI, which sees the plan after the push that has
+# already disclosed the embedded state.
+#
+# Deliberately `python3`, not `uv run`: the script is stdlib-only so the hook
+# keeps working before any `uv sync` and cannot be skipped by a broken
+# environment. If python3 is missing the hook fails, which is the safe
+# direction for a check whose job is to stop secrets entering history.
+python3 "$(git rev-parse --show-toplevel)/scripts/check_no_terraform_plans.py" --staged

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -28,3 +28,39 @@ fi
 # environment. If python3 is missing the hook fails, which is the safe
 # direction for a check whose job is to stop secrets entering history.
 python3 "$(git rev-parse --show-toplevel)/scripts/check_no_terraform_plans.py" --staged
+
+# Provenance sidecars, against the schema rather than against JSON syntax.
+# `scripts/check_provenance_sidecars.py` is the owner of that schema -- an
+# allowlist of keys with a 200-character scalar cap -- and CI already runs it.
+# Without this the hook only knew the file parsed, so citizen text staged as
+# valid JSON at an allowlisted name was committed and rejected only after the
+# push.
+#
+# The staged blob is checked, not the worktree file: those differ once a file
+# is staged and then edited, and the blob is what gets committed.
+root="$(git rev-parse --show-toplevel)"
+staged_sidecars="$(
+  git diff --cached --name-only -z --diff-filter=ACMR -- \
+    'data/external/provenance.json' \
+    'data/external/**/provenance.json' \
+    'data/external/*.provenance.json' \
+    'data/external/**/*.provenance.json' |
+    tr '\0' '\n'
+)"
+if [ -n "$staged_sidecars" ]; then
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf "$tmpdir"' EXIT
+  copies=""
+  printf '%s\n' "$staged_sidecars" | while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    mkdir -p "$tmpdir/$(dirname "$path")"
+    git cat-file blob ":$path" > "$tmpdir/$path"
+  done
+  # Run from inside the temp tree and pass relative paths, so a rejection
+  # names `data/external/...` as the author sees it rather than a temp path.
+  copies="$(cd "$tmpdir" && find . -type f | sed 's|^\./||')"
+  if [ -n "$copies" ]; then
+    # shellcheck disable=SC2086
+    (cd "$tmpdir" && python3 "$root/scripts/check_provenance_sidecars.py" $copies)
+  fi
+fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -58,9 +58,12 @@ if [ -n "$staged_sidecars" ]; then
   done
   # Run from inside the temp tree and pass relative paths, so a rejection
   # names `data/external/...` as the author sees it rather than a temp path.
-  copies="$(cd "$tmpdir" && find . -type f | sed 's|^\./||')"
-  if [ -n "$copies" ]; then
-    # shellcheck disable=SC2086
-    (cd "$tmpdir" && python3 "$root/scripts/check_provenance_sidecars.py" $copies)
-  fi
+  # NUL-delimited through xargs rather than an unquoted variable: a sidecar
+  # path containing a space or a glob character would otherwise be split into
+  # several arguments and the real file never checked.
+  (
+    cd "$tmpdir" || exit 1
+    find . -type f -print0 |
+      xargs -0 python3 "$root/scripts/check_provenance_sidecars.py"
+  )
 fi

--- a/.github/workflows/data-check.yml
+++ b/.github/workflows/data-check.yml
@@ -54,6 +54,12 @@ jobs:
           # shellcheck disable=SC2086
           python3 scripts/check_provenance_sidecars.py $sidecars
 
+      # `.tfplan` is here because matching on names that look like state was
+      # not enough. A plan archive is a zip *containing* tfstate and
+      # tfstate-prev, so it carries the account id, instance and subnet ids,
+      # SSH ingress CIDRs and the operator public key while being named like a
+      # plan. Two of them were committed on a branch and this step did not
+      # object, because every pattern below described state by its filename.
       - name: Reject local state and secret files
         shell: bash
         run: |
@@ -61,7 +67,7 @@ jobs:
 
           bad_files="$(
             git ls-files |
-              grep -E '(^|/)(terraform\.tfstate(\..*)?|terraform\.tfvars|.*\.auto\.tfvars|\.env|.*\.pem|id_rsa|id_ed25519)$' |
+              grep -E '(^|/)(terraform\.tfstate(\..*)?|terraform\.tfvars|.*\.auto\.tfvars|.*\.tfplan|\.env|.*\.pem|id_rsa|id_ed25519)$' |
               grep -Ev '(^|/)\.env\.example$|(^|/)terraform\.tfvars\.example$' || true
           )"
 
@@ -69,7 +75,8 @@ jobs:
             echo "The following local state/secret files are tracked directly by Git:"
             echo "$bad_files"
             echo ""
-            echo "Keep Terraform state, tfvars, env files, and private keys local."
+            echo "Keep Terraform state, plans, tfvars, env files, and private keys local."
+            echo "A .tfplan is a zip containing tfstate — it is state, despite the name."
             exit 1
           fi
 

--- a/.github/workflows/data-check.yml
+++ b/.github/workflows/data-check.yml
@@ -60,6 +60,12 @@ jobs:
       # SSH ingress CIDRs and the operator public key while being named like a
       # plan. Two of them were committed on a branch and this step did not
       # object, because every pattern below described state by its filename.
+      #
+      # The suffix is not the guard, though — see the content check below.
+      # `-out` takes any filename, and Terraform's own documentation uses
+      # `terraform plan -out=tfplan`, which has no suffix to match on. These
+      # patterns catch the obvious names and say what the rule is; the next
+      # step is what actually enforces it.
       - name: Reject local state and secret files
         shell: bash
         run: |
@@ -79,6 +85,14 @@ jobs:
             echo "A .tfplan is a zip containing tfstate — it is state, despite the name."
             exit 1
           fi
+
+      # Name-independent. Reads the bytes of every tracked file and fails on
+      # anything that is a zip carrying a tfstate/tfplan member, so a plan
+      # saved as `tfplan`, `plan.out` or with no extension at all is caught
+      # where the suffix patterns above would pass it.
+      - name: Reject terraform plan archives by content
+        shell: bash
+        run: python3 scripts/check_no_terraform_plans.py
 
       - name: Check DVC files are present
         shell: bash

--- a/scripts/check_no_terraform_plans.py
+++ b/scripts/check_no_terraform_plans.py
@@ -187,12 +187,16 @@ ALLOWLIST_PATHSPECS = (
 # `meta` and `cmd` are not accepted here at all: there is no field in which
 # arbitrary prose is allowed, which is a stronger statement than any cap. A
 # real pointer needing one fails loudly and a person decides.
-DVC_TOP_LEVEL_KEYS = frozenset({"outs", "deps", "wdir", "md5", "frozen"})
+# Measured from the 23 pointers in this repository, which use `outs` at top
+# level and nothing else. `wdir` and `remote` were the last fields whose
+# value was a free token, and a pointer needs neither, so they are refused
+# rather than pattern-matched. A real pointer needing one fails loudly.
+DVC_TOP_LEVEL_KEYS = frozenset({"outs"})
 # Keys that introduce a list rather than carrying a scalar.
-DVC_LIST_KEYS = frozenset({"outs", "deps"})
+DVC_LIST_KEYS = frozenset({"outs"})
 DVC_ENTRY_KEYS = frozenset(
     {"md5", "sha1", "sha256", "hash", "etag", "checksum", "path", "size",
-     "nfiles", "isexec", "remote", "cache", "persist", "push"}
+     "nfiles"}
 )
 
 # Every accepted value has a shape. Checked by pattern, so a field cannot be
@@ -250,7 +254,7 @@ def staged_allowlisted_entries() -> list[tuple[Path, str, str]]:
     changed = subprocess.run(
         [
             "git", "diff", "--cached", "--name-only", "-z",
-            "--diff-filter=ACMR", "--", *ALLOWLIST_PATHSPECS,
+            "--diff-filter=ACMRT", "--", *ALLOWLIST_PATHSPECS,
         ],
         check=True,
         capture_output=True,
@@ -292,11 +296,7 @@ def _scalar_problem(key: str, value: str) -> str | None:
         return None if value in HASH_NAMES else f"{key!r} is not a DVC hash name"
     if key in {"size", "nfiles"}:
         return None if INTEGER.match(value) else f"{key!r} is not an integer"
-    if key in {"isexec", "cache", "persist", "push", "frozen"}:
-        return None if value in BOOLEAN else f"{key!r} is not a boolean"
-    if key == "remote":
-        return None if TOKEN.match(value) else f"{key!r} is not a remote name"
-    if key in {"path", "wdir"}:
+    if key == "path":
         if len(value) > MAX_PATH:
             return f"{key!r} is {len(value)} characters, over the {MAX_PATH} cap"
         # Typed, not merely capped. A path is the last field in which prose
@@ -335,6 +335,7 @@ def dvc_pointer_problem(text: str, stem: str | None = None) -> str | None:
     items: list[dict[str, str]] = []
     current: dict[str, str] | None = None
     list_key: str | None = None
+    seen_top: set[str] = set()
 
     for number, line in enumerate(lines, start=1):
         stripped = line.strip()
@@ -347,6 +348,9 @@ def dvc_pointer_problem(text: str, stem: str | None = None) -> str | None:
             key = key.strip()
             if key not in DVC_TOP_LEVEL_KEYS:
                 return f"line {number}: unrecognised top-level key"
+            if key in seen_top:
+                return f"line {number}: duplicate top-level key"
+            seen_top.add(key)
             if value.strip() in BLOCK_SCALARS:
                 return f"block scalar not allowed at {key!r}"
 
@@ -386,6 +390,10 @@ def dvc_pointer_problem(text: str, stem: str | None = None) -> str | None:
         key = key.strip()
         if key not in DVC_ENTRY_KEYS:
             return f"line {number}: unrecognised key in an `outs:` entry"
+        if key in current:
+            # Overwriting hid the earlier value from every rule below while
+            # its bytes stayed in the commit.
+            return f"line {number}: duplicate key in an `outs:` entry"
         if value.strip() in BLOCK_SCALARS:
             return f"block scalar not allowed at {key!r}"
         problem = _scalar_problem(key, value.strip())
@@ -527,7 +535,7 @@ def staged_entries() -> list[tuple[Path, str]]:
     changed = subprocess.run(
         [
             "git", "diff", "--cached", "--name-only", "-z",
-            "--diff-filter=ACMR", "--", ".", ":(exclude)data/**",
+            "--diff-filter=ACMRT", "--", ".", ":(exclude)data/**",
         ],
         check=True,
         capture_output=True,

--- a/scripts/check_no_terraform_plans.py
+++ b/scripts/check_no_terraform_plans.py
@@ -42,7 +42,9 @@ from __future__ import annotations
 
 import argparse
 import io
+import hashlib
 import json
+import os
 import re
 import subprocess
 import sys
@@ -528,13 +530,41 @@ def main(argv: list[str] | None = None) -> int:
     return report(offenders + allowlisted_offenders(tracked_allowlisted_entries()))
 
 
+def in_public_log() -> bool:
+    """Whether output is going somewhere the world can read.
+
+    GitHub sets both of these on every runner. The pre-commit hook runs on the
+    author's machine, where the file is already in front of them and redacting
+    it would only make the message useless.
+    """
+    return bool(os.environ.get("GITHUB_ACTIONS") or os.environ.get("CI"))
+
+
+def safe_path(path: Path) -> str:
+    """A printable form of ``path``, redacted when the log is public.
+
+    A filename under ``data/`` can itself be the disclosure --
+    ``data/raw/Ram-Kumar-9876543210.dvc`` names a citizen in the path rather
+    than in the contents. In CI the directory and suffix are kept, since they
+    say what kind of file is wrong and where, and the stem becomes a digest of
+    itself so the author can identify it locally without it being published.
+
+    Paths outside ``data/`` are printed whole. They are source paths, they are
+    not protected, and a reviewer needs to read them.
+    """
+    if path.parts[:1] != ("data",) or not in_public_log():
+        return str(path)
+    digest = hashlib.sha256(path.name.encode("utf-8")).hexdigest()[:12]
+    return f"{path.parent}/<redacted:{digest}>{path.suffix}"
+
+
 def report(offenders: list[tuple[Path, list[str]]]) -> int:
     if not offenders:
         return 0
 
     print("The following tracked files must not be in Git:")
     for path, reasons in offenders:
-        print(f"  {path}  ({', '.join(reasons)})")
+        print(f"  {safe_path(path)}  ({', '.join(reasons)})")
     print()
 
     # Say why, or the next person deletes the file and saves it elsewhere.
@@ -558,7 +588,9 @@ def report(offenders: list[tuple[Path, list[str]]]) -> int:
             "Files under data/ are exempt from the data rules only for what "
             "they are: an empty marker, a DVC pointer, or a provenance "
             "sidecar. Anything else there is refused. Rejected content is "
-            "withheld on purpose: these logs are public."
+            "withheld on purpose, and in CI the filename is shown as "
+            "`sha256(name)[:12]` because a name under data/ can itself be "
+            "the disclosure: these logs are public."
         )
     return 1
 

--- a/scripts/check_no_terraform_plans.py
+++ b/scripts/check_no_terraform_plans.py
@@ -152,47 +152,49 @@ def _plan_members_in(entries: list[tuple[str, bool]]) -> list[str]:
     )
 
 
-def _is_name_byte(byte: bytes) -> bool:
-    """Whether ``byte`` could be part of a longer file name."""
-    return byte.isalnum() or byte in {b"_", b"-", b"."}
+LOCAL_HEADER = b"PK\x03\x04"
+# Offsets into a zip local file header: the name length is a two-byte
+# little-endian field at 26, and the name itself begins at 30.
+NAME_LENGTH_OFFSET = 26
+NAME_OFFSET = 30
 
 
 def damaged_plan_members(data: bytes) -> list[str]:
-    """Plan member names visible in a zip that will not parse.
+    """Plan member names in an archive whose directory cannot be read.
 
     A truncated or otherwise damaged plan still carries its secrets: the
     tfstate entry is in the archive whether or not the central directory
-    survives. Treating an unparseable zip as clean therefore lets exactly the
-    file this check exists to stop through, and truncation is not an exotic
-    accident -- an interrupted `terraform plan -out` produces one.
+    survives, and an interrupted `terraform plan -out` produces exactly that.
 
-    Zip stores each member's name uncompressed in its local file header, so
-    the names are still present as literal bytes even when the archive cannot
-    be opened.
+    The names are read from the *local file headers* rather than matched as
+    substrings. Each begins `PK\x03\x04` and declares its own name length, so
+    a name is recovered exactly even when everything after it is gone --
+    truncation takes the central directory first, and these are at the front.
+
+    Substring matching cannot be made to work here, which is what three
+    rounds of boundary rules established. `tfstate/` is a directory,
+    `mytfstate.json` merely contains the token, and a real `tfstate` is
+    followed by arbitrary compressed bytes that may look like either. Only
+    the declared length separates them, and the format supplies it.
     """
     found: set[str] = set()
-    for member in PLAN_MEMBERS:
-        needle = member.encode("utf-8")
-        start = data.find(needle)
-        while start != -1:
-            # A zip stores a directory as an entry whose name ends in `/`, so
-            # `tfstate/` is a folder holding no state while `tfstate` is the
-            # member that matters. Requiring one occurrence that is *not*
-            # followed by a slash keeps the directory-only case out without
-            # risking a real plan: its name is followed by the extra field or
-            # the compressed data, and every occurrence would have to be a
-            # slash for this to miss one.
-            before = data[start - 1 : start] if start else b""
-            after = data[start + len(needle) : start + len(needle) + 1]
-            # Both boundaries, for the same reason. `/` after it means a
-            # directory; a name character before or after it means a longer
-            # name that merely ends or begins with the token, like
-            # `mytfstate` or `tfstateold`. A real entry name is preceded by
-            # the header's length fields, which are not name characters.
-            if after != b"/" and not _is_name_byte(before) and not _is_name_byte(after):
-                found.add(member)
-                break
-            start = data.find(needle, start + 1)
+    position = data.find(LOCAL_HEADER)
+    while position != -1:
+        name_end = position + NAME_OFFSET
+        if name_end <= len(data):
+            length = int.from_bytes(
+                data[position + NAME_LENGTH_OFFSET : position + NAME_LENGTH_OFFSET + 2],
+                "little",
+            )
+            raw = data[name_end : name_end + length]
+            # A truncated final header may declare more name than survives.
+            if len(raw) == length:
+                name = raw.decode("utf-8", "replace")
+                if not name.endswith("/"):
+                    base = name.rsplit("/", 1)[-1]
+                    if base in PLAN_MEMBERS:
+                        found.add(base)
+        position = data.find(LOCAL_HEADER, position + 1)
     return sorted(found)
 
 

--- a/scripts/check_no_terraform_plans.py
+++ b/scripts/check_no_terraform_plans.py
@@ -50,7 +50,7 @@ import zipfile
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from check_provenance_sidecars import check_payload  # noqa: E402
+from check_provenance_sidecars import check_document  # noqa: E402
 
 ZIP_MAGIC = b"PK\x03\x04"
 
@@ -189,6 +189,7 @@ HEXISH = re.compile(r"\A[0-9a-fA-F]{8,64}(\.dir)?\Z")
 TOKEN = re.compile(r"\A[A-Za-z0-9_.-]{1,64}\Z")
 INTEGER = re.compile(r"\A[0-9]{1,20}\Z")
 BOOLEAN = frozenset({"true", "false", "True", "False"})
+PATHISH = re.compile(r"\A[A-Za-z0-9._][A-Za-z0-9._/@+-]*\Z")
 MAX_PATH = 255
 BLOCK_SCALARS = frozenset({"|", ">", "|-", ">-", "|+", ">+"})
 
@@ -261,10 +262,15 @@ def _scalar_problem(key: str, value: str) -> str | None:
         return None if INTEGER.match(value) else f"{key!r} is not an integer"
     if key in {"isexec", "cache", "persist", "push", "frozen"}:
         return None if value in BOOLEAN else f"{key!r} is not a boolean"
-    if key in {"path", "wdir", "remote"}:
+    if key == "remote":
+        return None if TOKEN.match(value) else f"{key!r} is not a remote name"
+    if key in {"path", "wdir"}:
         if len(value) > MAX_PATH:
             return f"{key!r} is {len(value)} characters, over the {MAX_PATH} cap"
-        return None
+        # Typed, not merely capped. A path is the last field in which prose
+        # could sit, and prose has spaces: `path: Ram Kumar 9876543210` is
+        # under any length cap and is not a path.
+        return None if PATHISH.match(value) else f"{key!r} is not a path"
 
     if len(value) > MAX_SCALAR:
         return f"{key!r} is {len(value)} characters, over the {MAX_SCALAR} cap"
@@ -416,7 +422,9 @@ def allowlisted_offenders(
                 # public CI logs, so only the fact is reported.
                 offenders.append((path, ["not valid JSON"]))
                 continue
-            problems = check_payload(payload)
+            # Path-aware: the legacy root sidecar is allowed to carry no
+            # `schema_version`, and only check_document knows that.
+            problems = check_document(path, payload)
             if problems:
                 offenders.append((path, problems))
     return offenders

--- a/scripts/check_no_terraform_plans.py
+++ b/scripts/check_no_terraform_plans.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Reject tracked Terraform plan archives, whatever they are called.
+
+A saved plan is a zip that contains the state it was planned against. Two of
+them were committed on `infra/dsi-reference-bucket` and carried the AWS
+account id, five instance ids, the SSH ingress CIDRs and the operator's public
+key into a pushed branch. The `.gitignore` and CI patterns that exist to stop
+exactly that all describe state *by filename* (`terraform.tfstate`,
+`terraform.tfvars`, `.env`, `*.pem`), and a plan is named like a plan, so
+nothing objected.
+
+The first fix added `.*\\.tfplan` to those patterns, which is the same mistake
+one step later: `-out` takes an arbitrary filename and Terraform's own
+documentation uses `terraform plan -out=tfplan`, with no suffix at all. A
+suffix list can only ever cover the names someone thought of.
+
+So this looks at the bytes. Every tracked file that begins with the zip local
+header is opened and its entry names are checked for the members a plan
+archive carries. That is name-independent: `tfplan`, `plan.out`, `foo.bin` and
+a plan with no extension are all caught, and a .pptx or .xlsx (also zips) is
+not, because it has no `tfstate` member.
+
+Deliberately dependency-free — stdlib only, so the check runs before any
+`uv sync` and cannot be skipped by an environment problem.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+ZIP_MAGIC = b"PK\x03\x04"
+
+# Members the Terraform plan format writes. `tfstate` is the state the plan
+# was made against and `tfstate-prev` the one before it; either is the
+# disclosure. `tfplan` is the plan proper, which also carries resource
+# attributes. Matched on the entry's base name because the layout has changed
+# across Terraform versions.
+PLAN_MEMBERS = frozenset({"tfstate", "tfstate-prev", "tfplan"})
+
+
+def tracked_files() -> list[Path]:
+    out = subprocess.run(
+        ["git", "ls-files", "-z"],
+        check=True,
+        capture_output=True,
+    ).stdout
+    return [Path(name) for name in out.decode("utf-8").split("\0") if name]
+
+
+def plan_members(path: Path) -> list[str]:
+    """Entry names identifying ``path`` as a Terraform plan archive, if any."""
+    try:
+        with path.open("rb") as handle:
+            if handle.read(4) != ZIP_MAGIC:
+                return []
+    except OSError:
+        return []
+
+    try:
+        with zipfile.ZipFile(path) as archive:
+            names = archive.namelist()
+    except (zipfile.BadZipFile, OSError):
+        # Starts like a zip and will not open as one. Not a plan we can
+        # confirm, and not something this check should fail the build over —
+        # the suffix patterns in the workflow still cover the obvious names.
+        return []
+
+    return sorted(
+        {name for name in names if Path(name).name in PLAN_MEMBERS}
+    )
+
+
+def main() -> int:
+    offenders: list[tuple[Path, list[str]]] = []
+    for path in tracked_files():
+        if not path.is_file():  # submodule entries, broken symlinks
+            continue
+        members = plan_members(path)
+        if members:
+            offenders.append((path, members))
+
+    if not offenders:
+        return 0
+
+    print("The following tracked files are Terraform plan archives:")
+    for path, members in offenders:
+        print(f"  {path}  (contains: {', '.join(members)})")
+    print()
+    print(
+        "A saved plan is a zip containing the state it was planned against, "
+        "so it carries the account id, instance and subnet ids, SSH ingress "
+        "CIDRs and the operator public key. Terraform state stays local "
+        "(docs/DEPLOY.md). Detected by content, not by filename, because "
+        "`-out` takes any name — `terraform plan -out=tfplan` has no suffix "
+        "to match on."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_no_terraform_plans.py
+++ b/scripts/check_no_terraform_plans.py
@@ -117,32 +117,39 @@ def _regular_files(entries: list[tuple[Path, str, str]]) -> list[tuple[Path, str
     ]
 
 
-def _archive_names(
+def _archive_entries(
     source: Path | io.BytesIO | io.BufferedReader,
-) -> list[str] | None:
-    """Every entry name in ``source``, or ``None`` if it will not open.
+) -> list[tuple[str, bool]] | None:
+    """``(name, is_dir)`` for every entry, or ``None`` if it will not open.
 
-    The distinction the caller needs is three-way, not two, and truncation is
-    why. A damaged archive does not necessarily raise: zipfile opens one whose
-    central directory is gone and reports an *empty* namelist. So "opened and
-    listed nothing" has to be treated like "would not open", while "opened and
-    listed entries, none of them a plan member" is an ordinary archive and
-    must not be second-guessed by scanning its bytes.
+    Directories are carried rather than dropped here, because the caller needs
+    two different facts and dropping them conflates the two. Whether the
+    archive listed *anything* decides damaged-or-not; whether an entry is a
+    file decides plan-or-not. Filtering directories at this level made a zip
+    holding only `tfstate/` look like an archive that listed nothing, which
+    sent it to the byte fallback and reported it as a plan again.
     """
     try:
         with zipfile.ZipFile(source) as archive:
-            return archive.namelist()
+            return [(info.filename, info.is_dir()) for info in archive.infolist()]
     except (zipfile.BadZipFile, OSError):
         return None
 
 
-def _plan_members_in(names: list[str]) -> list[str]:
-    """Plan member base names among ``names``.
+def _plan_members_in(entries: list[tuple[str, bool]]) -> list[str]:
+    """Plan member base names among ``entries``, ignoring directories.
 
-    Base name only: the directory above it is chosen by whoever built the
-    archive and `report()` prints into public logs.
+    A member named `tfstate/` is a folder and holds no state, but its base
+    name is `tfstate`. Base name only, since the directory above it is chosen
+    by whoever built the archive and `report()` prints into public logs.
     """
-    return sorted({Path(name).name for name in names if Path(name).name in PLAN_MEMBERS})
+    return sorted(
+        {
+            Path(name).name
+            for name, is_dir in entries
+            if not is_dir and Path(name).name in PLAN_MEMBERS
+        }
+    )
 
 
 def damaged_plan_members(data: bytes) -> list[str]:
@@ -167,14 +174,14 @@ def plan_members_of_blob(data: bytes) -> list[str]:
     """Plan member names in a blob, including one that will not parse."""
     if not data.startswith(ZIP_MAGIC):
         return []
-    names = _archive_names(io.BytesIO(data))
-    if not names:
+    entries = _archive_entries(io.BytesIO(data))
+    if not entries:
         # Would not open, or opened and listed nothing -- both mean a damaged
         # archive, whose secrets are still in the bytes. Fall back to them.
         return damaged_plan_members(data)
     # A real listing. An ordinary archive whose *contents* happen to contain
     # the word `tfstate` is not a plan, and scanning its bytes would say so.
-    return _plan_members_in(names)
+    return _plan_members_in(entries)
 
 
 # Mirrors MAX_BYTES in scripts/check_provenance_sidecars.py. A per-value

--- a/scripts/check_no_terraform_plans.py
+++ b/scripts/check_no_terraform_plans.py
@@ -172,6 +172,11 @@ DVC_ENTRY_KEYS = frozenset(
 )
 BLOCK_SCALARS = frozenset({"|", ">", "|-", ">-", "|+", ">+"})
 
+# Mirrors MAX_STRING in scripts/check_provenance_sidecars.py, and for the
+# same reason given there: prose does not survive a 200-character scalar
+# cap. Recognising a key is not enough when its value is free text.
+MAX_SCALAR = 200
+
 
 def _ls_files_entries(pathspecs: tuple[str, ...]) -> list[tuple[Path, str]]:
     listing = subprocess.run(
@@ -216,6 +221,22 @@ def blob_size(sha: str) -> int:
     return int(out.decode("utf-8").strip())
 
 
+def _scalar_problem(key: str, value: str) -> str | None:
+    """Why a recognised field's *value* is not acceptable, if it is not.
+
+    Validating the key and leaving the value free defeats the point: `cmd`,
+    `desc` and `meta` are recognised DVC fields, and citizen text placed in
+    one of them sits in a file the data rules exempt. Reported by key and
+    length only -- never by content, since this runs in CI whose logs are
+    public.
+    """
+    if len(value) > MAX_SCALAR:
+        return f"{key!r} is {len(value)} characters, over the {MAX_SCALAR} cap"
+    if any(ord(ch) < 32 for ch in value):
+        return f"{key!r} contains control characters"
+    return None
+
+
 def dvc_pointer_problem(text: str) -> str | None:
     """Why ``text`` is not a DVC pointer, or ``None`` if it is one.
 
@@ -252,6 +273,9 @@ def dvc_pointer_problem(text: str) -> str | None:
                 return f"unexpected top-level key {key!r}"
             if value.strip() in BLOCK_SCALARS:
                 return f"block scalar not allowed at {key!r}"
+            problem = _scalar_problem(key, value.strip())
+            if problem:
+                return problem
             list_key = key if key in {"outs", "deps"} and not value.strip() else None
             current = None
             continue
@@ -278,6 +302,9 @@ def dvc_pointer_problem(text: str) -> str | None:
             return f"unexpected key {key!r} in an entry"
         if value.strip() in BLOCK_SCALARS:
             return f"block scalar not allowed at {key!r}"
+        problem = _scalar_problem(key, value.strip())
+        if problem:
+            return problem
         current[key] = value.strip()
 
     if not items:

--- a/scripts/check_no_terraform_plans.py
+++ b/scripts/check_no_terraform_plans.py
@@ -178,9 +178,11 @@ ALLOWLIST_PATHSPECS = (
 # arbitrary prose is allowed, which is a stronger statement than any cap. A
 # real pointer needing one fails loudly and a person decides.
 DVC_TOP_LEVEL_KEYS = frozenset({"outs", "deps", "wdir", "md5", "frozen"})
+# Keys that introduce a list rather than carrying a scalar.
+DVC_LIST_KEYS = frozenset({"outs", "deps"})
 DVC_ENTRY_KEYS = frozenset(
     {"md5", "hash", "etag", "checksum", "path", "size", "nfiles", "isexec",
-     "remote", "cache", "persist", "push", "files"}
+     "remote", "cache", "persist", "push"}
 )
 
 # Every accepted value has a shape. Checked by pattern, so a field cannot be
@@ -193,10 +195,6 @@ PATHISH = re.compile(r"\A[A-Za-z0-9._][A-Za-z0-9._/@+-]*\Z")
 MAX_PATH = 255
 BLOCK_SCALARS = frozenset({"|", ">", "|-", ">-", "|+", ">+"})
 
-# Mirrors MAX_STRING in scripts/check_provenance_sidecars.py, and for the
-# same reason given there: prose does not survive a 200-character scalar
-# cap. Recognising a key is not enough when its value is free text.
-MAX_SCALAR = 200
 
 
 def _ls_files_entries(pathspecs: tuple[str, ...]) -> list[tuple[Path, str]]:
@@ -272,9 +270,7 @@ def _scalar_problem(key: str, value: str) -> str | None:
         # under any length cap and is not a path.
         return None if PATHISH.match(value) else f"{key!r} is not a path"
 
-    if len(value) > MAX_SCALAR:
-        return f"{key!r} is {len(value)} characters, over the {MAX_SCALAR} cap"
-    return None
+    return f"{key!r} has no value rule in this checker"
 
 
 def dvc_pointer_problem(text: str) -> str | None:
@@ -319,10 +315,20 @@ def dvc_pointer_problem(text: str) -> str | None:
                 return f"line {number}: unrecognised top-level key"
             if value.strip() in BLOCK_SCALARS:
                 return f"block scalar not allowed at {key!r}"
+
+            if key in DVC_LIST_KEYS:
+                # A list header carries no value of its own. `outs: <text>`
+                # is prose wearing a recognised key.
+                if value.strip():
+                    return f"line {number}: {key!r} must introduce a list"
+                list_key = key
+                current = None
+                continue
+
             problem = _scalar_problem(key, value.strip())
             if problem:
                 return problem
-            list_key = key if key in {"outs", "deps"} and not value.strip() else None
+            list_key = None
             current = None
             continue
 

--- a/scripts/check_no_terraform_plans.py
+++ b/scripts/check_no_terraform_plans.py
@@ -233,7 +233,10 @@ HASH_NAMES = frozenset({"md5", "sha256", "sha1", "etag", "checksum", "crc32"})
 # Aadhaar 12. Measured before choosing the threshold: across all 39 path
 # components in this repository the worst group holds 8 digits, so this
 # refuses the identifier shapes with margin and breaks nothing.
-DIGIT_GROUP = re.compile(r"\d(?:[\d\s._-]*\d)?")
+# The separator class is everything people put *between* digits when they
+# write a number down -- parentheses and slashes included, as in
+# `(987) 654-3210`. Anything not in this class ends the group.
+DIGIT_GROUP = re.compile(r"\d(?:[\d\s._\-()\[\]/+]*\d)?")
 IDENTIFIER_DIGITS = 9
 
 # Shapes that are an identifier whatever field they sit in.

--- a/scripts/check_no_terraform_plans.py
+++ b/scripts/check_no_terraform_plans.py
@@ -43,10 +43,14 @@ from __future__ import annotations
 import argparse
 import io
 import json
+import re
 import subprocess
 import sys
 import zipfile
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from check_provenance_sidecars import check_payload  # noqa: E402
 
 ZIP_MAGIC = b"PK\x03\x04"
 
@@ -168,14 +172,24 @@ ALLOWLIST_PATHSPECS = (
 # unrecognised content in an allowlisted file is the whole hazard: a pointer
 # is exempt from the data rules because of what it is, so anything that is not
 # that has to be refused rather than ignored.
-DVC_TOP_LEVEL_KEYS = frozenset(
-    {"outs", "deps", "cmd", "wdir", "md5", "frozen", "meta", "desc",
-     "params", "always_changed", "stage"}
-)
+# A pointer needs none of DVC's free-text fields, and a per-value length cap
+# cannot tell short citizen text from a legitimate description. So `desc`,
+# `meta` and `cmd` are not accepted here at all: there is no field in which
+# arbitrary prose is allowed, which is a stronger statement than any cap. A
+# real pointer needing one fails loudly and a person decides.
+DVC_TOP_LEVEL_KEYS = frozenset({"outs", "deps", "wdir", "md5", "frozen"})
 DVC_ENTRY_KEYS = frozenset(
     {"md5", "hash", "etag", "checksum", "path", "size", "nfiles", "isexec",
-     "remote", "cache", "persist", "desc", "files", "push"}
+     "remote", "cache", "persist", "push", "files"}
 )
+
+# Every accepted value has a shape. Checked by pattern, so a field cannot be
+# used as a container for something else.
+HEXISH = re.compile(r"\A[0-9a-fA-F]{8,64}(\.dir)?\Z")
+TOKEN = re.compile(r"\A[A-Za-z0-9_.-]{1,64}\Z")
+INTEGER = re.compile(r"\A[0-9]{1,20}\Z")
+BOOLEAN = frozenset({"true", "false", "True", "False"})
+MAX_PATH = 255
 BLOCK_SCALARS = frozenset({"|", ">", "|-", ">-", "|+", ">+"})
 
 # Mirrors MAX_STRING in scripts/check_provenance_sidecars.py, and for the
@@ -236,10 +250,24 @@ def _scalar_problem(key: str, value: str) -> str | None:
     length only -- never by content, since this runs in CI whose logs are
     public.
     """
-    if len(value) > MAX_SCALAR:
-        return f"{key!r} is {len(value)} characters, over the {MAX_SCALAR} cap"
     if any(ord(ch) < 32 for ch in value):
         return f"{key!r} contains control characters"
+
+    if key in {"md5", "etag", "checksum"}:
+        return None if HEXISH.match(value) else f"{key!r} is not a checksum"
+    if key == "hash":
+        return None if TOKEN.match(value) else f"{key!r} is not a hash name"
+    if key in {"size", "nfiles"}:
+        return None if INTEGER.match(value) else f"{key!r} is not an integer"
+    if key in {"isexec", "cache", "persist", "push", "frozen"}:
+        return None if value in BOOLEAN else f"{key!r} is not a boolean"
+    if key in {"path", "wdir", "remote"}:
+        if len(value) > MAX_PATH:
+            return f"{key!r} is {len(value)} characters, over the {MAX_PATH} cap"
+        return None
+
+    if len(value) > MAX_SCALAR:
+        return f"{key!r} is {len(value)} characters, over the {MAX_SCALAR} cap"
     return None
 
 
@@ -382,9 +410,15 @@ def allowlisted_offenders(
                 offenders.append((path, [f"not a DVC pointer: {problem}"]))
         else:  # provenance sidecar
             try:
-                json.loads(text)
-            except ValueError as exc:
-                offenders.append((path, [f"not valid JSON: {exc}"]))
+                payload = json.loads(text)
+            except ValueError:
+                # The exception text quotes the document; this prints to
+                # public CI logs, so only the fact is reported.
+                offenders.append((path, ["not valid JSON"]))
+                continue
+            problems = check_payload(payload)
+            if problems:
+                offenders.append((path, problems))
     return offenders
 
 
@@ -485,17 +519,33 @@ def report(offenders: list[tuple[Path, list[str]]]) -> int:
         return 0
 
     print("The following tracked files must not be in Git:")
-    for path, members in offenders:
-        print(f"  {path}  (contains: {', '.join(members)})")
+    for path, reasons in offenders:
+        print(f"  {path}  ({', '.join(reasons)})")
     print()
-    print(
-        "A saved plan is a zip containing the state it was planned against, "
-        "so it carries the account id, instance and subnet ids, SSH ingress "
-        "CIDRs and the operator public key. Terraform state stays local "
-        "(docs/DEPLOY.md). Detected by content, not by filename, because "
-        "`-out` takes any name — `terraform plan -out=tfplan` has no suffix "
-        "to match on."
+
+    # Say why, or the next person deletes the file and saves it elsewhere.
+    # The two rationales are different, so print the one that applies.
+    looks_like_plan = any(
+        reason in PLAN_MEMBERS or "zip archive" in reason
+        for _path, reasons in offenders
+        for reason in reasons
     )
+    if looks_like_plan:
+        print(
+            "A saved plan is a zip containing the state it was planned "
+            "against, so it carries the account id, instance and subnet ids, "
+            "SSH ingress CIDRs and the operator public key. Terraform state "
+            "stays local (docs/DEPLOY.md). Detected by content, not by "
+            "filename, because `-out` takes any name — `terraform plan "
+            "-out=tfplan` has no suffix to match on."
+        )
+    if any(str(path).startswith("data/") for path, _reasons in offenders):
+        print(
+            "Files under data/ are exempt from the data rules only for what "
+            "they are: an empty marker, a DVC pointer, or a provenance "
+            "sidecar. Anything else there is refused. Rejected content is "
+            "withheld on purpose: these logs are public."
+        )
     return 1
 
 

--- a/scripts/check_no_terraform_plans.py
+++ b/scripts/check_no_terraform_plans.py
@@ -139,6 +139,87 @@ def plan_members_of_blob(data: bytes) -> list[str]:
     return members or damaged_plan_members(data)
 
 
+DVC_POINTER_MAX_BYTES = 100_000
+POINTER_PATHSPEC = "data/**/*.dvc"
+
+
+def tracked_pointer_entries() -> list[tuple[Path, str]]:
+    """``(path, sha)`` for tracked ``.dvc`` files under ``data/``."""
+    listing = subprocess.run(
+        ["git", "ls-files", "-s", "-z", "--", POINTER_PATHSPEC],
+        check=True,
+        capture_output=True,
+    ).stdout
+    return _parse_ls_files(listing)
+
+
+def staged_pointer_entries() -> list[tuple[Path, str]]:
+    """The same, restricted to what is staged for the next commit."""
+    changed = subprocess.run(
+        [
+            "git", "diff", "--cached", "--name-only", "-z",
+            "--diff-filter=ACMR", "--", POINTER_PATHSPEC,
+        ],
+        check=True,
+        capture_output=True,
+    ).stdout
+    paths = [name for name in changed.decode("utf-8").split("\0") if name]
+    if not paths:
+        return []
+    listing = subprocess.run(
+        ["git", "--literal-pathspecs", "ls-files", "-s", "-z", "--", *paths],
+        check=True,
+        capture_output=True,
+    ).stdout
+    return _parse_ls_files(listing)
+
+
+def blob_size(sha: str) -> int:
+    """Size of a blob, without reading it."""
+    out = subprocess.run(
+        ["git", "cat-file", "-s", sha], check=True, capture_output=True
+    ).stdout
+    return int(out.decode("utf-8").strip())
+
+
+def pointer_offenders(entries: list[tuple[Path, str]]) -> list[tuple[Path, list[str]]]:
+    """``.dvc`` paths under ``data/`` that are not DVC pointers.
+
+    The exclusion that keeps this scan out of ``data/`` left a hole, because
+    the allowlist in ``data-check.yml`` accepts *any* name ending ``.dvc``
+    without checking what it is, and ``.gitignore`` un-ignores
+    ``data/raw/*.dvc``. A saved plan committed as ``data/raw/saved.dvc``
+    therefore passed the raw-data predicate and the content scan alike, and
+    carried the account id and SSH ingress CIDRs into history.
+
+    Reading these blobs is a deliberate, narrow exception to the data rule
+    and stays inside it in the way that matters. A pointer is a few hundred
+    bytes of YAML holding an md5, a size and a path -- not citizen data --
+    and it is read precisely to prove that is all it is. Anything at all
+    large is refused on its size alone, via ``git cat-file -s``, so no bulk
+    file under ``data/`` is ever read.
+    """
+    offenders: list[tuple[Path, list[str]]] = []
+    for path, sha in entries:
+        size = blob_size(sha)
+        if size > DVC_POINTER_MAX_BYTES:
+            offenders.append(
+                (path, [f"{size} bytes, far larger than a DVC pointer"])
+            )
+            continue
+
+        data = blob_bytes(sha)
+        if data.startswith(ZIP_MAGIC):
+            members = plan_members_of_blob(data)
+            offenders.append(
+                (path, [f"zip archive containing: {', '.join(members)}"] if members
+                 else ["a zip archive, not a pointer"])
+            )
+        elif b"outs:" not in data:
+            offenders.append((path, ["no `outs:` key: not a DVC pointer"]))
+    return offenders
+
+
 def staged_entries() -> list[tuple[Path, str]]:
     """``(path, blob_sha)`` for each regular file staged for commit.
 
@@ -215,8 +296,9 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv or [])
 
     if args.staged:
-        offenders = scan_staged()
-        return report(offenders)
+        return report(
+            scan_staged() + pointer_offenders(staged_pointer_entries())
+        )
 
     # Reads blobs, never the worktree: see `tracked_entries`. Nothing here
     # opens or stats a path, so a symlink, a symlinked ancestor and a hard
@@ -227,14 +309,14 @@ def main(argv: list[str] | None = None) -> int:
         if members:
             offenders.append((path, members))
 
-    return report(offenders)
+    return report(offenders + pointer_offenders(tracked_pointer_entries()))
 
 
 def report(offenders: list[tuple[Path, list[str]]]) -> int:
     if not offenders:
         return 0
 
-    print("The following files are Terraform plan archives:")
+    print("The following tracked files must not be in Git:")
     for path, members in offenders:
         print(f"  {path}  (contains: {', '.join(members)})")
     print()

--- a/scripts/check_no_terraform_plans.py
+++ b/scripts/check_no_terraform_plans.py
@@ -140,7 +140,10 @@ def plan_members_of_blob(data: bytes) -> list[str]:
     return members or damaged_plan_members(data)
 
 
-ALLOWLISTED_MAX_BYTES = 100_000
+# Mirrors MAX_BYTES in scripts/check_provenance_sidecars.py. A per-value
+# cap alone is not a bound: citizen text split across many recognised
+# fields keeps every scalar under the limit while the payload stays large.
+ALLOWLISTED_MAX_BYTES = 16 * 1024
 
 # Mirrors the allowlist in the raw-data step of .github/workflows/data-check.yml.
 # Every name that step lets through must be validated here, or the exemption
@@ -251,6 +254,12 @@ def dvc_pointer_problem(text: str) -> str | None:
     Deliberately hand-rolled: this module is stdlib-only so the hook runs
     before any `uv sync`, and PyYAML is not available to it. Being strict
     about shape is the right trade for a guard that must run everywhere.
+
+    No diagnostic here quotes the file's contents. A rejected line is named
+    by number, and a rejected key by number too whenever the key itself is
+    unrecognised and therefore arbitrary text. Only names already matched
+    against the allowlists are printed. This runs in CI, whose logs are
+    public: reporting the thing you are refusing to publish defeats the gate.
     """
     lines = [line.rstrip() for line in text.splitlines() if line.strip()]
     if not lines:
@@ -260,17 +269,17 @@ def dvc_pointer_problem(text: str) -> str | None:
     current: dict[str, str] | None = None
     list_key: str | None = None
 
-    for line in lines:
+    for number, line in enumerate(lines, start=1):
         stripped = line.strip()
         indented = line[:1].isspace()
 
         if not indented and not stripped.startswith("-"):
             key, sep, value = stripped.partition(":")
             if not sep:
-                return f"not a YAML mapping at {line!r}"
+                return f"line {number}: not a YAML mapping"
             key = key.strip()
             if key not in DVC_TOP_LEVEL_KEYS:
-                return f"unexpected top-level key {key!r}"
+                return f"line {number}: unrecognised top-level key"
             if value.strip() in BLOCK_SCALARS:
                 return f"block scalar not allowed at {key!r}"
             problem = _scalar_problem(key, value.strip())
@@ -281,7 +290,7 @@ def dvc_pointer_problem(text: str) -> str | None:
             continue
 
         if list_key is None:
-            return f"unexpected content at {line!r}"
+            return f"line {number}: unexpected content"
 
         if stripped.startswith("- "):
             current = {}
@@ -289,17 +298,17 @@ def dvc_pointer_problem(text: str) -> str | None:
                 items.append(current)
             stripped = stripped[2:]
         elif stripped.startswith("-"):
-            return f"malformed list item at {line!r}"
+            return f"line {number}: malformed list item"
 
         if current is None:
-            return f"unexpected content at {line!r}"
+            return f"line {number}: unexpected content"
 
         key, sep, value = stripped.partition(":")
         if not sep:
-            return f"not a key at {line!r}"
+            return f"line {number}: not a key"
         key = key.strip()
         if key not in DVC_ENTRY_KEYS:
-            return f"unexpected key {key!r} in an entry"
+            return f"line {number}: unrecognised key in an `outs:` entry"
         if value.strip() in BLOCK_SCALARS:
             return f"block scalar not allowed at {key!r}"
         problem = _scalar_problem(key, value.strip())

--- a/scripts/check_no_terraform_plans.py
+++ b/scripts/check_no_terraform_plans.py
@@ -226,11 +226,27 @@ TOKEN = re.compile(r"\A[A-Za-z0-9_.-]{1,64}\Z")
 # The algorithms DVC actually writes. A generic token accepted prose.
 HASH_NAMES = frozenset({"md5", "sha256", "sha1", "etag", "checksum", "crc32"})
 
-# A run of digits this long in a name under data/ is an identifier, not a
-# version or a count: an Indian mobile is 10 digits and an Aadhaar 12. The
-# longest run across all 33 allowlisted files in this repository is 8, so
-# this refuses the identifier shapes with margin and breaks nothing.
-IDENTIFIER_RUN = re.compile(r"\d{9,}")
+# Digits in a name under data/, counted across the separators people write
+# identifiers with: `987-654-3210` and `9876 543210` carry no nine-digit run
+# but are still a mobile number. Nine or more digits in one such group is an
+# identifier rather than a version or a count -- an Indian mobile is 10 and an
+# Aadhaar 12. Measured before choosing the threshold: across all 39 path
+# components in this repository the worst group holds 8 digits, so this
+# refuses the identifier shapes with margin and breaks nothing.
+DIGIT_GROUP = re.compile(r"\d(?:[\d\s._-]*\d)?")
+IDENTIFIER_DIGITS = 9
+
+# Shapes that are an identifier whatever field they sit in.
+MOBILE = re.compile(r"\A[6-9]\d{9}\Z")
+AADHAAR = re.compile(r"\A\d{12}\Z")
+
+
+def has_identifier(text: str) -> bool:
+    """Whether ``text`` carries an identifier-shaped run of digits."""
+    return any(
+        sum(character.isdigit() for character in group) >= IDENTIFIER_DIGITS
+        for group in DIGIT_GROUP.findall(text)
+    )
 INTEGER = re.compile(r"\A[0-9]{1,20}\Z")
 BOOLEAN = frozenset({"true", "false", "True", "False"})
 PATHISH = re.compile(r"\A[A-Za-z0-9._][A-Za-z0-9._/@+-]*\Z")
@@ -295,7 +311,16 @@ def _scalar_problem(key: str, value: str) -> str | None:
     if key == "hash":
         return None if value in HASH_NAMES else f"{key!r} is not a DVC hash name"
     if key in {"size", "nfiles"}:
-        return None if INTEGER.match(value) else f"{key!r} is not an integer"
+        if not INTEGER.match(value):
+            return f"{key!r} is not an integer"
+        if len(value) > 1 and value.startswith("0"):
+            return f"{key!r} has a leading zero"
+        # A count is not a phone number. Real sizes here reach 10 digits, so
+        # length alone cannot separate them -- the identifier *shapes* can,
+        # and no real value in this repository matches either.
+        if MOBILE.match(value) or AADHAAR.match(value):
+            return f"{key!r} is an identifier shape, not a count"
+        return None
     if key == "path":
         if len(value) > MAX_PATH:
             return f"{key!r} is {len(value)} characters, over the {MAX_PATH} cap"
@@ -462,7 +487,7 @@ def allowlisted_offenders(
         # disclosure on its own. Names that get past this are still never
         # printed to a public log: see `safe_path`.
         identifier_in = [
-            component for component in path.parts if IDENTIFIER_RUN.search(component)
+            component for component in path.parts if has_identifier(component)
         ]
         if identifier_in:
             # Every component, not just the leaf: `data/raw/9876543210/x.dvc`

--- a/scripts/check_no_terraform_plans.py
+++ b/scripts/check_no_terraform_plans.py
@@ -54,6 +54,9 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from check_provenance_sidecars import check_document  # noqa: E402
 
+# The local file header signature. It marks the start of a zip *and* the
+# start of every entry within one, which is why the damaged-archive scan
+# looks for it repeatedly rather than only at offset zero.
 ZIP_MAGIC = b"PK\x03\x04"
 
 # Members the Terraform plan format writes. `tfstate` is the state the plan
@@ -152,7 +155,6 @@ def _plan_members_in(entries: list[tuple[str, bool]]) -> list[str]:
     )
 
 
-LOCAL_HEADER = b"PK\x03\x04"
 # Offsets into a zip local file header: the name length is a two-byte
 # little-endian field at 26, and the name itself begins at 30.
 NAME_LENGTH_OFFSET = 26
@@ -178,7 +180,7 @@ def damaged_plan_members(data: bytes) -> list[str]:
     the declared length separates them, and the format supplies it.
     """
     found: set[str] = set()
-    position = data.find(LOCAL_HEADER)
+    position = data.find(ZIP_MAGIC)
     while position != -1:
         name_end = position + NAME_OFFSET
         if name_end <= len(data):
@@ -194,13 +196,17 @@ def damaged_plan_members(data: bytes) -> list[str]:
                     base = name.rsplit("/", 1)[-1]
                     if base in PLAN_MEMBERS:
                         found.add(base)
-        position = data.find(LOCAL_HEADER, position + 1)
+        position = data.find(ZIP_MAGIC, position + 1)
     return sorted(found)
 
 
 def plan_members_of_blob(data: bytes) -> list[str]:
     """Plan member names in a blob, including one that will not parse."""
-    if not data.startswith(ZIP_MAGIC):
+    # Not `startswith`: a self-extracting archive carries an executable stub
+    # ahead of the first entry, and zipfile opens it regardless -- it finds
+    # the central directory from the end. Gating on offset zero let a plan
+    # with any leading bytes through untouched.
+    if ZIP_MAGIC not in data:
         return []
     entries = _archive_entries(io.BytesIO(data))
     if not entries:
@@ -576,7 +582,7 @@ def allowlisted_offenders(
             continue
 
         data = blob_bytes(sha)
-        if data.startswith(ZIP_MAGIC):
+        if ZIP_MAGIC in data:
             members = plan_members_of_blob(data)
             offenders.append(
                 (path, [f"zip archive containing: {', '.join(members)}"] if members

--- a/scripts/check_no_terraform_plans.py
+++ b/scripts/check_no_terraform_plans.py
@@ -165,9 +165,23 @@ def damaged_plan_members(data: bytes) -> list[str]:
     the names are still present as literal bytes even when the archive cannot
     be opened.
     """
-    return sorted(
-        {name for name in PLAN_MEMBERS if name.encode("utf-8") in data}
-    )
+    found: set[str] = set()
+    for member in PLAN_MEMBERS:
+        needle = member.encode("utf-8")
+        start = data.find(needle)
+        while start != -1:
+            # A zip stores a directory as an entry whose name ends in `/`, so
+            # `tfstate/` is a folder holding no state while `tfstate` is the
+            # member that matters. Requiring one occurrence that is *not*
+            # followed by a slash keeps the directory-only case out without
+            # risking a real plan: its name is followed by the extra field or
+            # the compressed data, and every occurrence would have to be a
+            # slash for this to miss one.
+            if data[start + len(needle) : start + len(needle) + 1] != b"/":
+                found.add(member)
+                break
+            start = data.find(needle, start + 1)
+    return sorted(found)
 
 
 def plan_members_of_blob(data: bytes) -> list[str]:

--- a/scripts/check_no_terraform_plans.py
+++ b/scripts/check_no_terraform_plans.py
@@ -42,8 +42,18 @@ PLAN_MEMBERS = frozenset({"tfstate", "tfstate-prev", "tfplan"})
 
 
 def tracked_files() -> list[Path]:
+    """Tracked paths, excluding ``data/``.
+
+    The exclusion is a data-policy requirement, not an optimisation. AGENTS.md
+    forbids listing or reading anything under ``data/`` without explicit
+    per-path permission, and this check opens every file it is handed. Nothing
+    is lost by skipping it: the workflow step immediately before this one
+    already rejects any tracked file under ``data/`` that is not a ``.dvc``
+    pointer, a ``.gitkeep`` or a provenance sidecar, so a plan archive hidden
+    there fails the build one step earlier and never reaches this scan.
+    """
     out = subprocess.run(
-        ["git", "ls-files", "-z"],
+        ["git", "ls-files", "-z", "--", ".", ":(exclude)data/**"],
         check=True,
         capture_output=True,
     ).stdout

--- a/scripts/check_no_terraform_plans.py
+++ b/scripts/check_no_terraform_plans.py
@@ -84,17 +84,20 @@ def tracked_entries() -> list[tuple[Path, str]]:
         check=True,
         capture_output=True,
     ).stdout
-    return _parse_ls_files(listing)
+    return _regular_files(_parse_ls_files(listing))
 
 
-def _parse_ls_files(listing: bytes) -> list[tuple[Path, str]]:
-    """``(path, sha)`` from ``git ls-files -s -z`` output, regular files only.
+def _parse_ls_files(listing: bytes) -> list[tuple[Path, str, str]]:
+    """``(path, sha, mode)`` from ``git ls-files -s -z`` output.
 
-    Symlink (120000) and gitlink (160000) entries are dropped: git stores a
-    link's text rather than its target's bytes, so a link is never itself the
-    archive, and a submodule has no blob here.
+    The mode is carried rather than filtered here, because the two callers
+    want opposite things. The plan scan drops links -- git stores a link's
+    text, not its target's bytes, so a link is never itself the archive. The
+    allowlist must *reject* them: an exemption granted to `data/raw/x.dvc`
+    says that path holds a pointer, and a symlink there holds no pointer at
+    all while still occupying the exempt name.
     """
-    entries: list[tuple[Path, str]] = []
+    entries: list[tuple[Path, str, str]] = []
     for record in listing.decode("utf-8").split("\0"):
         if not record:
             continue
@@ -103,10 +106,15 @@ def _parse_ls_files(listing: bytes) -> list[tuple[Path, str]]:
         if len(fields) < 2:
             continue
         mode, sha = fields[0], fields[1]
-        if mode in {"120000", "160000"}:
-            continue
-        entries.append((Path(name), sha))
+        entries.append((Path(name), sha, mode))
     return entries
+
+
+def _regular_files(entries: list[tuple[Path, str, str]]) -> list[tuple[Path, str]]:
+    """Blob entries only, for the scan that has no use for links."""
+    return [
+        (path, sha) for path, sha, mode in entries if mode not in {"120000", "160000"}
+    ]
 
 
 def _members_of(source: Path | io.BytesIO | io.BufferedReader) -> list[str]:
@@ -191,6 +199,14 @@ DVC_ENTRY_KEYS = frozenset(
 # used as a container for something else.
 HEXISH = re.compile(r"\A[0-9a-fA-F]{8,64}(\.dir)?\Z")
 TOKEN = re.compile(r"\A[A-Za-z0-9_.-]{1,64}\Z")
+# The algorithms DVC actually writes. A generic token accepted prose.
+HASH_NAMES = frozenset({"md5", "sha256", "sha1", "etag", "checksum", "crc32"})
+
+# A run of digits this long in a name under data/ is an identifier, not a
+# version or a count: an Indian mobile is 10 digits and an Aadhaar 12. The
+# longest run across all 33 allowlisted files in this repository is 8, so
+# this refuses the identifier shapes with margin and breaks nothing.
+IDENTIFIER_RUN = re.compile(r"\d{9,}")
 INTEGER = re.compile(r"\A[0-9]{1,20}\Z")
 BOOLEAN = frozenset({"true", "false", "True", "False"})
 PATHISH = re.compile(r"\A[A-Za-z0-9._][A-Za-z0-9._/@+-]*\Z")
@@ -199,21 +215,17 @@ BLOCK_SCALARS = frozenset({"|", ">", "|-", ">-", "|+", ">+"})
 
 
 
-def _ls_files_entries(pathspecs: tuple[str, ...]) -> list[tuple[Path, str]]:
+def tracked_allowlisted_entries() -> list[tuple[Path, str, str]]:
+    """``(path, sha, mode)`` for every tracked entry the allowlist exempts."""
     listing = subprocess.run(
-        ["git", "ls-files", "-s", "-z", "--", *pathspecs],
+        ["git", "ls-files", "-s", "-z", "--", *ALLOWLIST_PATHSPECS],
         check=True,
         capture_output=True,
     ).stdout
     return _parse_ls_files(listing)
 
 
-def tracked_allowlisted_entries() -> list[tuple[Path, str]]:
-    """``(path, sha)`` for every tracked blob the data allowlist exempts."""
-    return _ls_files_entries(ALLOWLIST_PATHSPECS)
-
-
-def staged_allowlisted_entries() -> list[tuple[Path, str]]:
+def staged_allowlisted_entries() -> list[tuple[Path, str, str]]:
     """The same, restricted to what is staged for the next commit."""
     changed = subprocess.run(
         [
@@ -257,7 +269,7 @@ def _scalar_problem(key: str, value: str) -> str | None:
     if key in {"md5", "etag", "checksum"}:
         return None if HEXISH.match(value) else f"{key!r} is not a checksum"
     if key == "hash":
-        return None if TOKEN.match(value) else f"{key!r} is not a hash name"
+        return None if value in HASH_NAMES else f"{key!r} is not a DVC hash name"
     if key in {"size", "nfiles"}:
         return None if INTEGER.match(value) else f"{key!r} is not an integer"
     if key in {"isexec", "cache", "persist", "push", "frozen"}:
@@ -382,7 +394,7 @@ def dvc_pointer_problem(text: str, stem: str | None = None) -> str | None:
 
 
 def allowlisted_offenders(
-    entries: list[tuple[Path, str]],
+    entries: list[tuple[Path, str, str]],
 ) -> list[tuple[Path, list[str]]]:
     """Allowlisted ``data/`` blobs that are not what their name claims.
 
@@ -400,9 +412,30 @@ def allowlisted_offenders(
     unread, so no bulk file under ``data/`` is ever opened.
     """
     offenders: list[tuple[Path, list[str]]] = []
-    for path, sha in entries:
+    for path, sha, mode in entries:
+        if mode == "120000":
+            # The exemption is for a marker, a pointer or a sidecar. A link
+            # occupying the name is none of them, and dropping it silently
+            # would leave the exempt path unverified.
+            offenders.append((path, ["a symlink, not the file this name may hold"]))
+            continue
+        if mode == "160000":
+            offenders.append((path, ["a submodule, not the file this name may hold"]))
+            continue
+
         size = blob_size(sha)
         name = path.name
+
+        # The name is part of what is committed. This cannot decide whether a
+        # name is a person's -- no static check can -- but the identifier
+        # shapes are decidable, and they are the ones that make a filename a
+        # disclosure on its own. Names that get past this are still never
+        # printed to a public log: see `safe_path`.
+        if IDENTIFIER_RUN.search(name):
+            offenders.append(
+                (path, ["the filename contains a 9+ digit identifier"])
+            )
+            continue
 
         if name == ".gitkeep":
             if size:
@@ -488,7 +521,7 @@ def staged_entries() -> list[tuple[Path, str]]:
         capture_output=True,
     ).stdout
 
-    return _parse_ls_files(listing)
+    return _regular_files(_parse_ls_files(listing))
 
 
 def blob_bytes(sha: str) -> bytes:

--- a/scripts/check_no_terraform_plans.py
+++ b/scripts/check_no_terraform_plans.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 
 import argparse
 import io
+import json
 import subprocess
 import sys
 import zipfile
@@ -139,26 +140,41 @@ def plan_members_of_blob(data: bytes) -> list[str]:
     return members or damaged_plan_members(data)
 
 
-DVC_POINTER_MAX_BYTES = 100_000
-POINTER_PATHSPEC = "data/**/*.dvc"
+ALLOWLISTED_MAX_BYTES = 100_000
+
+# Mirrors the allowlist in the raw-data step of .github/workflows/data-check.yml.
+# Every name that step lets through must be validated here, or the exemption
+# becomes a way in: the predicate checks the name and nothing else.
+ALLOWLIST_PATHSPECS = (
+    "data/**/*.dvc",
+    "data/*.dvc",
+    "data/**/.gitkeep",
+    "data/.gitkeep",
+    "data/external/**/provenance.json",
+    "data/external/**/*.provenance.json",
+)
 
 
-def tracked_pointer_entries() -> list[tuple[Path, str]]:
-    """``(path, sha)`` for tracked ``.dvc`` files under ``data/``."""
+def _ls_files_entries(pathspecs: tuple[str, ...]) -> list[tuple[Path, str]]:
     listing = subprocess.run(
-        ["git", "ls-files", "-s", "-z", "--", POINTER_PATHSPEC],
+        ["git", "ls-files", "-s", "-z", "--", *pathspecs],
         check=True,
         capture_output=True,
     ).stdout
     return _parse_ls_files(listing)
 
 
-def staged_pointer_entries() -> list[tuple[Path, str]]:
+def tracked_allowlisted_entries() -> list[tuple[Path, str]]:
+    """``(path, sha)`` for every tracked blob the data allowlist exempts."""
+    return _ls_files_entries(ALLOWLIST_PATHSPECS)
+
+
+def staged_allowlisted_entries() -> list[tuple[Path, str]]:
     """The same, restricted to what is staged for the next commit."""
     changed = subprocess.run(
         [
             "git", "diff", "--cached", "--name-only", "-z",
-            "--diff-filter=ACMR", "--", POINTER_PATHSPEC,
+            "--diff-filter=ACMR", "--", *ALLOWLIST_PATHSPECS,
         ],
         check=True,
         capture_output=True,
@@ -182,30 +198,87 @@ def blob_size(sha: str) -> int:
     return int(out.decode("utf-8").strip())
 
 
-def pointer_offenders(entries: list[tuple[Path, str]]) -> list[tuple[Path, list[str]]]:
-    """``.dvc`` paths under ``data/`` that are not DVC pointers.
+def dvc_pointer_problem(text: str) -> str | None:
+    """Why ``text`` is not a DVC pointer, or ``None`` if it is one.
 
-    The exclusion that keeps this scan out of ``data/`` left a hole, because
-    the allowlist in ``data-check.yml`` accepts *any* name ending ``.dvc``
-    without checking what it is, and ``.gitignore`` un-ignores
-    ``data/raw/*.dvc``. A saved plan committed as ``data/raw/saved.dvc``
-    therefore passed the raw-data predicate and the content scan alike, and
-    carried the account id and SSH ingress CIDRs into history.
+    Parsed structurally rather than searched. A substring test for ``outs:``
+    passes any prose that happens to contain those bytes, which is no test at
+    all. Deliberately hand-rolled: this module is stdlib-only so the hook runs
+    before any `uv sync`, and PyYAML is not available to it.
+
+    A pointer is a YAML mapping with a top-level ``outs:`` list whose items
+    carry a ``path`` and a hash. Nothing else at top level is required, but
+    every line must fit that shape.
+    """
+    lines = [line.rstrip() for line in text.splitlines() if line.strip()]
+    if not lines:
+        return "empty"
+
+    if not any(line == "outs:" for line in lines):
+        return "no top-level `outs:` list"
+
+    items: list[dict[str, str]] = []
+    current: dict[str, str] | None = None
+    in_outs = False
+    for line in lines:
+        if not line.startswith((" ", "-")):  # a top-level key
+            in_outs = line == "outs:"
+            current = None
+            if ":" not in line:
+                return f"not a YAML mapping at {line!r}"
+            continue
+        if not in_outs:
+            continue
+        stripped = line.strip()
+        if stripped.startswith("- "):
+            current = {}
+            items.append(current)
+            stripped = stripped[2:]
+        if current is None or ":" not in stripped:
+            return f"not a pointer entry at {line!r}"
+        key, _, value = stripped.partition(":")
+        current[key.strip()] = value.strip()
+
+    if not items:
+        return "`outs:` list is empty"
+    for item in items:
+        if "path" not in item:
+            return "an `outs:` entry has no `path`"
+        if not {"md5", "hash", "etag", "checksum"} & set(item):
+            return "an `outs:` entry has no hash"
+    return None
+
+
+def allowlisted_offenders(
+    entries: list[tuple[Path, str]],
+) -> list[tuple[Path, list[str]]]:
+    """Allowlisted ``data/`` blobs that are not what their name claims.
+
+    Excluding ``data/`` from the content scan is a data-policy requirement,
+    but it means the raw-data allowlist is the only thing standing between a
+    tracked file and Git. That predicate checks the *name*: `.gitkeep`, any
+    `*.dvc`, and the provenance sidecars. So a saved plan committed as
+    ``data/raw/saved.dvc`` or ``data/raw/.gitkeep`` passed every check.
 
     Reading these blobs is a deliberate, narrow exception to the data rule
-    and stays inside it in the way that matters. A pointer is a few hundred
-    bytes of YAML holding an md5, a size and a path -- not citizen data --
-    and it is read precisely to prove that is all it is. Anything at all
-    large is refused on its size alone, via ``git cat-file -s``, so no bulk
-    file under ``data/`` is ever read.
+    and stays inside it in the way that matters. Each is meant to be a marker,
+    a few hundred bytes of pointer YAML, or a provenance sidecar -- not
+    citizen data -- and each is read precisely to prove that is all it is.
+    Size is taken from ``git cat-file -s`` first and anything large is refused
+    unread, so no bulk file under ``data/`` is ever opened.
     """
     offenders: list[tuple[Path, list[str]]] = []
     for path, sha in entries:
         size = blob_size(sha)
-        if size > DVC_POINTER_MAX_BYTES:
-            offenders.append(
-                (path, [f"{size} bytes, far larger than a DVC pointer"])
-            )
+        name = path.name
+
+        if name == ".gitkeep":
+            if size:
+                offenders.append((path, [f"a .gitkeep marker must be empty; {size} bytes"]))
+            continue
+
+        if size > ALLOWLISTED_MAX_BYTES:
+            offenders.append((path, [f"{size} bytes, far larger than {name} should be"]))
             continue
 
         data = blob_bytes(sha)
@@ -215,8 +288,23 @@ def pointer_offenders(entries: list[tuple[Path, str]]) -> list[tuple[Path, list[
                 (path, [f"zip archive containing: {', '.join(members)}"] if members
                  else ["a zip archive, not a pointer"])
             )
-        elif b"outs:" not in data:
-            offenders.append((path, ["no `outs:` key: not a DVC pointer"]))
+            continue
+
+        try:
+            text = data.decode("utf-8")
+        except UnicodeDecodeError:
+            offenders.append((path, ["not text: cannot be a pointer or sidecar"]))
+            continue
+
+        if name.endswith(".dvc"):
+            problem = dvc_pointer_problem(text)
+            if problem:
+                offenders.append((path, [f"not a DVC pointer: {problem}"]))
+        else:  # provenance sidecar
+            try:
+                json.loads(text)
+            except ValueError as exc:
+                offenders.append((path, [f"not valid JSON: {exc}"]))
     return offenders
 
 
@@ -297,7 +385,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.staged:
         return report(
-            scan_staged() + pointer_offenders(staged_pointer_entries())
+            scan_staged() + allowlisted_offenders(staged_allowlisted_entries())
         )
 
     # Reads blobs, never the worktree: see `tracked_entries`. Nothing here
@@ -309,7 +397,7 @@ def main(argv: list[str] | None = None) -> int:
         if members:
             offenders.append((path, members))
 
-    return report(offenders + pointer_offenders(tracked_pointer_entries()))
+    return report(offenders + allowlisted_offenders(tracked_allowlisted_entries()))
 
 
 def report(offenders: list[tuple[Path, list[str]]]) -> int:

--- a/scripts/check_no_terraform_plans.py
+++ b/scripts/check_no_terraform_plans.py
@@ -14,7 +14,13 @@ one step later: `-out` takes an arbitrary filename and Terraform's own
 documentation uses `terraform plan -out=tfplan`, with no suffix at all. A
 suffix list can only ever cover the names someone thought of.
 
-So this looks at the bytes. Every tracked file that begins with the zip local
+So this looks at the bytes -- and at the bytes *git* holds, not the
+worktree's. Reading the worktree made the tracked path an untrusted mapping
+to content: a symlink, a symlinked ancestor and a hard link each reached
+`data/` through it, and each fix was a new way to police the filesystem. A
+hard link ends that approach, being an ordinary directory entry no open-time
+flag can distinguish. Blobs are also the more correct object to test, since
+what matters is whether an archive is *in git*. Every tracked file that begins with the zip local
 header is opened and its entry names are checked for the members a plan
 archive carries. That is name-independent: `tfplan`, `plan.out`, `foo.bin` and
 a plan with no extension are all caught, and a .pptx or .xlsx (also zips) is
@@ -36,7 +42,6 @@ from __future__ import annotations
 
 import argparse
 import io
-import os
 import subprocess
 import sys
 import zipfile
@@ -52,71 +57,49 @@ ZIP_MAGIC = b"PK\x03\x04"
 PLAN_MEMBERS = frozenset({"tfstate", "tfstate-prev", "tfplan"})
 
 
-def tracked_files() -> list[Path]:
-    """Tracked paths, excluding ``data/``.
+def tracked_entries() -> list[tuple[Path, str]]:
+    """``(path, blob_sha)`` for every tracked regular file outside ``data/``.
 
-    The exclusion is a data-policy requirement, not an optimisation. AGENTS.md
-    forbids listing or reading anything under ``data/`` without explicit
-    per-path permission, and this check opens every file it is handed. Nothing
-    is lost by skipping it: the workflow step immediately before this one
-    already rejects any tracked file under ``data/`` that is not a ``.dvc``
-    pointer, a ``.gitkeep`` or a provenance sidecar, so a plan archive hidden
-    there fails the build one step earlier and never reaches this scan.
+    The scan reads git objects rather than the worktree. Four separate
+    findings on this PR -- a symlink at the final component, a symlink at an
+    ancestor, the stat prefilters in front of the open, and a hard link --
+    were all the same defect: the worktree is an untrusted mapping from
+    tracked path to bytes, and every fix was a new way to police it. A hard
+    link ends that approach, because it is an ordinary directory entry that
+    no open-time flag can distinguish.
+
+    The blob is also the more correct object to test. What matters is whether
+    a plan archive is *in git*, and the worktree copy can differ from it or
+    be absent entirely.
     """
-    out = subprocess.run(
-        ["git", "ls-files", "-z", "--", ".", ":(exclude)data/**"],
+    listing = subprocess.run(
+        ["git", "ls-files", "-s", "-z", "--", ".", ":(exclude)data/**"],
         check=True,
         capture_output=True,
     ).stdout
-    return [Path(name) for name in out.decode("utf-8").split("\0") if name]
+    return _parse_ls_files(listing)
 
 
-def _open_nofollow(path: Path) -> int | None:
-    """Open ``path`` for reading, refusing a symlink at *any* component.
+def _parse_ls_files(listing: bytes) -> list[tuple[Path, str]]:
+    """``(path, sha)`` from ``git ls-files -s -z`` output, regular files only.
 
-    ``Path.is_symlink()`` only describes the final component, so it does not
-    see an ancestor that has been replaced by a link: with the index still
-    listing ``public/payload`` and the worktree holding ``public -> data``,
-    ``public/payload`` is not a symlink and opening it reads ``data/payload``
-    straight through the ``:(exclude)data/**`` pathspec.
-
-    Walking the components with ``O_NOFOLLOW`` closes that, and closes it
-    without a race: each directory is opened relative to the previous one, so
-    there is no window between deciding a path is safe and opening it.
+    Symlink (120000) and gitlink (160000) entries are dropped: git stores a
+    link's text rather than its target's bytes, so a link is never itself the
+    archive, and a submodule has no blob here.
     """
-    parts = path.parts
-    if not parts:
-        return None
-    if path.is_absolute():
-        start, parts = parts[0], parts[1:]
-    else:
-        start = "."
-    if not parts:
-        return None
-
-    try:
-        dir_fd = os.open(start, os.O_RDONLY | os.O_DIRECTORY)
-    except OSError:
-        return None
-
-    try:
-        for component in parts[:-1]:
-            try:
-                nxt = os.open(
-                    component,
-                    os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
-                    dir_fd=dir_fd,
-                )
-            except OSError:
-                return None
-            os.close(dir_fd)
-            dir_fd = nxt
-        try:
-            return os.open(parts[-1], os.O_RDONLY | os.O_NOFOLLOW, dir_fd=dir_fd)
-        except OSError:
-            return None
-    finally:
-        os.close(dir_fd)
+    entries: list[tuple[Path, str]] = []
+    for record in listing.decode("utf-8").split("\0"):
+        if not record:
+            continue
+        meta, _, name = record.partition("\t")
+        fields = meta.split()
+        if len(fields) < 2:
+            continue
+        mode, sha = fields[0], fields[1]
+        if mode in {"120000", "160000"}:
+            continue
+        entries.append((Path(name), sha))
+    return entries
 
 
 def _members_of(source: Path | io.BytesIO | io.BufferedReader) -> list[str]:
@@ -125,40 +108,35 @@ def _members_of(source: Path | io.BytesIO | io.BufferedReader) -> list[str]:
         with zipfile.ZipFile(source) as archive:
             names = archive.namelist()
     except (zipfile.BadZipFile, OSError):
-        # Starts like a zip and will not open as one. Not a plan we can
-        # confirm, and not something this check should fail the build over —
-        # the suffix patterns in the workflow still cover the obvious names.
         return []
 
     return sorted({name for name in names if Path(name).name in PLAN_MEMBERS})
 
 
-def plan_members(path: Path) -> list[str]:
-    """Entry names identifying ``path`` as a Terraform plan archive, if any.
+def damaged_plan_members(data: bytes) -> list[str]:
+    """Plan member names visible in a zip that will not parse.
 
-    Opened through :func:`_open_nofollow`, so a symlink anywhere in the path
-    yields no members rather than a read of whatever it points at.
+    A truncated or otherwise damaged plan still carries its secrets: the
+    tfstate entry is in the archive whether or not the central directory
+    survives. Treating an unparseable zip as clean therefore lets exactly the
+    file this check exists to stop through, and truncation is not an exotic
+    accident -- an interrupted `terraform plan -out` produces one.
+
+    Zip stores each member's name uncompressed in its local file header, so
+    the names are still present as literal bytes even when the archive cannot
+    be opened.
     """
-    fd = _open_nofollow(path)
-    if fd is None:
-        return []
-
-    try:
-        with os.fdopen(fd, "rb") as handle:
-            if handle.read(4) != ZIP_MAGIC:
-                return []
-            handle.seek(0)
-            return _members_of(handle)
-    except OSError:
-        # Directories and unreadable entries land here; neither is an archive.
-        return []
+    return sorted(
+        {name for name in PLAN_MEMBERS if name.encode("utf-8") in data}
+    )
 
 
 def plan_members_of_blob(data: bytes) -> list[str]:
-    """Same test as :func:`plan_members`, against bytes read from the index."""
+    """Plan member names in a blob, including one that will not parse."""
     if not data.startswith(ZIP_MAGIC):
         return []
-    return _members_of(io.BytesIO(data))
+    members = _members_of(io.BytesIO(data))
+    return members or damaged_plan_members(data)
 
 
 def staged_entries() -> list[tuple[Path, str]]:
@@ -197,19 +175,7 @@ def staged_entries() -> list[tuple[Path, str]]:
         capture_output=True,
     ).stdout
 
-    entries: list[tuple[Path, str]] = []
-    for record in listing.decode("utf-8").split("\0"):
-        if not record:
-            continue
-        meta, _, name = record.partition("\t")
-        fields = meta.split()
-        if len(fields) < 2:
-            continue
-        mode, sha = fields[0], fields[1]
-        if mode in {"120000", "160000"}:
-            continue
-        entries.append((Path(name), sha))
-    return entries
+    return _parse_ls_files(listing)
 
 
 def blob_bytes(sha: str) -> bytes:
@@ -252,18 +218,12 @@ def main(argv: list[str] | None = None) -> int:
         offenders = scan_staged()
         return report(offenders)
 
+    # Reads blobs, never the worktree: see `tracked_entries`. Nothing here
+    # opens or stats a path, so a symlink, a symlinked ancestor and a hard
+    # link into data/ are all equally irrelevant.
     offenders: list[tuple[Path, list[str]]] = []
-    for path in tracked_files():
-        # No `is_symlink()`/`is_file()` prefilter here, deliberately. Both
-        # stat through a symlinked ancestor -- `lstat("public/payload")` and
-        # `stat("public/payload")` on the `public -> data` case -- and
-        # AGENTS.md forbids inspecting metadata under data/, not merely
-        # reading it. `_open_nofollow` is the only gate, and it never stats:
-        # it opens each component with O_NOFOLLOW and fails closed. The cases
-        # the prefilters used to cover still resolve correctly -- a directory
-        # or submodule entry opens but is not a zip, and a broken or
-        # symlinked path fails to open at all.
-        members = plan_members(path)
+    for path, sha in tracked_entries():
+        members = plan_members_of_blob(blob_bytes(sha))
         if members:
             offenders.append((path, members))
 

--- a/scripts/check_no_terraform_plans.py
+++ b/scripts/check_no_terraform_plans.py
@@ -117,17 +117,31 @@ def _regular_files(entries: list[tuple[Path, str, str]]) -> list[tuple[Path, str
     ]
 
 
-def _members_of(source: Path | io.BytesIO | io.BufferedReader) -> list[str]:
-    """Plan-archive entry names in ``source``, which may be a path or bytes."""
+def _archive_names(
+    source: Path | io.BytesIO | io.BufferedReader,
+) -> list[str] | None:
+    """Every entry name in ``source``, or ``None`` if it will not open.
+
+    The distinction the caller needs is three-way, not two, and truncation is
+    why. A damaged archive does not necessarily raise: zipfile opens one whose
+    central directory is gone and reports an *empty* namelist. So "opened and
+    listed nothing" has to be treated like "would not open", while "opened and
+    listed entries, none of them a plan member" is an ordinary archive and
+    must not be second-guessed by scanning its bytes.
+    """
     try:
         with zipfile.ZipFile(source) as archive:
-            names = archive.namelist()
+            return archive.namelist()
     except (zipfile.BadZipFile, OSError):
-        return []
+        return None
 
-    # Only the base name is returned, never the archive path it sat under.
-    # The directory part is attacker-chosen text and `report()` prints into
-    # public CI logs; the base name is one of PLAN_MEMBERS and so is safe.
+
+def _plan_members_in(names: list[str]) -> list[str]:
+    """Plan member base names among ``names``.
+
+    Base name only: the directory above it is chosen by whoever built the
+    archive and `report()` prints into public logs.
+    """
     return sorted({Path(name).name for name in names if Path(name).name in PLAN_MEMBERS})
 
 
@@ -153,8 +167,14 @@ def plan_members_of_blob(data: bytes) -> list[str]:
     """Plan member names in a blob, including one that will not parse."""
     if not data.startswith(ZIP_MAGIC):
         return []
-    members = _members_of(io.BytesIO(data))
-    return members or damaged_plan_members(data)
+    names = _archive_names(io.BytesIO(data))
+    if not names:
+        # Would not open, or opened and listed nothing -- both mean a damaged
+        # archive, whose secrets are still in the bytes. Fall back to them.
+        return damaged_plan_members(data)
+    # A real listing. An ordinary archive whose *contents* happen to contain
+    # the word `tfstate` is not a plan, and scanning its bytes would say so.
+    return _plan_members_in(names)
 
 
 # Mirrors MAX_BYTES in scripts/check_provenance_sidecars.py. A per-value
@@ -176,6 +196,12 @@ ALLOWLIST_PATHSPECS = (
     # workflow's `(.*/)?` also allows the sidecar to sit directly there.
     "data/external/provenance.json",
     "data/external/*.provenance.json",
+    # The raw-data step scans `outputs/**` under the same predicate, so the
+    # same names are exempt there and need the same verification.
+    "outputs/**/*.dvc",
+    "outputs/*.dvc",
+    "outputs/**/.gitkeep",
+    "outputs/.gitkeep",
 )
 
 # The keys a .dvc file may carry. Anything else is unrecognised content, and
@@ -653,7 +679,9 @@ def in_public_log() -> bool:
 
 # Directory names DVC and this repository create, which carry no citizen
 # information and are worth keeping in a message so it says where to look.
-SAFE_DATA_DIRS = frozenset({"data", "raw", "external", "clean", "interim", "processed"})
+SAFE_DATA_DIRS = frozenset(
+    {"data", "outputs", "raw", "external", "clean", "interim", "processed"}
+)
 
 
 def _redact(component: str) -> str:
@@ -675,7 +703,7 @@ def safe_path(path: Path) -> str:
     Paths outside ``data/`` print whole: they are source paths, they are not
     protected, and a reviewer has to be able to read them.
     """
-    if path.parts[:1] != ("data",) or not in_public_log():
+    if path.parts[:1] not in {("data",), ("outputs",)} or not in_public_log():
         return str(path)
 
     parts = []

--- a/scripts/check_no_terraform_plans.py
+++ b/scripts/check_no_terraform_plans.py
@@ -20,12 +20,22 @@ archive carries. That is name-independent: `tfplan`, `plan.out`, `foo.bin` and
 a plan with no extension are all caught, and a .pptx or .xlsx (also zips) is
 not, because it has no `tfstate` member.
 
+Runs in two places. In CI it scans every tracked file. With ``--staged`` it
+scans the blobs staged for the next commit instead, which is what
+``.githooks/pre-commit`` calls: a content scan that only runs in Actions sees
+the plan after the push that already disclosed the state, so the same test has
+to be available before the commit is made. The staged mode reads the index
+rather than the worktree, because those differ once a file is staged and then
+edited, and the index is what gets committed.
+
 Deliberately dependency-free — stdlib only, so the check runs before any
 `uv sync` and cannot be skipped by an environment problem.
 """
 
 from __future__ import annotations
 
+import argparse
+import io
 import subprocess
 import sys
 import zipfile
@@ -60,6 +70,20 @@ def tracked_files() -> list[Path]:
     return [Path(name) for name in out.decode("utf-8").split("\0") if name]
 
 
+def _members_of(source: Path | io.BytesIO) -> list[str]:
+    """Plan-archive entry names in ``source``, which may be a path or bytes."""
+    try:
+        with zipfile.ZipFile(source) as archive:
+            names = archive.namelist()
+    except (zipfile.BadZipFile, OSError):
+        # Starts like a zip and will not open as one. Not a plan we can
+        # confirm, and not something this check should fail the build over —
+        # the suffix patterns in the workflow still cover the obvious names.
+        return []
+
+    return sorted({name for name in names if Path(name).name in PLAN_MEMBERS})
+
+
 def plan_members(path: Path) -> list[str]:
     """Entry names identifying ``path`` as a Terraform plan archive, if any."""
     try:
@@ -69,21 +93,100 @@ def plan_members(path: Path) -> list[str]:
     except OSError:
         return []
 
-    try:
-        with zipfile.ZipFile(path) as archive:
-            names = archive.namelist()
-    except (zipfile.BadZipFile, OSError):
-        # Starts like a zip and will not open as one. Not a plan we can
-        # confirm, and not something this check should fail the build over —
-        # the suffix patterns in the workflow still cover the obvious names.
+    return _members_of(path)
+
+
+def plan_members_of_blob(data: bytes) -> list[str]:
+    """Same test as :func:`plan_members`, against bytes read from the index."""
+    if not data.startswith(ZIP_MAGIC):
+        return []
+    return _members_of(io.BytesIO(data))
+
+
+def staged_entries() -> list[tuple[Path, str]]:
+    """``(path, blob_sha)`` for each regular file staged for commit.
+
+    The worktree scan is the wrong source for a pre-commit check: what gets
+    committed is the *index*, and the two differ whenever a file is staged and
+    then edited. So this reads the staged blob.
+
+    Symlink (120000) and gitlink (160000) entries are dropped for the reason
+    given in :func:`main` — a symlink is never itself the archive, and reading
+    through one would defeat the ``data/`` exclusion.
+    """
+    changed = subprocess.run(
+        [
+            "git", "diff", "--cached", "--name-only", "-z",
+            "--diff-filter=ACMR", "--", ".", ":(exclude)data/**",
+        ],
+        check=True,
+        capture_output=True,
+    ).stdout
+    paths = [name for name in changed.decode("utf-8").split("\0") if name]
+    if not paths:
         return []
 
-    return sorted(
-        {name for name in names if Path(name).name in PLAN_MEMBERS}
+    listing = subprocess.run(
+        ["git", "ls-files", "-s", "-z", "--", *paths],
+        check=True,
+        capture_output=True,
+    ).stdout
+
+    entries: list[tuple[Path, str]] = []
+    for record in listing.decode("utf-8").split("\0"):
+        if not record:
+            continue
+        meta, _, name = record.partition("\t")
+        fields = meta.split()
+        if len(fields) < 2:
+            continue
+        mode, sha = fields[0], fields[1]
+        if mode in {"120000", "160000"}:
+            continue
+        entries.append((Path(name), sha))
+    return entries
+
+
+def blob_bytes(sha: str) -> bytes:
+    """Contents of a staged blob."""
+    return subprocess.run(
+        ["git", "cat-file", "blob", sha],
+        check=True,
+        capture_output=True,
+    ).stdout
+
+
+def scan_staged() -> list[tuple[Path, list[str]]]:
+    """Offenders among the blobs staged for the next commit."""
+    offenders: list[tuple[Path, list[str]]] = []
+    for path, sha in staged_entries():
+        members = plan_members_of_blob(blob_bytes(sha))
+        if members:
+            offenders.append((path, members))
+    return offenders
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--staged",
+        action="store_true",
+        help=(
+            "Scan the blobs staged for commit instead of the tracked "
+            "worktree. Used by .githooks/pre-commit, so a plan saved under "
+            "an arbitrary name is refused before it is pushed rather than "
+            "after CI has seen it."
+        ),
     )
+    # ``argv or []`` rather than ``None``: a bare ``main()`` is the
+    # in-process worktree scan, and must not read pytest's or any other
+    # caller's sys.argv. The CLI entry point below passes argv itself.
+    args = parser.parse_args(argv or [])
 
+    if args.staged:
+        offenders = scan_staged()
+        return report(offenders)
 
-def main() -> int:
     offenders: list[tuple[Path, list[str]]] = []
     for path in tracked_files():
         # Symlinks are skipped before anything opens them, and that is a
@@ -101,10 +204,14 @@ def main() -> int:
         if members:
             offenders.append((path, members))
 
+    return report(offenders)
+
+
+def report(offenders: list[tuple[Path, list[str]]]) -> int:
     if not offenders:
         return 0
 
-    print("The following tracked files are Terraform plan archives:")
+    print("The following files are Terraform plan archives:")
     for path, members in offenders:
         print(f"  {path}  (contains: {', '.join(members)})")
     print()
@@ -120,4 +227,4 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check_no_terraform_plans.py
+++ b/scripts/check_no_terraform_plans.py
@@ -152,6 +152,11 @@ def _plan_members_in(entries: list[tuple[str, bool]]) -> list[str]:
     )
 
 
+def _is_name_byte(byte: bytes) -> bool:
+    """Whether ``byte`` could be part of a longer file name."""
+    return byte.isalnum() or byte in {b"_", b"-", b"."}
+
+
 def damaged_plan_members(data: bytes) -> list[str]:
     """Plan member names visible in a zip that will not parse.
 
@@ -177,7 +182,14 @@ def damaged_plan_members(data: bytes) -> list[str]:
             # risking a real plan: its name is followed by the extra field or
             # the compressed data, and every occurrence would have to be a
             # slash for this to miss one.
-            if data[start + len(needle) : start + len(needle) + 1] != b"/":
+            before = data[start - 1 : start] if start else b""
+            after = data[start + len(needle) : start + len(needle) + 1]
+            # Both boundaries, for the same reason. `/` after it means a
+            # directory; a name character before or after it means a longer
+            # name that merely ends or begins with the token, like
+            # `mytfstate` or `tfstateold`. A real entry name is preceded by
+            # the header's length fields, which are not name characters.
+            if after != b"/" and not _is_name_byte(before) and not _is_name_byte(after):
                 found.add(member)
                 break
             start = data.find(needle, start + 1)

--- a/scripts/check_no_terraform_plans.py
+++ b/scripts/check_no_terraform_plans.py
@@ -254,17 +254,15 @@ def main(argv: list[str] | None = None) -> int:
 
     offenders: list[tuple[Path, list[str]]] = []
     for path in tracked_files():
-        # Cheap pre-filters only. The guarantee that nothing is read through
-        # a link lives in `_open_nofollow`, which checks every component --
-        # `is_symlink()` describes just the last one, and an ancestor
-        # replaced by a link is the case that reached data/. Nothing is lost
-        # by skipping links: git stores the link text, not the pointed-to
-        # bytes, so a symlink is never itself the committed archive, which is
-        # scanned at its own path.
-        if path.is_symlink():
-            continue
-        if not path.is_file():  # submodule entries, broken links
-            continue
+        # No `is_symlink()`/`is_file()` prefilter here, deliberately. Both
+        # stat through a symlinked ancestor -- `lstat("public/payload")` and
+        # `stat("public/payload")` on the `public -> data` case -- and
+        # AGENTS.md forbids inspecting metadata under data/, not merely
+        # reading it. `_open_nofollow` is the only gate, and it never stats:
+        # it opens each component with O_NOFOLLOW and fails closed. The cases
+        # the prefilters used to cover still resolve correctly -- a directory
+        # or submodule entry opens but is not a zip, and a broken or
+        # symlinked path fails to open at all.
         members = plan_members(path)
         if members:
             offenders.append((path, members))

--- a/scripts/check_no_terraform_plans.py
+++ b/scripts/check_no_terraform_plans.py
@@ -111,7 +111,10 @@ def _members_of(source: Path | io.BytesIO | io.BufferedReader) -> list[str]:
     except (zipfile.BadZipFile, OSError):
         return []
 
-    return sorted({name for name in names if Path(name).name in PLAN_MEMBERS})
+    # Only the base name is returned, never the archive path it sat under.
+    # The directory part is attacker-chosen text and `report()` prints into
+    # public CI logs; the base name is one of PLAN_MEMBERS and so is safe.
+    return sorted({Path(name).name for name in names if Path(name).name in PLAN_MEMBERS})
 
 
 def damaged_plan_members(data: bytes) -> list[str]:

--- a/scripts/check_no_terraform_plans.py
+++ b/scripts/check_no_terraform_plans.py
@@ -152,7 +152,25 @@ ALLOWLIST_PATHSPECS = (
     "data/.gitkeep",
     "data/external/**/provenance.json",
     "data/external/**/*.provenance.json",
+    # `**/` requires at least one directory below `external`, but the
+    # workflow's `(.*/)?` also allows the sidecar to sit directly there.
+    "data/external/provenance.json",
+    "data/external/*.provenance.json",
 )
+
+# The keys a .dvc file may carry. Anything else is unrecognised content, and
+# unrecognised content in an allowlisted file is the whole hazard: a pointer
+# is exempt from the data rules because of what it is, so anything that is not
+# that has to be refused rather than ignored.
+DVC_TOP_LEVEL_KEYS = frozenset(
+    {"outs", "deps", "cmd", "wdir", "md5", "frozen", "meta", "desc",
+     "params", "always_changed", "stage"}
+)
+DVC_ENTRY_KEYS = frozenset(
+    {"md5", "hash", "etag", "checksum", "path", "size", "nfiles", "isexec",
+     "remote", "cache", "persist", "desc", "files", "push"}
+)
+BLOCK_SCALARS = frozenset({"|", ">", "|-", ">-", "|+", ">+"})
 
 
 def _ls_files_entries(pathspecs: tuple[str, ...]) -> list[tuple[Path, str]]:
@@ -201,46 +219,69 @@ def blob_size(sha: str) -> int:
 def dvc_pointer_problem(text: str) -> str | None:
     """Why ``text`` is not a DVC pointer, or ``None`` if it is one.
 
-    Parsed structurally rather than searched. A substring test for ``outs:``
-    passes any prose that happens to contain those bytes, which is no test at
-    all. Deliberately hand-rolled: this module is stdlib-only so the hook runs
-    before any `uv sync`, and PyYAML is not available to it.
+    Parsed structurally rather than searched, and closed rather than lenient:
+    every line must be recognised. A substring test for ``outs:`` passes any
+    prose containing those bytes, and merely finding a well-formed ``outs``
+    entry is not enough either -- a pointer that also carries ``raw: |`` and
+    an indented block of citizen text is still a file smuggled into an
+    allowlisted name. So unknown top-level keys, unknown entry keys, block
+    scalars and any indented line outside a list are all refused.
 
-    A pointer is a YAML mapping with a top-level ``outs:`` list whose items
-    carry a ``path`` and a hash. Nothing else at top level is required, but
-    every line must fit that shape.
+    Deliberately hand-rolled: this module is stdlib-only so the hook runs
+    before any `uv sync`, and PyYAML is not available to it. Being strict
+    about shape is the right trade for a guard that must run everywhere.
     """
     lines = [line.rstrip() for line in text.splitlines() if line.strip()]
     if not lines:
         return "empty"
 
-    if not any(line == "outs:" for line in lines):
-        return "no top-level `outs:` list"
-
     items: list[dict[str, str]] = []
     current: dict[str, str] | None = None
-    in_outs = False
+    list_key: str | None = None
+
     for line in lines:
-        if not line.startswith((" ", "-")):  # a top-level key
-            in_outs = line == "outs:"
-            current = None
-            if ":" not in line:
-                return f"not a YAML mapping at {line!r}"
-            continue
-        if not in_outs:
-            continue
         stripped = line.strip()
+        indented = line[:1].isspace()
+
+        if not indented and not stripped.startswith("-"):
+            key, sep, value = stripped.partition(":")
+            if not sep:
+                return f"not a YAML mapping at {line!r}"
+            key = key.strip()
+            if key not in DVC_TOP_LEVEL_KEYS:
+                return f"unexpected top-level key {key!r}"
+            if value.strip() in BLOCK_SCALARS:
+                return f"block scalar not allowed at {key!r}"
+            list_key = key if key in {"outs", "deps"} and not value.strip() else None
+            current = None
+            continue
+
+        if list_key is None:
+            return f"unexpected content at {line!r}"
+
         if stripped.startswith("- "):
             current = {}
-            items.append(current)
+            if list_key == "outs":
+                items.append(current)
             stripped = stripped[2:]
-        if current is None or ":" not in stripped:
-            return f"not a pointer entry at {line!r}"
-        key, _, value = stripped.partition(":")
-        current[key.strip()] = value.strip()
+        elif stripped.startswith("-"):
+            return f"malformed list item at {line!r}"
+
+        if current is None:
+            return f"unexpected content at {line!r}"
+
+        key, sep, value = stripped.partition(":")
+        if not sep:
+            return f"not a key at {line!r}"
+        key = key.strip()
+        if key not in DVC_ENTRY_KEYS:
+            return f"unexpected key {key!r} in an entry"
+        if value.strip() in BLOCK_SCALARS:
+            return f"block scalar not allowed at {key!r}"
+        current[key] = value.strip()
 
     if not items:
-        return "`outs:` list is empty"
+        return "no `outs:` entries"
     for item in items:
         if "path" not in item:
             return "an `outs:` entry has no `path`"

--- a/scripts/check_no_terraform_plans.py
+++ b/scripts/check_no_terraform_plans.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import argparse
 import io
+import os
 import subprocess
 import sys
 import zipfile
@@ -70,7 +71,55 @@ def tracked_files() -> list[Path]:
     return [Path(name) for name in out.decode("utf-8").split("\0") if name]
 
 
-def _members_of(source: Path | io.BytesIO) -> list[str]:
+def _open_nofollow(path: Path) -> int | None:
+    """Open ``path`` for reading, refusing a symlink at *any* component.
+
+    ``Path.is_symlink()`` only describes the final component, so it does not
+    see an ancestor that has been replaced by a link: with the index still
+    listing ``public/payload`` and the worktree holding ``public -> data``,
+    ``public/payload`` is not a symlink and opening it reads ``data/payload``
+    straight through the ``:(exclude)data/**`` pathspec.
+
+    Walking the components with ``O_NOFOLLOW`` closes that, and closes it
+    without a race: each directory is opened relative to the previous one, so
+    there is no window between deciding a path is safe and opening it.
+    """
+    parts = path.parts
+    if not parts:
+        return None
+    if path.is_absolute():
+        start, parts = parts[0], parts[1:]
+    else:
+        start = "."
+    if not parts:
+        return None
+
+    try:
+        dir_fd = os.open(start, os.O_RDONLY | os.O_DIRECTORY)
+    except OSError:
+        return None
+
+    try:
+        for component in parts[:-1]:
+            try:
+                nxt = os.open(
+                    component,
+                    os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+                    dir_fd=dir_fd,
+                )
+            except OSError:
+                return None
+            os.close(dir_fd)
+            dir_fd = nxt
+        try:
+            return os.open(parts[-1], os.O_RDONLY | os.O_NOFOLLOW, dir_fd=dir_fd)
+        except OSError:
+            return None
+    finally:
+        os.close(dir_fd)
+
+
+def _members_of(source: Path | io.BytesIO | io.BufferedReader) -> list[str]:
     """Plan-archive entry names in ``source``, which may be a path or bytes."""
     try:
         with zipfile.ZipFile(source) as archive:
@@ -85,15 +134,24 @@ def _members_of(source: Path | io.BytesIO) -> list[str]:
 
 
 def plan_members(path: Path) -> list[str]:
-    """Entry names identifying ``path`` as a Terraform plan archive, if any."""
-    try:
-        with path.open("rb") as handle:
-            if handle.read(4) != ZIP_MAGIC:
-                return []
-    except OSError:
+    """Entry names identifying ``path`` as a Terraform plan archive, if any.
+
+    Opened through :func:`_open_nofollow`, so a symlink anywhere in the path
+    yields no members rather than a read of whatever it points at.
+    """
+    fd = _open_nofollow(path)
+    if fd is None:
         return []
 
-    return _members_of(path)
+    try:
+        with os.fdopen(fd, "rb") as handle:
+            if handle.read(4) != ZIP_MAGIC:
+                return []
+            handle.seek(0)
+            return _members_of(handle)
+    except OSError:
+        # Directories and unreadable entries land here; neither is an archive.
+        return []
 
 
 def plan_members_of_blob(data: bytes) -> list[str]:
@@ -196,13 +254,13 @@ def main(argv: list[str] | None = None) -> int:
 
     offenders: list[tuple[Path, list[str]]] = []
     for path in tracked_files():
-        # Symlinks are skipped before anything opens them, and that is a
-        # data-policy requirement rather than tidiness: `is_file()` follows
-        # the link, so a tracked link outside data/ whose target is inside it
-        # would be read straight through the pathspec exclusion. Nothing is
-        # lost -- git stores the link text, not the pointed-to bytes, so a
-        # symlink is never itself the committed plan archive. The archive, if
-        # tracked, appears under its own path and is scanned there.
+        # Cheap pre-filters only. The guarantee that nothing is read through
+        # a link lives in `_open_nofollow`, which checks every component --
+        # `is_symlink()` describes just the last one, and an ancestor
+        # replaced by a link is the case that reached data/. Nothing is lost
+        # by skipping links: git stores the link text, not the pointed-to
+        # bytes, so a symlink is never itself the committed archive, which is
+        # scanned at its own path.
         if path.is_symlink():
             continue
         if not path.is_file():  # submodule entries, broken links

--- a/scripts/check_no_terraform_plans.py
+++ b/scripts/check_no_terraform_plans.py
@@ -275,7 +275,7 @@ def _scalar_problem(key: str, value: str) -> str | None:
     return f"{key!r} has no value rule in this checker"
 
 
-def dvc_pointer_problem(text: str) -> str | None:
+def dvc_pointer_problem(text: str, stem: str | None = None) -> str | None:
     """Why ``text`` is not a DVC pointer, or ``None`` if it is one.
 
     Parsed structurally rather than searched, and closed rather than lenient:
@@ -368,6 +368,16 @@ def dvc_pointer_problem(text: str) -> str | None:
             return "an `outs:` entry has no `path`"
         if not {"md5", "hash", "etag", "checksum"} & set(item):
             return "an `outs:` entry has no hash"
+        # A pointer names the file beside it: `foo.csv.dvc` tracks `foo.csv`.
+        # Tying `path` to the pointer's own stem is what stops the field being
+        # a free string -- a path syntactically fine but carrying citizen
+        # information, `Ram-Kumar-9876543210`, has nowhere to sit, because the
+        # only accepted value is a name the filename already carries and the
+        # naming policy already governs. All 23 pointers in this repository
+        # satisfy it, which is DVC's own convention rather than a rule
+        # invented here.
+        if stem is not None and item["path"] != stem:
+            return "an `outs:` entry does not name the file beside it"
     return None
 
 
@@ -400,7 +410,11 @@ def allowlisted_offenders(
             continue
 
         if size > ALLOWLISTED_MAX_BYTES:
-            offenders.append((path, [f"{size} bytes, far larger than {name} should be"]))
+            # No filename in the reason: report() redacts the path field, and
+            # a name interpolated here would walk straight past that.
+            offenders.append(
+                (path, [f"{size} bytes, over the {ALLOWLISTED_MAX_BYTES}-byte cap"])
+            )
             continue
 
         data = blob_bytes(sha)
@@ -419,7 +433,7 @@ def allowlisted_offenders(
             continue
 
         if name.endswith(".dvc"):
-            problem = dvc_pointer_problem(text)
+            problem = dvc_pointer_problem(text, stem=name[: -len(".dvc")])
             if problem:
                 offenders.append((path, [f"not a DVC pointer: {problem}"]))
         else:  # provenance sidecar
@@ -540,22 +554,43 @@ def in_public_log() -> bool:
     return bool(os.environ.get("GITHUB_ACTIONS") or os.environ.get("CI"))
 
 
+# Directory names DVC and this repository create, which carry no citizen
+# information and are worth keeping in a message so it says where to look.
+SAFE_DATA_DIRS = frozenset({"data", "raw", "external", "clean", "interim", "processed"})
+
+
+def _redact(component: str) -> str:
+    return f"<redacted:{hashlib.sha256(component.encode('utf-8')).hexdigest()[:12]}>"
+
+
 def safe_path(path: Path) -> str:
     """A printable form of ``path``, redacted when the log is public.
 
-    A filename under ``data/`` can itself be the disclosure --
-    ``data/raw/Ram-Kumar-9876543210.dvc`` names a citizen in the path rather
-    than in the contents. In CI the directory and suffix are kept, since they
-    say what kind of file is wrong and where, and the stem becomes a digest of
-    itself so the author can identify it locally without it being published.
+    A path can be the disclosure on its own, in the leaf --
+    ``data/raw/Ram-Kumar-9876543210.dvc`` -- or in a directory above it --
+    ``data/raw/Ram-Kumar-9876543210/file.dvc``. So every component under
+    ``data/`` is redacted unless it is one of the fixed directory names this
+    repository and DVC create, which say where to look and carry nothing.
 
-    Paths outside ``data/`` are printed whole. They are source paths, they are
-    not protected, and a reviewer needs to read them.
+    The leaf keeps its suffix, which says what kind of file is wrong, and the
+    author can recompute `sha256(component)[:12]` locally to identify it.
+
+    Paths outside ``data/`` print whole: they are source paths, they are not
+    protected, and a reviewer has to be able to read them.
     """
     if path.parts[:1] != ("data",) or not in_public_log():
         return str(path)
-    digest = hashlib.sha256(path.name.encode("utf-8")).hexdigest()[:12]
-    return f"{path.parent}/<redacted:{digest}>{path.suffix}"
+
+    parts = []
+    for index, component in enumerate(path.parts):
+        if component in SAFE_DATA_DIRS:
+            parts.append(component)
+            continue
+        if index == len(path.parts) - 1:
+            parts.append(f"{_redact(Path(component).stem)}{Path(component).suffix}")
+        else:
+            parts.append(_redact(component))
+    return "/".join(parts)
 
 
 def report(offenders: list[tuple[Path, list[str]]]) -> int:
@@ -588,9 +623,10 @@ def report(offenders: list[tuple[Path, list[str]]]) -> int:
             "Files under data/ are exempt from the data rules only for what "
             "they are: an empty marker, a DVC pointer, or a provenance "
             "sidecar. Anything else there is refused. Rejected content is "
-            "withheld on purpose, and in CI the filename is shown as "
-            "`sha256(name)[:12]` because a name under data/ can itself be "
-            "the disclosure: these logs are public."
+            "withheld on purpose, and in CI each protected path component is "
+            "shown as `sha256(component)[:12]` -- the leaf keeps its "
+            "suffix -- because a name under data/ can itself be the "
+            "disclosure: these logs are public."
         )
     return 1
 

--- a/scripts/check_no_terraform_plans.py
+++ b/scripts/check_no_terraform_plans.py
@@ -86,7 +86,16 @@ def plan_members(path: Path) -> list[str]:
 def main() -> int:
     offenders: list[tuple[Path, list[str]]] = []
     for path in tracked_files():
-        if not path.is_file():  # submodule entries, broken symlinks
+        # Symlinks are skipped before anything opens them, and that is a
+        # data-policy requirement rather than tidiness: `is_file()` follows
+        # the link, so a tracked link outside data/ whose target is inside it
+        # would be read straight through the pathspec exclusion. Nothing is
+        # lost -- git stores the link text, not the pointed-to bytes, so a
+        # symlink is never itself the committed plan archive. The archive, if
+        # tracked, appears under its own path and is scanned there.
+        if path.is_symlink():
+            continue
+        if not path.is_file():  # submodule entries, broken links
             continue
         members = plan_members(path)
         if members:

--- a/scripts/check_no_terraform_plans.py
+++ b/scripts/check_no_terraform_plans.py
@@ -191,13 +191,33 @@ DVC_TOP_LEVEL_KEYS = frozenset({"outs", "deps", "wdir", "md5", "frozen"})
 # Keys that introduce a list rather than carrying a scalar.
 DVC_LIST_KEYS = frozenset({"outs", "deps"})
 DVC_ENTRY_KEYS = frozenset(
-    {"md5", "hash", "etag", "checksum", "path", "size", "nfiles", "isexec",
-     "remote", "cache", "persist", "push"}
+    {"md5", "sha1", "sha256", "hash", "etag", "checksum", "path", "size",
+     "nfiles", "isexec", "remote", "cache", "persist", "push"}
 )
 
 # Every accepted value has a shape. Checked by pattern, so a field cannot be
 # used as a container for something else.
-HEXISH = re.compile(r"\A[0-9a-fA-F]{8,64}(\.dir)?\Z")
+# Exact widths per algorithm. An 8-to-64 range accepted `md5: 9876543210`,
+# which is a mobile number that happens to be hex, and which then also
+# satisfied the "an entry has a hash" requirement.
+CHECKSUM_WIDTHS = {
+    "md5": (32,),
+    "sha1": (40,),
+    "sha256": (64,),
+    "etag": (32, 64),
+    "checksum": (32, 64),
+}
+
+
+def _checksum_problem(key: str, value: str) -> str | None:
+    body = value[:-4] if value.endswith(".dir") else value
+    widths = CHECKSUM_WIDTHS[key]
+    if len(body) not in widths:
+        expected = " or ".join(str(width) for width in widths)
+        return f"{key!r} is {len(body)} hex characters, expected {expected}"
+    if not all(character in "0123456789abcdefABCDEF" for character in body):
+        return f"{key!r} is not hexadecimal"
+    return None
 TOKEN = re.compile(r"\A[A-Za-z0-9_.-]{1,64}\Z")
 # The algorithms DVC actually writes. A generic token accepted prose.
 HASH_NAMES = frozenset({"md5", "sha256", "sha1", "etag", "checksum", "crc32"})
@@ -266,8 +286,8 @@ def _scalar_problem(key: str, value: str) -> str | None:
     if any(ord(ch) < 32 for ch in value):
         return f"{key!r} contains control characters"
 
-    if key in {"md5", "etag", "checksum"}:
-        return None if HEXISH.match(value) else f"{key!r} is not a checksum"
+    if key in CHECKSUM_WIDTHS:
+        return _checksum_problem(key, value)
     if key == "hash":
         return None if value in HASH_NAMES else f"{key!r} is not a DVC hash name"
     if key in {"size", "nfiles"}:
@@ -378,8 +398,10 @@ def dvc_pointer_problem(text: str, stem: str | None = None) -> str | None:
     for item in items:
         if "path" not in item:
             return "an `outs:` entry has no `path`"
-        if not {"md5", "hash", "etag", "checksum"} & set(item):
-            return "an `outs:` entry has no hash"
+        # The digest-bearing keys are exactly the ones with a width rule;
+        # `hash` names the algorithm rather than carrying a digest.
+        if not set(CHECKSUM_WIDTHS) & set(item):
+            return "an `outs:` entry has no checksum"
         # A pointer names the file beside it: `foo.csv.dvc` tracks `foo.csv`.
         # Tying `path` to the pointer's own stem is what stops the field being
         # a free string -- a path syntactically fine but carrying citizen
@@ -431,9 +453,15 @@ def allowlisted_offenders(
         # shapes are decidable, and they are the ones that make a filename a
         # disclosure on its own. Names that get past this are still never
         # printed to a public log: see `safe_path`.
-        if IDENTIFIER_RUN.search(name):
+        identifier_in = [
+            component for component in path.parts if IDENTIFIER_RUN.search(component)
+        ]
+        if identifier_in:
+            # Every component, not just the leaf: `data/raw/9876543210/x.dvc`
+            # puts the number in a directory. The reason names neither the
+            # component nor the digits.
             offenders.append(
-                (path, ["the filename contains a 9+ digit identifier"])
+                (path, ["a path component contains a 9+ digit identifier"])
             )
             continue
 

--- a/scripts/check_no_terraform_plans.py
+++ b/scripts/check_no_terraform_plans.py
@@ -126,8 +126,15 @@ def staged_entries() -> list[tuple[Path, str]]:
     if not paths:
         return []
 
+    # `--literal-pathspecs` because these are filenames, not pathspecs we
+    # wrote. Without it a staged file whose *name* is pathspec magic is
+    # reinterpreted rather than selected, and it fails both ways: a plan named
+    # `:(exclude,glob)**` excludes itself and passes the scan, while a file
+    # named `:(glob)**` re-includes paths this check must never open,
+    # `data/` among them. The exclusion above is ours and keeps its magic;
+    # it runs in a separate call for exactly that reason.
     listing = subprocess.run(
-        ["git", "ls-files", "-s", "-z", "--", *paths],
+        ["git", "--literal-pathspecs", "ls-files", "-s", "-z", "--", *paths],
         check=True,
         capture_output=True,
     ).stdout

--- a/scripts/check_provenance_sidecars.py
+++ b/scripts/check_provenance_sidecars.py
@@ -1268,14 +1268,15 @@ def check_payload(payload: Any) -> list[str]:
     return ["unrecognized provenance schema_version"]
 
 
-def check_file(path: Path) -> list[str]:
-    size = path.stat().st_size
-    if size > MAX_BYTES:
-        return [f"{size} bytes exceeds the {MAX_BYTES}-byte metadata cap"]
-    try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError as exc:
-        return [f"not valid JSON ({exc})"]
+def check_document(path: Path, payload: Any) -> list[str]:
+    """Check an already-parsed sidecar, given the path it is stored at.
+
+    Split out of :func:`check_file` so a caller holding the bytes -- the
+    pre-commit path in `check_no_terraform_plans.py` reads staged blobs, which
+    are not on disk -- gets the same verdict rather than a second, laxer one.
+    The location matters to the verdict, which is why the path is a parameter:
+    the legacy root sidecar is allowed to carry no `schema_version`.
+    """
     parts = path.parts
     for index in range(len(parts) - 1):
         if parts[index : index + 2] != ("data", "external"):
@@ -1295,6 +1296,17 @@ def check_file(path: Path) -> list[str]:
             ]
         break
     return check_payload(payload)
+
+
+def check_file(path: Path) -> list[str]:
+    size = path.stat().st_size
+    if size > MAX_BYTES:
+        return [f"{size} bytes exceeds the {MAX_BYTES}-byte metadata cap"]
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return [f"not valid JSON ({exc})"]
+    return check_document(path, payload)
 
 
 def main() -> int:

--- a/tests/test_check_no_terraform_plans.py
+++ b/tests/test_check_no_terraform_plans.py
@@ -275,12 +275,29 @@ def test_the_regex_alone_would_have_missed_it(tmp_path):
 # ---------------------------------------------------------------------------
 
 
+def _local_env() -> dict[str, str]:
+    """The environment the pre-commit hook actually runs in.
+
+    `CI` and `GITHUB_ACTIONS` are set on a runner, and `safe_path` redacts
+    protected filenames when they are. Tests of the *hook* have to state that
+    they are local, or they assert one thing on a laptop and another in
+    Actions -- which is exactly how these two got through review and failed
+    in CI.
+    """
+    return {
+        key: value
+        for key, value in os.environ.items()
+        if key not in {"CI", "GITHUB_ACTIONS"}
+    }
+
+
 def _run_staged(repo: Path) -> subprocess.CompletedProcess:
     return subprocess.run(
         [sys.executable, str(SCRIPT), "--staged"],
         cwd=repo,
         capture_output=True,
         text=True,
+        env=_local_env(),
     )
 
 
@@ -973,7 +990,11 @@ def test_a_sidecar_path_with_a_space_is_still_checked(tmp_path):
     _git(repo, "add", "-f", "data/external/my sidecar.provenance.json")
 
     result = subprocess.run(
-        ["git", "commit", "-m", "sidecar"], cwd=repo, capture_output=True, text=True
+        ["git", "commit", "-m", "sidecar"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        env=_local_env(),
     )
 
     assert result.returncode != 0, result.stdout + result.stderr
@@ -1143,9 +1164,12 @@ def test_the_same_run_names_the_file_locally(tmp_path):
     _git(repo, "add", "-f", "data/raw/Ram-Kumar-9876543210.dvc")
     _git(repo, "commit", "-qm", "named")
 
-    env = {k: v for k, v in os.environ.items() if k not in {"CI", "GITHUB_ACTIONS"}}
     result = subprocess.run(
-        [sys.executable, str(SCRIPT)], cwd=repo, capture_output=True, text=True, env=env
+        [sys.executable, str(SCRIPT)],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        env=_local_env(),
     )
 
     assert result.returncode == 1

--- a/tests/test_check_no_terraform_plans.py
+++ b/tests/test_check_no_terraform_plans.py
@@ -119,6 +119,29 @@ def test_this_repository_currently_passes():
     assert result.returncode == 0, result.stdout
 
 
+def test_tracked_files_never_returns_anything_under_data(monkeypatch):
+    """Codex P1 on #321: the scan opens every path it is handed.
+
+    AGENTS.md forbids reading anything under `data/` without explicit
+    per-path permission, and the repository tracks .dvc pointers and
+    provenance sidecars there. Nothing is lost by excluding it: the workflow
+    step before this one already rejects any tracked file under `data/` that
+    is not one of those, so a plan archive hidden there fails a step earlier.
+    """
+    monkeypatch.chdir(SCRIPT.parents[1])
+    files = tracked_files()
+    offenders = [f for f in files if str(f).startswith("data/")]
+    assert offenders == [], f"scan would open protected paths: {offenders[:5]}"
+    # Not vacuous: the repository does track files under data/.
+    tracked_under_data = subprocess.run(
+        ["git", "ls-files", "--", "data/"],
+        cwd=SCRIPT.parents[1], capture_output=True, text=True, check=True,
+    ).stdout.split()
+    assert tracked_under_data, "fixture assumption broken: nothing tracked under data/"
+    # And the rest of the tree is still scanned.
+    assert Path("pyproject.toml") in files
+
+
 def test_tracked_files_reads_the_git_index(monkeypatch):
     monkeypatch.chdir(SCRIPT.parents[1])
     files = tracked_files()

--- a/tests/test_check_no_terraform_plans.py
+++ b/tests/test_check_no_terraform_plans.py
@@ -1751,3 +1751,52 @@ def test_the_boundary_rule_never_costs_a_real_detection():
 
     for cut in (10, 20, 30, 40, 50, 60):
         assert plan_members_of_blob(data[: len(data) - cut]) == ["tfstate"], cut
+
+
+# ---------------------------------------------------------------------------
+# Codex P1 on #321: gating on offset zero let a plan with any leading bytes
+# through. A self-extracting archive carries a stub, and zipfile opens it.
+# ---------------------------------------------------------------------------
+
+
+STUB = b"MZ" + b"\x00" * 200
+
+
+def test_a_plan_behind_a_leading_stub_is_still_found():
+    # The direction that matters: this was a miss, not a false positive.
+    data = STUB + _zip_of(("tfstate", '{"serial": 1}'))
+
+    assert plan_members_of_blob(data) == ["tfstate"]
+
+
+def test_a_stubbed_plan_is_found_when_truncated_too():
+    data = STUB + _zip_of(("tfstate", '{"serial": 1}'))
+
+    assert plan_members_of_blob(data[: len(data) - 40]) == ["tfstate"]
+
+
+def test_a_stub_does_not_make_an_ordinary_archive_a_plan():
+    data = STUB + _zip_of(("ppt/presentation.xml", "<p/>"))
+
+    assert plan_members_of_blob(data) == []
+
+
+def test_a_stubbed_plan_is_refused_by_both_scans(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    (repo / "artifact.bin").write_bytes(STUB + _zip_of(("tfstate", '{"serial": 1}')))
+    _git(repo, "add", "artifact.bin")
+
+    staged = _run_staged(repo)
+    assert staged.returncode == 1
+
+    _git(repo, "commit", "-qm", "stubbed")
+    monkeypatch.chdir(repo)
+    assert main() == 1
+
+
+def test_the_signature_constant_is_not_duplicated():
+    # ZIP_MAGIC and the local file header signature are the same four bytes,
+    # and were defined twice under two names.
+    source = SCRIPT.read_text()
+
+    assert source.count('= b"PK\\x03\\x04"') == 1

--- a/tests/test_check_no_terraform_plans.py
+++ b/tests/test_check_no_terraform_plans.py
@@ -819,3 +819,45 @@ def test_the_real_repository_pointers_still_validate():
         text=True,
     )
     assert result.returncode == 0, result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Codex P1 on #321, follow-up: recognising a key says nothing about its value,
+# and JSON syntax says nothing about a sidecar's schema.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text, expected_ok",
+    [
+        ("outs:\n- md5: abc\n  path: thing\ncmd: dvc repro\n", True),
+        # Prose does not survive the scalar cap, per the sidecar checker.
+        ("outs:\n- md5: abc\n  path: thing\ncmd: " + "x" * 201 + "\n", False),
+        ("outs:\n- md5: abc\n  path: " + "y" * 201 + "\n", False),
+        ("outs:\n- md5: abc\n  path: thing\ndesc: " + "z" * 250 + "\n", False),
+    ],
+)
+def test_recognised_fields_still_bound_their_values(text, expected_ok):
+    assert (dvc_pointer_problem(text) is None) is expected_ok
+
+
+def test_the_scalar_cap_reports_by_length_never_by_content():
+    # This runs in CI, whose logs are public: refusing to publish something
+    # and then printing it defeats the gate.
+    secret = "Ram Kumar 9876543210 Sambalpur " * 10
+    problem = dvc_pointer_problem(f"outs:\n- md5: a\n  path: p\ncmd: {secret}\n")
+
+    assert problem is not None
+    assert "Ram Kumar" not in problem
+    assert "9876543210" not in problem
+    assert "characters" in problem
+
+
+def test_pre_commit_runs_the_provenance_schema_check():
+    hook = (
+        Path(__file__).resolve().parents[1] / ".githooks" / "pre-commit"
+    ).read_text()
+    assert "check_provenance_sidecars.py" in hook
+    # The staged blob, not the worktree file: those differ once a file is
+    # staged and then edited.
+    assert "cat-file blob" in hook

--- a/tests/test_check_no_terraform_plans.py
+++ b/tests/test_check_no_terraform_plans.py
@@ -23,6 +23,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from scripts.check_no_terraform_plans import (  # noqa: E402
     _members_of,
     main,
+    pointer_offenders,
+    tracked_pointer_entries,
     plan_members_of_blob,
     tracked_entries,
 )
@@ -568,3 +570,78 @@ def test_pre_commit_matches_the_workflow_filename_patterns():
     for pattern in ("terraform\\.tfstate", "terraform\\.tfvars", "\\.tfplan", "\\.pem"):
         assert pattern in hook, pattern
         assert pattern in workflow, pattern
+
+
+# ---------------------------------------------------------------------------
+# Codex P1 on #321: excluding data/ from the content scan left a hole, because
+# the raw-data allowlist accepts any name ending `.dvc` without checking what
+# it is, and .gitignore un-ignores data/raw/*.dvc.
+# ---------------------------------------------------------------------------
+
+
+def _pointer(path: Path) -> Path:
+    path.write_text("outs:\n- md5: d41d8cd98f00b204e9800998ecf8427e\n  path: thing\n")
+    return path
+
+
+def test_a_plan_committed_as_a_dvc_pointer_is_caught(tmp_path, monkeypatch):
+    # Reproduced on 5d266b1: this file passed the workflow's raw-data
+    # predicate and the content scan alike, carrying account id and SSH
+    # ingress CIDRs into history.
+    repo = _repo(tmp_path)
+    (repo / "data" / "raw").mkdir(parents=True)
+    _plan_archive(repo / "data" / "raw" / "saved.dvc", ("tfstate",))
+    _git(repo, "add", "-f", "data/raw/saved.dvc")
+    _git(repo, "commit", "-qm", "pointer")
+
+    monkeypatch.chdir(repo)
+    assert main() == 1
+
+
+def test_the_same_file_is_refused_before_the_commit(tmp_path):
+    repo = _repo(tmp_path)
+    (repo / "data" / "raw").mkdir(parents=True)
+    _plan_archive(repo / "data" / "raw" / "saved.dvc", ("tfstate",))
+    _git(repo, "add", "-f", "data/raw/saved.dvc")
+
+    result = _run_staged(repo)
+
+    assert result.returncode == 1
+    assert "saved.dvc" in result.stdout
+
+
+def test_a_genuine_pointer_passes(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    (repo / "data" / "raw").mkdir(parents=True)
+    _pointer(repo / "data" / "raw" / "thing.dvc")
+    _git(repo, "add", "-f", "data/raw/thing.dvc")
+    _git(repo, "commit", "-qm", "pointer")
+
+    monkeypatch.chdir(repo)
+    assert main() == 0
+    assert pointer_offenders(tracked_pointer_entries()) == []
+
+
+def test_a_file_too_large_to_be_a_pointer_is_refused_unread(tmp_path, monkeypatch):
+    # Refused on `git cat-file -s` alone, so no bulk file under data/ is read.
+    repo = _repo(tmp_path)
+    (repo / "data" / "raw").mkdir(parents=True)
+    (repo / "data" / "raw" / "big.dvc").write_bytes(b"outs:\n" + b"x" * 200_000)
+    _git(repo, "add", "-f", "data/raw/big.dvc")
+    _git(repo, "commit", "-qm", "big")
+
+    monkeypatch.chdir(repo)
+    offenders = pointer_offenders(tracked_pointer_entries())
+    assert [str(p) for p, _ in offenders] == ["data/raw/big.dvc"]
+    assert "larger than a DVC pointer" in offenders[0][1][0]
+
+
+def test_a_dvc_name_holding_something_else_entirely_is_refused(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    (repo / "data" / "raw").mkdir(parents=True)
+    (repo / "data" / "raw" / "notes.dvc").write_text("just some text\n")
+    _git(repo, "add", "-f", "data/raw/notes.dvc")
+    _git(repo, "commit", "-qm", "notes")
+
+    monkeypatch.chdir(repo)
+    assert main() == 1

--- a/tests/test_check_no_terraform_plans.py
+++ b/tests/test_check_no_terraform_plans.py
@@ -641,7 +641,7 @@ def test_a_file_too_large_to_be_a_pointer_is_refused_unread(tmp_path, monkeypatc
     monkeypatch.chdir(repo)
     offenders = allowlisted_offenders(tracked_allowlisted_entries())
     assert [str(p) for p, _ in offenders] == ["data/raw/big.dvc"]
-    assert "far larger than" in offenders[0][1][0]
+    assert "over the" in offenders[0][1][0]
 
 
 def test_a_dvc_name_holding_something_else_entirely_is_refused(tmp_path, monkeypatch):
@@ -1124,7 +1124,9 @@ def test_a_protected_filename_is_redacted_in_ci(tmp_path, monkeypatch):
     # Still says where and what kind, and stays identifiable locally.
     assert "data/raw/" in result.stdout
     assert ".dvc" in result.stdout
-    digest = hashlib.sha256(b"Ram-Kumar-9876543210.dvc").hexdigest()[:12]
+    # The stem is hashed and the suffix kept, so the message still says
+    # what kind of file is wrong.
+    digest = hashlib.sha256(b"Ram-Kumar-9876543210").hexdigest()[:12]
     assert digest in result.stdout
 
 
@@ -1154,3 +1156,97 @@ def test_source_paths_outside_data_are_never_redacted(monkeypatch):
     assert safe_path(Path("deploy/terraform/tfplan")) == "deploy/terraform/tfplan"
     assert safe_path(Path("scripts/thing.py")) == "scripts/thing.py"
     assert "<redacted:" in safe_path(Path("data/raw/x.dvc"))
+
+
+# ---------------------------------------------------------------------------
+# Codex P1 on #321, the class rather than the instance. Protected text reached
+# the public log three ways in turn: a quoted source line, an archive member's
+# directory, and a filename. This pins the property instead.
+# ---------------------------------------------------------------------------
+
+
+CITIZEN = "Ram-Kumar-9876543210"
+
+
+def test_no_protected_text_reaches_a_public_log_by_any_route(tmp_path):
+    # Every channel at once: the token is in a directory name, in a leaf
+    # filename, inside file contents, and inside a zip member's path.
+    repo = _repo(tmp_path)
+    nested = repo / "data" / "raw" / CITIZEN
+    nested.mkdir(parents=True)
+    (nested / "file.dvc").write_text(f"{CITIZEN}: prose\n")
+    (repo / "data" / "raw" / f"{CITIZEN}.dvc").write_text(f"note {CITIZEN}\n")
+    (repo / "data" / "raw" / ".gitkeep").write_text(f"{CITIZEN}\n")
+    _plan_archive(repo / "data" / "raw" / "arch.dvc", (f"{CITIZEN}/tfstate",))
+    _git(repo, "add", "-Af")
+    _git(repo, "commit", "-qm", "all channels")
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "GITHUB_ACTIONS": "true"},
+    )
+
+    assert result.returncode == 1
+    combined = result.stdout + result.stderr
+    for token in (CITIZEN, "Ram-Kumar", "9876543210", "Ram Kumar"):
+        assert token not in combined, f"{token!r} leaked:\n{combined}"
+    # Still useful: says where to look and what kind of file.
+    assert "data/raw" in combined
+    assert "<redacted:" in combined
+
+
+def test_a_protected_directory_name_is_redacted(monkeypatch):
+    from scripts.check_no_terraform_plans import safe_path
+
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    shown = safe_path(Path("data/raw") / CITIZEN / "file.dvc")
+
+    assert CITIZEN not in shown
+    assert shown.startswith("data/raw/")
+    assert shown.endswith(".dvc")
+
+
+def test_the_oversized_reason_carries_no_filename(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    (repo / "data" / "raw").mkdir(parents=True)
+    (repo / "data" / "raw" / f"{CITIZEN}.dvc").write_bytes(b"outs:\n" + b"x" * 200_000)
+    _git(repo, "add", "-f", f"data/raw/{CITIZEN}.dvc")
+    _git(repo, "commit", "-qm", "big")
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)], cwd=repo, capture_output=True, text=True,
+        env={**os.environ, "GITHUB_ACTIONS": "true"},
+    )
+
+    assert result.returncode == 1
+    assert CITIZEN not in result.stdout
+    assert "over the" in result.stdout
+
+
+@pytest.mark.parametrize(
+    "stem, path_value, expected_ok",
+    [
+        ("thing.csv", "thing.csv", True),
+        # A syntactically fine path that is not the file beside it. This is
+        # where citizen text without spaces used to sit.
+        ("thing.csv", "Ram-Kumar-9876543210", False),
+        ("thing.csv", "other.csv", False),
+    ],
+)
+def test_a_pointer_must_name_the_file_beside_it(stem, path_value, expected_ok):
+    text = f"outs:\n- md5: {_MD5}\n  path: {path_value}\n"
+    assert (dvc_pointer_problem(text, stem=stem) is None) is expected_ok
+
+
+def test_the_repositorys_own_pointers_satisfy_the_stem_rule():
+    # The rule is DVC's convention, not one invented here: all 23 pass.
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        cwd=SCRIPT.parents[1],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout

--- a/tests/test_check_no_terraform_plans.py
+++ b/tests/test_check_no_terraform_plans.py
@@ -697,12 +697,12 @@ def test_prose_containing_outs_is_not_a_pointer(tmp_path, monkeypatch):
 @pytest.mark.parametrize(
     "text, expected_ok",
     [
-        ("outs:\n- md5: abc\n  path: thing\n", True),
-        ("outs:\n- hash: md5\n  md5: abc\n  path: thing\n", True),
-        ("wdir: .\nouts:\n- md5: abc\n  path: thing\n", True),
+        ("outs:\n- md5: d41d8cd98f00b204e9800998ecf8427e\n  path: thing\n", True),
+        ("outs:\n- hash: md5\n  md5: d41d8cd98f00b204e9800998ecf8427e\n  path: thing\n", True),
+        ("wdir: .\nouts:\n- md5: d41d8cd98f00b204e9800998ecf8427e\n  path: thing\n", True),
         ("prose with outs: inside\n", False),
         ("outs:\n", False),
-        ("outs:\n- md5: abc\n", False),          # no path
+        ("outs:\n- md5: d41d8cd98f00b204e9800998ecf8427e\n", False),          # no path
         ("outs:\n- path: thing\n", False),        # no hash
         ("", False),
     ],
@@ -722,7 +722,10 @@ def test_a_corrupt_provenance_sidecar_is_caught(tmp_path, monkeypatch):
     assert main() == 1
 
 
-def test_a_valid_provenance_sidecar_passes(tmp_path, monkeypatch):
+def test_a_sidecar_is_judged_by_the_owning_schema_not_by_json_syntax(tmp_path, monkeypatch):
+    # `{"source": "x"}` is syntactically fine and schema-invalid. The check
+    # delegates to check_provenance_sidecars.check_payload rather than
+    # keeping a second, laxer notion of validity that would drift from it.
     repo = _repo(tmp_path)
     (repo / "data" / "external" / "thing").mkdir(parents=True)
     (repo / "data" / "external" / "thing" / "provenance.json").write_text('{"source": "x"}')
@@ -730,7 +733,9 @@ def test_a_valid_provenance_sidecar_passes(tmp_path, monkeypatch):
     _git(repo, "commit", "-qm", "sidecar")
 
     monkeypatch.chdir(repo)
-    assert main() == 0
+    assert main() == 1
+    # Real sidecars, which do satisfy the schema, are covered by
+    # test_the_real_repository_pointers_still_validate.
 
 
 def test_the_allowlist_pathspecs_cover_the_workflow_predicate():
@@ -784,7 +789,7 @@ def test_a_pointer_carrying_a_smuggled_block_is_refused(tmp_path, monkeypatch):
     repo = _repo(tmp_path)
     (repo / "data" / "raw").mkdir(parents=True)
     (repo / "data" / "raw" / "leak.dvc").write_text(
-        "outs:\n- md5: abc\n  path: thing\nraw: |\n  Ram Kumar, 9876543210, Sambalpur\n"
+        "outs:\n- md5: d41d8cd98f00b204e9800998ecf8427e\n  path: thing\nraw: |\n  Ram Kumar, 9876543210, Sambalpur\n"
     )
     _git(repo, "add", "-f", "data/raw/leak.dvc")
     _git(repo, "commit", "-qm", "leak")
@@ -797,15 +802,16 @@ def test_a_pointer_carrying_a_smuggled_block_is_refused(tmp_path, monkeypatch):
     "text, expected_ok",
     [
         # Accepted: the shapes DVC actually writes.
-        ("outs:\n- md5: abc\n  path: thing\n", True),
-        ("wdir: .\nouts:\n- md5: abc\n  path: thing\n  size: 12\n", True),
-        ("md5: abc\ncmd: echo hi\nouts:\n- md5: a\n  path: p\n"
-         "deps:\n- md5: b\n  path: q\n", True),
+        ("outs:\n- md5: d41d8cd98f00b204e9800998ecf8427e\n  path: thing\n", True),
+        ("wdir: .\nouts:\n- md5: d41d8cd98f00b204e9800998ecf8427e\n  path: thing\n  size: 12\n", True),
+        ("md5: d41d8cd98f00b204e9800998ecf8427e\nouts:\n"
+         "- md5: d41d8cd98f00b204e9800998ecf8427e\n  path: p\n"
+         "deps:\n- md5: d41d8cd98f00b204e9800998ecf8427e\n  path: q\n", True),
         # Refused: unrecognised content, in each place it can hide.
-        ("outs:\n- md5: abc\n  path: thing\nraw: |\n  secret\n", False),
-        ("outs:\n- md5: abc\n  path: thing\n  leaked: citizen\n", False),
+        ("outs:\n- md5: d41d8cd98f00b204e9800998ecf8427e\n  path: thing\nraw: |\n  secret\n", False),
+        ("outs:\n- md5: d41d8cd98f00b204e9800998ecf8427e\n  path: thing\n  leaked: citizen\n", False),
         ("outs: |\n  secret\n", False),
-        ("outs:\n- md5: abc\n  path: thing\nnotes: hello\n", False),
+        ("outs:\n- md5: d41d8cd98f00b204e9800998ecf8427e\n  path: thing\nnotes: hello\n", False),
     ],
 )
 def test_dvc_pointer_problem_is_closed_not_lenient(text, expected_ok):
@@ -832,22 +838,29 @@ def test_the_real_repository_pointers_still_validate():
 @pytest.mark.parametrize(
     "text, expected_ok",
     [
-        ("outs:\n- md5: abc\n  path: thing\ncmd: dvc repro\n", True),
-        # Prose does not survive the scalar cap, per the sidecar checker.
-        ("outs:\n- md5: abc\n  path: thing\ncmd: " + "x" * 201 + "\n", False),
-        ("outs:\n- md5: abc\n  path: " + "y" * 201 + "\n", False),
-        ("outs:\n- md5: abc\n  path: thing\ndesc: " + "z" * 250 + "\n", False),
+        ("outs:\n- md5: d41d8cd98f00b204e9800998ecf8427e\n  path: thing\n", True),
+        # Free-text fields are not accepted at all. A length cap cannot tell
+        # short citizen text from a legitimate description, so there is no
+        # field here in which prose is allowed.
+        ("outs:\n- md5: d41d8cd98f00b204e9800998ecf8427e\n  path: thing\ncmd: dvc repro\n", False),
+        ("outs:\n- md5: d41d8cd98f00b204e9800998ecf8427e\n  path: thing\ndesc: a note\n", False),
+        ("outs:\n- md5: d41d8cd98f00b204e9800998ecf8427e\n  path: thing\n  desc: a note\n", False),
+        # Values that are accepted have a shape.
+        ("outs:\n- md5: not-a-checksum\n  path: thing\n", False),
+        ("outs:\n- md5: d41d8cd98f00b204e9800998ecf8427e\n  path: thing\n  size: twelve\n", False),
+        ("outs:\n- md5: d41d8cd98f00b204e9800998ecf8427e\n  path: thing\n  isexec: maybe\n", False),
+        ("outs:\n- md5: d41d8cd98f00b204e9800998ecf8427e\n  path: " + "p" * 256 + "\n", False),
     ],
 )
-def test_recognised_fields_still_bound_their_values(text, expected_ok):
+def test_recognised_fields_are_typed_not_merely_named(text, expected_ok):
     assert (dvc_pointer_problem(text) is None) is expected_ok
 
 
-def test_the_scalar_cap_reports_by_length_never_by_content():
+def test_a_rejected_value_is_reported_by_shape_never_by_content():
     # This runs in CI, whose logs are public: refusing to publish something
     # and then printing it defeats the gate.
     secret = "Ram Kumar 9876543210 Sambalpur " * 10
-    problem = dvc_pointer_problem(f"outs:\n- md5: a\n  path: p\ncmd: {secret}\n")
+    problem = dvc_pointer_problem(f"outs:\n- md5: d41d8cd98f00b204e9800998ecf8427e\n  path: {secret}\n")
 
     assert problem is not None
     assert "Ram Kumar" not in problem
@@ -855,27 +868,24 @@ def test_the_scalar_cap_reports_by_length_never_by_content():
     assert "characters" in problem
 
 
-def test_pre_commit_runs_the_provenance_schema_check():
+def test_pre_commit_covers_sidecars_through_the_staged_scan():
     hook = (
         Path(__file__).resolve().parents[1] / ".githooks" / "pre-commit"
     ).read_text()
-    assert "check_provenance_sidecars.py" in hook
-    # The staged blob, not the worktree file: those differ once a file is
-    # staged and then edited.
-    assert "cat-file blob" in hook
-
-
-# ---------------------------------------------------------------------------
-# Codex P1 on #321, follow-up: a per-value cap is not an aggregate bound, and
-# a diagnostic that quotes the offending line publishes it.
-# ---------------------------------------------------------------------------
+    # One Python call, which validates every allowlisted blob including
+    # sidecars. The earlier shell pipeline could not carry a filename
+    # containing a newline and failed by checking nothing.
+    assert "check_no_terraform_plans.py" in hook
+    assert "--staged" in hook
+    assert "cat-file blob" not in hook
+    assert "tr '\\0'" not in hook
 
 
 def test_text_split_across_many_fields_is_still_bounded(tmp_path, monkeypatch):
     # Every scalar stays under the per-value cap while the payload does not.
     repo = _repo(tmp_path)
     (repo / "data" / "raw").mkdir(parents=True)
-    lines = ["outs:", "- md5: abc", "  path: thing"]
+    lines = ["outs:", "- md5: d41d8cd98f00b204e9800998ecf8427e", "  path: thing"]
     lines += [f"  desc: Ram Kumar 9876543210 Sambalpur entry {i}" for i in range(600)]
     (repo / "data" / "raw" / "big.dvc").write_text("\n".join(lines) + "\n")
     _git(repo, "add", "-f", "data/raw/big.dvc")
@@ -908,7 +918,9 @@ def test_no_diagnostic_ever_quotes_the_file(text):
 
 def test_rejections_still_say_where_and_why():
     # Withholding content must not make the message useless to the author.
-    problem = dvc_pointer_problem("outs:\n- md5: a\n  path: p\nnotes: hello\n")
+    problem = dvc_pointer_problem(
+        "outs:\n- md5: d41d8cd98f00b204e9800998ecf8427e\n  path: p\nnotes: hello\n"
+    )
 
     assert problem is not None
     assert "line 4" in problem
@@ -932,17 +944,9 @@ def test_a_zip_member_directory_never_reaches_the_message(tmp_path):
     assert not any("Ram Kumar" in member for member in members)
 
 
-def test_pre_commit_passes_sidecar_paths_without_word_splitting():
-    hook = (
-        Path(__file__).resolve().parents[1] / ".githooks" / "pre-commit"
-    ).read_text()
-    # NUL-delimited: a path with a space must stay one argument.
-    assert "-print0" in hook
-    assert "xargs -0" in hook
-
-
 def test_a_sidecar_path_with_a_space_is_still_checked(tmp_path):
-    # Exercises the hook's argument handling against a real repository.
+    # Argument handling, exercised against a real repository with the hook
+    # installed rather than asserted on the script text.
     repo = _repo(tmp_path)
     hooks = repo / ".githooks"
     hooks.mkdir()
@@ -967,3 +971,5 @@ def test_a_sidecar_path_with_a_space_is_still_checked(tmp_path):
 
     assert result.returncode != 0, result.stdout + result.stderr
     assert "my sidecar.provenance.json" in (result.stdout + result.stderr)
+
+

--- a/tests/test_check_no_terraform_plans.py
+++ b/tests/test_check_no_terraform_plans.py
@@ -1710,8 +1710,45 @@ def test_the_byte_fallback_separates_a_member_from_a_directory():
 
     # A zip stores a directory as an entry whose name ends in `/`. One
     # occurrence not followed by a slash is what distinguishes them, and a
-    # real member's name is followed by the extra field or compressed data.
-    assert damaged_plan_members(b"...tfstate/...") == []
-    assert damaged_plan_members(b"...tfstate{...") == ["tfstate"]
+    # real member's name sits between the header's length fields (NUL here)
+    # and the extra field or compressed data.
+    assert damaged_plan_members(b"\x00tfstate/\x00") == []
+    assert damaged_plan_members(b"\x00tfstate{") == ["tfstate"]
     # Both present: the file member wins.
-    assert damaged_plan_members(b"tfstate/ and tfstate{") == ["tfstate"]
+    assert damaged_plan_members(b"\x00tfstate/ and \x00tfstate{") == ["tfstate"]
+    # A longer name that merely contains the token is not a member.
+    assert damaged_plan_members(b"\x00mytfstate.json\x00") == []
+
+
+# ---------------------------------------------------------------------------
+# Codex P2 on #321: the byte fallback matched a plan token inside a longer
+# name, so `mytfstate.json` in a damaged archive read as a plan.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "member, expected",
+    [
+        # Real plan members, at the root and under a directory.
+        (("tfstate", '{"serial": 1}'), ["tfstate"]),
+        (("plan/tfstate", '{"serial": 1}'), ["tfstate"]),
+        # A directory, and longer names that merely contain the token.
+        (("tfstate/", ""), []),
+        (("mytfstate.json", '{"a": 1}'), []),
+        (("tfstateold", '{"a": 1}'), []),
+        (("backup-tfstate-2", '{"a": 1}'), []),
+    ],
+)
+def test_the_byte_fallback_respects_name_boundaries(member, expected):
+    data = _zip_of(member)
+
+    assert plan_members_of_blob(data[: len(data) - 40]) == expected
+
+
+def test_the_boundary_rule_never_costs_a_real_detection():
+    # The direction that matters: a missed plan is the failure this exists to
+    # prevent. Checked across truncations rather than at one.
+    data = _zip_of(("tfstate", '{"serial": 1, "secret": "acct-123"}'))
+
+    for cut in (10, 20, 30, 40, 50, 60):
+        assert plan_members_of_blob(data[: len(data) - cut]) == ["tfstate"], cut

--- a/tests/test_check_no_terraform_plans.py
+++ b/tests/test_check_no_terraform_plans.py
@@ -10,6 +10,7 @@ cannot see.
 from __future__ import annotations
 
 import io
+import json
 import os
 import subprocess
 import sys
@@ -41,6 +42,9 @@ def plan_members(path: Path) -> list[str]:
     return plan_members_of_blob(path.read_bytes())
 
 SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "check_no_terraform_plans.py"
+
+# A real-shaped md5: the value rules require one.
+_MD5 = "d41d8cd98f00b204e9800998ecf8427e"
 
 
 def _plan_archive(path: Path, members: tuple[str, ...] = ("tfstate", "tfplan")) -> Path:
@@ -973,3 +977,72 @@ def test_a_sidecar_path_with_a_space_is_still_checked(tmp_path):
     assert "my sidecar.provenance.json" in (result.stdout + result.stderr)
 
 
+
+
+# ---------------------------------------------------------------------------
+# Codex on #321, final pair: `path` was the last field prose could sit in, and
+# calling check_payload directly skipped the owning checker's path-aware
+# normalisation for the legacy root sidecar.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text, expected_ok",
+    [
+        (f"outs:\n- md5: {_MD5}\n  path: data/raw/thing.parquet\n", True),
+        (f"outs:\n- md5: {_MD5}\n  path: thing\n  remote: myremote\n", True),
+        # Prose has spaces; a path does not need them.
+        (f"outs:\n- md5: {_MD5}\n  path: Ram Kumar 9876543210\n", False),
+        (f"outs:\n- md5: {_MD5}\n  path: thing\n  remote: Ram Kumar 987\n", False),
+        (f"outs:\n- md5: {_MD5}\n  wdir: Ram Kumar 987\n  path: thing\n", False),
+    ],
+)
+def test_paths_are_typed_not_merely_capped(text, expected_ok):
+    assert (dvc_pointer_problem(text) is None) is expected_ok
+
+
+def _legacy_root_payload() -> dict:
+    """The valid PII-rederived sidecar, minus its `schema_version`.
+
+    That is the legacy root shape `check_document` deliberately accepts.
+    Loaded from the sidecar checker's own fixture so this cannot drift.
+    """
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "_sidecar_tests", Path(__file__).with_name("test_check_provenance_sidecars.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    payload = dict(module.VALID)
+    payload.pop("schema_version")
+    return payload
+
+
+def test_the_legacy_root_sidecar_is_still_accepted(tmp_path, monkeypatch):
+    # Regression: calling check_payload directly reported "unrecognized
+    # provenance schema_version" for a file the owning checker accepts.
+    repo = _repo(tmp_path)
+    (repo / "data" / "external").mkdir(parents=True)
+    (repo / "data" / "external" / "provenance.json").write_text(
+        json.dumps(_legacy_root_payload())
+    )
+    _git(repo, "add", "-f", "data/external/provenance.json")
+    _git(repo, "commit", "-qm", "legacy")
+
+    monkeypatch.chdir(repo)
+    assert main() == 0
+
+
+def test_a_nested_sidecar_still_needs_its_schema_version(tmp_path, monkeypatch):
+    # The other half of the same path-aware rule: only the root is exempt.
+    repo = _repo(tmp_path)
+    (repo / "data" / "external" / "thing").mkdir(parents=True)
+    (repo / "data" / "external" / "thing" / "provenance.json").write_text(
+        json.dumps(_legacy_root_payload())
+    )
+    _git(repo, "add", "-f", "data/external/thing/provenance.json")
+    _git(repo, "commit", "-qm", "nested")
+
+    monkeypatch.chdir(repo)
+    assert main() == 1

--- a/tests/test_check_no_terraform_plans.py
+++ b/tests/test_check_no_terraform_plans.py
@@ -142,21 +142,54 @@ def test_tracked_files_never_returns_anything_under_data(tmp_path, monkeypatch):
     (repo / "data" / "external" / "thing.json.dvc").write_text("outs: []\n")
     (repo / "deploy" / "main.tf").write_text("# infra\n")
     (repo / "pyproject.toml").write_text("[project]\nname='x'\n")
-    for args in (["init", "-q"], ["add", "-A"],
+    # -f, because a global core.excludesFile that ignores data/ would leave
+    # the synthetic protected files untracked while the commit still
+    # succeeded on the others -- and then this test would pass even with the
+    # scanner's exclusion removed, which is the vacuousness it exists to rule
+    # out.
+    for args in (["init", "-q"], ["add", "-Af"],
                  ["-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "seed"]):
         subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+    # Asserted against this throwaway repo's index, never the real one.
+    indexed = subprocess.run(
+        ["git", "ls-files"], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout.split()
+    assert "data/secret.parquet" in indexed
+    assert "data/external/thing.json.dvc" in indexed
 
     monkeypatch.chdir(repo)
     files = tracked_files()
 
     offenders = [f for f in files if str(f).startswith("data/")]
     assert offenders == [], f"scan would open protected paths: {offenders}"
-    # Non-vacuous: those files really are tracked in this repo -- asserted by
-    # construction above, not by asking git about a protected directory.
-    assert (repo / "data" / "secret.parquet").is_file()
     # And the rest of the tree is still scanned.
     assert Path("pyproject.toml") in files
     assert Path("deploy/main.tf") in files
+
+
+def test_a_symlink_into_data_is_not_followed(tmp_path, monkeypatch):
+    """Codex P1 on #321: the pathspec excludes paths, not link targets.
+
+    `is_file()` follows a symlink, so a tracked link *outside* data/ whose
+    target is inside it was read straight through the exclusion — and would
+    have been reported by name and members if the target were a plan.
+    """
+    repo = tmp_path / "repo"
+    (repo / "data").mkdir(parents=True)
+    _plan_archive(repo / "data" / "hidden-plan")
+    (repo / "public-link").symlink_to(Path("data") / "hidden-plan")
+    (repo / "pyproject.toml").write_text("[project]\nname='x'\n")
+    for args in (["init", "-q"], ["add", "-Af"],
+                 ["-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "seed"]):
+        subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+    monkeypatch.chdir(repo)
+    # The link itself is tracked and outside data/, so the pathspec returns it.
+    assert Path("public-link") in tracked_files()
+
+    # It must not be followed: no finding, and nothing under data/ opened.
+    assert main() == 0
 
 
 def test_tracked_files_reads_the_git_index(monkeypatch):

--- a/tests/test_check_no_terraform_plans.py
+++ b/tests/test_check_no_terraform_plans.py
@@ -744,3 +744,78 @@ def test_the_allowlist_pathspecs_cover_the_workflow_predicate():
     for token in (".gitkeep", ".dvc", "provenance"):
         assert any(token in spec for spec in ALLOWLIST_PATHSPECS), token
         assert token in predicate[0], token
+
+
+# ---------------------------------------------------------------------------
+# Codex P1 on #321, follow-up: `**/` needs a directory below `external`, and
+# a pointer that parses is not the same as a pointer that carries nothing else.
+# ---------------------------------------------------------------------------
+
+
+def test_a_sidecar_directly_under_external_is_scanned(tmp_path, monkeypatch):
+    # `data/external/**/provenance.json` requires a subdirectory; the
+    # workflow's `(.*/)?` does not.
+    repo = _repo(tmp_path)
+    (repo / "data" / "external").mkdir(parents=True)
+    _plan_archive(repo / "data" / "external" / "provenance.json", ("tfstate",))
+    _git(repo, "add", "-f", "data/external/provenance.json")
+    _git(repo, "commit", "-qm", "sidecar")
+
+    monkeypatch.chdir(repo)
+    assert main() == 1
+
+
+def test_a_prefixed_sidecar_directly_under_external_is_scanned(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    (repo / "data" / "external").mkdir(parents=True)
+    _plan_archive(repo / "data" / "external" / "thing.provenance.json", ("tfstate",))
+    _git(repo, "add", "-f", "data/external/thing.provenance.json")
+    _git(repo, "commit", "-qm", "sidecar")
+
+    monkeypatch.chdir(repo)
+    assert main() == 1
+
+
+def test_a_pointer_carrying_a_smuggled_block_is_refused(tmp_path, monkeypatch):
+    # The entry is well formed; the file is still a container for something
+    # the allowlist was never meant to exempt.
+    repo = _repo(tmp_path)
+    (repo / "data" / "raw").mkdir(parents=True)
+    (repo / "data" / "raw" / "leak.dvc").write_text(
+        "outs:\n- md5: abc\n  path: thing\nraw: |\n  Ram Kumar, 9876543210, Sambalpur\n"
+    )
+    _git(repo, "add", "-f", "data/raw/leak.dvc")
+    _git(repo, "commit", "-qm", "leak")
+
+    monkeypatch.chdir(repo)
+    assert main() == 1
+
+
+@pytest.mark.parametrize(
+    "text, expected_ok",
+    [
+        # Accepted: the shapes DVC actually writes.
+        ("outs:\n- md5: abc\n  path: thing\n", True),
+        ("wdir: .\nouts:\n- md5: abc\n  path: thing\n  size: 12\n", True),
+        ("md5: abc\ncmd: echo hi\nouts:\n- md5: a\n  path: p\n"
+         "deps:\n- md5: b\n  path: q\n", True),
+        # Refused: unrecognised content, in each place it can hide.
+        ("outs:\n- md5: abc\n  path: thing\nraw: |\n  secret\n", False),
+        ("outs:\n- md5: abc\n  path: thing\n  leaked: citizen\n", False),
+        ("outs: |\n  secret\n", False),
+        ("outs:\n- md5: abc\n  path: thing\nnotes: hello\n", False),
+    ],
+)
+def test_dvc_pointer_problem_is_closed_not_lenient(text, expected_ok):
+    assert (dvc_pointer_problem(text) is None) is expected_ok
+
+
+def test_the_real_repository_pointers_still_validate():
+    # The strictness above must not reject DVC's own output.
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        cwd=SCRIPT.parents[1],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout

--- a/tests/test_check_no_terraform_plans.py
+++ b/tests/test_check_no_terraform_plans.py
@@ -1705,25 +1705,24 @@ def test_a_truncated_real_plan_is_still_caught(cut):
     assert plan_members_of_blob(data[: len(data) - cut]) == ["tfstate"]
 
 
-def test_the_byte_fallback_separates_a_member_from_a_directory():
+def test_the_fallback_reads_names_from_local_headers(tmp_path):
     from scripts.check_no_terraform_plans import damaged_plan_members
 
-    # A zip stores a directory as an entry whose name ends in `/`. One
-    # occurrence not followed by a slash is what distinguishes them, and a
-    # real member's name sits between the header's length fields (NUL here)
-    # and the extra field or compressed data.
-    assert damaged_plan_members(b"\x00tfstate/\x00") == []
-    assert damaged_plan_members(b"\x00tfstate{") == ["tfstate"]
-    # Both present: the file member wins.
-    assert damaged_plan_members(b"\x00tfstate/ and \x00tfstate{") == ["tfstate"]
-    # A longer name that merely contains the token is not a member.
-    assert damaged_plan_members(b"\x00mytfstate.json\x00") == []
-
-
-# ---------------------------------------------------------------------------
-# Codex P2 on #321: the byte fallback matched a plan token inside a longer
-# name, so `mytfstate.json` in a damaged archive read as a plan.
-# ---------------------------------------------------------------------------
+    # Names come from each entry's local file header, which declares its own
+    # length and survives truncation -- the central directory goes first.
+    # Substring matching could not separate these: `tfstate/` is a directory,
+    # `mytfstate.json` merely contains the token, and a real `tfstate` is
+    # followed by arbitrary compressed bytes that may resemble either.
+    assert damaged_plan_members(_zip_of(("tfstate", '{"serial": 1}'))) == ["tfstate"]
+    assert damaged_plan_members(_zip_of(("plan/tfstate", "x"))) == ["tfstate"]
+    assert damaged_plan_members(_zip_of(("tfstate/", ""))) == []
+    assert damaged_plan_members(_zip_of(("mytfstate.json", "x"))) == []
+    assert damaged_plan_members(_zip_of(("tfstateold", "x"))) == []
+    # The case a byte-boundary rule got wrong: the payload immediately after
+    # the name is alphanumeric.
+    assert damaged_plan_members(_zip_of(("tfstate", "aaaaaaaaaaaaaaaa"))) == ["tfstate"]
+    # Not a zip at all.
+    assert damaged_plan_members(b"tfstate mentioned in prose") == []
 
 
 @pytest.mark.parametrize(
@@ -1739,7 +1738,7 @@ def test_the_byte_fallback_separates_a_member_from_a_directory():
         (("backup-tfstate-2", '{"a": 1}'), []),
     ],
 )
-def test_the_byte_fallback_respects_name_boundaries(member, expected):
+def test_a_truncated_archive_yields_exact_member_names(member, expected):
     data = _zip_of(member)
 
     assert plan_members_of_blob(data[: len(data) - 40]) == expected

--- a/tests/test_check_no_terraform_plans.py
+++ b/tests/test_check_no_terraform_plans.py
@@ -86,7 +86,9 @@ def test_a_plan_written_under_a_directory_prefix_is_caught(tmp_path):
     # Layout has moved across Terraform versions, so members are matched on
     # their base name rather than the full entry path.
     plan = _plan_archive(tmp_path / "p", ("plan/tfstate",))
-    assert plan_members(plan) == ["plan/tfstate"]
+    # Reported by base name only: the directory part is attacker-chosen and
+    # the message reaches public CI logs.
+    assert plan_members(plan) == ["tfstate"]
 
 
 def test_an_ordinary_zip_is_not_a_plan(tmp_path):
@@ -911,3 +913,57 @@ def test_rejections_still_say_where_and_why():
     assert problem is not None
     assert "line 4" in problem
     assert "top-level key" in problem
+
+
+# ---------------------------------------------------------------------------
+# Codex P1 on #321, final: the hook word-split its argument list, and an
+# archive member's directory reached the log.
+# ---------------------------------------------------------------------------
+
+
+def test_a_zip_member_directory_never_reaches_the_message(tmp_path):
+    plan = _plan_archive(
+        tmp_path / "p", ("Ram Kumar 9876543210 Sambalpur/tfstate",)
+    )
+
+    members = plan_members(plan)
+
+    assert members == ["tfstate"]
+    assert not any("Ram Kumar" in member for member in members)
+
+
+def test_pre_commit_passes_sidecar_paths_without_word_splitting():
+    hook = (
+        Path(__file__).resolve().parents[1] / ".githooks" / "pre-commit"
+    ).read_text()
+    # NUL-delimited: a path with a space must stay one argument.
+    assert "-print0" in hook
+    assert "xargs -0" in hook
+
+
+def test_a_sidecar_path_with_a_space_is_still_checked(tmp_path):
+    # Exercises the hook's argument handling against a real repository.
+    repo = _repo(tmp_path)
+    hooks = repo / ".githooks"
+    hooks.mkdir()
+    root = Path(__file__).resolve().parents[1]
+    (hooks / "pre-commit").write_text((root / ".githooks" / "pre-commit").read_text())
+    (hooks / "pre-commit").chmod(0o755)
+    (repo / "scripts").mkdir()
+    for name in ("check_provenance_sidecars.py", "check_no_terraform_plans.py"):
+        (repo / "scripts" / name).write_text((root / "scripts" / name).read_text())
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "hooks")
+    _git(repo, "config", "core.hooksPath", ".githooks")
+
+    (repo / "data" / "external").mkdir(parents=True)
+    bad = repo / "data" / "external" / "my sidecar.provenance.json"
+    bad.write_text('{"complaint": "citizen text"}')
+    _git(repo, "add", "-f", "data/external/my sidecar.provenance.json")
+
+    result = subprocess.run(
+        ["git", "commit", "-m", "sidecar"], cwd=repo, capture_output=True, text=True
+    )
+
+    assert result.returncode != 0, result.stdout + result.stderr
+    assert "my sidecar.provenance.json" in (result.stdout + result.stderr)

--- a/tests/test_check_no_terraform_plans.py
+++ b/tests/test_check_no_terraform_plans.py
@@ -861,3 +861,53 @@ def test_pre_commit_runs_the_provenance_schema_check():
     # The staged blob, not the worktree file: those differ once a file is
     # staged and then edited.
     assert "cat-file blob" in hook
+
+
+# ---------------------------------------------------------------------------
+# Codex P1 on #321, follow-up: a per-value cap is not an aggregate bound, and
+# a diagnostic that quotes the offending line publishes it.
+# ---------------------------------------------------------------------------
+
+
+def test_text_split_across_many_fields_is_still_bounded(tmp_path, monkeypatch):
+    # Every scalar stays under the per-value cap while the payload does not.
+    repo = _repo(tmp_path)
+    (repo / "data" / "raw").mkdir(parents=True)
+    lines = ["outs:", "- md5: abc", "  path: thing"]
+    lines += [f"  desc: Ram Kumar 9876543210 Sambalpur entry {i}" for i in range(600)]
+    (repo / "data" / "raw" / "big.dvc").write_text("\n".join(lines) + "\n")
+    _git(repo, "add", "-f", "data/raw/big.dvc")
+    _git(repo, "commit", "-qm", "big")
+
+    monkeypatch.chdir(repo)
+    assert main() == 1
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Ram Kumar 9876543210: Sambalpur\n",
+        "outs:\n- md5: a\n  path: p\nRam Kumar 9876543210: x\n",
+        "outs:\n- md5: a\n  path: p\n  Ram Kumar 9876543210: x\n",
+        "Ram Kumar 9876543210 Sambalpur\n",
+        "outs:\n- md5: a\n  path: p\n-Ram Kumar 9876543210\n",
+    ],
+)
+def test_no_diagnostic_ever_quotes_the_file(text):
+    # CI logs are public. Refusing to publish something and then printing it
+    # in the rejection defeats the gate.
+    problem = dvc_pointer_problem(text)
+
+    assert problem is not None
+    assert "Ram Kumar" not in problem
+    assert "9876543210" not in problem
+    assert "Sambalpur" not in problem
+
+
+def test_rejections_still_say_where_and_why():
+    # Withholding content must not make the message useless to the author.
+    problem = dvc_pointer_problem("outs:\n- md5: a\n  path: p\nnotes: hello\n")
+
+    assert problem is not None
+    assert "line 4" in problem
+    assert "top-level key" in problem

--- a/tests/test_check_no_terraform_plans.py
+++ b/tests/test_check_no_terraform_plans.py
@@ -9,6 +9,7 @@ cannot see.
 
 from __future__ import annotations
 
+import io
 import os
 import subprocess
 import sys
@@ -20,10 +21,21 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from scripts.check_no_terraform_plans import (  # noqa: E402
+    _members_of,
     main,
-    plan_members,
-    tracked_files,
+    plan_members_of_blob,
+    tracked_entries,
 )
+
+
+def plan_members(path: Path) -> list[str]:
+    """Archive-detection helper: the scanner reads blobs, tests read files.
+
+    The production scan never touches the filesystem (see `tracked_entries`),
+    so the byte-level detection is exercised here by handing it the file's
+    bytes directly.
+    """
+    return plan_members_of_blob(path.read_bytes())
 
 SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "check_no_terraform_plans.py"
 
@@ -34,6 +46,24 @@ def _plan_archive(path: Path, members: tuple[str, ...] = ("tfstate", "tfplan")) 
         for name in members:
             archive.writestr(name, '{"serial": 1, "outputs": {}}')
     return path
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=repo, check=True, capture_output=True, text=True
+    ).stdout
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "T")
+    (repo / "README.md").write_text("seed\n")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-qm", "seed")
+    return repo
 
 
 def test_a_plan_with_no_suffix_is_caught(tmp_path):
@@ -84,10 +114,13 @@ def test_a_truncated_zip_does_not_crash_the_check(tmp_path):
 
 
 def test_reports_the_offender_and_its_members(tmp_path, monkeypatch, capsys):
-    plan = _plan_archive(tmp_path / "tfplan")
-    monkeypatch.setattr(
-        "scripts.check_no_terraform_plans.tracked_files", lambda: [plan]
-    )
+    # Against a real repository rather than a patched `tracked_files`: the
+    # scan reads git objects now, so the index is what it must be given.
+    repo = _repo(tmp_path)
+    _plan_archive(repo / "tfplan")
+    _git(repo, "add", "tfplan")
+    _git(repo, "commit", "-qm", "plan")
+    monkeypatch.chdir(repo)
 
     assert main() == 1
     out = capsys.readouterr().out
@@ -99,11 +132,11 @@ def test_reports_the_offender_and_its_members(tmp_path, monkeypatch, capsys):
 
 
 def test_passes_when_nothing_is_tracked_as_a_plan(tmp_path, monkeypatch, capsys):
-    ordinary = tmp_path / "main.tf"
-    ordinary.write_text("# nothing\n")
-    monkeypatch.setattr(
-        "scripts.check_no_terraform_plans.tracked_files", lambda: [ordinary]
-    )
+    repo = _repo(tmp_path)
+    (repo / "main.tf").write_text("# nothing\n")
+    _git(repo, "add", "main.tf")
+    _git(repo, "commit", "-qm", "tf")
+    monkeypatch.chdir(repo)
 
     assert main() == 0
     assert capsys.readouterr().out == ""
@@ -120,7 +153,7 @@ def test_this_repository_currently_passes():
     assert result.returncode == 0, result.stdout
 
 
-def test_tracked_files_never_returns_anything_under_data(tmp_path, monkeypatch):
+def test_tracked_entries_never_returns_anything_under_data(tmp_path, monkeypatch):
     """Codex P1 on #321: the scan opens every path it is handed.
 
     AGENTS.md forbids reading anything under `data/` without explicit
@@ -160,7 +193,7 @@ def test_tracked_files_never_returns_anything_under_data(tmp_path, monkeypatch):
     assert "data/external/thing.json.dvc" in indexed
 
     monkeypatch.chdir(repo)
-    files = tracked_files()
+    files = [path for path, _sha in tracked_entries()]
 
     offenders = [f for f in files if str(f).startswith("data/")]
     assert offenders == [], f"scan would open protected paths: {offenders}"
@@ -186,16 +219,18 @@ def test_a_symlink_into_data_is_not_followed(tmp_path, monkeypatch):
         subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
 
     monkeypatch.chdir(repo)
-    # The link itself is tracked and outside data/, so the pathspec returns it.
-    assert Path("public-link") in tracked_files()
+    # The link is tracked and outside data/, so the pathspec still selects it
+    # -- but it is dropped as mode 120000, and in any case the scan reads the
+    # blob, which holds the link *text* rather than the target's bytes.
+    assert Path("public-link") not in [path for path, _sha in tracked_entries()]
 
-    # It must not be followed: no finding, and nothing under data/ opened.
+    # No finding, and nothing under data/ read.
     assert main() == 0
 
 
-def test_tracked_files_reads_the_git_index(monkeypatch):
+def test_tracked_entries_reads_the_git_index(monkeypatch):
     monkeypatch.chdir(SCRIPT.parents[1])
-    files = tracked_files()
+    files = [path for path, _sha in tracked_entries()]
     assert Path("pyproject.toml") in files
     assert Path(".github/workflows/data-check.yml") in files
 
@@ -228,24 +263,6 @@ def test_the_regex_alone_would_have_missed_it(tmp_path):
 # the disclosure — and only then rejected by CI. These cover the staged scan
 # that closes that window.
 # ---------------------------------------------------------------------------
-
-
-def _git(repo: Path, *args: str) -> str:
-    return subprocess.run(
-        ["git", *args], cwd=repo, check=True, capture_output=True, text=True
-    ).stdout
-
-
-def _repo(tmp_path: Path) -> Path:
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    _git(repo, "init", "-q")
-    _git(repo, "config", "user.email", "t@example.com")
-    _git(repo, "config", "user.name", "T")
-    (repo / "README.md").write_text("seed\n")
-    _git(repo, "add", "README.md")
-    _git(repo, "commit", "-qm", "seed")
-    return repo
 
 
 def _run_staged(repo: Path) -> subprocess.CompletedProcess:
@@ -401,31 +418,6 @@ def test_a_symlinked_ancestor_is_not_followed_into_data(tmp_path, monkeypatch):
     assert main() == 0
 
 
-def test_open_nofollow_refuses_a_link_at_the_final_component(tmp_path):
-    from scripts.check_no_terraform_plans import _open_nofollow
-
-    target = _plan_archive(tmp_path / "real")
-    link = tmp_path / "link"
-    link.symlink_to(target)
-
-    assert _open_nofollow(link) is None
-    assert plan_members(link) == []
-    # The archive is still found at its own path.
-    assert plan_members(target) == ["tfplan", "tfstate"]
-
-
-def test_open_nofollow_refuses_a_link_at_an_ancestor(tmp_path):
-    from scripts.check_no_terraform_plans import _open_nofollow
-
-    real_dir = tmp_path / "real_dir"
-    real_dir.mkdir()
-    _plan_archive(real_dir / "payload")
-    (tmp_path / "via_link").symlink_to(real_dir)
-
-    assert _open_nofollow(tmp_path / "via_link" / "payload") is None
-    assert plan_members(tmp_path / "via_link" / "payload") == []
-
-
 def test_staged_scan_never_touches_the_filesystem_for_content(tmp_path):
     # The staged mode reads blobs with `git cat-file`, so symlinked ancestors
     # cannot arise there at all: deleting the worktree copy entirely leaves
@@ -480,8 +472,8 @@ def test_no_metadata_is_read_through_a_symlinked_ancestor(tmp_path, monkeypatch)
 
 
 def test_a_directory_entry_is_not_mistaken_for_an_archive(tmp_path, monkeypatch):
-    # The removed `is_file()` prefilter used to skip these; opening a
-    # directory now fails on the read instead, which must not raise.
+    # Directories never appear in the scan at all now: `git ls-files -s`
+    # lists blobs, so there is no entry for `adir` to misread.
     repo = _repo(tmp_path)
     (repo / "adir").mkdir()
     (repo / "adir" / "keep").write_text("x\n")
@@ -490,7 +482,7 @@ def test_a_directory_entry_is_not_mistaken_for_an_archive(tmp_path, monkeypatch)
 
     monkeypatch.chdir(repo)
     assert main() == 0
-    assert plan_members(Path("adir")) == []
+    assert Path("adir") not in [path for path, _sha in tracked_entries()]
 
 
 def test_a_broken_symlink_does_not_crash_the_scan(tmp_path, monkeypatch):
@@ -501,3 +493,78 @@ def test_a_broken_symlink_does_not_crash_the_scan(tmp_path, monkeypatch):
 
     monkeypatch.chdir(repo)
     assert main() == 0
+
+
+# ---------------------------------------------------------------------------
+# Codex P2 on #321, final round: a hard link is an ordinary directory entry,
+# so no open-time flag distinguishes it. Reading git blobs rather than the
+# worktree retires that whole class, and closes the damaged-archive gap.
+# ---------------------------------------------------------------------------
+
+
+def test_a_hard_link_into_data_is_not_read(tmp_path, monkeypatch):
+    # Reproduced on 6fb981e: `public/payload` hard-linked to a plan under
+    # data/ was opened and reported, because O_NOFOLLOW cannot see a hard
+    # link. The blob for public/payload is its own committed content.
+    repo = _repo(tmp_path)
+    (repo / "data").mkdir()
+    (repo / "public").mkdir()
+    _plan_archive(repo / "data" / "secret")
+    (repo / "public" / "payload").write_text("placeholder\n")
+    _git(repo, "add", "-f", "data/secret", "public/payload")
+    _git(repo, "commit", "-qm", "seed2")
+
+    (repo / "public" / "payload").unlink()
+    os.link(repo / "data" / "secret", repo / "public" / "payload")
+
+    monkeypatch.chdir(repo)
+    assert Path("public/payload").is_symlink() is False  # precondition
+    assert main() == 0
+
+
+def test_a_damaged_plan_is_still_caught(tmp_path):
+    # A truncated plan keeps its secrets: the tfstate entry is in the archive
+    # whether or not the central directory survives, and an interrupted
+    # `terraform plan -out` produces exactly this.
+    plan = _plan_archive(tmp_path / "plan", ("tfstate",))
+    intact = plan.read_bytes()
+    assert plan_members_of_blob(intact) == ["tfstate"]
+
+    damaged = intact[:-40]
+    # The archive no longer parses as a zip...
+    assert _members_of(io.BytesIO(damaged)) == []
+    # ...but is still recognised, and still refused.
+    assert plan_members_of_blob(damaged) == ["tfstate"]
+
+
+def test_a_damaged_plan_is_refused_by_the_staged_scan(tmp_path):
+    repo = _repo(tmp_path)
+    plan = _plan_archive(repo / "artifact", ("tfstate",))
+    plan.write_bytes(plan.read_bytes()[:-40])
+    _git(repo, "add", "artifact")
+
+    result = _run_staged(repo)
+
+    assert result.returncode == 1
+    assert "artifact" in result.stdout
+
+
+def test_an_ordinary_damaged_zip_is_not_called_a_plan(tmp_path):
+    deck = tmp_path / "deck.pptx"
+    with zipfile.ZipFile(deck, "w") as archive:
+        archive.writestr("ppt/presentation.xml", "<p/>")
+    damaged = deck.read_bytes()[:-20]
+
+    assert plan_members_of_blob(damaged) == []
+
+
+def test_pre_commit_matches_the_workflow_filename_patterns():
+    # Defence in depth alongside the content scan, and the gap Codex noted:
+    # CI's filename regex included `.tfplan` and the hook's did not.
+    root = Path(__file__).resolve().parents[1]
+    hook = (root / ".githooks" / "pre-commit").read_text()
+    workflow = (root / ".github" / "workflows" / "data-check.yml").read_text()
+
+    for pattern in ("terraform\\.tfstate", "terraform\\.tfvars", "\\.tfplan", "\\.pem"):
+        assert pattern in hook, pattern
+        assert pattern in workflow, pattern

--- a/tests/test_check_no_terraform_plans.py
+++ b/tests/test_check_no_terraform_plans.py
@@ -369,3 +369,72 @@ def test_a_staged_filename_cannot_re_include_data(tmp_path):
 def test_staged_scan_uses_literal_pathspecs():
     source = SCRIPT.read_text()
     assert "--literal-pathspecs" in source
+
+
+# ---------------------------------------------------------------------------
+# Codex P2 on #321: `is_symlink()` describes only the final component, so an
+# ancestor replaced by a link was followed into data/.
+# ---------------------------------------------------------------------------
+
+
+def test_a_symlinked_ancestor_is_not_followed_into_data(tmp_path, monkeypatch):
+    # Reproduced before the fix: the index still lists `public/payload`, the
+    # worktree has `public -> data`, so `public/payload` is not itself a
+    # symlink and opening it read `data/payload` through the
+    # `:(exclude)data/**` pathspec.
+    repo = _repo(tmp_path)
+    (repo / "data").mkdir()
+    (repo / "public").mkdir()
+    _plan_archive(repo / "data" / "payload")
+    (repo / "public" / "payload").write_text("placeholder\n")
+    _git(repo, "add", "-f", "data/payload", "public/payload")
+    _git(repo, "commit", "-qm", "seed2")
+
+    (repo / "public" / "payload").unlink()
+    (repo / "public").rmdir()
+    (repo / "public").symlink_to(repo / "data")
+
+    monkeypatch.chdir(repo)
+    # Precondition: the case only bites because this is False.
+    assert Path("public/payload").is_symlink() is False
+    assert main() == 0
+
+
+def test_open_nofollow_refuses_a_link_at_the_final_component(tmp_path):
+    from scripts.check_no_terraform_plans import _open_nofollow
+
+    target = _plan_archive(tmp_path / "real")
+    link = tmp_path / "link"
+    link.symlink_to(target)
+
+    assert _open_nofollow(link) is None
+    assert plan_members(link) == []
+    # The archive is still found at its own path.
+    assert plan_members(target) == ["tfplan", "tfstate"]
+
+
+def test_open_nofollow_refuses_a_link_at_an_ancestor(tmp_path):
+    from scripts.check_no_terraform_plans import _open_nofollow
+
+    real_dir = tmp_path / "real_dir"
+    real_dir.mkdir()
+    _plan_archive(real_dir / "payload")
+    (tmp_path / "via_link").symlink_to(real_dir)
+
+    assert _open_nofollow(tmp_path / "via_link" / "payload") is None
+    assert plan_members(tmp_path / "via_link" / "payload") == []
+
+
+def test_staged_scan_never_touches_the_filesystem_for_content(tmp_path):
+    # The staged mode reads blobs with `git cat-file`, so symlinked ancestors
+    # cannot arise there at all: deleting the worktree copy entirely leaves
+    # the staged archive still detectable.
+    repo = _repo(tmp_path)
+    _plan_archive(repo / "artifact.bin")
+    _git(repo, "add", "artifact.bin")
+    (repo / "artifact.bin").unlink()
+
+    result = _run_staged(repo)
+
+    assert result.returncode == 1
+    assert "artifact.bin" in result.stdout

--- a/tests/test_check_no_terraform_plans.py
+++ b/tests/test_check_no_terraform_plans.py
@@ -1,0 +1,148 @@
+"""Tests for scripts/check_no_terraform_plans.py.
+
+Codex P1 on #321: the first version of this guard matched `.*\\.tfplan` in the
+workflow regex, which is the same failure one step removed — `-out` takes an
+arbitrary filename and `terraform plan -out=tfplan` produces a plan with no
+suffix at all. The cases that matter here are the ones a name-based check
+cannot see.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.check_no_terraform_plans import (  # noqa: E402
+    main,
+    plan_members,
+    tracked_files,
+)
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "check_no_terraform_plans.py"
+
+
+def _plan_archive(path: Path, members: tuple[str, ...] = ("tfstate", "tfplan")) -> Path:
+    """A zip shaped like a Terraform saved plan."""
+    with zipfile.ZipFile(path, "w") as archive:
+        for name in members:
+            archive.writestr(name, '{"serial": 1, "outputs": {}}')
+    return path
+
+
+def test_a_plan_with_no_suffix_is_caught(tmp_path):
+    """`terraform plan -out=tfplan` is Terraform's own documented example."""
+    plan = _plan_archive(tmp_path / "tfplan")
+    assert plan_members(plan) == ["tfplan", "tfstate"]
+
+
+@pytest.mark.parametrize(
+    "name", ["tfplan", "plan.out", "bucket.tfplan", "saved", "artifact.bin"]
+)
+def test_the_verdict_does_not_depend_on_the_filename(tmp_path, name):
+    assert plan_members(_plan_archive(tmp_path / name, ("tfstate",))) == ["tfstate"]
+
+
+def test_a_plan_written_under_a_directory_prefix_is_caught(tmp_path):
+    # Layout has moved across Terraform versions, so members are matched on
+    # their base name rather than the full entry path.
+    plan = _plan_archive(tmp_path / "p", ("plan/tfstate",))
+    assert plan_members(plan) == ["plan/tfstate"]
+
+
+def test_an_ordinary_zip_is_not_a_plan(tmp_path):
+    ordinary = tmp_path / "deck.pptx"
+    with zipfile.ZipFile(ordinary, "w") as archive:
+        archive.writestr("[Content_Types].xml", "<Types/>")
+        archive.writestr("ppt/presentation.xml", "<p:presentation/>")
+    assert plan_members(ordinary) == []
+
+
+def test_non_zip_files_are_cheap_and_clean(tmp_path):
+    text = tmp_path / "main.tf"
+    text.write_text('resource "aws_s3_bucket" "x" {}\n')
+    assert plan_members(text) == []
+
+    empty = tmp_path / "empty"
+    empty.write_bytes(b"")
+    assert plan_members(empty) == []
+
+
+def test_a_truncated_zip_does_not_crash_the_check(tmp_path):
+    # Starts with the zip magic and will not open. It must not raise: an
+    # unreadable file is not evidence of a plan, and the suffix patterns in
+    # the workflow still cover the obvious names.
+    broken = tmp_path / "half.zip"
+    broken.write_bytes(b"PK\x03\x04" + b"\x00" * 16)
+    assert plan_members(broken) == []
+
+
+def test_reports_the_offender_and_its_members(tmp_path, monkeypatch, capsys):
+    plan = _plan_archive(tmp_path / "tfplan")
+    monkeypatch.setattr(
+        "scripts.check_no_terraform_plans.tracked_files", lambda: [plan]
+    )
+
+    assert main() == 1
+    out = capsys.readouterr().out
+    assert "tfplan" in out
+    assert "tfstate" in out
+    # The message has to say why, or the next person deletes the file and
+    # saves the plan under another name.
+    assert "state stays local" in out
+
+
+def test_passes_when_nothing_is_tracked_as_a_plan(tmp_path, monkeypatch, capsys):
+    ordinary = tmp_path / "main.tf"
+    ordinary.write_text("# nothing\n")
+    monkeypatch.setattr(
+        "scripts.check_no_terraform_plans.tracked_files", lambda: [ordinary]
+    )
+
+    assert main() == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_this_repository_currently_passes():
+    """The check the workflow runs, run against the real index."""
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        cwd=SCRIPT.parents[1],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout
+
+
+def test_tracked_files_reads_the_git_index(monkeypatch):
+    monkeypatch.chdir(SCRIPT.parents[1])
+    files = tracked_files()
+    assert Path("pyproject.toml") in files
+    assert Path(".github/workflows/data-check.yml") in files
+
+
+def test_the_regex_alone_would_have_missed_it(tmp_path):
+    """Why the content check exists, pinned as a test rather than a comment.
+
+    The workflow's suffix pattern is the one from the first fix. It matches
+    `bucket.tfplan` and not `tfplan`, which is exactly the gap.
+    """
+    import re
+
+    pattern = re.compile(
+        r"(^|/)(terraform\.tfstate(\..*)?|terraform\.tfvars|.*\.auto\.tfvars"
+        r"|.*\.tfplan|\.env|.*\.pem|id_rsa|id_ed25519)$"
+    )
+
+    assert pattern.search("deploy/terraform/bucket.tfplan")
+    assert not pattern.search("deploy/terraform/tfplan")
+    assert not pattern.search("deploy/terraform/plan.out")
+
+    # Both of the names the regex lets through are caught by content.
+    for name in ("tfplan", "plan.out"):
+        assert plan_members(_plan_archive(tmp_path / name, ("tfstate",)))

--- a/tests/test_check_no_terraform_plans.py
+++ b/tests/test_check_no_terraform_plans.py
@@ -1324,3 +1324,74 @@ def test_the_identifier_rule_admits_real_names_and_refuses_identifiers(name, exp
     from scripts.check_no_terraform_plans import IDENTIFIER_RUN
 
     assert (IDENTIFIER_RUN.search(name) is None) is expected_ok
+
+
+# ---------------------------------------------------------------------------
+# Codex P1 on #321: the identifier rule looked only at the leaf, and an
+# 8-to-64 checksum range accepted a mobile number that happens to be hex.
+# ---------------------------------------------------------------------------
+
+
+def test_an_identifier_in_a_directory_is_refused(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    nested = repo / "data" / "raw" / "9876543210"
+    nested.mkdir(parents=True)
+    (nested / "thing.dvc").write_text(f"outs:\n- md5: {_MD5}\n  path: thing\n")
+    _git(repo, "add", "-f", "data/raw/9876543210/thing.dvc")
+    _git(repo, "commit", "-qm", "nested id")
+
+    monkeypatch.chdir(repo)
+    assert main() == 1
+
+
+def test_the_identifier_reason_names_neither_component_nor_digits(tmp_path):
+    repo = _repo(tmp_path)
+    nested = repo / "data" / "raw" / "9876543210"
+    nested.mkdir(parents=True)
+    (nested / "thing.dvc").write_text(f"outs:\n- md5: {_MD5}\n  path: thing\n")
+    _git(repo, "add", "-f", "data/raw/9876543210/thing.dvc")
+    _git(repo, "commit", "-qm", "nested id")
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)], cwd=repo, capture_output=True, text=True,
+        env={**os.environ, "GITHUB_ACTIONS": "true"},
+    )
+
+    assert result.returncode == 1
+    assert "9876543210" not in result.stdout
+
+
+@pytest.mark.parametrize(
+    "line, expected_ok",
+    [
+        (f"md5: {_MD5}", True),
+        (f"md5: {_MD5}.dir", True),
+        # A mobile number that happens to be hex. This satisfied an 8-to-64
+        # range, and then satisfied "the entry has a hash" as well.
+        ("md5: 9876543210", False),
+        ("md5: " + "a" * 31, False),
+        ("md5: " + "a" * 33, False),
+        ("md5: " + "z" * 32, False),
+        ("sha256: " + "a" * 64, True),
+        ("sha256: " + "a" * 32, False),
+    ],
+)
+def test_checksums_have_the_width_their_algorithm_implies(line, expected_ok):
+    key = line.split(":")[0]
+    text = f"outs:\n- {line}\n  path: thing\n"
+    problem = dvc_pointer_problem(text, stem="thing")
+    if expected_ok:
+        assert problem is None, problem
+    else:
+        assert problem is not None
+        assert key in problem
+
+
+def test_the_repository_still_passes_the_tightened_checksum_rule():
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        cwd=SCRIPT.parents[1],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout

--- a/tests/test_check_no_terraform_plans.py
+++ b/tests/test_check_no_terraform_plans.py
@@ -1681,3 +1681,37 @@ def test_the_damaged_fallback_still_fires_for_a_truncated_plan():
 
     assert not _archive_entries(io.BytesIO(damaged))
     assert plan_members_of_blob(damaged) == ["tfstate"]
+
+
+# ---------------------------------------------------------------------------
+# Codex P2 on #321: a truncated archive holding only `tfstate/` reached the
+# byte fallback, which cannot see entry types.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("cut", [20, 40, 60])
+def test_a_truncated_directory_only_archive_is_not_a_plan(cut):
+    data = _zip_of(("tfstate/", ""))
+
+    assert plan_members_of_blob(data[: len(data) - cut]) == []
+
+
+@pytest.mark.parametrize("cut", [20, 40, 60])
+def test_a_truncated_real_plan_is_still_caught(cut):
+    # The direction that matters: missing a plan is the failure this exists
+    # to prevent, so the refinement must not cost a detection.
+    data = _zip_of(("tfstate", '{"serial": 1, "secret": "acct-123"}'))
+
+    assert plan_members_of_blob(data[: len(data) - cut]) == ["tfstate"]
+
+
+def test_the_byte_fallback_separates_a_member_from_a_directory():
+    from scripts.check_no_terraform_plans import damaged_plan_members
+
+    # A zip stores a directory as an entry whose name ends in `/`. One
+    # occurrence not followed by a slash is what distinguishes them, and a
+    # real member's name is followed by the extra field or compressed data.
+    assert damaged_plan_members(b"...tfstate/...") == []
+    assert damaged_plan_members(b"...tfstate{...") == ["tfstate"]
+    # Both present: the file member wins.
+    assert damaged_plan_members(b"tfstate/ and tfstate{") == ["tfstate"]

--- a/tests/test_check_no_terraform_plans.py
+++ b/tests/test_check_no_terraform_plans.py
@@ -119,7 +119,7 @@ def test_this_repository_currently_passes():
     assert result.returncode == 0, result.stdout
 
 
-def test_tracked_files_never_returns_anything_under_data(monkeypatch):
+def test_tracked_files_never_returns_anything_under_data(tmp_path, monkeypatch):
     """Codex P1 on #321: the scan opens every path it is handed.
 
     AGENTS.md forbids reading anything under `data/` without explicit
@@ -127,19 +127,36 @@ def test_tracked_files_never_returns_anything_under_data(monkeypatch):
     provenance sidecars there. Nothing is lost by excluding it: the workflow
     step before this one already rejects any tracked file under `data/` that
     is not one of those, so a plan archive hidden there fails a step earlier.
+
+    In a throwaway repository, never the real one. The first version of this
+    test proved non-vacuousness by running `git ls-files -- data/` against
+    the checkout, which enumerated every protected path and reproduced the
+    exact violation the fix had just removed. A synthetic repo gives the
+    stronger guarantee -- files under `data/` provably exist and are
+    provably excluded -- while touching nothing real.
     """
-    monkeypatch.chdir(SCRIPT.parents[1])
+    repo = tmp_path / "repo"
+    (repo / "data" / "external").mkdir(parents=True)
+    (repo / "deploy").mkdir()
+    (repo / "data" / "secret.parquet").write_bytes(b"pretend citizen data")
+    (repo / "data" / "external" / "thing.json.dvc").write_text("outs: []\n")
+    (repo / "deploy" / "main.tf").write_text("# infra\n")
+    (repo / "pyproject.toml").write_text("[project]\nname='x'\n")
+    for args in (["init", "-q"], ["add", "-A"],
+                 ["-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "seed"]):
+        subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+    monkeypatch.chdir(repo)
     files = tracked_files()
+
     offenders = [f for f in files if str(f).startswith("data/")]
-    assert offenders == [], f"scan would open protected paths: {offenders[:5]}"
-    # Not vacuous: the repository does track files under data/.
-    tracked_under_data = subprocess.run(
-        ["git", "ls-files", "--", "data/"],
-        cwd=SCRIPT.parents[1], capture_output=True, text=True, check=True,
-    ).stdout.split()
-    assert tracked_under_data, "fixture assumption broken: nothing tracked under data/"
+    assert offenders == [], f"scan would open protected paths: {offenders}"
+    # Non-vacuous: those files really are tracked in this repo -- asserted by
+    # construction above, not by asking git about a protected directory.
+    assert (repo / "data" / "secret.parquet").is_file()
     # And the rest of the tree is still scanned.
     assert Path("pyproject.toml") in files
+    assert Path("deploy/main.tf") in files
 
 
 def test_tracked_files_reads_the_git_index(monkeypatch):

--- a/tests/test_check_no_terraform_plans.py
+++ b/tests/test_check_no_terraform_plans.py
@@ -1483,6 +1483,12 @@ def test_the_accepted_keys_are_the_ones_the_repository_actually_uses():
         ("x_9876_543210.dvc", True),
         ("x.9876.543210.dvc", True),
         ("aadhaar-1234 5678 9012.dvc", True),
+        # Written the way a phone number is printed.
+        ("(987) 654-3210.dvc", True),
+        ("x-(9876)543210.dvc", True),
+        ("a[9876]543210.dvc", True),
+        ("987/654/3210.dvc", True),
+        ("+91 98765 43210.dvc", True),
         # Real names from this repository, which must keep passing.
         ("Dump20250730.sql.dvc", False),
         ("historical_gold_180.jsonl.dvc", False),

--- a/tests/test_check_no_terraform_plans.py
+++ b/tests/test_check_no_terraform_plans.py
@@ -23,7 +23,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from scripts.check_no_terraform_plans import (  # noqa: E402
-    _members_of,
+    _archive_names,
     main,
     allowlisted_offenders,
     dvc_pointer_problem,
@@ -541,8 +541,8 @@ def test_a_damaged_plan_is_still_caught(tmp_path):
     assert plan_members_of_blob(intact) == ["tfstate"]
 
     damaged = intact[:-40]
-    # The archive no longer parses as a zip...
-    assert _members_of(io.BytesIO(damaged)) == []
+    # A damaged archive does not raise: zipfile opens it and lists nothing.
+    assert not _archive_names(io.BytesIO(damaged))
     # ...but is still recognised, and still refused.
     assert plan_members_of_blob(damaged) == ["tfstate"]
 
@@ -1543,3 +1543,66 @@ def test_the_real_size_values_still_pass():
         text=True,
     )
     assert result.returncode == 0, result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Codex on #321: the workflow's raw-data predicate covers `outputs/**` too,
+# and the damaged-archive fallback fired on archives that parsed fine.
+# ---------------------------------------------------------------------------
+
+
+def test_an_allowlisted_name_under_outputs_is_verified(tmp_path, monkeypatch):
+    # The raw-data step scans `outputs/**` under the same predicate, so the
+    # same exemptions apply there and need the same checking.
+    repo = _repo(tmp_path)
+    (repo / "outputs" / "run").mkdir(parents=True)
+    _plan_archive(repo / "outputs" / "run" / "saved.dvc", ("tfstate",))
+    _git(repo, "add", "-f", "outputs/run/saved.dvc")
+    _git(repo, "commit", "-qm", "outputs plan")
+
+    monkeypatch.chdir(repo)
+    assert main() == 1
+
+
+def test_an_outputs_gitkeep_must_still_be_empty(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    (repo / "outputs").mkdir()
+    _plan_archive(repo / "outputs" / ".gitkeep", ("tfstate",))
+    _git(repo, "add", "-f", "outputs/.gitkeep")
+    _git(repo, "commit", "-qm", "outputs marker")
+
+    monkeypatch.chdir(repo)
+    assert main() == 1
+
+
+def test_an_outputs_path_is_redacted_in_ci(monkeypatch):
+    from scripts.check_no_terraform_plans import safe_path
+
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    shown = safe_path(Path("outputs") / CITIZEN / "x.dvc")
+
+    assert CITIZEN not in shown
+    assert shown.startswith("outputs/")
+
+
+def test_an_ordinary_archive_mentioning_tfstate_is_not_a_plan():
+    # False positive: the fallback used to fire whenever no plan member was
+    # found, including for archives that listed their entries perfectly well.
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr("notes.txt", "this document mentions tfstate in prose")
+
+    assert plan_members_of_blob(buffer.getvalue()) == []
+
+
+def test_a_damaged_archive_still_reaches_the_byte_fallback():
+    # And the fallback must still fire for a truncated plan, which is the
+    # case that makes the three-way distinction necessary: zipfile opens it
+    # without raising and lists nothing.
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr("tfstate", '{"serial": 1}')
+    damaged = buffer.getvalue()[:-40]
+
+    assert not _archive_names(io.BytesIO(damaged))
+    assert plan_members_of_blob(damaged) == ["tfstate"]

--- a/tests/test_check_no_terraform_plans.py
+++ b/tests/test_check_no_terraform_plans.py
@@ -9,6 +9,7 @@ cannot see.
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import zipfile
@@ -438,3 +439,65 @@ def test_staged_scan_never_touches_the_filesystem_for_content(tmp_path):
 
     assert result.returncode == 1
     assert "artifact.bin" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Codex P2 on #321, follow-up: the cheap prefilters still statted through a
+# symlinked ancestor. AGENTS.md forbids inspecting metadata under data/, not
+# only reading it, so the prefilters were removed rather than reordered.
+# ---------------------------------------------------------------------------
+
+
+def test_no_metadata_is_read_through_a_symlinked_ancestor(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    (repo / "data").mkdir()
+    (repo / "public").mkdir()
+    _plan_archive(repo / "data" / "payload")
+    (repo / "public" / "payload").write_text("placeholder\n")
+    _git(repo, "add", "-f", "data/payload", "public/payload")
+    _git(repo, "commit", "-qm", "seed2")
+    (repo / "public" / "payload").unlink()
+    (repo / "public").rmdir()
+    (repo / "public").symlink_to(repo / "data")
+
+    touched: list[str] = []
+    real_stat, real_lstat = os.stat, os.lstat
+
+    def record(fn):
+        def wrapper(path, *a, **kw):
+            if isinstance(path, (str, Path)) and "public" in str(path):
+                touched.append(str(path))
+            return fn(path, *a, **kw)
+
+        return wrapper
+
+    monkeypatch.setattr(os, "stat", record(real_stat))
+    monkeypatch.setattr(os, "lstat", record(real_lstat))
+    monkeypatch.chdir(repo)
+
+    assert main() == 0
+    assert touched == [], touched
+
+
+def test_a_directory_entry_is_not_mistaken_for_an_archive(tmp_path, monkeypatch):
+    # The removed `is_file()` prefilter used to skip these; opening a
+    # directory now fails on the read instead, which must not raise.
+    repo = _repo(tmp_path)
+    (repo / "adir").mkdir()
+    (repo / "adir" / "keep").write_text("x\n")
+    _git(repo, "add", "adir/keep")
+    _git(repo, "commit", "-qm", "dir")
+
+    monkeypatch.chdir(repo)
+    assert main() == 0
+    assert plan_members(Path("adir")) == []
+
+
+def test_a_broken_symlink_does_not_crash_the_scan(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    (repo / "dangling").symlink_to(repo / "nothing-here")
+    _git(repo, "add", "dangling")
+    _git(repo, "commit", "-qm", "dangling")
+
+    monkeypatch.chdir(repo)
+    assert main() == 0

--- a/tests/test_check_no_terraform_plans.py
+++ b/tests/test_check_no_terraform_plans.py
@@ -1046,3 +1046,51 @@ def test_a_nested_sidecar_still_needs_its_schema_version(tmp_path, monkeypatch):
 
     monkeypatch.chdir(repo)
     assert main() == 1
+
+
+# ---------------------------------------------------------------------------
+# Codex P1 on #321: `files` is a collection, and reaching a generic length
+# check meant the parser failed open for any key without a rule.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text, expected_ok",
+    [
+        (f"outs:\n- md5: {_MD5}\n  path: thing\n", True),
+        (f"wdir: .\nouts:\n- md5: {_MD5}\n  path: thing\n", True),
+        # `files` is a list in DVC's directory pointers, not a scalar. It is
+        # no longer accepted at all rather than validated as one.
+        (f"outs:\n- md5: {_MD5}\n  path: thing\n  files: Ram Kumar 9876543210\n", False),
+        # A list header carries no value of its own.
+        ("outs: Ram Kumar 9876543210\n", False),
+        ("deps: Ram Kumar 9876543210\n", False),
+    ],
+)
+def test_collection_fields_cannot_hold_a_scalar(text, expected_ok):
+    assert (dvc_pointer_problem(text) is None) is expected_ok
+
+
+def test_every_accepted_key_has_an_explicit_value_rule():
+    # The parser fails closed: a key added to the allowlist without a rule is
+    # refused rather than falling through to a length check, which is how
+    # `files` was accepted as prose.
+    from scripts.check_no_terraform_plans import (
+        DVC_ENTRY_KEYS,
+        _scalar_problem,
+    )
+
+    unruled = [
+        key for key in DVC_ENTRY_KEYS if "no value rule" in (_scalar_problem(key, "x") or "")
+    ]
+    assert unruled == [], unruled
+
+
+def test_an_unruled_key_would_be_refused_not_accepted():
+    from scripts.check_no_terraform_plans import _scalar_problem
+
+    problem = _scalar_problem("invented", "Ram Kumar 9876543210")
+
+    assert problem is not None
+    assert "no value rule" in problem
+    assert "Ram Kumar" not in problem

--- a/tests/test_check_no_terraform_plans.py
+++ b/tests/test_check_no_terraform_plans.py
@@ -219,3 +219,108 @@ def test_the_regex_alone_would_have_missed_it(tmp_path):
     # Both of the names the regex lets through are caught by content.
     for name in ("tfplan", "plan.out"):
         assert plan_members(_plan_archive(tmp_path / name, ("tfstate",)))
+
+
+# ---------------------------------------------------------------------------
+# Codex P1 on #321, second round: the pre-commit hook matched filenames only,
+# so a plan saved under an arbitrary name was committed and pushed — which is
+# the disclosure — and only then rejected by CI. These cover the staged scan
+# that closes that window.
+# ---------------------------------------------------------------------------
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=repo, check=True, capture_output=True, text=True
+    ).stdout
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "T")
+    (repo / "README.md").write_text("seed\n")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-qm", "seed")
+    return repo
+
+
+def _run_staged(repo: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--staged"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_staged_scan_catches_a_plan_under_an_unignored_name(tmp_path):
+    # The exact case in the finding: `deploy/terraform/saved` matches no
+    # suffix pattern and no .gitignore rule, so only a content scan sees it.
+    repo = _repo(tmp_path)
+    (repo / "deploy" / "terraform").mkdir(parents=True)
+    _plan_archive(repo / "deploy" / "terraform" / "saved")
+    _git(repo, "add", "deploy/terraform/saved")
+
+    result = _run_staged(repo)
+
+    assert result.returncode == 1
+    assert "deploy/terraform/saved" in result.stdout
+    assert "tfstate" in result.stdout
+
+
+def test_staged_scan_reads_the_index_not_the_worktree(tmp_path):
+    # A pre-commit check must judge what is being committed. Stage the plan,
+    # then overwrite the worktree copy with innocuous text: the commit still
+    # carries the archive, so the check must still fail.
+    repo = _repo(tmp_path)
+    _plan_archive(repo / "artifact.bin")
+    _git(repo, "add", "artifact.bin")
+    (repo / "artifact.bin").write_text("harmless now\n")
+
+    result = _run_staged(repo)
+
+    assert result.returncode == 1
+    assert "artifact.bin" in result.stdout
+
+
+def test_staged_scan_passes_on_an_ordinary_zip(tmp_path):
+    repo = _repo(tmp_path)
+    deck = repo / "deck.pptx"
+    with zipfile.ZipFile(deck, "w") as archive:
+        archive.writestr("ppt/presentation.xml", "<p/>")
+    _git(repo, "add", "deck.pptx")
+
+    assert _run_staged(repo).returncode == 0
+
+
+def test_staged_scan_passes_when_nothing_is_staged(tmp_path):
+    assert _run_staged(_repo(tmp_path)).returncode == 0
+
+
+def test_staged_scan_does_not_follow_a_symlink(tmp_path):
+    # Same data-policy reason as the worktree scan: git stores the link text,
+    # so a symlink is never itself the archive, and following one would read
+    # through the data/ exclusion.
+    repo = _repo(tmp_path)
+    outside = tmp_path / "outside_plan"
+    _plan_archive(outside)
+    (repo / "link").symlink_to(outside)
+    _git(repo, "add", "link")
+
+    assert _run_staged(repo).returncode == 0
+
+
+def test_pre_commit_hook_invokes_the_staged_scan():
+    hook = (Path(__file__).resolve().parents[1] / ".githooks" / "pre-commit").read_text()
+    invocation = [
+        line
+        for line in hook.splitlines()
+        if "check_no_terraform_plans.py" in line and not line.lstrip().startswith("#")
+    ]
+    assert len(invocation) == 1, invocation
+    assert "--staged" in invocation[0]
+    # stdlib-only by design, so the hook works before any `uv sync`.
+    assert invocation[0].lstrip().startswith("python3 ")

--- a/tests/test_check_no_terraform_plans.py
+++ b/tests/test_check_no_terraform_plans.py
@@ -23,8 +23,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from scripts.check_no_terraform_plans import (  # noqa: E402
     _members_of,
     main,
-    pointer_offenders,
-    tracked_pointer_entries,
+    allowlisted_offenders,
+    dvc_pointer_problem,
+    tracked_allowlisted_entries,
     plan_members_of_blob,
     tracked_entries,
 )
@@ -619,7 +620,7 @@ def test_a_genuine_pointer_passes(tmp_path, monkeypatch):
 
     monkeypatch.chdir(repo)
     assert main() == 0
-    assert pointer_offenders(tracked_pointer_entries()) == []
+    assert allowlisted_offenders(tracked_allowlisted_entries()) == []
 
 
 def test_a_file_too_large_to_be_a_pointer_is_refused_unread(tmp_path, monkeypatch):
@@ -631,9 +632,9 @@ def test_a_file_too_large_to_be_a_pointer_is_refused_unread(tmp_path, monkeypatc
     _git(repo, "commit", "-qm", "big")
 
     monkeypatch.chdir(repo)
-    offenders = pointer_offenders(tracked_pointer_entries())
+    offenders = allowlisted_offenders(tracked_allowlisted_entries())
     assert [str(p) for p, _ in offenders] == ["data/raw/big.dvc"]
-    assert "larger than a DVC pointer" in offenders[0][1][0]
+    assert "far larger than" in offenders[0][1][0]
 
 
 def test_a_dvc_name_holding_something_else_entirely_is_refused(tmp_path, monkeypatch):
@@ -645,3 +646,101 @@ def test_a_dvc_name_holding_something_else_entirely_is_refused(tmp_path, monkeyp
 
     monkeypatch.chdir(repo)
     assert main() == 1
+
+
+# ---------------------------------------------------------------------------
+# Codex P1 on #321, follow-up: the allowlist exempts more than `.dvc`, and a
+# substring test for `outs:` is not a validation.
+# ---------------------------------------------------------------------------
+
+
+def test_a_plan_committed_as_a_gitkeep_marker_is_caught(tmp_path, monkeypatch):
+    # `.gitkeep` is allowlisted by the same predicate, and the first version
+    # of this fix added back only `.dvc`.
+    repo = _repo(tmp_path)
+    (repo / "data" / "raw").mkdir(parents=True)
+    _plan_archive(repo / "data" / "raw" / ".gitkeep", ("tfstate",))
+    _git(repo, "add", "-f", "data/raw/.gitkeep")
+    _git(repo, "commit", "-qm", "marker")
+
+    monkeypatch.chdir(repo)
+    assert main() == 1
+
+
+def test_an_empty_gitkeep_still_passes(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    (repo / "data" / "raw").mkdir(parents=True)
+    (repo / "data" / "raw" / ".gitkeep").write_text("")
+    _git(repo, "add", "-f", "data/raw/.gitkeep")
+    _git(repo, "commit", "-qm", "marker")
+
+    monkeypatch.chdir(repo)
+    assert main() == 0
+
+
+def test_prose_containing_outs_is_not_a_pointer(tmp_path, monkeypatch):
+    # The substring test this replaces accepted exactly this file.
+    repo = _repo(tmp_path)
+    (repo / "data" / "raw").mkdir(parents=True)
+    (repo / "data" / "raw" / "leak.dvc").write_text(
+        "some prose mentioning outs: in passing\nand more text\n"
+    )
+    _git(repo, "add", "-f", "data/raw/leak.dvc")
+    _git(repo, "commit", "-qm", "leak")
+
+    monkeypatch.chdir(repo)
+    assert main() == 1
+
+
+@pytest.mark.parametrize(
+    "text, expected_ok",
+    [
+        ("outs:\n- md5: abc\n  path: thing\n", True),
+        ("outs:\n- hash: md5\n  md5: abc\n  path: thing\n", True),
+        ("wdir: .\nouts:\n- md5: abc\n  path: thing\n", True),
+        ("prose with outs: inside\n", False),
+        ("outs:\n", False),
+        ("outs:\n- md5: abc\n", False),          # no path
+        ("outs:\n- path: thing\n", False),        # no hash
+        ("", False),
+    ],
+)
+def test_dvc_pointer_problem_parses_structure(text, expected_ok):
+    assert (dvc_pointer_problem(text) is None) is expected_ok
+
+
+def test_a_corrupt_provenance_sidecar_is_caught(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    (repo / "data" / "external" / "thing").mkdir(parents=True)
+    (repo / "data" / "external" / "thing" / "provenance.json").write_text("not json{")
+    _git(repo, "add", "-f", "data/external/thing/provenance.json")
+    _git(repo, "commit", "-qm", "sidecar")
+
+    monkeypatch.chdir(repo)
+    assert main() == 1
+
+
+def test_a_valid_provenance_sidecar_passes(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    (repo / "data" / "external" / "thing").mkdir(parents=True)
+    (repo / "data" / "external" / "thing" / "provenance.json").write_text('{"source": "x"}')
+    _git(repo, "add", "-f", "data/external/thing/provenance.json")
+    _git(repo, "commit", "-qm", "sidecar")
+
+    monkeypatch.chdir(repo)
+    assert main() == 0
+
+
+def test_the_allowlist_pathspecs_cover_the_workflow_predicate():
+    # If the workflow starts exempting a new name, this check must validate
+    # it too, or the exemption becomes a way in.
+    from scripts.check_no_terraform_plans import ALLOWLIST_PATHSPECS
+
+    workflow = (
+        Path(__file__).resolve().parents[1] / ".github" / "workflows" / "data-check.yml"
+    ).read_text()
+    predicate = [line for line in workflow.splitlines() if "gitkeep" in line]
+    assert predicate, "raw-data predicate not found"
+    for token in (".gitkeep", ".dvc", "provenance"):
+        assert any(token in spec for spec in ALLOWLIST_PATHSPECS), token
+        assert token in predicate[0], token

--- a/tests/test_check_no_terraform_plans.py
+++ b/tests/test_check_no_terraform_plans.py
@@ -1314,22 +1314,6 @@ def test_an_identifier_shaped_filename_is_refused(tmp_path, monkeypatch):
     assert main() == 1
 
 
-@pytest.mark.parametrize(
-    "name, expected_ok",
-    [
-        ("Dump20250730.sql.dvc", True),      # a date, 8 digits
-        ("historical_gold_180.jsonl.dvc", True),
-        ("validation_5_page_audit.sqlite.dvc", True),
-        ("Ram-Kumar-9876543210.dvc", False),  # mobile, 10
-        ("x-123456789012.dvc", False),        # Aadhaar, 12
-    ],
-)
-def test_the_identifier_rule_admits_real_names_and_refuses_identifiers(name, expected_ok):
-    from scripts.check_no_terraform_plans import IDENTIFIER_RUN
-
-    assert (IDENTIFIER_RUN.search(name) is None) is expected_ok
-
-
 # ---------------------------------------------------------------------------
 # Codex P1 on #321: the identifier rule looked only at the leaf, and an
 # 8-to-64 checksum range accepted a mobile number that happens to be hex.
@@ -1482,3 +1466,74 @@ def test_the_accepted_keys_are_the_ones_the_repository_actually_uses():
     assert {"md5", "size", "hash", "path", "nfiles"} <= DVC_ENTRY_KEYS
     assert "wdir" not in DVC_TOP_LEVEL_KEYS
     assert "remote" not in DVC_ENTRY_KEYS
+
+
+# ---------------------------------------------------------------------------
+# Codex P1 on #321: identifiers are written with separators, and `size`/
+# `nfiles` accepted any 1-20 digit string.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name, is_identifier",
+    [
+        # Written the way people write them.
+        ("Ram-987-654-3210.dvc", True),
+        ("x-9876 543210.dvc", True),
+        ("x_9876_543210.dvc", True),
+        ("x.9876.543210.dvc", True),
+        ("aadhaar-1234 5678 9012.dvc", True),
+        # Real names from this repository, which must keep passing.
+        ("Dump20250730.sql.dvc", False),
+        ("historical_gold_180.jsonl.dvc", False),
+        ("validation_5_page_audit.sqlite.dvc", False),
+        ("interrupted_300_page_audit.sqlite.dvc", False),
+    ],
+)
+def test_identifiers_are_counted_across_separators(name, is_identifier):
+    from scripts.check_no_terraform_plans import has_identifier
+
+    assert has_identifier(name) is is_identifier
+
+
+def test_a_separator_formatted_identifier_in_a_path_is_refused(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    (repo / "data" / "raw").mkdir(parents=True)
+    (repo / "data" / "raw" / "Ram-987-654-3210.dvc").write_text(
+        f"outs:\n- md5: {_MD5}\n  path: Ram-987-654-3210\n"
+    )
+    _git(repo, "add", "-f", "data/raw/Ram-987-654-3210.dvc")
+    _git(repo, "commit", "-qm", "sep id")
+
+    monkeypatch.chdir(repo)
+    assert main() == 1
+
+
+@pytest.mark.parametrize(
+    "line, expected_ok",
+    [
+        ("size: 3221225472", True),      # 3 GiB, ten digits and legitimate
+        ("size: 1234567890123", True),   # thirteen digits, not an identifier shape
+        ("size: 12", True),
+        ("nfiles: 11", True),
+        ("size: 9876543210", False),     # mobile
+        ("nfiles: 123456789012", False),  # Aadhaar
+        ("size: 0123", False),           # leading zero
+        ("size: twelve", False),
+    ],
+)
+def test_counts_are_not_identifiers(line, expected_ok):
+    text = f"outs:\n- md5: {_MD5}\n  path: thing\n  {line}\n"
+    assert (dvc_pointer_problem(text, stem="thing") is None) is expected_ok
+
+
+def test_the_real_size_values_still_pass():
+    # Sizes here reach ten digits, so length alone could not have been the
+    # rule; the identifier shapes are what separate them.
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        cwd=SCRIPT.parents[1],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout

--- a/tests/test_check_no_terraform_plans.py
+++ b/tests/test_check_no_terraform_plans.py
@@ -1212,8 +1212,8 @@ def test_a_protected_directory_name_is_redacted(monkeypatch):
 def test_the_oversized_reason_carries_no_filename(tmp_path, monkeypatch):
     repo = _repo(tmp_path)
     (repo / "data" / "raw").mkdir(parents=True)
-    (repo / "data" / "raw" / f"{CITIZEN}.dvc").write_bytes(b"outs:\n" + b"x" * 200_000)
-    _git(repo, "add", "-f", f"data/raw/{CITIZEN}.dvc")
+    (repo / "data" / "raw" / "Ram-Kumar.dvc").write_bytes(b"outs:\n" + b"x" * 200_000)
+    _git(repo, "add", "-f", "data/raw/Ram-Kumar.dvc")
     _git(repo, "commit", "-qm", "big")
 
     result = subprocess.run(
@@ -1222,7 +1222,7 @@ def test_the_oversized_reason_carries_no_filename(tmp_path, monkeypatch):
     )
 
     assert result.returncode == 1
-    assert CITIZEN not in result.stdout
+    assert "Ram-Kumar" not in result.stdout
     assert "over the" in result.stdout
 
 
@@ -1250,3 +1250,77 @@ def test_the_repositorys_own_pointers_satisfy_the_stem_rule():
         text=True,
     )
     assert result.returncode == 0, result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Codex P1 on #321: an allowlisted name occupied by a symlink escaped
+# verification, `hash` took any token, and the stem rule assumed a naming
+# policy that nothing enforced.
+# ---------------------------------------------------------------------------
+
+
+def test_a_symlink_at_an_allowlisted_name_is_refused(tmp_path, monkeypatch):
+    # The exemption says that path holds a pointer. A link holds no pointer
+    # while still occupying the exempt name, and was previously dropped.
+    repo = _repo(tmp_path)
+    (repo / "data" / "raw").mkdir(parents=True)
+    (repo / "target.txt").write_text("elsewhere\n")
+    (repo / "data" / "raw" / "leak.dvc").symlink_to(Path("..") / ".." / "target.txt")
+    _git(repo, "add", "-Af")
+    _git(repo, "commit", "-qm", "link")
+
+    monkeypatch.chdir(repo)
+    assert main() == 1
+
+
+def test_the_plan_scan_still_ignores_symlinks(tmp_path, monkeypatch):
+    # Opposite requirement, same parser: outside the allowlist a link is not
+    # the archive, and must not be reported.
+    repo = _repo(tmp_path)
+    (repo / "real_plan").write_bytes(_plan_archive(tmp_path / "p").read_bytes())
+    (repo / "link_to_plan").symlink_to("real_plan")
+    _git(repo, "add", "link_to_plan")
+    _git(repo, "commit", "-qm", "link only")
+
+    monkeypatch.chdir(repo)
+    assert main() == 0
+
+
+@pytest.mark.parametrize(
+    "value, expected_ok",
+    [("md5", True), ("sha256", True), ("Ram-Kumar-9876543210", False), ("prose", False)],
+)
+def test_hash_names_an_algorithm(value, expected_ok):
+    text = f"outs:\n- hash: {value}\n  md5: {_MD5}\n  path: thing\n"
+    assert (dvc_pointer_problem(text, stem="thing") is None) is expected_ok
+
+
+def test_an_identifier_shaped_filename_is_refused(tmp_path, monkeypatch):
+    # The stem rule made `path` safe only if the filename was. Nothing
+    # enforced that, so a 10-digit mobile in the name passed everything.
+    repo = _repo(tmp_path)
+    (repo / "data" / "raw").mkdir(parents=True)
+    (repo / "data" / "raw" / f"{CITIZEN}.dvc").write_text(
+        f"outs:\n- md5: {_MD5}\n  path: {CITIZEN}\n"
+    )
+    _git(repo, "add", "-f", f"data/raw/{CITIZEN}.dvc")
+    _git(repo, "commit", "-qm", "named")
+
+    monkeypatch.chdir(repo)
+    assert main() == 1
+
+
+@pytest.mark.parametrize(
+    "name, expected_ok",
+    [
+        ("Dump20250730.sql.dvc", True),      # a date, 8 digits
+        ("historical_gold_180.jsonl.dvc", True),
+        ("validation_5_page_audit.sqlite.dvc", True),
+        ("Ram-Kumar-9876543210.dvc", False),  # mobile, 10
+        ("x-123456789012.dvc", False),        # Aadhaar, 12
+    ],
+)
+def test_the_identifier_rule_admits_real_names_and_refuses_identifiers(name, expected_ok):
+    from scripts.check_no_terraform_plans import IDENTIFIER_RUN
+
+    assert (IDENTIFIER_RUN.search(name) is None) is expected_ok

--- a/tests/test_check_no_terraform_plans.py
+++ b/tests/test_check_no_terraform_plans.py
@@ -704,7 +704,7 @@ def test_prose_containing_outs_is_not_a_pointer(tmp_path, monkeypatch):
     [
         ("outs:\n- md5: d41d8cd98f00b204e9800998ecf8427e\n  path: thing\n", True),
         ("outs:\n- hash: md5\n  md5: d41d8cd98f00b204e9800998ecf8427e\n  path: thing\n", True),
-        ("wdir: .\nouts:\n- md5: d41d8cd98f00b204e9800998ecf8427e\n  path: thing\n", True),
+        ("wdir: .\nouts:\n- md5: d41d8cd98f00b204e9800998ecf8427e\n  path: thing\n", False),
         ("prose with outs: inside\n", False),
         ("outs:\n", False),
         ("outs:\n- md5: d41d8cd98f00b204e9800998ecf8427e\n", False),          # no path
@@ -808,10 +808,12 @@ def test_a_pointer_carrying_a_smuggled_block_is_refused(tmp_path, monkeypatch):
     [
         # Accepted: the shapes DVC actually writes.
         ("outs:\n- md5: d41d8cd98f00b204e9800998ecf8427e\n  path: thing\n", True),
-        ("wdir: .\nouts:\n- md5: d41d8cd98f00b204e9800998ecf8427e\n  path: thing\n  size: 12\n", True),
+        ("wdir: .\nouts:\n- md5: d41d8cd98f00b204e9800998ecf8427e\n  path: thing\n  size: 12\n", False),
+        # `deps`, `wdir` and a top-level `md5` are refused: a pointer
+        # needs none of them.
         ("md5: d41d8cd98f00b204e9800998ecf8427e\nouts:\n"
          "- md5: d41d8cd98f00b204e9800998ecf8427e\n  path: p\n"
-         "deps:\n- md5: d41d8cd98f00b204e9800998ecf8427e\n  path: q\n", True),
+         "deps:\n- md5: d41d8cd98f00b204e9800998ecf8427e\n  path: q\n", False),
         # Refused: unrecognised content, in each place it can hide.
         ("outs:\n- md5: d41d8cd98f00b204e9800998ecf8427e\n  path: thing\nraw: |\n  secret\n", False),
         ("outs:\n- md5: d41d8cd98f00b204e9800998ecf8427e\n  path: thing\n  leaked: citizen\n", False),
@@ -991,7 +993,7 @@ def test_a_sidecar_path_with_a_space_is_still_checked(tmp_path):
     "text, expected_ok",
     [
         (f"outs:\n- md5: {_MD5}\n  path: data/raw/thing.parquet\n", True),
-        (f"outs:\n- md5: {_MD5}\n  path: thing\n  remote: myremote\n", True),
+        (f"outs:\n- md5: {_MD5}\n  path: thing\n  remote: myremote\n", False),
         # Prose has spaces; a path does not need them.
         (f"outs:\n- md5: {_MD5}\n  path: Ram Kumar 9876543210\n", False),
         (f"outs:\n- md5: {_MD5}\n  path: thing\n  remote: Ram Kumar 987\n", False),
@@ -1059,7 +1061,9 @@ def test_a_nested_sidecar_still_needs_its_schema_version(tmp_path, monkeypatch):
     "text, expected_ok",
     [
         (f"outs:\n- md5: {_MD5}\n  path: thing\n", True),
-        (f"wdir: .\nouts:\n- md5: {_MD5}\n  path: thing\n", True),
+        # `wdir` is refused now: a pointer does not need it, and it was one of
+        # the last fields whose value was a free token.
+        (f"wdir: .\nouts:\n- md5: {_MD5}\n  path: thing\n", False),
         # `files` is a list in DVC's directory pointers, not a scalar. It is
         # no longer accepted at all rather than validated as one.
         (f"outs:\n- md5: {_MD5}\n  path: thing\n  files: Ram Kumar 9876543210\n", False),
@@ -1395,3 +1399,86 @@ def test_the_repository_still_passes_the_tightened_checksum_rule():
         text=True,
     )
     assert result.returncode == 0, result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Codex P1 on #321: a type change is not in ACMR, a repeated key overwrote the
+# earlier value, and `wdir`/`remote` were the last free-token fields.
+# ---------------------------------------------------------------------------
+
+
+def test_replacing_a_pointer_with_a_symlink_is_caught_before_the_commit(tmp_path):
+    # Git stages this as `T`, which `--diff-filter=ACMR` does not select, so
+    # the staged scan never saw it.
+    repo = _repo(tmp_path)
+    (repo / "data" / "raw").mkdir(parents=True)
+    (repo / "data" / "raw" / "thing.dvc").write_text(
+        f"outs:\n- md5: {_MD5}\n  path: thing\n"
+    )
+    (repo / "target.txt").write_text("x\n")
+    _git(repo, "add", "-f", "data/raw/thing.dvc", "target.txt")
+    _git(repo, "commit", "-qm", "seed2")
+
+    (repo / "data" / "raw" / "thing.dvc").unlink()
+    (repo / "data" / "raw" / "thing.dvc").symlink_to(Path("..") / ".." / "target.txt")
+    _git(repo, "add", "-A")
+
+    status = _git(repo, "diff", "--cached", "--name-status")
+    assert status.startswith("T"), status  # precondition: it really is a T
+
+    result = _run_staged(repo)
+
+    assert result.returncode == 1
+    assert "symlink" in result.stdout
+
+
+def test_the_hook_filename_check_also_selects_type_changes():
+    hook = (
+        Path(__file__).resolve().parents[1] / ".githooks" / "pre-commit"
+    ).read_text()
+    assert "--diff-filter=ACMR\n" not in hook
+    assert "ACMRT" in hook
+
+
+@pytest.mark.parametrize(
+    "text, expected_ok",
+    [
+        (f"outs:\n- md5: {_MD5}\n  path: thing\n", True),
+        # The second assignment hid the first from every rule below while its
+        # bytes stayed in the commit.
+        (f"outs:\n- md5: {_MD5}\n  md5: 9876543210\n  path: thing\n", False),
+        (f"outs:\n- md5: {_MD5}\n  path: thing\n  path: other\n", False),
+        (f"outs:\n- md5: {_MD5}\n  path: thing\nouts:\n- md5: {_MD5}\n  path: t\n", False),
+    ],
+)
+def test_a_repeated_key_is_refused(text, expected_ok):
+    assert (dvc_pointer_problem(text, stem="thing") is None) is expected_ok
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "wdir: Ram-Kumar\nouts:\n- md5: {m}\n  path: thing\n",
+        "outs:\n- md5: {m}\n  path: thing\n  remote: Ram-Kumar\n",
+    ],
+)
+def test_the_last_free_token_fields_are_gone(text):
+    # A pointer needs neither, so they are refused rather than pattern-matched.
+    problem = dvc_pointer_problem(text.format(m=_MD5), stem="thing")
+
+    assert problem is not None
+    assert "Ram-Kumar" not in problem
+
+
+def test_the_accepted_keys_are_the_ones_the_repository_actually_uses():
+    from scripts.check_no_terraform_plans import (
+        DVC_ENTRY_KEYS,
+        DVC_TOP_LEVEL_KEYS,
+    )
+
+    # Measured from the 23 real pointers. Widening either set is a conscious
+    # edit, and this is what makes it one.
+    assert DVC_TOP_LEVEL_KEYS == {"outs"}
+    assert {"md5", "size", "hash", "path", "nfiles"} <= DVC_ENTRY_KEYS
+    assert "wdir" not in DVC_TOP_LEVEL_KEYS
+    assert "remote" not in DVC_ENTRY_KEYS

--- a/tests/test_check_no_terraform_plans.py
+++ b/tests/test_check_no_terraform_plans.py
@@ -23,7 +23,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from scripts.check_no_terraform_plans import (  # noqa: E402
-    _archive_names,
+    _archive_entries,
     main,
     allowlisted_offenders,
     dvc_pointer_problem,
@@ -559,7 +559,7 @@ def test_a_damaged_plan_is_still_caught(tmp_path):
 
     damaged = intact[:-40]
     # A damaged archive does not raise: zipfile opens it and lists nothing.
-    assert not _archive_names(io.BytesIO(damaged))
+    assert not _archive_entries(io.BytesIO(damaged))
     # ...but is still recognised, and still refused.
     assert plan_members_of_blob(damaged) == ["tfstate"]
 
@@ -1628,5 +1628,56 @@ def test_a_damaged_archive_still_reaches_the_byte_fallback():
         archive.writestr("tfstate", '{"serial": 1}')
     damaged = buffer.getvalue()[:-40]
 
-    assert not _archive_names(io.BytesIO(damaged))
+    assert not _archive_entries(io.BytesIO(damaged))
+    assert plan_members_of_blob(damaged) == ["tfstate"]
+
+
+# ---------------------------------------------------------------------------
+# Codex P2 on #321: a member named `tfstate/` is a directory and holds no
+# state, but its base name matched. Fixing it interacts with the damaged-
+# archive fallback, so both facts are kept separate.
+# ---------------------------------------------------------------------------
+
+
+def _zip_of(*items: tuple[str, str]) -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        for name, content in items:
+            archive.writestr(name, content)
+    return buffer.getvalue()
+
+
+@pytest.mark.parametrize(
+    "entries, expected",
+    [
+        # Directories named like plan members hold nothing.
+        ((("tfstate/", ""),), []),
+        ((("tfstate/", ""), ("tfstate/readme.txt", "notes")), []),
+        # Real plans, at the root and under a directory.
+        ((("tfstate", '{"serial": 1}'),), ["tfstate"]),
+        ((("plan/tfstate", '{"serial": 1}'),), ["tfstate"]),
+        # An ordinary archive that merely mentions the word.
+        ((("notes.txt", "mentions tfstate in prose"),), []),
+    ],
+)
+def test_directory_entries_are_not_plan_members(entries, expected):
+    assert plan_members_of_blob(_zip_of(*entries)) == expected
+
+
+def test_a_directory_only_archive_is_not_treated_as_damaged():
+    # The interaction: filtering directories out of the listing made a zip
+    # holding only `tfstate/` look like one that listed nothing, which sent it
+    # to the byte fallback and reported it as a plan again. Whether the
+    # archive listed anything and whether an entry is a file are separate
+    # facts, and `_archive_entries` keeps both.
+    data = _zip_of(("tfstate/", ""))
+
+    assert _archive_entries(io.BytesIO(data))  # it did list something
+    assert plan_members_of_blob(data) == []
+
+
+def test_the_damaged_fallback_still_fires_for_a_truncated_plan():
+    damaged = _zip_of(("tfstate", '{"serial": 1}'))[:-40]
+
+    assert not _archive_entries(io.BytesIO(damaged))
     assert plan_members_of_blob(damaged) == ["tfstate"]

--- a/tests/test_check_no_terraform_plans.py
+++ b/tests/test_check_no_terraform_plans.py
@@ -9,6 +9,7 @@ cannot see.
 
 from __future__ import annotations
 
+import hashlib
 import io
 import json
 import os
@@ -1094,3 +1095,62 @@ def test_an_unruled_key_would_be_refused_not_accepted():
     assert problem is not None
     assert "no value rule" in problem
     assert "Ram Kumar" not in problem
+
+
+# ---------------------------------------------------------------------------
+# Codex P1 on #321: a filename under data/ can itself be the disclosure, and
+# report() printed the whole path into public CI logs.
+# ---------------------------------------------------------------------------
+
+
+def test_a_protected_filename_is_redacted_in_ci(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    (repo / "data" / "raw").mkdir(parents=True)
+    (repo / "data" / "raw" / "Ram-Kumar-9876543210.dvc").write_text("not a pointer\n")
+    _git(repo, "add", "-f", "data/raw/Ram-Kumar-9876543210.dvc")
+    _git(repo, "commit", "-qm", "named")
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "GITHUB_ACTIONS": "true"},
+    )
+
+    assert result.returncode == 1
+    assert "Ram-Kumar" not in result.stdout
+    assert "9876543210" not in result.stdout
+    # Still says where and what kind, and stays identifiable locally.
+    assert "data/raw/" in result.stdout
+    assert ".dvc" in result.stdout
+    digest = hashlib.sha256(b"Ram-Kumar-9876543210.dvc").hexdigest()[:12]
+    assert digest in result.stdout
+
+
+def test_the_same_run_names_the_file_locally(tmp_path):
+    # The hook runs on the author's machine, where the file is already in
+    # front of them; redacting there would only make the message useless.
+    repo = _repo(tmp_path)
+    (repo / "data" / "raw").mkdir(parents=True)
+    (repo / "data" / "raw" / "Ram-Kumar-9876543210.dvc").write_text("not a pointer\n")
+    _git(repo, "add", "-f", "data/raw/Ram-Kumar-9876543210.dvc")
+    _git(repo, "commit", "-qm", "named")
+
+    env = {k: v for k, v in os.environ.items() if k not in {"CI", "GITHUB_ACTIONS"}}
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)], cwd=repo, capture_output=True, text=True, env=env
+    )
+
+    assert result.returncode == 1
+    assert "data/raw/Ram-Kumar-9876543210.dvc" in result.stdout
+
+
+def test_source_paths_outside_data_are_never_redacted(monkeypatch):
+    from scripts.check_no_terraform_plans import safe_path
+
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+
+    assert safe_path(Path("deploy/terraform/tfplan")) == "deploy/terraform/tfplan"
+    assert safe_path(Path("scripts/thing.py")) == "scripts/thing.py"
+    assert "<redacted:" in safe_path(Path("data/raw/x.dvc"))

--- a/tests/test_check_no_terraform_plans.py
+++ b/tests/test_check_no_terraform_plans.py
@@ -324,3 +324,48 @@ def test_pre_commit_hook_invokes_the_staged_scan():
     assert "--staged" in invocation[0]
     # stdlib-only by design, so the hook works before any `uv sync`.
     assert invocation[0].lstrip().startswith("python3 ")
+
+
+# ---------------------------------------------------------------------------
+# Codex P2 on #321: staged *filenames* were passed to `git ls-files` as
+# pathspecs, so a name that is pathspec magic was reinterpreted rather than
+# selected. Both directions were reproduced before the fix.
+# ---------------------------------------------------------------------------
+
+
+def test_a_plan_named_like_pathspec_magic_cannot_exclude_itself(tmp_path):
+    # Reproduced on ab5dcee: this exact archive passed the staged scan,
+    # because `:(exclude,glob)**` was read as a pathspec that excluded
+    # everything rather than as the filename it is.
+    repo = _repo(tmp_path)
+    _plan_archive(repo / ":(exclude,glob)**")
+    _git(repo, "--literal-pathspecs", "add", ":(exclude,glob)**")
+
+    result = _run_staged(repo)
+
+    assert result.returncode == 1
+    assert "tfstate" in result.stdout
+
+
+def test_a_staged_filename_cannot_re_include_data(tmp_path):
+    # The other direction, and the one with a data-policy consequence: a
+    # staged file whose name is `:(glob)**` must not widen the scan back over
+    # data/, which the check must never open.
+    repo = _repo(tmp_path)
+    (repo / "data").mkdir()
+    _plan_archive(repo / "data" / "secret")
+    _git(repo, "add", "-f", "data/secret")
+    _git(repo, "commit", "-qm", "data")
+
+    (repo / ":(glob)**").write_text("harmless\n")
+    _git(repo, "--literal-pathspecs", "add", ":(glob)**")
+
+    result = _run_staged(repo)
+
+    assert result.returncode == 0, result.stdout
+    assert "data/secret" not in result.stdout
+
+
+def test_staged_scan_uses_literal_pathspecs():
+    source = SCRIPT.read_text()
+    assert "--literal-pathspecs" in source


### PR DESCRIPTION
## Why

`janasunani-documents-main` has a lifecycle rule with an **empty prefix** — STANDARD_IA at 30 days, GLACIER at 90 — so everything in it ends up archived. Of the 70,029 documents in the DSI clinic corpus, **61,530 are already in GLACIER**.

A Glacier restore does not undo that. It stages a *temporary* readable copy; the storage class stays `GLACIER` and the copy expires. Our own code encodes this at `janasunani/evaluation/sarvam_s3.py:114-122`, and the module docstring records the incident: a 3-day window set on 9 August expired on the 13th, the day before the demo it was built for.

That is acceptable for ad-hoc sampling. It is wrong for the fixed input every future benchmark has to re-read, which is what #319 asks the DSI corpus to become.

## Why not the alternatives

**Copy objects onto themselves as STANDARD.** Lifecycle transitions are measured from creation date, and copy-in-place sets a new one. They re-archive 90 days later, forever. It also writes to the citizen-document bucket, breaking the guarantee `sarvam_s3.py` states outright: *"It never writes objects, and it never deletes them."* Versioning is Enabled, so the old GLACIER version also persists and keeps billing.

**Exempt them from the rule.** Not expressible. S3 lifecycle filters have no negation and the corpus shares no key prefix (`AN063/E/2021/…`, `CMO2021…`). The workaround is to invert it — tag the ~960,000 objects you *do* want archived and filter on that — where any future object arriving untagged silently never archives. That failure surfaces as a bill, months later.

A separate bucket with no rule makes "stays readable" the default rather than something maintained. ~$1.40/month for 56 GB.

## What changed

- `reference_bucket.tf` — the bucket, versioning, SSE-S3 (matching the main bucket), full public-access block, `prevent_destroy`. **Deliberately no lifecycle configuration**, with the reasoning in the file header.
- `iam.tf` — `s3:ListBucket` plus **`s3:GetObject` only**. Read-only is the point: the box that runs the benchmarks must not be able to alter what it is measuring. Population happens once, from an operator workstation.
- `variables.tf`, `docs/DEPLOY.md` — the fourth bucket, and why it is the one Terraform manages.

## Terraform-managed, unlike the other three

Called out because it breaks the convention recorded in `iam.tf`'s header. The property that makes this bucket worth having is the **absence** of a lifecycle rule, and an absence is not something a hand-created bucket records anywhere. Declaring it here is what stops someone adding a transition rule later "for consistency".

## Checks

- `terraform validate` — Success
- `terraform fmt -check` — clean
- **Not applied.** `plan`/`apply` run from the main checkout, which holds the state. This branch's `.terraform` is `init -backend=false` for validation only.

## Context

A Bulk-tier restore of the 61,530 archived objects is running now (~$1.54). Tier matters at this object count: Glacier bills per request, so Expedited would have been ~$615 for the same result, and `sarvam_s3.py` still defaults to `Expedited` — correct for the 92-ticket sample it was written for, a footgun at 61,530. Filed separately.

Server-side copy into this bucket happens once the restore lands, so nothing transits the laptop.