### PR TITLE
feat(dedup): index any scope, not only one district-year

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,24 @@ Slice-at-a-time by design: everything downstream reads the redacted text, not
 the raw grievance. The dedup index is what the workload and spike findings
 (§2c) count distinct problems with.
 
+Dedup is the one stage where the slice is not just a convenience. Text
+candidates are blocked by district, script and time window, so per-slice runs
+find the same ones a corpus run would — but identity candidates (mobile,
+email) are deliberately unblocked, because a resubmission can land months
+later under any district. A same-citizen duplicate that crosses a district or
+year boundary is only ever visible to a run whose scope contains both sides of
+it, so looping over every slice finds none of them. For the whole corpus:
+
+```bash
+uv run janasunani-dedup-index --all --refresh-stale
+```
+
+`--all` is required rather than implied: a bare invocation errors, because a
+missing `--slice` and a deliberate 1.37M-row rebuild look identical from the
+command line. `--refresh-stale` is required after any redaction run, since
+grouping otherwise fails closed rather than mixing current text with
+signatures built on superseded redactions.
+
 ### 5 · Sample English complaints + documents (evaluation bundles)
 
 ```bash

--- a/janasunani/analytics/findings/spike.py
+++ b/janasunani/analytics/findings/spike.py
@@ -114,6 +114,7 @@ SPIKE_AGG_FIELDS = (
     "distinct_citizens",
     "source_name",
     "source_snapshot_id",
+    "grouping_scope_snapshot_id",
     "interpretation",
 )
 
@@ -158,7 +159,8 @@ def _read_oltp_groups(oltp_url: str, district: str, year: int):
         with engine.connect() as conn:
             rows = conn.execute(
                 text(
-                    "SELECT ticket_no, duplicate_group_id, group_size, source_name, source_snapshot_id, block_key "
+                    "SELECT ticket_no, duplicate_group_id, group_size, source_name, source_snapshot_id, "
+                    "grouping_scope_snapshot_id, block_key "
                     "FROM dedup_groups WHERE district = :d AND created_year = :y"
                 ),
                 {"d": district, "y": year},
@@ -209,7 +211,12 @@ def compute_spike_with_dedup(
     if not group_rows_raw:
         raise ValueError(f"No dedup_groups for {district}/{year}")
     group_rows = [
-        {"ticket_no": r["ticket_no"], "source_name": r["source_name"], "source_snapshot_id": r["source_snapshot_id"]}
+        {
+            "ticket_no": r["ticket_no"],
+            "source_name": r["source_name"],
+            "source_snapshot_id": r["source_snapshot_id"],
+            "grouping_scope_snapshot_id": r["grouping_scope_snapshot_id"],
+        }
         for r in group_rows_raw
     ]
     assert_group_source_snapshot(group_rows, source_records)
@@ -286,6 +293,7 @@ def compute_spike_with_dedup(
         "distinct_citizens": distinct_citizens,
         "source_name": DEDUP_SOURCE_NAME,
         "source_snapshot_id": expected_snapshot,
+        "grouping_scope_snapshot_id": group_rows_raw[0]["grouping_scope_snapshot_id"],
         "interpretation": interpretation,
     }
 
@@ -331,6 +339,14 @@ def publish_intelligence_aggregates(
     s_row = compute_spike_with_dedup(lake_dir=lake_dir, oltp_url=oltp_url, district=district, year=year)
     if w_row["source_snapshot_id"] != s_row["source_snapshot_id"]:
         raise ValueError("workload and spike digests diverged — refusing to publish mixed snapshot")
+    # #317. Equal slice digests are no longer sufficient: a corpus grouping
+    # depends on records outside this slice, so two runs can agree here and
+    # still carry different group assignments.
+    if w_row["grouping_scope_snapshot_id"] != s_row["grouping_scope_snapshot_id"]:
+        raise ValueError(
+            "workload and spike grouping scopes diverged — refusing to publish "
+            "figures from two different group assignments"
+        )
     if w_row["source_name"] != s_row["source_name"]:
         raise ValueError("workload and spike source names diverged")
     w_path = write_workload(w_row, dest)

--- a/janasunani/analytics/findings/workload.py
+++ b/janasunani/analytics/findings/workload.py
@@ -38,6 +38,7 @@ WORKLOAD_FIELDS = (
     "duplicate_adjustment",
     "source_name",
     "source_snapshot_id",
+    "grouping_scope_snapshot_id",
 )
 
 
@@ -83,8 +84,8 @@ def _read_oltp_groups(oltp_url: str, district: str, year: int):
         with engine.connect() as conn:
             rows = conn.execute(
                 text(
-                    "SELECT ticket_no, duplicate_group_id, group_size, source_name, source_snapshot_id "
-                    "FROM dedup_groups WHERE district = :d AND created_year = :y"
+                    "SELECT ticket_no, duplicate_group_id, group_size, source_name, source_snapshot_id, "
+                    "grouping_scope_snapshot_id FROM dedup_groups WHERE district = :d AND created_year = :y"
                 ),
                 {"d": district, "y": year},
             ).mappings().all()
@@ -119,6 +120,7 @@ def compute_workload(
             "ticket_no": r["ticket_no"],
             "source_name": r["source_name"],
             "source_snapshot_id": r["source_snapshot_id"],
+            "grouping_scope_snapshot_id": r["grouping_scope_snapshot_id"],
         }
         for r in group_rows_raw
     ]
@@ -137,6 +139,11 @@ def compute_workload(
         "duplicate_adjustment": duplicate_adjustment,
         "source_name": DEDUP_SOURCE_NAME,
         "source_snapshot_id": expected_snapshot,
+        # #317. The slice digest above cannot certify a corpus grouping: a
+        # ticket outside this slice can bridge two groups inside it. This is
+        # the digest of everything the grouping run read, so two artifacts
+        # built from different assignments are distinguishable.
+        "grouping_scope_snapshot_id": group_rows_raw[0]["grouping_scope_snapshot_id"],
     }
 
 

--- a/janasunani/db/alembic/versions/a4e17c93b820_dedup_group_grouping_scope_snapshot.py
+++ b/janasunani/db/alembic/versions/a4e17c93b820_dedup_group_grouping_scope_snapshot.py
@@ -1,0 +1,48 @@
+"""add grouping-scope provenance to dedup groups
+
+f3a91c0d54e7 gave every group row the snapshot of the source records it
+describes, which was complete while a grouping run could only ever cover one
+district-year. Corpus-wide runs (#317) break that completeness: a ticket
+outside a row's district-year can bridge two otherwise separate groups inside
+it, so changing that outside ticket and regrouping changes the slice's
+distinct-problem count while its source_snapshot_id -- which hashes only the
+slice -- stays identical. Two artifacts with different numbers would then
+present the same provenance, and the serving layer uses exactly that value to
+reject mixed outputs.
+
+source_snapshot_id keeps its meaning and stays the value a slice-scoped
+consumer can recompute from the lake. grouping_scope_snapshot_id is the
+digest of every record the grouping run actually read. A consumer cannot
+reproduce it from one slice, and is not meant to: it exists so rows from
+different group assignments are detectably different rather than silently
+combinable.
+
+Nullable for the same reason as f3a91c0d54e7 -- an existing index cannot be
+truthfully backfilled by a migration, only by re-running the command.
+
+Revision ID: a4e17c93b820
+Revises: f3a91c0d54e7
+Create Date: 2026-08-27
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a4e17c93b820"
+down_revision: Union[str, None] = "f3a91c0d54e7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "dedup_groups",
+        sa.Column("grouping_scope_snapshot_id", sa.String(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("dedup_groups", "grouping_scope_snapshot_id")

--- a/janasunani/db/models.py
+++ b/janasunani/db/models.py
@@ -478,5 +478,20 @@ class DedupGroup(Base):
     source_name = Column(String, nullable=True)
     source_snapshot_id = Column(String, nullable=True)
 
+    # #317. `source_snapshot_id` above hashes the records of *this row's*
+    # district-year, which is what a slice-scoped consumer can recompute from
+    # the lake -- and was the complete story while a run could only cover one
+    # district-year. A corpus-wide run breaks that: a ticket outside this row's
+    # slice can bridge two otherwise separate groups inside it, so changing
+    # that outside ticket and regrouping changes this slice's distinct-problem
+    # count while `source_snapshot_id` stays byte-identical.
+    #
+    # This field is the digest of every record the grouping run actually read.
+    # A consumer cannot recompute it from one slice and is not meant to; it
+    # exists so rows produced by different group assignments are detectably
+    # different rather than silently combinable. NULL on rows written before
+    # the column existed, and those are not valid for the assertion.
+    grouping_scope_snapshot_id = Column(String, nullable=True)
+
     index_version = Column(String, nullable=True)
     grouped_at = Column(DateTime, nullable=False, server_default=func.now())

--- a/janasunani/pipeline/dedup.py
+++ b/janasunani/pipeline/dedup.py
@@ -236,6 +236,33 @@ def source_snapshot_id_from_record_digests(
     return f"sha256:{digest.hexdigest()}"
 
 
+def grouping_scope_id(grouping_version: str, record_digests: Iterable[tuple[str, str]]) -> str:
+    """Digest of the inputs *and* the parameters that produced an assignment.
+
+    `source_snapshot_id_from_record_digests` covers only which records were
+    read. Two runs over the identical record set with a different
+    ``--threshold`` or ``--window-days``, or after the grouping algorithm
+    changes, produce different duplicate groups and an identical record
+    digest -- so artifacts from the two would compare equal and be served as
+    one snapshot. Folding the grouping version in is what makes them differ.
+
+    Deliberately *not* mixed into the per-slice `source_snapshot_id`: a
+    consumer recomputes that one from lake records alone and knows nothing
+    about grouping parameters, so adding them there would make it
+    unverifiable. The two digests answer different questions -- "are these the
+    same source records" and "did the same grouping run produce these rows".
+    """
+    if not isinstance(grouping_version, str) or not grouping_version.strip():
+        raise ValueError("grouping scope id requires a non-blank grouping version")
+    records = source_snapshot_id_from_record_digests(record_digests)
+    digest = hashlib.sha256()
+    digest.update(b"janasunani-dedup-grouping-scope-v1\n")
+    digest.update(grouping_version.encode("utf-8"))
+    digest.update(b"\0")
+    digest.update(records.encode("ascii"))
+    return f"sha256:{digest.hexdigest()}"
+
+
 def source_snapshot_id(records: Iterable[Mapping[str, object]]) -> str:
     """Stable manifest of the exact historical inputs used for a dedup slice.
 

--- a/janasunani/pipeline/dedup.py
+++ b/janasunani/pipeline/dedup.py
@@ -239,7 +239,7 @@ def source_snapshot_id_from_record_digests(
 def grouping_scope_id(
     grouping_version: str,
     record_digests: Iterable[tuple[str, str]],
-    signature_versions: Iterable[str | None] = (),
+    signature_versions: Iterable[tuple[str, str | None]] = (),
 ) -> str:
     """Digest of the inputs *and* the parameters that produced an assignment.
 
@@ -271,7 +271,26 @@ def grouping_scope_id(
     # produces different, correct assignments from identical source records
     # under the identical requested version, so without this the two runs are
     # indistinguishable and their artifacts compare equal.
-    for version in sorted({v for v in signature_versions}, key=lambda v: (v is None, v or "")):
+    #
+    # Bound to the ticket, not collapsed to the set of distinct values. A
+    # partial `--refresh-stale --limit` leaves the *same* two versions spread
+    # differently across tickets: {A:v1, B:v1, C:v2} and {A:v1, B:v2, C:v2}
+    # reduce to the same {v1, v2} under the same records and the same
+    # requested version. Those two layouts do not group the same way -- where
+    # identity candidates are separated from text candidates by a time window,
+    # the first can union A/B and the second B/C -- so a slice holding A and B
+    # gets a different distinct-problem count while the two artifacts still
+    # compare equal. The pairing is what distinguishes them.
+    # Keyed rather than compared directly: ticket_no is unique per signature
+    # row so the version is never reached as a tiebreak, but a bare sort would
+    # raise on None the day that stops being true.
+    ordered = sorted(
+        signature_versions,
+        key=lambda pair: (pair[0], pair[1] is None, pair[1] or ""),
+    )
+    for ticket, version in ordered:
+        digest.update(ticket.encode("utf-8"))
+        digest.update(b"\t")
         digest.update((version or "\x00none").encode("utf-8"))
         digest.update(b"\n")
     digest.update(b"\0")

--- a/janasunani/pipeline/dedup.py
+++ b/janasunani/pipeline/dedup.py
@@ -236,7 +236,11 @@ def source_snapshot_id_from_record_digests(
     return f"sha256:{digest.hexdigest()}"
 
 
-def grouping_scope_id(grouping_version: str, record_digests: Iterable[tuple[str, str]]) -> str:
+def grouping_scope_id(
+    grouping_version: str,
+    record_digests: Iterable[tuple[str, str]],
+    signature_versions: Iterable[str | None] = (),
+) -> str:
     """Digest of the inputs *and* the parameters that produced an assignment.
 
     `source_snapshot_id_from_record_digests` covers only which records were
@@ -256,8 +260,20 @@ def grouping_scope_id(grouping_version: str, record_digests: Iterable[tuple[str,
         raise ValueError("grouping scope id requires a non-blank grouping version")
     records = source_snapshot_id_from_record_digests(record_digests)
     digest = hashlib.sha256()
-    digest.update(b"janasunani-dedup-grouping-scope-v1\n")
+    digest.update(b"janasunani-dedup-grouping-scope-v2\n")
     digest.update(grouping_version.encode("utf-8"))
+    digest.update(b"\0")
+    # The versions actually stored on the signatures, not only the one this
+    # run requested. Without --refresh-stale the runner deliberately leaves
+    # stale signatures in place, so a run can group old-salt rows together
+    # with newly indexed new-salt ones -- identity linkage breaks across that
+    # boundary (#136) and the assignments are wrong. A later full refresh
+    # produces different, correct assignments from identical source records
+    # under the identical requested version, so without this the two runs are
+    # indistinguishable and their artifacts compare equal.
+    for version in sorted({v for v in signature_versions}, key=lambda v: (v is None, v or "")):
+        digest.update((version or "\x00none").encode("utf-8"))
+        digest.update(b"\n")
     digest.update(b"\0")
     digest.update(records.encode("ascii"))
     return f"sha256:{digest.hexdigest()}"

--- a/janasunani/pipeline/dedup.py
+++ b/janasunani/pipeline/dedup.py
@@ -276,6 +276,7 @@ def assert_group_source_snapshot(
     source_tickets = {record["ticket_no"] for record in source_records}
 
     observed: set[tuple[object, object]] = set()
+    scopes: set[object] = set()
     group_tickets: set[str] = set()
     duplicate_group_tickets = 0
     blank_group_tickets = 0
@@ -288,6 +289,7 @@ def assert_group_source_snapshot(
         else:
             group_tickets.add(ticket_no)
         observed.add((row.get("source_name"), row.get("source_snapshot_id")))
+        scopes.add(row.get("grouping_scope_snapshot_id"))
 
     if blank_group_tickets:
         raise DedupSourceSnapshotMismatch(
@@ -311,6 +313,15 @@ def assert_group_source_snapshot(
             "dedup group ticket population does not match the asserted source snapshot: "
             f"missing_group_rows={len(source_tickets - group_tickets)}, "
             f"extra_group_rows={len(group_tickets - source_tickets)}"
+        )
+    # #317. Rows that agree on the source snapshot can still come from
+    # different grouping runs once a run can span slices, because a corpus
+    # grouping depends on records this slice's digest does not cover. Differing
+    # scopes here means the rows were assembled from two assignments.
+    if len(scopes) > 1:
+        raise DedupSourceSnapshotMismatch(
+            "dedup group rows mix grouping scopes and cannot be combined: "
+            f"observed_scopes={len(scopes)}"
         )
     return expected
 

--- a/janasunani/pipeline/dedup.py
+++ b/janasunani/pipeline/dedup.py
@@ -318,6 +318,19 @@ def assert_group_source_snapshot(
     # different grouping runs once a run can span slices, because a corpus
     # grouping depends on records this slice's digest does not cover. Differing
     # scopes here means the rows were assembled from two assignments.
+    if None in scopes:
+        # Absence is not agreement. Rows written before a4e17c93b820 all carry
+        # NULL here, so a "no two different values" test would pass on {None}
+        # and both findings would publish a blank scope that compares equal to
+        # every other blank one -- the mixed-output hole this field exists to
+        # close, reopened by the legacy case. A migration cannot invent this
+        # provenance; only re-running the index can.
+        raise DedupSourceSnapshotMismatch(
+            "dedup group rows lack grouping-scope provenance "
+            f"({sum(1 for s in scopes if s is None)} distinct NULL scope(s)); "
+            "re-run janasunani-dedup-index to populate "
+            "grouping_scope_snapshot_id"
+        )
     if len(scopes) > 1:
         raise DedupSourceSnapshotMismatch(
             "dedup group rows mix grouping scopes and cannot be combined: "

--- a/janasunani/pipeline/dedup_index.py
+++ b/janasunani/pipeline/dedup_index.py
@@ -176,6 +176,7 @@ import argparse
 import asyncio
 import math
 from collections import Counter, defaultdict
+from dataclasses import dataclass
 from datetime import date, datetime, timezone
 import hashlib
 from itertools import combinations
@@ -594,6 +595,19 @@ async def _source_digest_mismatches(conn, district: Optional[str], year: Optiona
     current redacted text, so allowing these two inputs to differ would create
     an unprovable mixed run. Missing legacy digests are handled separately as
     pending signature rows; non-NULL disagreement requires --refresh-stale.
+
+    Returns ``(ticket_no, district, created_year)`` triples -- **identity
+    only, never the text**. Every caller of this needs a count, a membership
+    check, or a ticket list; the redacted text is needed only to rebuild a
+    signature, and `_refresh_mismatched_signatures` re-reads it one bounded
+    batch at a time.
+
+    That is not a tidiness point. The documented run after a corpus redaction
+    is `--all --refresh-stale`, where every one of ~1.37M signatures mismatches
+    at once. Carrying each row's grievance text through this scan would hold
+    the entire redacted corpus in memory before a single signature was
+    rebuilt. The query is streamed for the same reason: the result set is the
+    whole corpus even when the mismatch list is short.
     """
     stmt = (
         select(
@@ -612,10 +626,10 @@ async def _source_digest_mismatches(conn, district: Optional[str], year: Optiona
         .where(*_slice_filters(DedupSignature, district, year))
         .order_by(DedupSignature.ticket_no)
     )
-    result = await conn.execute(stmt)
-    mismatches = []
-    missing_source = []
-    for (
+    mismatches: list[tuple[str, Optional[str], Optional[int]]] = []
+    missing_source: list[str] = []
+    result = await conn.stream(stmt)
+    async for (
         ticket_no,
         stored_digest,
         row_district,
@@ -634,10 +648,36 @@ async def _source_digest_mismatches(conn, district: Optional[str], year: Optiona
             )
         )
         if stored_digest is not None and stored_digest != current:
-            mismatches.append(
-                (ticket_no, redacted_text, row_district, row_year, created_on, mobile, email)
-            )
+            mismatches.append((ticket_no, row_district, row_year))
     return mismatches, missing_source
+
+
+async def _load_source_rows_for_tickets(conn, ticket_nos: list[str]):
+    """Full source rows for exactly these tickets, in the batch shape
+    `_signature_rows_for_source_batch` consumes.
+
+    The other half of keeping `_source_digest_mismatches` text-free: the
+    grievance text comes back only for the batch about to be rebuilt, and is
+    released with it.
+    """
+    stmt = (
+        select(
+            DedupSignature.ticket_no,
+            GrievanceRedaction.grievance_redacted,
+            Complaint.district,
+            Complaint.created_year,
+            Complaint.created_on,
+            Complaint.petitioner_mobile,
+            Complaint.petitioner_email,
+        )
+        .select_from(DedupSignature)
+        .outerjoin(Complaint, Complaint.ticket_no == DedupSignature.ticket_no)
+        .outerjoin(GrievanceRedaction, GrievanceRedaction.ticket_no == DedupSignature.ticket_no)
+        .where(DedupSignature.ticket_no.in_(ticket_nos))
+        .order_by(DedupSignature.ticket_no)
+    )
+    result = await conn.execute(stmt)
+    return result.all()
 
 
 def _source_digest_mismatch_error(count: int) -> ValueError:
@@ -680,8 +720,9 @@ def _moved_sources(source_mismatches, district: Optional[str], year: Optional[in
     return [
         row
         for row in source_mismatches
-        if (district is not None and row[2] != district)
-        or (year is not None and row[3] != year)
+        # (ticket_no, district, created_year) -- see _source_digest_mismatches.
+        if (district is not None and row[1] != district)
+        or (year is not None and row[2] != year)
     ]
 
 
@@ -755,20 +796,42 @@ async def _index_signatures(
             len(source_mismatches),
         )
         now = datetime.now(timezone.utc).replace(tzinfo=None)
-        rows = _signature_rows_for_source_batch(
-            source_mismatches,
-            salt=salt,
-            epoch=epoch,
-            window_days=window_days,
-            version=version,
-            now=now,
-        )
-        async with engine.begin() as conn:
-            await conn.execute(
-                _dialect_upsert(DedupSignature, conn.dialect.name, rows, "ticket_no")
+        # Batched on the same BATCH_SIZE as the pending-signature loop below,
+        # and for the same reason. The documented post-redaction run is
+        # `--all --refresh-stale`, where every one of ~1.37M signatures
+        # mismatches: one pass would fetch the whole redacted corpus, build
+        # 1.37M replacement rows beside it, and hand the lot to a single
+        # multi-row upsert -- millions of bind parameters, past both the
+        # memory envelope and the statement limits, before this loop's
+        # existing batching was ever reached.
+        #
+        # Each batch is its own transaction, so an interrupted refresh leaves
+        # the batches it completed durably rebuilt. That is safe because the
+        # rebuilt rows carry the current digest: a rerun simply finds fewer
+        # mismatches, and the not-yet-rebuilt ones are still found by the scan.
+        mismatched_tickets = [row[0] for row in source_mismatches]
+        for start in range(0, len(mismatched_tickets), BATCH_SIZE):
+            chunk = mismatched_tickets[start : start + BATCH_SIZE]
+            async with engine.begin() as conn:
+                batch = await _load_source_rows_for_tickets(conn, chunk)
+                rows = _signature_rows_for_source_batch(
+                    batch,
+                    salt=salt,
+                    epoch=epoch,
+                    window_days=window_days,
+                    version=version,
+                    now=now,
+                )
+                await conn.execute(
+                    _dialect_upsert(DedupSignature, conn.dialect.name, rows, "ticket_no")
+                )
+            refreshed_tickets.update(chunk)
+            processed += len(rows)
+            logger.info(
+                "source refresh: {}/{} signature(s) rebuilt",
+                min(start + BATCH_SIZE, len(mismatched_tickets)),
+                len(mismatched_tickets),
             )
-        refreshed_tickets.update(row[0] for row in source_mismatches)
-        processed += len(rows)
 
     while True:
         remaining = None if limit is None else limit - processed
@@ -840,7 +903,62 @@ async def _index_signatures(
 # --- stage 2: grouping ------------------------------------------------------
 
 
-async def _load_slice_signatures(conn, district: Optional[str], year: Optional[int]):
+@dataclass(frozen=True, slots=True)
+class _BandedSignature:
+    """One signature row with its bands precomputed and the signature dropped.
+
+    The 128-element MinHash array is only ever used to compute band hashes:
+    exact verification re-reads the redacted text (`_load_redacted_text`) and
+    scores true Jaccard on shingles, never the sketch. So the array has no
+    reason to outlive banding, and at corpus scale it is the whole memory
+    problem -- 1.37M rows x 128 Python ints is roughly 4.6 GiB for the
+    integers plus about 1.3 GiB for the list objects holding them, before
+    SQLAlchemy rows, strings, buckets and union-find state. That does not fit
+    the 8 GiB box.
+
+    Sixteen band hashes in a tuple is about an eighth of that, and the rest of
+    the row is small. `slots=True` because a per-row `__dict__` at this count
+    is itself hundreds of megabytes.
+    """
+
+    ticket_no: str
+    district: str
+    created_year: int
+    block_key: str
+    identity_key_mobile: Optional[str]
+    identity_key_email: Optional[str]
+    #: ``None`` where `minhash_signature` abstained -- nothing to band.
+    bands: Optional[tuple[int, ...]]
+
+
+def _band_signature_row(row, num_bands: int) -> _BandedSignature:
+    """Convert a DB row to its banded form, discarding the raw signature."""
+    return _BandedSignature(
+        ticket_no=row.ticket_no,
+        district=row.district,
+        created_year=row.created_year,
+        block_key=row.block_key,
+        identity_key_mobile=row.identity_key_mobile,
+        identity_key_email=row.identity_key_email,
+        bands=(
+            None
+            if row.signature is None
+            else tuple(lsh_bands(tuple(row.signature), num_bands=num_bands))
+        ),
+    )
+
+
+async def _load_slice_signatures(
+    conn, district: Optional[str], year: Optional[int], num_bands: int = DEFAULT_NUM_BANDS
+) -> list[_BandedSignature]:
+    """Stream the slice's signatures, keeping only what grouping needs.
+
+    Streamed rather than `result.all()` because `--all` selects the whole
+    corpus. Materialising every ORM-decoded row first and converting after
+    would peak at the same size the conversion exists to avoid; the driver
+    hands back a bounded window and each signature is banded and released as
+    it arrives.
+    """
     stmt = select(
         DedupSignature.ticket_no,
         DedupSignature.district,
@@ -850,8 +968,12 @@ async def _load_slice_signatures(conn, district: Optional[str], year: Optional[i
         DedupSignature.identity_key_mobile,
         DedupSignature.identity_key_email,
     ).where(*_slice_filters(DedupSignature, district, year))
-    result = await conn.execute(stmt)
-    return result.all()
+
+    rows: list[_BandedSignature] = []
+    result = await conn.stream(stmt)
+    async for row in result:
+        rows.append(_band_signature_row(row, num_bands))
+    return rows
 
 
 async def _raise_if_scope_would_split_existing_groups(
@@ -962,7 +1084,7 @@ async def _source_snapshots_by_slice(
     scope = grouping_scope_id(
         grouping_version,
         [(row.ticket_no, row.source_record_digest) for row in rows],
-        signature_versions=[row.index_version for row in rows],
+        signature_versions=[(row.ticket_no, row.index_version) for row in rows],
     )
     return per_slice, scope
 
@@ -985,6 +1107,40 @@ async def _load_redacted_text(conn, ticket_nos: list[str]) -> dict[str, str]:
     return text_by_ticket
 
 
+def _banded(rows, num_bands: int):
+    """Yield rows that have bands, banding on the fly if they arrive raw.
+
+    Production reaches here with `_BandedSignature` rows: `_load_slice_signatures`
+    bands each row as the driver hands it over and never keeps the 128-element
+    signature. This accepts a raw DB row too, so the pure bucket functions
+    below stay directly callable from a test with a plain signature.
+
+    The band count is checked rather than assumed. Banding at load time and
+    bucketing at a different `num_bands` would silently produce buckets that
+    are not LSH bands of anything, and the two call sites take the count as a
+    parameter, so the mismatch is reachable.
+
+    Yields ``(row, bands)`` rather than a rebuilt row so a caller's own row
+    type passes through untouched -- the tests build partial rows on purpose.
+    """
+    for row in rows:
+        bands = getattr(row, "bands", None)
+        if bands is None:
+            signature = getattr(row, "signature", None)
+            if signature is None:
+                # `minhash_signature` abstained; there is nothing to band
+                # (dedup.py module docstring point 5).
+                continue
+            bands = tuple(lsh_bands(tuple(signature), num_bands=num_bands))
+        if len(bands) != num_bands:
+            raise ValueError(
+                f"signature for {row.ticket_no} carries {len(bands)} band(s) "
+                f"but bucketing was asked for {num_bands}; the bands were "
+                "computed at load time and must match."
+            )
+        yield row, bands
+
+
 def _text_candidate_pairs(rows, num_bands: int) -> set[tuple[str, str]]:
     """LSH candidate pairs, blocked by `block_key` — a shared band hash
     within the same block is a candidate, never across blocks. Rows with no
@@ -999,11 +1155,8 @@ def _text_candidate_pairs(rows, num_bands: int) -> set[tuple[str, str]]:
     verify against whichever ticket landed first in iteration order.
     """
     buckets: dict[tuple[str, int, int], list[str]] = defaultdict(list)
-    for row in rows:
-        if row.signature is None:
-            continue
-        signature = tuple(row.signature)
-        for band_index, band_hash in enumerate(lsh_bands(signature, num_bands=num_bands)):
+    for row, bands in _banded(rows, num_bands):
+        for band_index, band_hash in enumerate(bands):
             buckets[(row.block_key, band_index, band_hash)].append(row.ticket_no)
 
     pairs: set[tuple[str, str]] = set()
@@ -1075,11 +1228,8 @@ def _candidate_buckets(rows, num_bands: int) -> list[tuple[Optional[str], list[s
     that production uses.
     """
     band_buckets: dict[tuple[str, int, int], list[str]] = defaultdict(list)
-    for row in rows:
-        if row.signature is None:
-            continue
-        signature = tuple(row.signature)
-        for band_index, band_hash in enumerate(lsh_bands(signature, num_bands=num_bands)):
+    for row, bands in _banded(rows, num_bands):
+        for band_index, band_hash in enumerate(bands):
             band_buckets[(row.block_key, band_index, band_hash)].append(row.ticket_no)
 
     identity_buckets: dict[tuple[str, str], list[str]] = defaultdict(list)
@@ -1219,7 +1369,7 @@ async def _group_duplicates(
     )
 
     async with engine.begin() as conn:
-        rows = await _load_slice_signatures(conn, district, year)
+        rows = await _load_slice_signatures(conn, district, year, DEFAULT_NUM_BANDS)
         source_mismatches, missing_source = await _source_digest_mismatches(
             conn, district, year
         )

--- a/janasunani/pipeline/dedup_index.py
+++ b/janasunani/pipeline/dedup_index.py
@@ -197,6 +197,7 @@ from janasunani.pipeline.dedup import (
     lsh_bands,
     minhash_signature,
     source_record_digest,
+    grouping_scope_id,
     source_snapshot_id_from_record_digests,
     shingles,
 )
@@ -903,7 +904,7 @@ async def _raise_if_scope_would_split_existing_groups(
 
 
 async def _source_snapshots_by_slice(
-    conn, district: Optional[str], year: Optional[int]
+    conn, district: Optional[str], year: Optional[int], grouping_version: str
 ) -> tuple[dict[tuple[str, int], str], str]:
     """Manifest the indexed inputs, **one digest per district-year**.
 
@@ -957,8 +958,8 @@ async def _source_snapshots_by_slice(
     # determined the assignments -- see DedupGroup.grouping_scope_snapshot_id.
     # For a single-slice run this equals that slice's own digest, so the two
     # fields agree exactly where they always did.
-    scope = source_snapshot_id_from_record_digests(
-        [(row.ticket_no, row.source_record_digest) for row in rows]
+    scope = grouping_scope_id(
+        grouping_version, [(row.ticket_no, row.source_record_digest) for row in rows]
     )
     return per_slice, scope
 
@@ -1202,6 +1203,18 @@ async def _group_duplicates(
     representative_cap: int = REPRESENTATIVE_COMPARISON_CAP,
     anchor_count: int = LARGE_BUCKET_ANCHOR_COUNT,
 ) -> dict[str, int]:
+    # Computed before the snapshot read, because the grouping scope digest
+    # has to cover the parameters that produced an assignment and not only
+    # which records were read.
+    version = _index_version(
+        window_days,
+        threshold,
+        salt,
+        grouping_algorithm=GROUPING_ALGORITHM,
+        representative_cap=representative_cap,
+        anchor_count=anchor_count,
+    )
+
     async with engine.begin() as conn:
         rows = await _load_slice_signatures(conn, district, year)
         source_mismatches, missing_source = await _source_digest_mismatches(
@@ -1212,7 +1225,7 @@ async def _group_duplicates(
         )
         await _raise_if_scope_would_split_existing_groups(conn, district, year)
         snapshots_by_slice, scope_snapshot = await _source_snapshots_by_slice(
-            conn, district, year
+            conn, district, year, version
         )
 
     if not rows:
@@ -1310,14 +1323,6 @@ async def _group_duplicates(
     groups = {ticket: _find(parent, ticket) for ticket in all_tickets}
     group_sizes = Counter(groups.values())
 
-    version = _index_version(
-        window_days,
-        threshold,
-        salt,
-        grouping_algorithm=GROUPING_ALGORITHM,
-        representative_cap=representative_cap,
-        anchor_count=anchor_count,
-    )
     now = datetime.now(timezone.utc).replace(tzinfo=None)
     # district/created_year describe the *record*, taken from its signature
     # row -- not the scope the run was invoked with. Those coincided while

--- a/janasunani/pipeline/dedup_index.py
+++ b/janasunani/pipeline/dedup_index.py
@@ -931,6 +931,7 @@ async def _source_snapshots_by_slice(
             DedupSignature.district,
             DedupSignature.created_year,
             DedupSignature.source_record_digest,
+            DedupSignature.index_version,
         )
         .where(*_slice_filters(DedupSignature, district, year))
         .order_by(DedupSignature.ticket_no)
@@ -959,7 +960,9 @@ async def _source_snapshots_by_slice(
     # For a single-slice run this equals that slice's own digest, so the two
     # fields agree exactly where they always did.
     scope = grouping_scope_id(
-        grouping_version, [(row.ticket_no, row.source_record_digest) for row in rows]
+        grouping_version,
+        [(row.ticket_no, row.source_record_digest) for row in rows],
+        signature_versions=[row.index_version for row in rows],
     )
     return per_slice, scope
 

--- a/janasunani/pipeline/dedup_index.py
+++ b/janasunani/pipeline/dedup_index.py
@@ -1227,11 +1227,36 @@ def _candidate_buckets(rows, num_bands: int) -> list[tuple[Optional[str], list[s
     the all-pairs invariant from #101. This function is the streaming path
     that production uses.
     """
-    band_buckets: dict[tuple[str, int, int], list[str]] = defaultdict(list)
-    for row, bands in _banded(rows, num_bands):
-        for band_index, band_hash in enumerate(bands):
-            band_buckets[(row.block_key, band_index, band_hash)].append(row.ticket_no)
+    # One band at a time, not all sixteen at once.
+    #
+    # Building the full map first and filtering singletons afterwards costs
+    # 16N dictionary entries at peak -- about 21.9M for the corpus, measured
+    # at ~5.2 GiB, which dwarfs the 1.05 GiB the banded rows themselves take
+    # and was enough to exhaust an 8 GiB box on its own. Almost all of those
+    # entries are singletons that are then thrown away: a signature that
+    # collides with nothing still occupies sixteen of them.
+    #
+    # Banding is independent per band index, so a bucket can never span two
+    # of them. Handling one band per pass therefore yields exactly the same
+    # buckets while holding only N entries at a time -- a sixteenth of the
+    # peak -- and the singletons are discarded at the end of each pass
+    # instead of at the end of everything. The extra passes are over a list
+    # already in memory and cost no I/O.
+    out: list[tuple[Optional[str], list[str]]] = []
+    for band_index in range(num_bands):
+        band_buckets: dict[tuple[str, int], list[str]] = defaultdict(list)
+        for row, bands in _banded(rows, num_bands):
+            band_buckets[(row.block_key, bands[band_index])].append(row.ticket_no)
+        out.extend(
+            (block_key, members)
+            for (block_key, _band_hash), members in band_buckets.items()
+            if len(set(members)) > 1
+        )
+        del band_buckets
 
+    # Identity buckets are keyed by the citizen, not by a band, so there is
+    # no equivalent split: two dicts over the rows that carry a key at all,
+    # measured at ~0.38 GiB for the corpus.
     identity_buckets: dict[tuple[str, str], list[str]] = defaultdict(list)
     for row in rows:
         for kind, key in (
@@ -1241,11 +1266,10 @@ def _candidate_buckets(rows, num_bands: int) -> list[tuple[Optional[str], list[s
             if key is not None:
                 identity_buckets[(kind, key)].append(row.ticket_no)
 
-    return [
-        (block_key, members)
-        for (block_key, _band_index, _band_hash), members in band_buckets.items()
-        if len(set(members)) > 1
-    ] + [(None, members) for members in identity_buckets.values() if len(set(members)) > 1]
+    out.extend(
+        (None, members) for members in identity_buckets.values() if len(set(members)) > 1
+    )
+    return out
 
 
 def _find(parent: dict[str, str], item: str) -> str:

--- a/janasunani/pipeline/dedup_index.py
+++ b/janasunani/pipeline/dedup_index.py
@@ -904,7 +904,7 @@ async def _raise_if_scope_would_split_existing_groups(
 
 async def _source_snapshots_by_slice(
     conn, district: Optional[str], year: Optional[int]
-) -> dict[tuple[str, int], str]:
+) -> tuple[dict[tuple[str, int], str], str]:
     """Manifest the indexed inputs, **one digest per district-year**.
 
     This intentionally reads the digest stored at signature time, never the
@@ -949,10 +949,18 @@ async def _source_snapshots_by_slice(
         by_slice[(row.district, row.created_year)].append(
             (row.ticket_no, row.source_record_digest)
         )
-    return {
+    per_slice = {
         slice_key: source_snapshot_id_from_record_digests(record_digests)
         for slice_key, record_digests in by_slice.items()
     }
+    # Everything the grouping run read, which is the input set that actually
+    # determined the assignments -- see DedupGroup.grouping_scope_snapshot_id.
+    # For a single-slice run this equals that slice's own digest, so the two
+    # fields agree exactly where they always did.
+    scope = source_snapshot_id_from_record_digests(
+        [(row.ticket_no, row.source_record_digest) for row in rows]
+    )
+    return per_slice, scope
 
 
 async def _load_redacted_text(conn, ticket_nos: list[str]) -> dict[str, str]:
@@ -1203,7 +1211,9 @@ async def _group_duplicates(
             source_mismatches, missing_source, district, year
         )
         await _raise_if_scope_would_split_existing_groups(conn, district, year)
-        snapshots_by_slice = await _source_snapshots_by_slice(conn, district, year)
+        snapshots_by_slice, scope_snapshot = await _source_snapshots_by_slice(
+            conn, district, year
+        )
 
     if not rows:
         return {
@@ -1331,6 +1341,7 @@ async def _group_duplicates(
                     signature_by_ticket[ticket_no].created_year,
                 )
             ],
+            "grouping_scope_snapshot_id": scope_snapshot,
             "index_version": version,
             "grouped_at": now,
         }

--- a/janasunani/pipeline/dedup_index.py
+++ b/janasunani/pipeline/dedup_index.py
@@ -10,8 +10,10 @@ result — that is what this module does, one stage after
 
 Mirrors `redact_grievance.py`'s shape on purpose (argparse entrypoint,
 `def main() -> None` wrapping `asyncio.run`, its own `create_async_engine`,
-`--district`/`--year` with no defaults, batched and resumable): they are the
-same kind of job, one stage apart, over the same slice.
+scope flags with no defaults, batched and resumable): they are the same kind
+of job, one stage apart, over the same records. It diverges in one place:
+this runner also accepts `--all`, because dedup is the only stage whose
+answer depends on which *other* records are in scope.
 
 **Built from `grievance_redactions.grievance_redacted` only.** Never from
 `complaints.grievance` — that column has never met Presidio, and indexing it
@@ -34,7 +36,9 @@ created_on, petitioner_mobile/email); it never selects `complaints.grievance`.
    redacted text and never feeds `shingles()` (dedup.py module docstring
    point 3; see `identity_key()`'s contract). Writes `dedup_signatures`.
 2. `_group_duplicates()` — not batched. It loads every signature already
-   written for the slice (tens of thousands of rows, comfortably in memory),
+   written for the scope (tens of thousands of rows for a district-year,
+   comfortably in memory; 1.37M for `--all`, where that claim has not been
+   verified and #317 tracks measuring it),
    buckets by `(block_key, lsh band)` to find text candidates, adds
    identity-key equality as a second, unblocked source of candidates
    (same-citizen resubmission does not need to fall in the same time
@@ -57,6 +61,18 @@ created_on, petitioner_mobile/email); it never selects `complaints.grievance`.
    duplicate-adjusted analytics consumer.  That consumer must assert the
    match before aggregation; a stale/incomplete lake or a mixture of group
    runs is an error, not a number to publish.
+
+   The digest is per district-year, never per run, so a corpus-wide run
+   still stamps each row with the digest of the slice that row belongs to
+   and slice-scoped consumers keep verifying (`_source_snapshots_by_slice`).
+
+   **One consequence of corpus grouping, for whoever reads these counts.**
+   A group whose members straddle two district-years is counted as a
+   distinct problem in *both* when each is aggregated on its own. That is
+   the right answer per slice — each really did receive a filing about that
+   problem — but it means per-slice distinct-problem counts no longer sum
+   to the corpus figure. Report the corpus number from a corpus
+   aggregation, not by adding slices up.
 
    **Above `REPRESENTATIVE_COMPARISON_CAP` members, a bucket trades recall
    for time (#158).** A campaign-heavy district-year produces buckets in the
@@ -166,7 +182,7 @@ from itertools import combinations
 from typing import Optional
 
 from loguru import logger
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 from janasunani.config import settings
@@ -354,6 +370,23 @@ def _index_version(
 # --- stage 1: signatures ---------------------------------------------------
 
 
+def _indexable_filters(model) -> list:
+    """Require the dimensions a signature row cannot be written without.
+
+    ``Complaint.district`` and ``Complaint.created_year`` are nullable, while
+    ``DedupSignature`` and ``DedupGroup`` declare both NOT NULL. A scoped run
+    never saw such a record, because SQL ``NULL = 'Sambalpur'`` is NULL and
+    the row was silently filtered out by the scope predicate itself. Removing
+    that predicate for a corpus-wide run removes the accidental filter with
+    it, and the run dies on an integrity error partway through the backfill.
+
+    Stated explicitly so the exclusion is a decision rather than a side effect
+    of how the scope happened to be expressed, and applied on every path so a
+    scoped and an unscoped run agree on which records are indexable.
+    """
+    return [model.district.isnot(None), model.created_year.isnot(None)]
+
+
 def _slice_filters(model, district: Optional[str], year: Optional[int]) -> list:
     """Scope predicates for ``model``, empty when the scope is unbounded.
 
@@ -392,6 +425,7 @@ async def _count_signature_slice(
         .join(Complaint, Complaint.ticket_no == GrievanceRedaction.ticket_no)
         .where(
             *_slice_filters(Complaint, district, year),
+            *_indexable_filters(Complaint),
             GrievanceRedaction.grievance_redacted.isnot(None),
         )
     )
@@ -468,6 +502,7 @@ async def _load_pending_signature_batch(
         .join(Complaint, Complaint.ticket_no == GrievanceRedaction.ticket_no)
         .where(
             *_slice_filters(Complaint, district, year),
+            *_indexable_filters(Complaint),
             GrievanceRedaction.grievance_redacted.isnot(None),
             ~done.exists(),
         )
@@ -628,26 +663,34 @@ def _source_membership_changed_error(count: int) -> ValueError:
     )
 
 
-def _raise_if_source_is_not_current(
-    source_mismatches, missing_source: list[str], district: Optional[str], year: Optional[int]
-) -> None:
-    """Fail grouping before a stored signature and current text can diverge.
+def _moved_sources(source_mismatches, district: Optional[str], year: Optional[int]) -> list:
+    """Mismatched sources that left the scope their signature was indexed under.
 
-    "Moved" means the source record left the scope its signature was indexed
-    under. Only bound dimensions can be left: for a corpus-wide run both are
-    ``None`` and nothing can move out of the corpus, so the check must compare
-    against the dimensions actually pinned rather than against ``None`` --
-    otherwise every mismatch reads as moved and the run fails with the wrong
-    error.
+    Only a *bound* dimension can be left. For a corpus-wide run both are
+    ``None`` and nothing can move out of the corpus, so this compares against
+    the dimensions actually pinned rather than against ``None`` -- otherwise
+    every mismatch reads as moved and the run fails with the wrong error.
+
+    Deliberately one function rather than a copy at each call site: this
+    predicate is evaluated both during signature refresh and again before
+    groups are persisted, and the two drifting apart is exactly how a scope
+    fix gets applied to one path and not the other.
     """
-    if missing_source:
-        raise _missing_source_error(missing_source)
-    moved_sources = [
+    return [
         row
         for row in source_mismatches
         if (district is not None and row[2] != district)
         or (year is not None and row[3] != year)
     ]
+
+
+def _raise_if_source_is_not_current(
+    source_mismatches, missing_source: list[str], district: Optional[str], year: Optional[int]
+) -> None:
+    """Fail grouping before a stored signature and current text can diverge."""
+    if missing_source:
+        raise _missing_source_error(missing_source)
+    moved_sources = _moved_sources(source_mismatches, district, year)
     if moved_sources:
         raise _source_membership_changed_error(len(moved_sources))
     if source_mismatches:
@@ -694,9 +737,7 @@ async def _index_signatures(
         )
     if missing_source:
         raise _missing_source_error(missing_source)
-    moved_sources = [
-        row for row in source_mismatches if row[2] != district or row[3] != year
-    ]
+    moved_sources = _moved_sources(source_mismatches, district, year)
     if moved_sources:
         raise _source_membership_changed_error(len(moved_sources))
     if source_mismatches and not refresh_stale:
@@ -812,10 +853,59 @@ async def _load_slice_signatures(conn, district: Optional[str], year: Optional[i
     return result.all()
 
 
-async def _source_snapshot_for_signature_slice(
+async def _raise_if_scope_would_split_existing_groups(
     conn, district: Optional[str], year: Optional[int]
-) -> str:
-    """Manifest the exact indexed inputs represented by this group run.
+) -> None:
+    """Refuse a scoped run that would tear apart a wider existing group.
+
+    Grouping recomputes whole and upserts only the tickets it loaded. That is
+    correct while every group is contained in the scope that built it, which
+    was guaranteed while the only possible scope was one district-year.
+
+    Once ``--all`` has unioned a same-citizen resubmission across a district
+    or year boundary, it stops being guaranteed. A later scoped run loads one
+    side of that group, cannot see the other, recomputes its half as a
+    singleton (or a smaller local group) and upserts only those rows. The
+    other half keeps the old ``duplicate_group_id`` and a ``group_size`` that
+    no longer matches how many rows carry it. Nothing errors, and the
+    duplicate-adjusted counts downstream are quietly wrong in both directions.
+
+    So this fails closed instead, in the same spirit as the source-currency
+    check above: the operator is told to widen the scope rather than being
+    allowed to half-rebuild. An unbounded run can never trip it, because
+    nothing lies outside the corpus.
+    """
+    if district is None and year is None:
+        return
+
+    in_scope = select(DedupGroup.duplicate_group_id).where(
+        *_slice_filters(DedupGroup, district, year)
+    )
+    # "Outside the scope" is the negation of the whole conjunction, so the
+    # negated predicates are OR-ed. AND-ing them would only find rows outside
+    # *every* bound dimension at once and miss, for example, the same district
+    # in a different year -- which is the common case.
+    outside = or_(*[~predicate for predicate in _slice_filters(DedupGroup, district, year)])
+    straddling = await conn.scalar(
+        select(func.count(func.distinct(DedupGroup.duplicate_group_id))).where(
+            DedupGroup.duplicate_group_id.in_(in_scope),
+            outside,
+        )
+    )
+    if straddling:
+        raise ValueError(
+            f"{straddling} existing duplicate group(s) have members outside "
+            f"{_scope_label(district, year)}, so regrouping this scope alone "
+            "would split them and leave the outside half stamped with a group "
+            "id and size that no longer hold. Rerun with --all, or widen the "
+            "scope to contain them."
+        )
+
+
+async def _source_snapshots_by_slice(
+    conn, district: Optional[str], year: Optional[int]
+) -> dict[tuple[str, int], str]:
+    """Manifest the indexed inputs, **one digest per district-year**.
 
     This intentionally reads the digest stored at signature time, never the
     current redaction row. If OLTP changes without re-indexing, persisted
@@ -823,25 +913,46 @@ async def _source_snapshot_for_signature_slice(
     lake join fails the public assertion rather than being stamped as current.
     A partial signature run likewise has a manifest only for its actual subset
     and cannot validate a full lake slice.
+
+    Keyed by district-year rather than by run, because that is the unit
+    consumers verify against. `analytics/findings/workload.py` and `spike.py`
+    read the lake for one district-year, recompute `source_snapshot_id` over
+    it, and assert every group row carries that value. A corpus-wide run that
+    stamped one whole-corpus digest onto every row would fail that assertion
+    for every slice, breaking both findings — the digest has to describe the
+    slice the *record* belongs to, not the scope the run happened to use.
+
+    A scoped run yields exactly one entry, so its behaviour is unchanged.
     """
     stmt = (
         select(
             DedupSignature.ticket_no,
+            DedupSignature.district,
+            DedupSignature.created_year,
             DedupSignature.source_record_digest,
         )
         .where(*_slice_filters(DedupSignature, district, year))
         .order_by(DedupSignature.ticket_no)
     )
     result = await conn.execute(stmt)
-    row_digests = result.all()
-    missing = [ticket_no for ticket_no, digest in row_digests if digest is None]
+    rows = result.all()
+    missing = [row.ticket_no for row in rows if row.source_record_digest is None]
     if missing:
         raise ValueError(
             "dedup groups cannot be stamped with source provenance while "
             f"{len(missing)} signature(s) lack source_record_digest; rerun "
             "janasunani-dedup-index so #137 can rebuild them"
         )
-    return source_snapshot_id_from_record_digests(row_digests)
+
+    by_slice: dict[tuple[str, int], list[tuple[str, str]]] = defaultdict(list)
+    for row in rows:
+        by_slice[(row.district, row.created_year)].append(
+            (row.ticket_no, row.source_record_digest)
+        )
+    return {
+        slice_key: source_snapshot_id_from_record_digests(record_digests)
+        for slice_key, record_digests in by_slice.items()
+    }
 
 
 async def _load_redacted_text(conn, ticket_nos: list[str]) -> dict[str, str]:
@@ -1091,7 +1202,8 @@ async def _group_duplicates(
         _raise_if_source_is_not_current(
             source_mismatches, missing_source, district, year
         )
-        snapshot_id = await _source_snapshot_for_signature_slice(conn, district, year)
+        await _raise_if_scope_would_split_existing_groups(conn, district, year)
+        snapshots_by_slice = await _source_snapshots_by_slice(conn, district, year)
 
     if not rows:
         return {
@@ -1213,7 +1325,12 @@ async def _group_duplicates(
             "duplicate_group_id": group_id,
             "group_size": group_sizes[group_id],
             "source_name": DEDUP_SOURCE_NAME,
-            "source_snapshot_id": snapshot_id,
+            "source_snapshot_id": snapshots_by_slice[
+                (
+                    signature_by_ticket[ticket_no].district,
+                    signature_by_ticket[ticket_no].created_year,
+                )
+            ],
             "index_version": version,
             "grouped_at": now,
         }

--- a/janasunani/pipeline/dedup_index.py
+++ b/janasunani/pipeline/dedup_index.py
@@ -83,10 +83,25 @@ created_on, petitioner_mobile/email); it never selects `complaints.grievance`.
 district-year slice runs to tens of thousands of rows — 55,544 for
 Sambalpur 2024, ~1.5 billion unordered pairs if compared directly. Each
 signature is assigned a `block_key` of `district:script:window_index`
-(`window_index` is `(created_on - Jan 1 of --year).days // --window-days`,
+(`window_index` is `(created_on - DEDUP_WINDOW_EPOCH).days // --window-days`,
 `None`/"undated" for complaints with no `created_on`), and LSH candidate
 generation only buckets within one block. Only pairs that land in the same
-block can ever become candidates.
+block can ever become candidates. The epoch is a fixed absolute date, not
+the run's own scope, so a record's block key is a property of the record;
+it is part of `_index_version` for the same reason the salt marker is.
+
+Because the block key still partitions by district and window, this bounds
+work the same way at 1.37M rows as it does at 55,544 — a corpus-wide run
+does not create one giant bucket.
+
+**Scope is optional, and identity matching is why it matters.** `--slice`,
+`--district` and `--year` narrow a run; `--all` indexes everything. Text
+candidates are blocked, so per-slice runs find the same ones a corpus run
+would. Identity candidates (mobile/email) are deliberately *not* blocked,
+so a same-citizen resubmission that crosses a district or year boundary is
+only visible to a run whose scope contains both sides of it. Looping over
+every district-year finds every text duplicate and no cross-slice identity
+duplicate at all.
 
 **Cross-script recall is explicitly unsupported.** `script` (`"odia"` if the
 redacted text contains any Odia-script codepoint, else `"latin"`) is part of
@@ -197,6 +212,25 @@ DEFAULT_WINDOW_DAYS = 30
 # opening a DB connection, since this backfill persists what it computes.
 DEFAULT_DUPLICATE_THRESHOLD = 0.5
 
+# Absolute origin for `_window_index`. Time windows have to be a property of
+# the *record*, not of the run that indexed it, or the same complaint lands in
+# a different block depending on what scope it was indexed under and the two
+# never become candidates.
+#
+# This used to be `date(year, 1, 1)` -- Jan 1 of the slice's --year -- which is
+# well defined only while every run is one district-year. It is not defined at
+# all for a corpus-wide run, and worse, it silently made block keys
+# run-dependent: `_index_version` never carried the epoch, so signatures built
+# under different origins were stamped as mutually current and grouping mixed
+# them with no error. Same failure class the salt marker exists to catch
+# (#136). The epoch is now in the version stamp, so anything built under the
+# old per-year origin is detected as stale and rebuilt.
+#
+# The specific date is arbitrary and only has to be stable and earlier than any
+# complaint in the corpus. It must never be "tidied" -- changing it rewrites
+# every block key, which is why it is versioned rather than merely fixed.
+DEDUP_WINDOW_EPOCH = date(2000, 1, 1)
+
 # Bucket size at which `_verify_bucket` switches from exhaustive all-pairs
 # comparison to fixed-anchor comparison (#158; see the module
 # docstring for the recall trade this makes). The Sambalpur 2024 measurement
@@ -246,7 +280,8 @@ def _window_index(
     created_on: Optional[datetime], epoch: date, window_days: int
 ) -> Optional[int]:
     """Bucket ``created_on`` into a time-window index relative to ``epoch``
-    (Jan 1 of the slice's ``--year``). ``None`` for a missing timestamp —
+    (`DEDUP_WINDOW_EPOCH`, a fixed absolute date — never the run's own scope;
+    see that constant for why). ``None`` for a missing timestamp —
     deliberately not bucket 0, so an undated row does not silently
     block-match every row that happens to fall in the first window; see
     `_block_key`'s "undated" label."""
@@ -302,6 +337,7 @@ def _index_version(
     base = (
         f"shingle_size={DEFAULT_SHINGLE_SIZE} num_hashes={DEFAULT_NUM_HASHES} "
         f"num_bands={DEFAULT_NUM_BANDS} window_days={window_days} "
+        f"epoch={DEDUP_WINDOW_EPOCH.isoformat()} "
         f"threshold={threshold} salt={_salt_marker(salt)}"
     )
     grouping_values = (grouping_algorithm, representative_cap, anchor_count)
@@ -318,30 +354,58 @@ def _index_version(
 # --- stage 1: signatures ---------------------------------------------------
 
 
-async def _count_signature_slice(conn, district: str, year: int) -> tuple[int, int]:
+def _slice_filters(model, district: Optional[str], year: Optional[int]) -> list:
+    """Scope predicates for ``model``, empty when the scope is unbounded.
+
+    ``None`` means "every district" / "every year", so a corpus-wide run is
+    the absence of a predicate rather than a wildcard value. Both are
+    independently optional: ``--district`` with no ``--year`` is a whole
+    district across all years, which the identity path in particular needs,
+    since a resubmission can cross a year boundary.
+
+    ``model`` is `Complaint` or `DedupSignature` -- both carry ``district``
+    and ``created_year``, and the caller picks whichever table the query is
+    already filtering on.
+    """
+    filters = []
+    if district is not None:
+        filters.append(model.district == district)
+    if year is not None:
+        filters.append(model.created_year == year)
+    return filters
+
+
+def _scope_label(district: Optional[str], year: Optional[int]) -> str:
+    """Human-readable run scope for logs and errors."""
+    if district is None and year is None:
+        return "the whole corpus"
+    return f"{district or 'all districts'}/{year or 'all years'}"
+
+
+async def _count_signature_slice(
+    conn, district: Optional[str], year: Optional[int]
+) -> tuple[int, int]:
     """(redacted complaints in the slice, already indexed)."""
     total = await conn.scalar(
         select(func.count())
         .select_from(GrievanceRedaction)
         .join(Complaint, Complaint.ticket_no == GrievanceRedaction.ticket_no)
         .where(
-            Complaint.district == district,
-            Complaint.created_year == year,
+            *_slice_filters(Complaint, district, year),
             GrievanceRedaction.grievance_redacted.isnot(None),
         )
     )
     done = await conn.scalar(
         select(func.count())
         .select_from(DedupSignature)
-        .where(
-            DedupSignature.district == district,
-            DedupSignature.created_year == year,
-        )
+        .where(*_slice_filters(DedupSignature, district, year))
     )
     return int(total or 0), int(done or 0)
 
 
-async def _count_stale_signatures(conn, district: str, year: int, version: str) -> int:
+async def _count_stale_signatures(
+    conn, district: Optional[str], year: Optional[int], version: str
+) -> int:
     """Signatures produced under different parameters than the current ones.
 
     Reported by every run whether or not it acts on them, so a salt rotation
@@ -354,8 +418,7 @@ async def _count_stale_signatures(conn, district: str, year: int, version: str) 
             .select_from(DedupSignature)
             .join(Complaint, Complaint.ticket_no == DedupSignature.ticket_no)
             .where(
-                Complaint.district == district,
-                Complaint.created_year == year,
+                *_slice_filters(Complaint, district, year),
                 DedupSignature.index_version != version,
             )
         )
@@ -364,7 +427,11 @@ async def _count_stale_signatures(conn, district: str, year: int, version: str) 
 
 
 async def _load_pending_signature_batch(
-    conn, district: str, year: int, limit: int, version: str | None = None
+    conn,
+    district: Optional[str],
+    year: Optional[int],
+    limit: int,
+    version: str | None = None,
 ):
     """Redacted complaints in the slice with no current `dedup_signatures` row.
 
@@ -400,8 +467,7 @@ async def _load_pending_signature_batch(
         )
         .join(Complaint, Complaint.ticket_no == GrievanceRedaction.ticket_no)
         .where(
-            Complaint.district == district,
-            Complaint.created_year == year,
+            *_slice_filters(Complaint, district, year),
             GrievanceRedaction.grievance_redacted.isnot(None),
             ~done.exists(),
         )
@@ -484,7 +550,7 @@ def _signature_rows_for_source_batch(
     return rows
 
 
-async def _source_digest_mismatches(conn, district: str, year: int):
+async def _source_digest_mismatches(conn, district: Optional[str], year: Optional[int]):
     """Current source records whose existing signature digest is no longer true.
 
     This is deliberately a source read before grouping. Candidate generation
@@ -507,10 +573,7 @@ async def _source_digest_mismatches(conn, district: str, year: int):
         .select_from(DedupSignature)
         .outerjoin(Complaint, Complaint.ticket_no == DedupSignature.ticket_no)
         .outerjoin(GrievanceRedaction, GrievanceRedaction.ticket_no == DedupSignature.ticket_no)
-        .where(
-            DedupSignature.district == district,
-            DedupSignature.created_year == year,
-        )
+        .where(*_slice_filters(DedupSignature, district, year))
         .order_by(DedupSignature.ticket_no)
     )
     result = await conn.execute(stmt)
@@ -566,13 +629,24 @@ def _source_membership_changed_error(count: int) -> ValueError:
 
 
 def _raise_if_source_is_not_current(
-    source_mismatches, missing_source: list[str], district: str, year: int
+    source_mismatches, missing_source: list[str], district: Optional[str], year: Optional[int]
 ) -> None:
-    """Fail grouping before a stored signature and current text can diverge."""
+    """Fail grouping before a stored signature and current text can diverge.
+
+    "Moved" means the source record left the scope its signature was indexed
+    under. Only bound dimensions can be left: for a corpus-wide run both are
+    ``None`` and nothing can move out of the corpus, so the check must compare
+    against the dimensions actually pinned rather than against ``None`` --
+    otherwise every mismatch reads as moved and the run fails with the wrong
+    error.
+    """
     if missing_source:
         raise _missing_source_error(missing_source)
     moved_sources = [
-        row for row in source_mismatches if row[2] != district or row[3] != year
+        row
+        for row in source_mismatches
+        if (district is not None and row[2] != district)
+        or (year is not None and row[3] != year)
     ]
     if moved_sources:
         raise _source_membership_changed_error(len(moved_sources))
@@ -582,8 +656,8 @@ def _raise_if_source_is_not_current(
 
 async def _index_signatures(
     engine: AsyncEngine,
-    district: str,
-    year: int,
+    district: Optional[str],
+    year: Optional[int],
     salt: str,
     window_days: int,
     threshold: float,
@@ -591,7 +665,7 @@ async def _index_signatures(
     refresh_stale: bool = False,
 ) -> dict[str, int]:
     version = _index_version(window_days, threshold, salt)
-    epoch = date(year, 1, 1)
+    epoch = DEDUP_WINDOW_EPOCH
     processed = 0
     refreshed_tickets: set[str] = set()
 
@@ -602,9 +676,8 @@ async def _index_signatures(
             conn, district, year
         )
     logger.info(
-        "slice {}/{}: {} redacted complaints, {} already indexed",
-        district,
-        year,
+        "{}: {} redacted complaints, {} already indexed",
+        _scope_label(district, year),
         total,
         already,
     )
@@ -725,22 +798,23 @@ async def _index_signatures(
 # --- stage 2: grouping ------------------------------------------------------
 
 
-async def _load_slice_signatures(conn, district: str, year: int):
+async def _load_slice_signatures(conn, district: Optional[str], year: Optional[int]):
     stmt = select(
         DedupSignature.ticket_no,
+        DedupSignature.district,
+        DedupSignature.created_year,
         DedupSignature.block_key,
         DedupSignature.signature,
         DedupSignature.identity_key_mobile,
         DedupSignature.identity_key_email,
-    ).where(
-        DedupSignature.district == district,
-        DedupSignature.created_year == year,
-    )
+    ).where(*_slice_filters(DedupSignature, district, year))
     result = await conn.execute(stmt)
     return result.all()
 
 
-async def _source_snapshot_for_signature_slice(conn, district: str, year: int) -> str:
+async def _source_snapshot_for_signature_slice(
+    conn, district: Optional[str], year: Optional[int]
+) -> str:
     """Manifest the exact indexed inputs represented by this group run.
 
     This intentionally reads the digest stored at signature time, never the
@@ -755,10 +829,7 @@ async def _source_snapshot_for_signature_slice(conn, district: str, year: int) -
             DedupSignature.ticket_no,
             DedupSignature.source_record_digest,
         )
-        .where(
-            DedupSignature.district == district,
-            DedupSignature.created_year == year,
-        )
+        .where(*_slice_filters(DedupSignature, district, year))
         .order_by(DedupSignature.ticket_no)
     )
     result = await conn.execute(stmt)
@@ -1004,8 +1075,8 @@ def _verify_bucket(
 
 async def _group_duplicates(
     engine: AsyncEngine,
-    district: str,
-    year: int,
+    district: Optional[str],
+    year: Optional[int],
     window_days: int,
     threshold: float,
     salt: str,
@@ -1126,13 +1197,19 @@ async def _group_duplicates(
         anchor_count=anchor_count,
     )
     now = datetime.now(timezone.utc).replace(tzinfo=None)
-    block_key_by_ticket = {row.ticket_no: row.block_key for row in rows}
+    # district/created_year describe the *record*, taken from its signature
+    # row -- not the scope the run was invoked with. Those coincided while
+    # every run was a single district-year, and stop coinciding the moment one
+    # run spans more than one: a corpus-wide run would otherwise stamp NULL
+    # over every group row, which the NOT NULL constraint catches, and a
+    # district-wide run would silently stamp the wrong year, which it does not.
+    signature_by_ticket = {row.ticket_no: row for row in rows}
     group_rows = [
         {
             "ticket_no": ticket_no,
-            "district": district,
-            "created_year": year,
-            "block_key": block_key_by_ticket[ticket_no],
+            "district": signature_by_ticket[ticket_no].district,
+            "created_year": signature_by_ticket[ticket_no].created_year,
+            "block_key": signature_by_ticket[ticket_no].block_key,
             "duplicate_group_id": group_id,
             "group_size": group_sizes[group_id],
             "source_name": DEDUP_SOURCE_NAME,
@@ -1245,8 +1322,8 @@ def evaluate_held_out_recall(
 
 
 def build_dedup_index(
-    district: str,
-    year: int,
+    district: Optional[str],
+    year: Optional[int],
     oltp_url: Optional[str] = None,
     salt: Optional[str] = None,
     window_days: int = DEFAULT_WINDOW_DAYS,
@@ -1256,7 +1333,16 @@ def build_dedup_index(
     representative_cap: int = REPRESENTATIVE_COMPARISON_CAP,
     anchor_count: int = LARGE_BUCKET_ANCHOR_COUNT,
 ) -> dict[str, int]:
-    """Index one district-year slice and (re)compute its duplicate groups.
+    """Index a scope and (re)compute its duplicate groups.
+
+    ``district`` and ``year`` are independently optional; ``None`` means
+    unbounded on that dimension, so ``(None, None)`` indexes the whole
+    corpus. Scope is not merely a convenience: identity buckets
+    (mobile/email) are deliberately unblocked, because a resubmission can
+    land months later under any district, so a same-citizen duplicate that
+    crosses a district or year boundary is only ever visible to a run whose
+    scope contains both sides of it. Running 150 district-years in a loop
+    finds the text duplicates and none of those.
 
     Returns per-run counts from both stages. Raises ``ValueError``
     immediately — before opening any DB connection — if no salt is
@@ -1351,6 +1437,16 @@ def main() -> None:
     parser.add_argument("--year", required=False, type=int, default=None, help="created_year to process.")
     parser.add_argument("--slice", required=False, default=None, help="Shorthand for --district/--year as District/YYYY (e.g. Sambalpur/2024).")
     parser.add_argument(
+        "--all",
+        action="store_true",
+        help=(
+            "Index every district and year. Required to run corpus-wide: an "
+            "unscoped invocation errors rather than silently rebuilding 1.37M "
+            "rows. Needed for same-citizen duplicates that cross a district or "
+            "year boundary, which no per-slice run can see."
+        ),
+    )
+    parser.add_argument(
         "--oltp-url", default=None, help="OLTP DB URL (default: settings.OLTP_DB_URL)."
     )
     parser.add_argument(
@@ -1363,7 +1459,10 @@ def main() -> None:
         "--window-days",
         type=int,
         default=DEFAULT_WINDOW_DAYS,
-        help="Time-window width (days) for blocking, within the district-year slice.",
+        help="Time-window width (days) for blocking. Windows are measured from a "
+        "fixed absolute epoch, so a record's window is the same whatever scope "
+        "indexed it; changing this value changes every block key and is "
+        "recorded in the index version.",
     )
     parser.add_argument(
         "--threshold",
@@ -1403,8 +1502,18 @@ def main() -> None:
         if year is not None and year != slice_year:
             parser.error("--year conflicts with --slice year")
         district, year = slice_district, slice_year
-    if district is None or year is None:
-        parser.error("--district/--year or --slice is required")
+    # No scope at all is a corpus-wide run, and it has to be asked for
+    # explicitly. A bare invocation is far more often a forgotten --slice than
+    # a deliberate 1.37M-row rebuild, and the two are indistinguishable from
+    # argv alone.
+    if district is None and year is None and not args.all:
+        parser.error(
+            "no scope given. Pass --slice/--district/--year for part of the "
+            "corpus, or --all to index every district and year. --all is a "
+            "full rebuild over the whole corpus, so it is never implied."
+        )
+    if args.all and (district is not None or year is not None):
+        parser.error("--all cannot be combined with --slice/--district/--year")
 
     counts = build_dedup_index(
         district,
@@ -1418,7 +1527,7 @@ def main() -> None:
     )
     logger.info(
         "done: {} processed this run, {} of {} indexed, {} duplicate groups "
-        "over {} signatures (comparison_pairs={}, large_buckets={}) in slice {}/{}",
+        "over {} signatures (comparison_pairs={}, large_buckets={}) in {}",
         counts["processed"],
         counts["already_indexed"] + counts["processed"],
         counts["total"],
@@ -1426,8 +1535,7 @@ def main() -> None:
         counts["slice_signatures"],
         counts["comparison_pairs"],
         counts["large_buckets"],
-        district,
-        year,
+        _scope_label(district, year),
     )
 
 

--- a/janasunani/serving/intelligence.py
+++ b/janasunani/serving/intelligence.py
@@ -83,6 +83,9 @@ _WORKLOAD_FIELDS = frozenset(
         "duplicate_adjustment",
         "source_name",
         "source_snapshot_id",
+        # #317. Corpus-wide grouping depends on records outside a slice, so
+        # the slice digest above cannot tell two group assignments apart.
+        "grouping_scope_snapshot_id",
     }
 )
 _SPIKE_FIELDS = frozenset(
@@ -95,6 +98,7 @@ _SPIKE_FIELDS = frozenset(
         "distinct_citizens",
         "source_name",
         "source_snapshot_id",
+        "grouping_scope_snapshot_id",
         "interpretation",
     }
 )
@@ -201,7 +205,9 @@ class ArtifactSupervisorProvider:
             w_row = self._read_raw_workload_row()
             s_row = self._read_raw_spike_row()
             if w_row is not None and s_row is not None:
-                if w_row.get("source_snapshot_id") != s_row.get("source_snapshot_id"):
+                if w_row.get("source_snapshot_id") != s_row.get("source_snapshot_id") or w_row.get(
+                    "grouping_scope_snapshot_id"
+                ) != s_row.get("grouping_scope_snapshot_id"):
                     workload = None
                     spike = None
                     digest_reason = (
@@ -505,7 +511,7 @@ def _read_workload_row(path: Path) -> dict[str, object]:
     total = _parse_nonnegative_int(row["total_filings"])
     distinct = _parse_nonnegative_int(row["distinct_problems"])
     adjustment = _parse_nonnegative_int(row["duplicate_adjustment"])
-    for key in ("slice_district", "slice_category", "slice_period", "source_name", "source_snapshot_id"):
+    for key in ("slice_district", "slice_category", "slice_period", "source_name", "source_snapshot_id", "grouping_scope_snapshot_id"):
         val = row.get(key)
         if not isinstance(val, str) or not val or val.strip() != val:
             raise ValueError(f"workload {key} is missing or has whitespace")
@@ -522,6 +528,7 @@ def _read_workload_row(path: Path) -> dict[str, object]:
         "duplicate_adjustment": adjustment,
         "source_name": row["source_name"],
         "source_snapshot_id": row["source_snapshot_id"],
+        "grouping_scope_snapshot_id": row["grouping_scope_snapshot_id"],
     }
 
 
@@ -538,7 +545,7 @@ def _read_spike_row(path: Path) -> dict[str, object]:
     filings = _parse_nonnegative_int(row["filings"])
     distinct = _parse_nonnegative_int(row["distinct_problems"])
     citizens = _parse_nonnegative_int(row["distinct_citizens"])
-    for key in ("slice_district", "slice_category", "slice_period", "source_name", "source_snapshot_id", "interpretation"):
+    for key in ("slice_district", "slice_category", "slice_period", "source_name", "source_snapshot_id", "grouping_scope_snapshot_id", "interpretation"):
         val = row.get(key)
         if not isinstance(val, str) or not val or val.strip() != val:
             raise ValueError(f"spike {key} is missing or has whitespace")
@@ -555,6 +562,7 @@ def _read_spike_row(path: Path) -> dict[str, object]:
         "distinct_citizens": citizens,
         "source_name": row["source_name"],
         "source_snapshot_id": row["source_snapshot_id"],
+        "grouping_scope_snapshot_id": row["grouping_scope_snapshot_id"],
         "interpretation": row["interpretation"],
     }
 

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -644,3 +644,71 @@ class TestEmptySignatureIsRejected:
         signature = minhash_signature({"abc", "bcd", "cde"}, num_hashes=8)
         assert signature is not None
         assert len(lsh_bands(signature, num_bands=4)) == 4
+
+
+class TestGroupingScopeId:
+    """The digest that distinguishes two grouping runs over the same records.
+
+    `source_snapshot_id` answers "were these the same source records", and a
+    consumer recomputes it from lake rows alone. This one answers "did the
+    same grouping run produce these rows", which the consumer cannot
+    reconstruct and which is the only thing standing between two different
+    assignments and being served as one snapshot.
+    """
+
+    RECORDS = [("A", "sha256:aa"), ("B", "sha256:bb"), ("C", "sha256:cc")]
+
+    def _scope(self, version="v1", records=None, versions=()):
+        from janasunani.pipeline.dedup import grouping_scope_id
+
+        return grouping_scope_id(
+            version, self.RECORDS if records is None else records, versions
+        )
+
+    def test_same_inputs_give_the_same_digest(self):
+        assert self._scope() == self._scope()
+
+    def test_a_different_grouping_version_changes_it(self):
+        # A different --threshold or --window-days produces different groups
+        # from identical records; without this they compare equal.
+        assert self._scope(version="v1") != self._scope(version="v2")
+
+    def test_a_changed_record_changes_it(self):
+        other = [("A", "sha256:aa"), ("B", "sha256:ZZ"), ("C", "sha256:cc")]
+        assert self._scope() != self._scope(records=other)
+
+    def test_the_same_versions_spread_differently_across_tickets_differ(self):
+        """Codex P1 on #325 — the case a set of distinct versions cannot see.
+
+        A partial `--refresh-stale --limit` leaves both layouts below with the
+        same records, the same requested version, and the same set {v1, v2}.
+        They do not group the same way: where identity candidates are split
+        from text candidates by a time window, the first can union A/B and the
+        second B/C. A slice holding A and B then reports a different
+        distinct-problem count while the artifacts still compare equal.
+        """
+        first = [("A", "idx-v1"), ("B", "idx-v1"), ("C", "idx-v2")]
+        second = [("A", "idx-v1"), ("B", "idx-v2"), ("C", "idx-v2")]
+        assert {v for _, v in first} == {v for _, v in second}
+        assert self._scope(versions=first) != self._scope(versions=second)
+
+    def test_ordering_of_the_version_pairs_does_not_matter(self):
+        pairs = [("A", "idx-v1"), ("B", "idx-v2")]
+        assert self._scope(versions=pairs) == self._scope(versions=list(reversed(pairs)))
+
+    def test_a_missing_version_is_distinguishable_from_a_present_one(self):
+        assert self._scope(versions=[("A", None)]) != self._scope(
+            versions=[("A", "idx-v1")]
+        )
+
+    def test_a_missing_version_does_not_break_the_sort(self):
+        # ticket_no is unique per signature row so the version is never
+        # reached as a tiebreak, but the sort must not depend on that.
+        mixed = [("B", None), ("A", "idx-v1"), ("C", None)]
+        assert self._scope(versions=mixed) == self._scope(
+            versions=list(reversed(mixed))
+        )
+
+    def test_a_blank_grouping_version_is_refused(self):
+        with pytest.raises(ValueError, match="non-blank grouping version"):
+            self._scope(version="   ")

--- a/tests/test_dedup_index.py
+++ b/tests/test_dedup_index.py
@@ -2191,3 +2191,98 @@ class TestCorpusScaleMemory:
         )
         with pytest.raises(ValueError, match="carries 4 band"):
             di._candidate_buckets([row], 16)
+
+
+class TestBandBucketsAreBuiltOneBandAtATime:
+    """Codex P1 on #325, after the raw signatures were already dropped.
+
+    Dropping the 128-element arrays fixed the rows; the bucket map was the
+    larger half and survived it. Building all sixteen bands before filtering
+    singletons costs 16N dictionary entries at peak -- ~21.9M for the corpus
+    -- and nearly all of them are singletons thrown away immediately: a
+    signature colliding with nothing still occupies sixteen.
+    """
+
+    @staticmethod
+    def _rows(n, num_bands, seed=11):
+        import random
+
+        from janasunani.pipeline.dedup_index import _BandedSignature
+
+        rng = random.Random(seed)
+        return [
+            _BandedSignature(
+                ticket_no=f"CMO2024{i:07d}",
+                district=f"D{i % 7}",
+                created_year=2024,
+                block_key=f"D{i % 7}:latin:{i % 5}",
+                identity_key_mobile=(f"m{i // 3}" if i % 3 == 0 else None),
+                identity_key_email=None,
+                # 2% of bands collide, so real buckets exist to be found.
+                bands=tuple(
+                    rng.getrandbits(63) if rng.random() > 0.02 else rng.randrange(40)
+                    for _ in range(num_bands)
+                ),
+            )
+            for i in range(n)
+        ]
+
+    @staticmethod
+    def _all_at_once(rows, num_bands):
+        """The previous implementation, kept here as the thing to match."""
+        from collections import defaultdict
+
+        band = defaultdict(list)
+        for r in rows:
+            for bi, bh in enumerate(r.bands):
+                band[(r.block_key, bi, bh)].append(r.ticket_no)
+        ident = defaultdict(list)
+        for r in rows:
+            for kind, k in (
+                ("mobile", r.identity_key_mobile),
+                ("email", r.identity_key_email),
+            ):
+                if k is not None:
+                    ident[(kind, k)].append(r.ticket_no)
+        return [
+            (b, m) for (b, _i, _h), m in band.items() if len(set(m)) > 1
+        ] + [(None, m) for m in ident.values() if len(set(m)) > 1]
+
+    @staticmethod
+    def _norm(buckets):
+        return sorted((b, tuple(sorted(m))) for b, m in buckets)
+
+    def test_the_buckets_are_exactly_what_the_all_at_once_build_produced(self):
+        """Banding is independent per band index, so a bucket can never span
+        two of them -- which is why the split is safe. Asserted rather than
+        argued, because a wrong bucket here silently changes group membership.
+        """
+        from janasunani.pipeline import dedup_index as di
+
+        rows = self._rows(3000, 8)
+        got = di._candidate_buckets(rows, 8)
+        assert self._norm(got) == self._norm(self._all_at_once(rows, 8))
+        assert got, "fixture must produce real (non-singleton) buckets"
+
+    def test_peak_memory_is_a_fraction_of_the_all_at_once_build(self):
+        import tracemalloc
+
+        from janasunani.pipeline import dedup_index as di
+
+        rows = self._rows(20_000, 16)
+
+        def peak(fn):
+            tracemalloc.start()
+            fn(rows, 16)
+            _, pk = tracemalloc.get_traced_memory()
+            tracemalloc.stop()
+            return pk
+
+        before = peak(self._all_at_once)
+        after = peak(di._candidate_buckets)
+        # Measured ~17x on a corpus-shaped fixture. Asserted well below that
+        # so the test pins the property, not the machine it ran on.
+        assert after * 4 < before, (
+            f"peak {after / 2**20:.1f} MiB vs {before / 2**20:.1f} MiB — "
+            "band buckets are being retained across bands again"
+        )

--- a/tests/test_dedup_index.py
+++ b/tests/test_dedup_index.py
@@ -1865,14 +1865,47 @@ class TestGroupingScopeProvenance:
     does not. The grouping-scope digest is what makes the two runs tell
     apart."""
 
-    def test_scoped_run_scope_digest_equals_its_slice_digest(self, oltp):
-        """For a single-slice run the two describe the same record set, so
-        they must agree -- otherwise the new field changes existing meaning."""
+    def test_regrouping_the_same_records_is_deterministic(self, oltp):
         async_url, sync_url = oltp
         build_dedup_index("Khordha", 2024, oltp_url=async_url, salt=_SALT)
+        first = _group_rows(sync_url)["T1"].grouping_scope_snapshot_id
 
-        row = _group_rows(sync_url)["T1"]
-        assert row.grouping_scope_snapshot_id == row.source_snapshot_id
+        build_dedup_index("Khordha", 2024, oltp_url=async_url, salt=_SALT)
+        assert _group_rows(sync_url)["T1"].grouping_scope_snapshot_id == first
+
+    def test_a_different_threshold_changes_the_scope_but_not_the_slice_digest(
+        self, oltp
+    ):
+        """The scope digest covers the parameters that produced an assignment,
+        not only which records were read. Regrouping the identical records at
+        a different --threshold yields different duplicate groups, so two
+        artifacts from the two runs must not compare equal.
+
+        The slice digest must *not* move: a consumer recomputes it from lake
+        records and knows nothing about grouping parameters, so folding them
+        in there would make it unverifiable."""
+        async_url, sync_url = oltp
+        build_dedup_index("Khordha", 2024, oltp_url=async_url, salt=_SALT)
+        before = _group_rows(sync_url)["T1"]
+
+        build_dedup_index(
+            "Khordha", 2024, oltp_url=async_url, salt=_SALT, threshold=0.9
+        )
+        after = _group_rows(sync_url)["T1"]
+
+        assert after.grouping_scope_snapshot_id != before.grouping_scope_snapshot_id
+        assert after.source_snapshot_id == before.source_snapshot_id
+
+    def test_a_different_window_changes_the_scope(self, oltp):
+        async_url, sync_url = oltp
+        build_dedup_index("Khordha", 2024, oltp_url=async_url, salt=_SALT)
+        before = _group_rows(sync_url)["T1"].grouping_scope_snapshot_id
+
+        build_dedup_index(
+            "Khordha", 2024, oltp_url=async_url, salt=_SALT, window_days=7,
+            refresh_stale=True,
+        )
+        assert _group_rows(sync_url)["T1"].grouping_scope_snapshot_id != before
 
     def test_corpus_run_scope_digest_is_wider_than_the_slice_digest(self, oltp):
         async_url, sync_url = oltp

--- a/tests/test_dedup_index.py
+++ b/tests/test_dedup_index.py
@@ -2015,3 +2015,35 @@ class TestGroupingScopeProvenance:
         ]
         with pytest.raises(DedupSourceSnapshotMismatch, match="lack grouping-scope"):
             assert_group_source_snapshot(legacy, records)
+
+    def test_stale_signatures_produce_a_distinct_scope_from_a_refreshed_run(
+        self, oltp
+    ):
+        """Without --refresh-stale the runner deliberately leaves stale
+        signatures in place, so a run can group old-parameter rows together
+        with newly indexed ones. Identity linkage breaks across that boundary
+        (#136) and the assignments are wrong; a later full refresh produces
+        different, correct ones from identical source records under the
+        identical *requested* version. Hashing only the requested version made
+        those two runs indistinguishable."""
+        async_url, sync_url = oltp
+        build_dedup_index("Khordha", 2024, oltp_url=async_url, salt=_SALT)
+
+        # A different salt makes every stored signature stale. Without
+        # --refresh-stale they survive, so this run groups over rows whose
+        # stored version is not the one it asked for.
+        stale_run = build_dedup_index(
+            "Khordha", 2024, oltp_url=async_url, salt="a-rotated-salt"
+        )
+        assert stale_run["processed"] == 0  # nothing rebuilt: they are stale, not missing
+        mixed = _group_rows(sync_url)["T1"].grouping_scope_snapshot_id
+
+        refreshed = build_dedup_index(
+            "Khordha",
+            2024,
+            oltp_url=async_url,
+            salt="a-rotated-salt",
+            refresh_stale=True,
+        )
+        assert refreshed["processed"] > 0
+        assert _group_rows(sync_url)["T1"].grouping_scope_snapshot_id != mixed

--- a/tests/test_dedup_index.py
+++ b/tests/test_dedup_index.py
@@ -1843,3 +1843,102 @@ class TestCodexFollowups317:
         # They are excluded from the denominator too, so the run does not
         # report itself as perpetually incomplete.
         assert counts["total"] == 1
+
+
+class TestGroupingScopeProvenance:
+    """#317 follow-up. The per-slice source digest cannot certify a corpus
+    grouping, because a ticket outside a row's district-year can bridge two
+    otherwise separate groups inside it. Change that outside ticket, regroup,
+    and the slice's distinct-problem count moves while its source_snapshot_id
+    does not. The grouping-scope digest is what makes the two runs tell
+    apart."""
+
+    def test_scoped_run_scope_digest_equals_its_slice_digest(self, oltp):
+        """For a single-slice run the two describe the same record set, so
+        they must agree -- otherwise the new field changes existing meaning."""
+        async_url, sync_url = oltp
+        build_dedup_index("Khordha", 2024, oltp_url=async_url, salt=_SALT)
+
+        row = _group_rows(sync_url)["T1"]
+        assert row.grouping_scope_snapshot_id == row.source_snapshot_id
+
+    def test_corpus_run_scope_digest_is_wider_than_the_slice_digest(self, oltp):
+        async_url, sync_url = oltp
+        build_dedup_index(None, None, oltp_url=async_url, salt=_SALT)
+
+        rows = _group_rows(sync_url)
+        # One scope for the whole run...
+        assert len({r.grouping_scope_snapshot_id for r in rows.values()}) == 1
+        # ...and it is not any individual slice's digest.
+        assert rows["T1"].grouping_scope_snapshot_id != rows["T1"].source_snapshot_id
+
+    def test_changing_an_out_of_slice_record_changes_the_scope_digest(
+        self, cross_scope_oltp
+    ):
+        """The failure Codex described, pinned directly. X1 (2023) is outside
+        Khordha/2024 but participates in its grouping. Editing X1 must change
+        what Khordha/2024's rows advertise, or two different group
+        assignments are publishable as the same snapshot."""
+        async_url, sync_url = cross_scope_oltp
+        build_dedup_index(None, None, oltp_url=async_url, salt=_SALT)
+        before = _group_rows(sync_url)["X2"]
+
+        engine = create_engine(sync_url)
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "UPDATE grievance_redactions SET grievance_redacted = :t "
+                    "WHERE ticket_no = 'X1'"
+                ),
+                {"t": UNRELATED_C},
+            )
+        engine.dispose()
+        build_dedup_index(
+            None, None, oltp_url=async_url, salt=_SALT, refresh_stale=True
+        )
+        after = _group_rows(sync_url)["X2"]
+
+        # X2's own slice is untouched, so the old stamp cannot distinguish them.
+        assert after.source_snapshot_id == before.source_snapshot_id
+        # The scope digest can.
+        assert after.grouping_scope_snapshot_id != before.grouping_scope_snapshot_id
+
+    def test_mixed_grouping_scopes_are_refused(self):
+        """assert_group_source_snapshot must reject rows assembled from two
+        group assignments even when their slice digests agree."""
+        records = [
+            {
+                "ticket_no": ticket,
+                "district": "Khordha",
+                "created_year": 2024,
+                "created_on": datetime(2024, 1, 5),
+                "petitioner_mobile": None,
+                "petitioner_email": None,
+                "grievance_redacted": text_,
+            }
+            for ticket, text_ in (("A1", UNRELATED_A), ("A2", UNRELATED_B))
+        ]
+        digest = source_snapshot_id(records)
+
+        def rows_with(scope_a, scope_b):
+            return [
+                {
+                    "ticket_no": "A1",
+                    "source_name": DEDUP_SOURCE_NAME,
+                    "source_snapshot_id": digest,
+                    "grouping_scope_snapshot_id": scope_a,
+                },
+                {
+                    "ticket_no": "A2",
+                    "source_name": DEDUP_SOURCE_NAME,
+                    "source_snapshot_id": digest,
+                    "grouping_scope_snapshot_id": scope_b,
+                },
+            ]
+
+        # Uniform scope is fine, and the ticket population is complete in both
+        # cases so only the scope differs between them.
+        assert assert_group_source_snapshot(rows_with("s1", "s1"), records) == digest
+
+        with pytest.raises(DedupSourceSnapshotMismatch, match="mix grouping scopes"):
+            assert_group_source_snapshot(rows_with("s1", "s2"), records)

--- a/tests/test_dedup_index.py
+++ b/tests/test_dedup_index.py
@@ -253,6 +253,7 @@ class TestGroupSourceSnapshotProvenance:
                 "ticket_no": row.ticket_no,
                 "source_name": row.source_name,
                 "source_snapshot_id": row.source_snapshot_id,
+                "grouping_scope_snapshot_id": row.grouping_scope_snapshot_id,
             }
             for row in groups.values()
         ]
@@ -297,6 +298,7 @@ class TestGroupSourceSnapshotProvenance:
                 "ticket_no": "synthetic-extra-ticket",
                 "source_name": group_rows[0]["source_name"],
                 "source_snapshot_id": group_rows[0]["source_snapshot_id"],
+                "grouping_scope_snapshot_id": group_rows[0]["grouping_scope_snapshot_id"],
             }
         )
 
@@ -1424,7 +1426,12 @@ class TestHeldOutRecall:
         # Baseline passes.
         assert assert_group_source_snapshot(
             [
-                {"ticket_no": r.ticket_no, "source_name": r.source_name, "source_snapshot_id": r.source_snapshot_id}
+                {
+                "ticket_no": r.ticket_no,
+                "source_name": r.source_name,
+                "source_snapshot_id": r.source_snapshot_id,
+                "grouping_scope_snapshot_id": r.grouping_scope_snapshot_id,
+            }
                 for r in groups.values()
             ],
             source_records,
@@ -1432,7 +1439,12 @@ class TestHeldOutRecall:
         # Tamper one group's snapshot — downstream join must fail loudly,
         # not silently mix.
         tampered = [
-            {"ticket_no": r.ticket_no, "source_name": r.source_name, "source_snapshot_id": "sha256:deadbeef"}
+            {
+                "ticket_no": r.ticket_no,
+                "source_name": r.source_name,
+                "source_snapshot_id": "sha256:deadbeef",
+                "grouping_scope_snapshot_id": r.grouping_scope_snapshot_id,
+            }
             for r in groups.values()
         ]
         with pytest.raises(DedupSourceSnapshotMismatch):
@@ -1942,3 +1954,31 @@ class TestGroupingScopeProvenance:
 
         with pytest.raises(DedupSourceSnapshotMismatch, match="mix grouping scopes"):
             assert_group_source_snapshot(rows_with("s1", "s2"), records)
+
+    def test_absent_grouping_scope_is_refused_not_treated_as_agreement(self):
+        """A set of scopes that is exactly {None} passes a 'no two different
+        values' test. Rows written before the column existed all carry NULL,
+        so without this the legacy case publishes a blank scope that compares
+        equal to every other blank one -- reopening the hole the field closes."""
+        records = [
+            {
+                "ticket_no": "L1",
+                "district": "Khordha",
+                "created_year": 2024,
+                "created_on": datetime(2024, 1, 5),
+                "petitioner_mobile": None,
+                "petitioner_email": None,
+                "grievance_redacted": UNRELATED_A,
+            }
+        ]
+        digest = source_snapshot_id(records)
+        legacy = [
+            {
+                "ticket_no": "L1",
+                "source_name": DEDUP_SOURCE_NAME,
+                "source_snapshot_id": digest,
+                "grouping_scope_snapshot_id": None,
+            }
+        ]
+        with pytest.raises(DedupSourceSnapshotMismatch, match="lack grouping-scope"):
+            assert_group_source_snapshot(legacy, records)

--- a/tests/test_dedup_index.py
+++ b/tests/test_dedup_index.py
@@ -1700,3 +1700,146 @@ class TestGroupRowsDescribeTheRecordNotTheRun:
         assert groups["T1"].district == "Khordha"
         assert groups["T5"].district == "Puri"
         assert groups["T4"].created_year == 2023
+
+
+class TestCodexFollowups317:
+    """The four findings on #325, each pinned by the failure it caused."""
+
+    def test_refresh_stale_does_not_call_every_mismatch_moved(self, cross_scope_oltp):
+        """P1. The moved-source predicate had a second copy inside
+        _index_signatures. Fixing only the one in
+        _raise_if_source_is_not_current left --all --refresh-stale comparing
+        every row against None and raising "moved outside this district-year
+        source slice" for a corpus run, where nothing can move."""
+        async_url, sync_url = cross_scope_oltp
+        build_dedup_index(None, None, oltp_url=async_url, salt=_SALT)
+
+        # Change a source record so its stored digest no longer matches.
+        engine = create_engine(sync_url)
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "UPDATE grievance_redactions SET grievance_redacted = :t "
+                    "WHERE ticket_no = 'X3'"
+                ),
+                {"t": UNRELATED_C},
+            )
+        engine.dispose()
+
+        # Must rebuild, not raise a membership error.
+        counts = build_dedup_index(
+            None, None, oltp_url=async_url, salt=_SALT, refresh_stale=True
+        )
+        assert counts["processed"] >= 1
+
+    def test_group_rows_carry_their_own_slice_snapshot(self, oltp):
+        """P1. analytics/findings/workload.py reads one district-year from the
+        lake, recomputes source_snapshot_id over it, and asserts every group
+        row carries that value. Stamping one corpus-wide digest on every row
+        would fail that assertion for every slice."""
+        async_url, sync_url = oltp
+        build_dedup_index(None, None, oltp_url=async_url, salt=_SALT)
+
+        groups = _group_rows(sync_url)
+        khordha_2024 = {groups[t].source_snapshot_id for t in ("T1", "T2", "T3")}
+        assert len(khordha_2024) == 1
+
+        # Different district-years must not share a digest, or the stamp is
+        # not describing the slice at all.
+        assert groups["T4"].source_snapshot_id not in khordha_2024  # Khordha/2023
+        assert groups["T5"].source_snapshot_id not in khordha_2024  # Puri/2024
+
+    def test_scoped_snapshot_matches_what_a_scoped_run_would_stamp(self, oltp, tmp_path):
+        """The per-slice digest from a corpus run must equal the digest a
+        district-year run produces, or consumers still cannot verify."""
+        scoped_dir = tmp_path / "scoped"
+        scoped_dir.mkdir()
+        complaints = [
+            {
+                "ticket_no": t,
+                "district": d,
+                "created_year": y,
+                "created_on": c,
+                "petitioner_mobile": m,
+                "grievance": f"raw grievance for {t}",
+            }
+            for t, d, y, c, m, _ in _SMALL_ROWS
+        ]
+        redactions = [
+            {"ticket_no": t, "grievance_redacted": r}
+            for t, _, _, _, _, r in _SMALL_ROWS
+            if r is not None
+        ]
+        scoped_async, scoped_sync = _make_oltp(scoped_dir, complaints, redactions)
+
+        corpus_async, corpus_sync = oltp
+        build_dedup_index("Khordha", 2024, oltp_url=scoped_async, salt=_SALT)
+        build_dedup_index(None, None, oltp_url=corpus_async, salt=_SALT)
+
+        assert (
+            _group_rows(scoped_sync)["T1"].source_snapshot_id
+            == _group_rows(corpus_sync)["T1"].source_snapshot_id
+        )
+
+    def test_scoped_rerun_refuses_to_split_a_cross_scope_group(self, cross_scope_oltp):
+        """P1. X1/X2 are one group spanning 2023 and 2024. Regrouping 2024
+        alone would recompute X2 as a singleton and upsert only it, leaving
+        X1 stamped with a group id and size that no longer hold."""
+        async_url, _ = cross_scope_oltp
+        build_dedup_index(None, None, oltp_url=async_url, salt=_SALT)
+
+        # Matched on the guard's own wording: _source_membership_changed_error
+        # also says "outside", and this must not pass on that instead.
+        with pytest.raises(ValueError, match="would split them"):
+            build_dedup_index("Khordha", 2024, oltp_url=async_url, salt=_SALT)
+
+    def test_scoped_rerun_is_allowed_when_no_group_straddles(self, oltp):
+        """The guard must not block the ordinary case, or every slice run
+        breaks the moment a corpus index exists."""
+        async_url, sync_url = oltp
+        build_dedup_index(None, None, oltp_url=async_url, salt=_SALT)
+        build_dedup_index("Khordha", 2024, oltp_url=async_url, salt=_SALT)
+        assert set(_group_rows(sync_url)) >= {"T1", "T2", "T3"}
+
+    def test_complaints_missing_district_or_year_are_not_indexed(self, tmp_path):
+        """P2. Complaint.district/created_year are nullable; DedupSignature
+        declares both NOT NULL. A scoped run never saw such a row because
+        `district = 'X'` is NULL for it. Removing the predicate for --all
+        removed that accidental filter and the backfill died on an integrity
+        error partway through."""
+        complaints = [
+            {
+                "ticket_no": "N1",
+                "district": "Khordha",
+                "created_year": 2024,
+                "created_on": datetime(2024, 1, 5),
+                "grievance": "raw n1",
+            },
+            {
+                "ticket_no": "N2",
+                "district": None,
+                "created_year": 2024,
+                "created_on": datetime(2024, 1, 6),
+                "grievance": "raw n2",
+            },
+            {
+                "ticket_no": "N3",
+                "district": "Khordha",
+                "created_year": None,
+                "created_on": datetime(2024, 1, 7),
+                "grievance": "raw n3",
+            },
+        ]
+        redactions = [
+            {"ticket_no": "N1", "grievance_redacted": UNRELATED_A},
+            {"ticket_no": "N2", "grievance_redacted": UNRELATED_B},
+            {"ticket_no": "N3", "grievance_redacted": UNRELATED_C},
+        ]
+        async_url, sync_url = _make_oltp(tmp_path, complaints, redactions)
+
+        counts = build_dedup_index(None, None, oltp_url=async_url, salt=_SALT)
+
+        assert set(_signature_rows(sync_url)) == {"N1"}
+        # They are excluded from the denominator too, so the run does not
+        # report itself as perpetually incomplete.
+        assert counts["total"] == 1

--- a/tests/test_dedup_index.py
+++ b/tests/test_dedup_index.py
@@ -2047,3 +2047,147 @@ class TestGroupingScopeProvenance:
         )
         assert refreshed["processed"] > 0
         assert _group_rows(sync_url)["T1"].grouping_scope_snapshot_id != mixed
+
+
+class TestCorpusScaleMemory:
+    """Codex P1 (two findings) on #325: `--all` is the point of the PR, and
+    at corpus scale both the refresh and the grouping load would have failed
+    before doing any work.
+
+    These pin the shape of the fix rather than the byte count, which no unit
+    test can assert honestly. What is checkable is that the text never
+    accumulates and the signature never survives banding.
+    """
+
+    def test_the_mismatch_scan_carries_identity_not_text(self, cross_scope_oltp):
+        """The documented post-redaction run is `--all --refresh-stale`, where
+        every signature mismatches at once. Carrying each row's grievance text
+        through this scan would hold the whole redacted corpus in memory
+        before rebuilding a single signature.
+        """
+        import asyncio
+
+        from sqlalchemy.ext.asyncio import create_async_engine
+
+        from janasunani.pipeline import dedup_index as di
+
+        async_url, sync_url = cross_scope_oltp
+        build_dedup_index(None, None, oltp_url=async_url, salt=_SALT)
+
+        engine = create_engine(sync_url)
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "UPDATE grievance_redactions SET grievance_redacted = :t "
+                    "WHERE ticket_no = 'X3'"
+                ),
+                {"t": UNRELATED_C},
+            )
+        engine.dispose()
+
+        async def _scan():
+            aengine = create_async_engine(async_url)
+            try:
+                async with aengine.begin() as conn:
+                    return await di._source_digest_mismatches(conn, None, None)
+            finally:
+                await aengine.dispose()
+
+        mismatches, missing = asyncio.run(_scan())
+
+        assert missing == []
+        assert [m[0] for m in mismatches] == ["X3"]
+        # (ticket_no, district, created_year) and nothing else. The assertion
+        # that matters is the width: a text column here is the whole defect.
+        for row in mismatches:
+            assert len(row) == 3
+            assert not any(
+                isinstance(value, str) and len(value) > 64 for value in row
+            )
+
+    def test_the_source_refresh_runs_in_batches(self, cross_scope_oltp, monkeypatch):
+        """One pass would build every replacement row beside the whole fetched
+        corpus and submit them through a single multi-row upsert."""
+        from janasunani.pipeline import dedup_index as di
+
+        async_url, sync_url = cross_scope_oltp
+        build_dedup_index(None, None, oltp_url=async_url, salt=_SALT)
+
+        engine = create_engine(sync_url)
+        with engine.begin() as conn:
+            # Every row mismatches, which is the post-redaction shape.
+            conn.execute(
+                text("UPDATE grievance_redactions SET grievance_redacted = :t"),
+                {"t": UNRELATED_C},
+            )
+            total = conn.execute(
+                text("SELECT count(*) FROM dedup_signatures")
+            ).scalar_one()
+        engine.dispose()
+        assert total > 1, "fixture must have more than one signature to batch"
+
+        monkeypatch.setattr(di, "BATCH_SIZE", 1)
+        seen: list[int] = []
+        original = di._load_source_rows_for_tickets
+
+        async def _spy(conn, ticket_nos):
+            seen.append(len(ticket_nos))
+            return await original(conn, ticket_nos)
+
+        monkeypatch.setattr(di, "_load_source_rows_for_tickets", _spy)
+
+        build_dedup_index(None, None, oltp_url=async_url, salt=_SALT, refresh_stale=True)
+
+        # One fetch per batch, each bounded by BATCH_SIZE — never one call
+        # holding every mismatched ticket's text at once.
+        assert len(seen) == total
+        assert set(seen) == {1}
+
+    def test_loaded_signatures_keep_bands_and_drop_the_signature(self, oltp):
+        """1.37M rows x a 128-element JSON array is roughly 4.6 GiB of Python
+        ints before anything else. The array is only ever used to compute
+        bands — verification re-reads the text — so it must not survive the
+        load.
+        """
+        import asyncio
+
+        from sqlalchemy.ext.asyncio import create_async_engine
+
+        from janasunani.pipeline import dedup_index as di
+
+        async_url, _sync_url = oltp
+        build_dedup_index(None, None, oltp_url=async_url, salt=_SALT)
+
+        async def _load():
+            aengine = create_async_engine(async_url)
+            try:
+                async with aengine.begin() as conn:
+                    return await di._load_slice_signatures(conn, None, None, 16)
+            finally:
+                await aengine.dispose()
+
+        rows = asyncio.run(_load())
+
+        assert rows, "fixture must produce signatures"
+        for row in rows:
+            assert not hasattr(row, "signature")
+            assert row.bands is None or len(row.bands) == 16
+        # At least one real signature, or the assertion above is vacuous.
+        assert any(row.bands is not None for row in rows)
+
+    def test_bucketing_refuses_bands_built_for_a_different_band_count(self):
+        """Banding at load time and bucketing at another count would produce
+        buckets that are not LSH bands of anything."""
+        from janasunani.pipeline import dedup_index as di
+
+        row = di._BandedSignature(
+            ticket_no="T1",
+            district="Khordha",
+            created_year=2024,
+            block_key="Khordha:latin:0",
+            identity_key_mobile=None,
+            identity_key_email=None,
+            bands=(1, 2, 3, 4),
+        )
+        with pytest.raises(ValueError, match="carries 4 band"):
+            di._candidate_buckets([row], 16)

--- a/tests/test_dedup_index.py
+++ b/tests/test_dedup_index.py
@@ -587,7 +587,7 @@ def _dup_oltp(tmp_path, rows):
 @pytest.fixture
 def dup_oltp(tmp_path):
     rows = [
-        # --- campaign block (window 0: Jan 2024) ---
+        # --- campaign block (all within one 30-day window: Jan 2024) ---
         ("T1", "Sambalpur", 2024, datetime(2024, 1, 5), "9861234567", None, "raw t1", CAMPAIGN_A),
         ("T2", "Sambalpur", 2024, datetime(2024, 1, 10), None, None, "raw t2", CAMPAIGN_A),
         ("T3", "Sambalpur", 2024, datetime(2024, 1, 12), None, None, "raw t3", CAMPAIGN_C_REWORDED),
@@ -601,18 +601,18 @@ def dup_oltp(tmp_path):
         ("T6", "Puri", 2024, datetime(2024, 1, 5), None, None, "raw t6", CAMPAIGN_A),
         ("T7", "Sambalpur", 2024, datetime(2024, 1, 5), None, None, "raw t7 with 9999999999", None),
         # --- hard constraint: index built from grievance_redacted, never
-        # complaints.grievance (window 8: Sept 2024) ---
+        # complaints.grievance (a different window: Sept 2024) ---
         ("T8", "Sambalpur", 2024, datetime(2024, 9, 5), None, None, "same raw text for t8 and t9", CAMPAIGN_A),
         ("T9", "Sambalpur", 2024, datetime(2024, 9, 6), None, None, "same raw text for t8 and t9", UNRELATED_A),
         ("T10", "Sambalpur", 2024, datetime(2024, 9, 10), None, None, "unique raw text for t10", CAMPAIGN_A),
         ("T11", "Sambalpur", 2024, datetime(2024, 9, 12), None, None, "totally different raw text for t11", CAMPAIGN_A),
         # --- abstention: too short/empty to shingle ---
         ("T12", "Sambalpur", 2024, datetime(2024, 1, 6), None, None, "raw t12", ""),
-        # --- cross-script (window 2: Mar 2024) ---
+        # --- cross-script (a different window: Mar 2024) ---
         ("T13", "Sambalpur", 2024, datetime(2024, 3, 1), None, None, "raw t13", ODIA_TEXT),
         ("T14", "Sambalpur", 2024, datetime(2024, 3, 2), None, None, "raw t14", ROMANIZED_TEXT),
         ("T15", "Sambalpur", 2024, datetime(2024, 3, 3), None, None, "raw t15", ODIA_TEXT),
-        # --- blocking: identical text to T1's campaign, but window 6 (Jul 2024) ---
+        # --- blocking: identical text to T1's campaign, different window (Jul 2024) ---
         ("T18", "Sambalpur", 2024, datetime(2024, 7, 1), None, None, "raw t18", CAMPAIGN_A),
         # --- same citizen (email), different issue: must NOT group ---
         ("T19", "Sambalpur", 2024, datetime(2024, 1, 6), None, "citizen@example.com", "raw t19", UNRELATED_B),
@@ -699,10 +699,17 @@ class TestBlockingByTimeWindow:
         assert groups["T18"].duplicate_group_id != groups["T1"].duplicate_group_id
 
     def test_block_key_encodes_district_script_and_window(self, dup_oltp):
+        from janasunani.pipeline.dedup_index import DEDUP_WINDOW_EPOCH
+
         async_url, sync_url = dup_oltp
         build_dedup_index("Sambalpur", 2024, oltp_url=async_url, salt=_SALT)
         row = _signature_rows(sync_url)["T1"]
-        assert row.block_key == "Sambalpur:latin:0"
+        # The window index counts from the fixed epoch, not from Jan 1 of the
+        # slice year, so it is not 0 for the first complaint of a year. That
+        # is the point: the bucket is a property of the record, so the same
+        # complaint keeps it under any run scope.
+        expected_window = (datetime(2024, 1, 5).date() - DEDUP_WINDOW_EPOCH).days // 30
+        assert row.block_key == f"Sambalpur:latin:{expected_window}"
 
 
 class TestBucketVerifiesAllPairsNotJustStarEdges:
@@ -1461,3 +1468,235 @@ class TestHeldOutRecall:
             sys.argv = old_argv
         groups_via_slice = {r.ticket_no: r.duplicate_group_id for r in _group_rows(sync_url).values()}
         assert groups_via_args == groups_via_slice
+
+
+# --- #317: corpus-wide scope ----------------------------------------------
+
+# A citizen refiling the same complaint in a later year, from the same
+# mobile. Both halves are needed: identity alone is "same citizen, not same
+# issue" and never unions on its own, so the text has to clear the Jaccard
+# threshold too.
+_REFILED_2023 = (
+    "the community water pump near the panchayat office has been broken "
+    "for months and no one has come to repair it despite several visits"
+)
+_REFILED_2024 = (
+    "the community water pump near the panchayat office has been broken "
+    "for months and nobody has come to repair it despite several visits"
+)
+
+_CROSS_SCOPE_ROWS = [
+    # ticket, district,   year, created_on,           mobile,        redacted
+    ("X1", "Khordha", 2023, datetime(2023, 3, 4), "9861111111", _REFILED_2023),
+    ("X2", "Khordha", 2024, datetime(2024, 7, 9), "9861111111", _REFILED_2024),
+    ("X3", "Khordha", 2024, datetime(2024, 7, 9), None, UNRELATED_A),
+]
+
+
+@pytest.fixture
+def cross_scope_oltp(tmp_path):
+    complaints = [
+        {
+            "ticket_no": t,
+            "district": d,
+            "created_year": y,
+            "created_on": c,
+            "petitioner_mobile": m,
+            "grievance": f"raw grievance for {t}",
+        }
+        for t, d, y, c, m, _ in _CROSS_SCOPE_ROWS
+    ]
+    redactions = [
+        {"ticket_no": t, "grievance_redacted": r} for t, _, _, _, _, r in _CROSS_SCOPE_ROWS
+    ]
+    return _make_oltp(tmp_path, complaints, redactions)
+
+
+class TestCorpusWideScope:
+    """`district`/`year` are independently optional; None means unbounded."""
+
+    def test_corpus_wide_indexes_every_district_and_year(self, oltp):
+        async_url, sync_url = oltp
+        build_dedup_index(None, None, oltp_url=async_url, salt=_SALT)
+        # T6 stays out: it has no redaction row, which is orthogonal to scope.
+        assert set(_signature_rows(sync_url)) == {"T1", "T2", "T3", "T4", "T5"}
+
+    def test_district_without_year_spans_years(self, oltp):
+        async_url, sync_url = oltp
+        build_dedup_index("Khordha", None, oltp_url=async_url, salt=_SALT)
+        assert set(_signature_rows(sync_url)) == {"T1", "T2", "T3", "T4"}
+
+    def test_year_without_district_spans_districts(self, oltp):
+        async_url, sync_url = oltp
+        build_dedup_index(None, 2024, oltp_url=async_url, salt=_SALT)
+        assert set(_signature_rows(sync_url)) == {"T1", "T2", "T3", "T5"}
+
+
+class TestCrossSliceIdentityDuplicates:
+    """The reason corpus-wide exists, and the thing a per-slice loop cannot do.
+
+    Text candidates are blocked by `district:script:window_index`, so a
+    per-slice run finds every text duplicate a corpus run would. Identity
+    candidates are deliberately unblocked -- but `build_dedup_index` scopes
+    its rows before bucketing, so only a run whose scope contains *both*
+    sides of a same-citizen pair can ever see it.
+    """
+
+    def test_per_year_runs_never_group_the_refiling(self, cross_scope_oltp):
+        async_url, sync_url = cross_scope_oltp
+        build_dedup_index("Khordha", 2023, oltp_url=async_url, salt=_SALT)
+        build_dedup_index("Khordha", 2024, oltp_url=async_url, salt=_SALT)
+
+        groups = _group_rows(sync_url)
+        assert set(groups) == {"X1", "X2", "X3"}
+        # Each slice saw one half of the pair, so nothing could union.
+        assert groups["X1"].duplicate_group_id != groups["X2"].duplicate_group_id
+
+    def test_corpus_wide_groups_the_refiling(self, cross_scope_oltp):
+        async_url, sync_url = cross_scope_oltp
+        build_dedup_index(None, None, oltp_url=async_url, salt=_SALT)
+
+        groups = _group_rows(sync_url)
+        assert groups["X1"].duplicate_group_id == groups["X2"].duplicate_group_id
+        # An unrelated filing in the same district-year stays separate: the
+        # identity path is not unioning everything it touches.
+        assert groups["X3"].duplicate_group_id != groups["X1"].duplicate_group_id
+
+
+class TestWindowEpochIsAbsolute:
+    """A record's time window must be a property of the record, not of the
+    run that indexed it.
+
+    The epoch used to be `date(year, 1, 1)`, so the same complaint got a
+    different `window_index` -- and therefore a different `block_key` --
+    depending on the scope it was indexed under. Two signatures built under
+    different origins would then never bucket together, silently.
+    """
+
+    def test_block_key_does_not_depend_on_run_scope(self, tmp_path):
+        complaints = [
+            {
+                "ticket_no": t,
+                "district": d,
+                "created_year": y,
+                "created_on": c,
+                "petitioner_mobile": m,
+                "grievance": f"raw grievance for {t}",
+            }
+            for t, d, y, c, m, _ in _SMALL_ROWS
+        ]
+        redactions = [
+            {"ticket_no": t, "grievance_redacted": r}
+            for t, _, _, _, _, r in _SMALL_ROWS
+            if r is not None
+        ]
+
+        # Two independent databases with identical contents, so the only
+        # difference between the runs is the scope they were invoked with.
+        scoped_dir = tmp_path / "scoped"
+        corpus_dir = tmp_path / "corpus"
+        scoped_dir.mkdir()
+        corpus_dir.mkdir()
+
+        scoped_async, scoped_sync = _make_oltp(scoped_dir, complaints, redactions)
+        corpus_async, corpus_sync = _make_oltp(corpus_dir, complaints, redactions)
+
+        build_dedup_index("Khordha", 2024, oltp_url=scoped_async, salt=_SALT)
+        build_dedup_index(None, None, oltp_url=corpus_async, salt=_SALT)
+
+        assert (
+            _signature_rows(scoped_sync)["T1"].block_key
+            == _signature_rows(corpus_sync)["T1"].block_key
+        )
+
+    def test_epoch_is_part_of_the_index_version(self):
+        """Without this, changing the epoch rewrites every block key while
+        leaving the version stamp claiming the rows are current, so
+        --refresh-stale would not rebuild them (#136's failure mode)."""
+        from janasunani.pipeline.dedup_index import DEDUP_WINDOW_EPOCH, _index_version
+
+        version = _index_version(30, 0.5, _SALT)
+        assert f"epoch={DEDUP_WINDOW_EPOCH.isoformat()}" in version
+
+    def test_window_index_counts_from_the_absolute_epoch(self):
+        from janasunani.pipeline.dedup_index import DEDUP_WINDOW_EPOCH, _window_index
+
+        created = datetime(2024, 1, 5)
+        expected = (created.date() - DEDUP_WINDOW_EPOCH).days // 30
+        assert _window_index(created, DEDUP_WINDOW_EPOCH, 30) == expected
+        # Same record, a scope that knows nothing about 2024: same bucket.
+        assert _window_index(created, DEDUP_WINDOW_EPOCH, 30) != 0
+
+
+class TestScopeIsNeverImplied:
+    """A bare invocation is far more often a forgotten --slice than a
+    deliberate 1.37M-row rebuild, and argv cannot tell them apart. Corpus
+    scope has to be asked for."""
+
+    def test_no_scope_at_all_is_rejected(self, monkeypatch):
+        from janasunani.pipeline import dedup_index
+
+        monkeypatch.setattr("sys.argv", ["janasunani-dedup-index"])
+        with pytest.raises(SystemExit) as exc:
+            dedup_index.main()
+        assert exc.value.code == 2
+
+    def test_all_conflicts_with_an_explicit_scope(self, monkeypatch):
+        from janasunani.pipeline import dedup_index
+
+        monkeypatch.setattr(
+            "sys.argv",
+            ["janasunani-dedup-index", "--all", "--slice", "Khordha/2024"],
+        )
+        with pytest.raises(SystemExit) as exc:
+            dedup_index.main()
+        assert exc.value.code == 2
+
+    def test_all_runs_corpus_wide(self, oltp, monkeypatch):
+        from janasunani.pipeline import dedup_index
+
+        async_url, sync_url = oltp
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "janasunani-dedup-index",
+                "--all",
+                "--oltp-url",
+                async_url,
+                "--salt",
+                _SALT,
+            ],
+        )
+        dedup_index.main()
+        assert set(_signature_rows(sync_url)) == {"T1", "T2", "T3", "T4", "T5"}
+
+
+class TestGroupRowsDescribeTheRecordNotTheRun:
+    """`dedup_groups.district`/`created_year` come from the signature row.
+
+    They used to be stamped from the run's own scope, which was
+    indistinguishable from correct while every run was a single
+    district-year. A corpus-wide run makes it a NOT NULL violation, which is
+    loud. A district-wide run makes it a wrong year on every row, which is
+    not -- so this is pinned rather than left to the constraint.
+    """
+
+    def test_district_wide_run_stamps_each_row_with_its_own_year(self, oltp):
+        async_url, sync_url = oltp
+        build_dedup_index("Khordha", None, oltp_url=async_url, salt=_SALT)
+
+        groups = _group_rows(sync_url)
+        assert groups["T1"].created_year == 2024
+        # T4 is the 2023 row. Stamping the run scope would have made this
+        # 2024 as well, or None, depending on what the run was invoked with.
+        assert groups["T4"].created_year == 2023
+        assert {g.district for g in groups.values()} == {"Khordha"}
+
+    def test_corpus_wide_run_stamps_each_row_with_its_own_district(self, oltp):
+        async_url, sync_url = oltp
+        build_dedup_index(None, None, oltp_url=async_url, salt=_SALT)
+
+        groups = _group_rows(sync_url)
+        assert groups["T1"].district == "Khordha"
+        assert groups["T5"].district == "Puri"
+        assert groups["T4"].created_year == 2023

--- a/tests/test_demo_integration.py
+++ b/tests/test_demo_integration.py
@@ -108,7 +108,7 @@ def _write_closure(findings_dir: Path, name: str = "closure_recording_no_action.
     return path
 
 
-def _write_workload(agg_dir: Path, digest: str) -> Path:
+def _write_workload(agg_dir: Path, digest: str, scope: str = "sha256:" + "c" * 64) -> Path:
     path = agg_dir / "workload.csv"
     with path.open("w", newline="", encoding="utf-8") as handle:
         writer = csv.DictWriter(
@@ -122,6 +122,7 @@ def _write_workload(agg_dir: Path, digest: str) -> Path:
                 "duplicate_adjustment",
                 "source_name",
                 "source_snapshot_id",
+                "grouping_scope_snapshot_id",
             ],
         )
         writer.writeheader()
@@ -135,12 +136,13 @@ def _write_workload(agg_dir: Path, digest: str) -> Path:
                 "duplicate_adjustment": "20",
                 "source_name": "oltp:complaints+grievance_redactions",
                 "source_snapshot_id": digest,
+                "grouping_scope_snapshot_id": scope,
             }
         )
     return path
 
 
-def _write_spike(agg_dir: Path, digest: str) -> Path:
+def _write_spike(agg_dir: Path, digest: str, scope: str = "sha256:" + "c" * 64) -> Path:
     path = agg_dir / "spike.csv"
     with path.open("w", newline="", encoding="utf-8") as handle:
         writer = csv.DictWriter(
@@ -154,6 +156,7 @@ def _write_spike(agg_dir: Path, digest: str) -> Path:
                 "distinct_citizens",
                 "source_name",
                 "source_snapshot_id",
+                "grouping_scope_snapshot_id",
                 "interpretation",
             ],
         )
@@ -168,6 +171,7 @@ def _write_spike(agg_dir: Path, digest: str) -> Path:
                 "distinct_citizens": "45",
                 "source_name": "oltp:complaints+grievance_redactions",
                 "source_snapshot_id": digest,
+                "grouping_scope_snapshot_id": scope,
                 "interpretation": "Sambalpur 2024 spike: 50 filings decomposed into 40 problems and 45 citizens",
             }
         )

--- a/tests/test_intelligence.py
+++ b/tests/test_intelligence.py
@@ -29,6 +29,7 @@ _WORKLOAD_FIELDS = (
     "duplicate_adjustment",
     "source_name",
     "source_snapshot_id",
+    "grouping_scope_snapshot_id",
 )
 _SPIKE_FIELDS = (
     "slice_district",
@@ -39,6 +40,7 @@ _SPIKE_FIELDS = (
     "distinct_citizens",
     "source_name",
     "source_snapshot_id",
+    "grouping_scope_snapshot_id",
     "interpretation",
 )
 _CLOSURE_FIELDS = (
@@ -57,6 +59,10 @@ _CLOSURE_FIELDS = (
 
 DEDUP_SOURCE = "oltp:complaints+grievance_redactions"
 FAKE_DIGEST = "sha256:" + "a" * 64
+# #317. The grouping scope is a separate digest: a corpus-wide run depends on
+# records outside the slice, so equal source digests no longer imply the same
+# group assignment.
+FAKE_SCOPE = "sha256:" + "c" * 64
 OTHER_DIGEST = "sha256:" + "b" * 64
 
 
@@ -82,7 +88,7 @@ def _write_closure(tmp_path: Path):
     return path
 
 
-def _write_workload(tmp_path: Path, digest: str = FAKE_DIGEST, extra: tuple[str, ...] = (), overrides: dict | None = None):
+def _write_workload(tmp_path: Path, digest: str = FAKE_DIGEST, scope: str = FAKE_SCOPE, extra: tuple[str, ...] = (), overrides: dict | None = None):
     row = {
         "slice_district": "Sambalpur",
         "slice_category": "all",
@@ -92,6 +98,7 @@ def _write_workload(tmp_path: Path, digest: str = FAKE_DIGEST, extra: tuple[str,
         "duplicate_adjustment": "3",
         "source_name": DEDUP_SOURCE,
         "source_snapshot_id": digest,
+        "grouping_scope_snapshot_id": scope,
     }
     if overrides:
         row.update(overrides)
@@ -107,7 +114,7 @@ def _write_workload(tmp_path: Path, digest: str = FAKE_DIGEST, extra: tuple[str,
     return path
 
 
-def _write_spike(tmp_path: Path, digest: str = FAKE_DIGEST, extra: tuple[str, ...] = (), overrides: dict | None = None):
+def _write_spike(tmp_path: Path, digest: str = FAKE_DIGEST, scope: str = FAKE_SCOPE, extra: tuple[str, ...] = (), overrides: dict | None = None):
     row = {
         "slice_district": "Sambalpur",
         "slice_category": "Water",
@@ -117,6 +124,7 @@ def _write_spike(tmp_path: Path, digest: str = FAKE_DIGEST, extra: tuple[str, ..
         "distinct_citizens": "15",
         "source_name": DEDUP_SOURCE,
         "source_snapshot_id": digest,
+        "grouping_scope_snapshot_id": scope,
         "interpretation": "20 filings, 5 problems, 15 citizens. Lift 3.0x vs trailing mean.",
     }
     if overrides:
@@ -265,3 +273,30 @@ def test_closure_still_served_when_workload_spike_missing(tmp_path):
     assert dash.closure.provenance.state == "recorded"
     assert dash.workload.provenance.state == "unavailable"
     assert dash.spike.provenance.state == "unavailable"
+
+
+def test_divergent_grouping_scopes_are_refused_even_when_source_digests_agree(tmp_path):
+    """#317. Corpus-wide grouping depends on records outside a slice, so two
+    runs can agree on the source digest and still carry different group
+    assignments. Serving must refuse that pair, or the mixed-output guard is
+    only checking the half of the provenance that cannot move."""
+    _write_closure(tmp_path)
+    _write_workload(tmp_path, scope="sha256:" + "c" * 64)
+    _write_spike(tmp_path, scope="sha256:" + "d" * 64)
+
+    dash = ArtifactSupervisorProvider(tmp_path).dashboard()
+
+    assert dash.workload.provenance.state == "unavailable"
+    assert dash.spike.provenance.state == "unavailable"
+
+
+def test_matching_scopes_and_digests_still_serve(tmp_path):
+    """The negative case above must not be passing for an unrelated reason."""
+    _write_closure(tmp_path)
+    _write_workload(tmp_path)
+    _write_spike(tmp_path)
+
+    dash = ArtifactSupervisorProvider(tmp_path).dashboard()
+
+    assert dash.workload.provenance.state == "recorded"
+    assert dash.spike.provenance.state == "recorded"


### PR DESCRIPTION
Fixes #317.

## Why a loop over slices is not equivalent

#317 originally recorded that `--district`/`--year` were already optional and no code change was needed. Both halves were wrong.

`main()` rejects a bare invocation. More importantly, `_candidate_buckets` ([dedup_index.py:857-905](janasunani/pipeline/dedup_index.py#L857-L905)) builds two kinds of bucket:

- **Text/band buckets** are keyed by `block_key` = `district:script:window_index`, so they are slice-local and a loop reproduces them exactly.
- **Identity buckets** (mobile, email) are deliberately *not* blocked. The docstring says why: *"a resubmission can land months later and a phone number carries no script."*

But `build_dedup_index` scoped its rows to one district-year *before* any bucketing. So a same-citizen duplicate crossing a district or year boundary was invisible to every possible run. That is a large part of what corpus-wide dedup exists to find, and exactly the class the single-slice index could never see.

`district` and `year` are now independently optional. Text blocking is unchanged, so this does not create one giant bucket at 1.37M rows.

## Three things this turned up

### The window epoch was scope-dependent, and unversioned

`epoch = date(year, 1, 1)`, feeding `_window_index` → `block_key`. So a record's block key depended on **which run indexed it**. Undefined for a corpus run, and silently run-dependent for any other.

The hazard is that `_index_version` never carried the epoch. Signatures built under different origins carried identical version stamps, so `--refresh-stale` would not rebuild them, and grouping would mix block keys computed against different origins — dropping candidates that should have matched and reporting a quietly low duplicate rate with **no error**. Same failure class the salt marker exists to catch (#136).

The epoch is now a fixed absolute date and part of the version stamp.

**This invalidates the existing Sambalpur/2024 signatures.** They are rebuilt, not migrated — correct anyway, since they predate #316's corpus redaction.

### `dedup_groups` stamped the run, not the record

`district`/`created_year` on group rows came from the run's scope. Indistinguishable from correct while every run was one district-year. A corpus run makes it a `NOT NULL` violation, which is loud. A **district-wide** run makes it a wrong year on every row, which is not. Both now come from the signature row, and both cases are pinned.

### `_raise_if_source_is_not_current` inverted on an unbounded scope

It compared every row against `district` and `year` to detect a record that left its slice. With `None`, `row[2] != None` is true for everything, so every mismatch would read as "moved" and the run would fail with the wrong error. It now compares only the dimensions actually pinned.

## `--all` is required, not implied

A forgotten `--slice` and a deliberate 1.37M-row rebuild are indistinguishable from argv. Only one of them should ever happen by accident, so an unscoped invocation errors.

## Tests

+16 tests, real code path against SQLite OLTP, synthetic text only.

The load-bearing one is `TestCrossSliceIdentityDuplicates`: a citizen refiling in 2024 what they filed in 2023, same mobile, text above threshold. Per-year runs leave the two in separate groups; the corpus run unions them. An unrelated filing in the same district-year stays separate, so the identity path is not just unioning everything it touches.

```
153 passed   (tests/test_dedup_index.py + tests/test_dedup.py)
972 passed   (full suite, excl. a pre-existing local-env failure in
              test_makefile_dotenv.py — 21 of those fail on unrelated
              branches too and are green in CI)
ruff         All checks passed
```

## Operational note

The corpus run needs `--refresh-stale`, because #316 rewrote every source record and the epoch change invalidates every existing signature:

```bash
uv run janasunani-dedup-index --all --refresh-stale
```

Memory at 1.37M is still unmeasured — `_load_slice_signatures` holds all signatures at once for grouping, and the docstring's "tens of thousands, comfortably in memory" is written for 25x less. #317 asks for that to be measured rather than assumed, and it will be, on the run itself.