### PR TITLE
fix(evaluation): salvage the non-deck work from the retired deck PRs

### DIFF
--- a/docs/DELIVERY.md
+++ b/docs/DELIVERY.md
@@ -15,6 +15,18 @@ status: Internal
 > intake-time actionability and congestion remain unresolved, so it supports no
 > routing gain, deployable threshold, causal impact or recommendation. See
 > [QUALITY_BENCHMARKS.md](QUALITY_BENCHMARKS.md#routing--outcome-not-destination).
+>
+> **Sarvam spend resumed, 25 August 2026.** "No new paid calls" and "new spend
+> is paused" below describe the position up to 14 August and are superseded. A
+> 200-page stratified draw from Sambalpur/2024 ran on 25 August across both
+> endpoints, ₹300 at list price, 87 grievances. It supersedes the cached
+> aggregate and changes three statements below: a latency distribution now
+> exists (digitise median 6 s a page, extract 11 s, derived from the egress
+> audit log, 5 s polling resolution); divergence is 0.995 on 198 scored pages
+> with a character ratio of 1.56, not 1.3345 on 56; and a category grade now
+> exists but measures our own v1 schema, which offered no enum, rather than the
+> provider. Still absent, and still blocking any accuracy claim: a
+> hand-transcribed reference (#53). Schema v2 is now the pinned default.
 
 ## What is built
 

--- a/docs/DELIVERY.md
+++ b/docs/DELIVERY.md
@@ -25,8 +25,11 @@ status: Internal
 > audit log, 5 s polling resolution); divergence is 0.995 on 198 scored pages
 > with a character ratio of 1.56, not 1.3345 on 56; and a category grade now
 > exists but measures our own v1 schema, which offered no enum, rather than the
-> provider. Still absent, and still blocking any accuracy claim: a
-> hand-transcribed reference (#53). Schema v2 is now the pinned default.
+> provider. Still absent, and still blocking any **OCR accuracy** claim
+> specifically: a hand-transcribed reference (#53). It does not block the
+> latency or category results above, which have their own referees — the
+> egress audit log and the recorded category. Schema v2 is now the pinned
+> default.
 
 ## What is built
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -90,7 +90,7 @@ The only place phase status is recorded.
 | 14 | II | **Spam & duplicate detection** *(b)* | 🔄 *(55,544/55,544 indexed into 10,963 groups; bounded low-signal regression and binary actionability development scorer measured; officer gold and a release gate remain)* |
 | 15 | II | **Structured analytics I**: metrics layer, dashboards, spikes *(c)* — metric-registry slice: governed total-filings definition and protected grouped releases; cluster/citizen metrics remain unavailable pending dedup lake artifacts | 🔄 |
 | 16 | II | **A/B instrumentation + retrospective impact evidence** *(d)* | 🔄 *(draft design and developmental routing-outcome diagnostics built; assignment, exposure, shadow execution, locked power inputs and a governed pilot remain unbuilt)* |
-| 17 | II | **Sarvam benchmark + provider registry + egress control** *(e)* | 🔄 *(cached provider evidence and governed local release wiring built; no hand-transcribed OCR accuracy set and no new paid calls)* |
+| 17 | II | **Sarvam benchmark + provider registry + egress control** *(e)* | 🔄 *(200-page paid run on Sambalpur/2024, 25 Aug 2026, ₹300 list: latency distribution and divergence 0.995 measured, category grade measures our own v1 schema not the provider; schema v2 pinned; no hand-transcribed OCR accuracy set (#53))* |
 | 18 | III | Evaluation harness & operational safety (RBAC, restore, observability) | ⬜ |
 | 19 | III | Model & pipeline platform (one recipe, release manifest, API v1) | 🔄 *(immutable local release/materialization slice built; no reviewed production manifest, shared recipe or API-v1 policy yet)* |
 | 20 | III | Structured analytics II (adjusted comparisons, NL query) | ⬜ |

--- a/janasunani/evaluation/sarvam_evaluate.py
+++ b/janasunani/evaluation/sarvam_evaluate.py
@@ -8,8 +8,10 @@ but promotes it to a proper evaluation module with:
   extract = structured fields vs gold category + BART summary, both = ₹1.50/page)
 * ``--join-metadata``  (lake/OLTP slice for gold_category, pipeline_category,
   pipeline_summary, handwritten, language — redacted metadata only)
-* ``--schema-version v1``  (pins :mod:`sarvam_grievance_schema` before any
-  output is read, per #127)
+* ``--schema-version v2``  (the default; pins :mod:`sarvam_grievance_schema`
+  before any output is read, per #127. Omit the flag. ``v1`` reproduces the
+  2026-08-25 run, whose category field had neither an enum nor a ``required``
+  and which therefore answered the primary outcome on 11 of 87 grievances)
 
 Live Sarvam calls are identical to the sample runner: one async job per page
 via :class:`SarvamVisionAdapter`, audit-logged with ticket/stage/provider/

--- a/janasunani/evaluation/sarvam_grievance_schema.py
+++ b/janasunani/evaluation/sarvam_grievance_schema.py
@@ -27,7 +27,11 @@ from __future__ import annotations
 
 from typing import Any
 
-SCHEMA_VERSION = "v1"
+#: v2 is the default because v1 cannot answer its own declared primary
+#: outcome: its category field has no enum, so the 2026-08-25 run billed 200
+#: pages and returned free-text subject lines. v1 stays reachable so that run
+#: can be reproduced exactly; nothing else should select it.
+SCHEMA_VERSION = "v2"
 SCHEMA_VERSION_V1 = "v1"
 
 #: The field map. Not sendable on its own — see ``GRIEVANCE_EXTRACT_SCHEMA_V1``.
@@ -56,8 +60,94 @@ GRIEVANCE_EXTRACT_SCHEMA_V1: dict[str, Any] = {
     "properties": GRIEVANCE_EXTRACT_FIELDS_V1,
 }
 
+SCHEMA_VERSION_V2 = "v2"
+
+#: The 35 labels ``complaints.category`` actually takes, read off the lake on
+#: 2026-08-25. ``Scheme & Benefits`` is stored double-escaped as
+#: ``Scheme &amp;amp; Benefits``; the enum carries the readable form and the
+#: comparison unescapes before matching, because asking a model to emit an
+#: HTML entity would be absurd and would fail for the wrong reason.
+GRIEVANCE_CATEGORIES: tuple[str, ...] = (
+    "Accident",
+    "Agriculture & Farming",
+    "BSKY",
+    "CMRF",
+    "COVID-19",
+    "Culture",
+    "Disaster Management",
+    "Education",
+    "Energy",
+    "Environment",
+    "Excise",
+    "Financial Assistance",
+    "General",
+    "Health Care",
+    "Housing",
+    "ICDS",
+    "Infrastructure",
+    "Irrigation",
+    "Land Matters",
+    "Legal",
+    "Miscellaneous",
+    "Pension/Retirement Benefits",
+    "Police Case",
+    "Public Utility",
+    "Scheme & Benefits",
+    "School & College",
+    "Service Matters",
+    "Social Welfare",
+    "Sports",
+    "Tourism",
+    "Traffic",
+    "Transport",
+    "Waste Management",
+    "Water Supply",
+    "Women Issues",
+)
+
+#: v2 field map. Two changes, both forced by the 2026-08-25 run.
+#:
+#: ``grievance_category`` gains an ``enum``. v1 described it as the
+#: "taxonomy of complaints.grievance_category" and then never said what that
+#: taxonomy was, so the model had nothing to choose from and answered with
+#: free-text subject lines: "Sanction of new AWC buildings" against a gold
+#: label of ICDS, "Revenue & law Order" against Land Matters. It matched gold
+#: on 0 of the 11 grievances where it answered at all, which measured our
+#: schema rather than the provider.
+#:
+#: ``district`` is dropped. It is a structured column on ``complaints`` that is
+#: recorded at intake and known with certainty for every grievance, so paying
+#: an extraction endpoint to read it back off a scan buys nothing. It was also
+#: the best-populated field in the run, 100 of 198 pages against the category's
+#: 11, because it sits on the letterhead: the budget went to the one field we
+#: already had. Reinstate it only as an explicit intake-accuracy cross-check,
+#: and say so if you do.
+GRIEVANCE_EXTRACT_FIELDS_V2: dict[str, dict[str, Any]] = {
+    "grievance_category": {
+        "type": "string",
+        "enum": list(GRIEVANCE_CATEGORIES),
+        "description": (
+            "The single grievance category. Choose exactly one value from enum."
+        ),
+    },
+    "summary": {
+        "type": "string",
+        "description": "One-paragraph grievance summary",
+    },
+    "grievance_text": {
+        "type": "string",
+        "description": "Full grievance text (redacted prose)",
+    },
+}
+
+GRIEVANCE_EXTRACT_SCHEMA_V2: dict[str, Any] = {
+    "type": "object",
+    "properties": GRIEVANCE_EXTRACT_FIELDS_V2,
+}
+
 SUPPORTED_SCHEMA_VERSIONS: dict[str, dict[str, Any]] = {
     "v1": GRIEVANCE_EXTRACT_SCHEMA_V1,
+    "v2": GRIEVANCE_EXTRACT_SCHEMA_V2,
 }
 
 

--- a/janasunani/evaluation/sarvam_grievance_schema.py
+++ b/janasunani/evaluation/sarvam_grievance_schema.py
@@ -110,10 +110,10 @@ GRIEVANCE_CATEGORIES: tuple[str, ...] = (
 #: ``grievance_category`` gains an ``enum``. v1 described it as the
 #: "taxonomy of complaints.grievance_category" and then never said what that
 #: taxonomy was, so the model had nothing to choose from and answered with
-#: free-text subject lines: "Sanction of new AWC buildings" against a gold
-#: label of ICDS, "Revenue & law Order" against Land Matters. It matched gold
-#: on 0 of the 11 grievances where it answered at all, which measured our
-#: schema rather than the provider.
+#: free-text subject lines — the specific relief each petitioner asked for, or
+#: the name of an administrative wing — none of which is a value the taxonomy
+#: takes. It matched gold on 0 of the 11 grievances where it answered at all,
+#: which measured our schema rather than the provider.
 #:
 #: ``district`` is dropped. It is a structured column on ``complaints`` that is
 #: recorded at intake and known with certainty for every grievance, so paying

--- a/janasunani/evaluation/sarvam_grievance_schema.py
+++ b/janasunani/evaluation/sarvam_grievance_schema.py
@@ -3,8 +3,13 @@
 This module is the single source for the JSON schema passed to
 ``SarvamVisionAdapter.extract(schema=...)`` in the benchmark. The schema is
 versioned so a later change cannot silently shift the headline category
-accuracy number; callers pin ``--schema-version v1`` and the scorecard
-records the version.
+accuracy number, and the scorecard records the version it ran under.
+
+**Use v2, which is the default. Do not pass ``--schema-version v1`` unless you
+are deliberately reproducing the 2026-08-25 run.** v1's category field has no
+enum and no ``required``, which is why that run billed 200 pages and returned
+free-text subject lines on 11 of 87 grievances. Passing the flag explicitly
+overrides the default and buys that outcome again, at full price.
 
 The illustrative schema in the rehearsal plan (Part 5) is reproduced
 verbatim here as ``GRIEVANCE_EXTRACT_FIELDS_V1``. Field names are aligned
@@ -140,9 +145,21 @@ GRIEVANCE_EXTRACT_FIELDS_V2: dict[str, dict[str, Any]] = {
     },
 }
 
+#: ``grievance_category`` is declared ``required``. JSON Schema properties are
+#: optional by default, so without this a run could return only ``summary`` and
+#: ``grievance_text`` and omit the field the benchmark exists to measure --
+#: which is close to what the 2026-08-25 run did, answering the category on 11
+#: of 87 grievances. The enum fixes *what* the model may say; this fixes
+#: *whether* it has to say it. The other two fields stay optional: a page with
+#: no legible prose returning no ``grievance_text`` is a real outcome, not a
+#: malformed response.
+#:
+#: v1 deliberately gains nothing here. It stays byte-for-byte what the
+#: 2026-08-25 run sent, or that run stops being reproducible.
 GRIEVANCE_EXTRACT_SCHEMA_V2: dict[str, Any] = {
     "type": "object",
     "properties": GRIEVANCE_EXTRACT_FIELDS_V2,
+    "required": ["grievance_category"],
 }
 
 SUPPORTED_SCHEMA_VERSIONS: dict[str, dict[str, Any]] = {

--- a/janasunani/evaluation/sarvam_scorecard.py
+++ b/janasunani/evaluation/sarvam_scorecard.py
@@ -577,26 +577,53 @@ def build_scorecard(
     n_pages = len(pages)
     n_tickets = len({p.ticket for p in pages})
 
-    # Category arm — paired, ticket-clustered. De-duplicate by ticket for
-    # category (one category per ticket/document, not per page).
-    # If a ticket appears on multiple pages, its category should be consistent;
-    # we take the first non-None and require consistency (warn if not).
+    # Category arm — paired, ticket-clustered. Category is a property of the
+    # grievance, not of a page, so it is de-duplicated to one value per ticket.
+    #
+    # **Disagreement between pages is recorded, never resolved by position.**
+    # This used to keep the first non-null answer and `pass` on any later
+    # value that differed. That was survivable while a page with no grievance
+    # content could return null and let a later page's answer through. Schema
+    # v2 makes `grievance_category` `required`, and Extract is invoked per page
+    # (sarvam_evaluate.py:604), so every page must now answer — including cover
+    # sheets and attachments that have no category to give. First-wins then
+    # lets a forced guess on page one mask a correct answer on the
+    # grievance-bearing page, silently, in the primary outcome.
+    #
+    # Picking a different page is not a fix either: majority favours whichever
+    # page type is most numerous, which for a multi-page grievance is usually
+    # the attachments. Without knowing which page bears the grievance there is
+    # no defensible winner, so a ticket whose pages disagree is marked
+    # ambiguous and excluded from accuracy, with the count reported. The real
+    # fix is to extract once per grievance rather than per page.
     ticket_gold: dict[str, str | None] = {}
     ticket_pipe: dict[str, str | None] = {}
     ticket_sarvam: dict[str, str | None] = {}
+    # ticket -> set of distinct non-null answers seen, per field
+    seen_gold: dict[str, set[str]] = defaultdict(set)
+    seen_pipe: dict[str, set[str]] = defaultdict(set)
+    seen_sarvam: dict[str, set[str]] = defaultdict(set)
     for p in pages:
-        for d, val in [
-            (ticket_gold, p.gold_category),
-            (ticket_pipe, p.pipeline_category),
-            (ticket_sarvam, p.sarvam_category),
+        for d, seen, val in [
+            (ticket_gold, seen_gold, p.gold_category),
+            (ticket_pipe, seen_pipe, p.pipeline_category),
+            (ticket_sarvam, seen_sarvam, p.sarvam_category),
         ]:
+            key = category_key(val)
+            if key is not None:
+                seen[p.ticket].add(key)
             if p.ticket not in d:
                 d[p.ticket] = val
             elif d[p.ticket] is None and val is not None:
                 d[p.ticket] = val
-            elif val is not None and d[p.ticket] is not None and d[p.ticket] != val:
-                # Inconsistent label for same ticket — keep first, note later
-                pass
+
+    # A ticket whose pages gave two different answers has no usable value.
+    ambiguous_sarvam = {t for t, vals in seen_sarvam.items() if len(vals) > 1}
+    ambiguous_pipeline = {t for t, vals in seen_pipe.items() if len(vals) > 1}
+    for ticket in ambiguous_sarvam:
+        ticket_sarvam[ticket] = None
+    for ticket in ambiguous_pipeline:
+        ticket_pipe[ticket] = None
 
     # Only tickets with a gold label contribute to paired accuracy
     # Arm-aware: digitise-only does not score category (gold Category requires Extract)
@@ -625,6 +652,17 @@ def build_scorecard(
                 "ci_low": diff["ci_low"],
                 "ci_high": diff["ci_high"],
                 "n_clusters": diff["n_clusters"],
+                # Tickets whose pages disagreed. These score as incorrect
+                # because no page's answer is defensible, so a high count means
+                # the marginal rates understate the provider rather than
+                # measuring it. Reported so that is visible instead of being
+                # absorbed into the accuracy figure.
+                "sarvam_ambiguous_tickets": len(
+                    [t for t in cat_tickets if t in ambiguous_sarvam]
+                ),
+                "pipeline_ambiguous_tickets": len(
+                    [t for t in cat_tickets if t in ambiguous_pipeline]
+                ),
                 "interpretation": "difference + CI is the result; marginal rates are description (#127)",
             }
         else:

--- a/janasunani/evaluation/sarvam_scorecard.py
+++ b/janasunani/evaluation/sarvam_scorecard.py
@@ -36,6 +36,7 @@ recorded Sarvam markdown fixtures; no live network call is made.
 
 from __future__ import annotations
 
+import html
 import json
 import random
 import re
@@ -120,6 +121,49 @@ def normalize_text(text: str | None) -> str:
     # collapse whitespace (including newlines to single space for comparison)
     text = re.sub(r"\s+", " ", text).strip()
     return text
+
+
+def unescape_label(label: str | None) -> str | None:
+    """Return *label* in its readable form, undoing HTML entity escaping.
+
+    Some ``complaints.category`` values reached the lake double-escaped:
+    ``Scheme & Benefits`` is stored as ``Scheme &amp;amp; Benefits``. Unescaping
+    is applied repeatedly until it reaches a fixed point so both single and
+    double escaping resolve, with a bounded loop so a pathological value cannot
+    spin. Returns ``None`` for a missing or blank label.
+    """
+    if label is None:
+        return None
+    text = unicodedata.normalize("NFC", str(label))
+    for _ in range(3):
+        decoded = html.unescape(text)
+        if decoded == text:
+            break
+        text = decoded
+    text = re.sub(r"\s+", " ", text).strip()
+    return text or None
+
+
+def category_key(label: str | None) -> str | None:
+    """Comparison key for a category label, or ``None`` if there is no label.
+
+    Category accuracy compares a stored gold label against a model's answer.
+    The schema enum offers the readable form (``Scheme & Benefits``), so an
+    exact-equality comparison against the escaped stored form would score every
+    correct prediction for that category as wrong. Comparisons must go through
+    this function rather than ``==`` on the raw strings.
+
+    ``None`` never equals ``None`` for scoring purposes: callers filter on a
+    present gold label first, so a missing prediction cannot match.
+    """
+    cleaned = unescape_label(label)
+    return cleaned.casefold() if cleaned else None
+
+
+def _labels_match(gold: str | None, predicted: str | None) -> bool:
+    """True when *predicted* is the same category as *gold*, ignoring escaping."""
+    gold_key = category_key(gold)
+    return gold_key is not None and gold_key == category_key(predicted)
 
 
 # ---------------------------------------------------------------------------
@@ -383,16 +427,18 @@ def per_category_table(pages: list[PageRecord]) -> dict[str, dict[str, Any]]:
                 d[p.ticket] = val
             elif d[p.ticket] is None and val is not None:
                 d[p.ticket] = val
-    # group tickets by gold category
+    # Group tickets by gold category. The row label is the readable form, so
+    # escaped and unescaped spellings of one category are a single row.
     groups: dict[str, list[str]] = defaultdict(list)
     for ticket, gold in ticket_gold.items():
-        if gold is not None:
-            groups[gold].append(ticket)
+        readable = unescape_label(gold)
+        if readable is not None:
+            groups[readable].append(ticket)
     out: dict[str, dict[str, Any]] = {}
     for category in sorted(groups):
         tickets = groups[category]
-        pipe_correct = [1 if ticket_pipe.get(t) == category else 0 for t in tickets]
-        sarv_correct = [1 if ticket_sarvam.get(t) == category else 0 for t in tickets]
+        pipe_correct = [1 if _labels_match(category, ticket_pipe.get(t)) else 0 for t in tickets]
+        sarv_correct = [1 if _labels_match(category, ticket_sarvam.get(t)) else 0 for t in tickets]
         pipe_acc = sum(pipe_correct) / len(pipe_correct) if pipe_correct else 0.0
         sarv_acc = sum(sarv_correct) / len(sarv_correct) if sarv_correct else 0.0
         out[category] = {
@@ -561,8 +607,12 @@ def build_scorecard(
         cat_tickets = [t for t in ticket_gold if ticket_gold[t] is not None]
         cat_clusters = cat_tickets  # one per ticket
         if cat_tickets:
-            pipe_correct = [1 if ticket_pipe.get(t) == ticket_gold[t] else 0 for t in cat_tickets]
-            sarvam_correct = [1 if ticket_sarvam.get(t) == ticket_gold[t] else 0 for t in cat_tickets]
+            pipe_correct = [
+                1 if _labels_match(ticket_gold[t], ticket_pipe.get(t)) else 0 for t in cat_tickets
+            ]
+            sarvam_correct = [
+                1 if _labels_match(ticket_gold[t], ticket_sarvam.get(t)) else 0 for t in cat_tickets
+            ]
             pipe_rate = sum(pipe_correct) / len(pipe_correct) if pipe_correct else 0.0
             sarvam_rate = sum(sarvam_correct) / len(sarvam_correct) if sarvam_correct else 0.0
             diff = paired_difference(sarvam_correct, pipe_correct, cat_clusters)

--- a/janasunani/evaluation/sarvam_scorecard.py
+++ b/janasunani/evaluation/sarvam_scorecard.py
@@ -44,7 +44,7 @@ import unicodedata
 from collections import defaultdict
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple, Sequence
 
 from janasunani.config import DEMO_SLICE_DISTRICT, DEMO_SLICE_LABEL, DEMO_SLICE_YEAR
 from janasunani.evaluation.stats import (
@@ -404,29 +404,79 @@ def sample_compliance(n_pages: int, slice_label: str | None = None) -> dict[str,
 # Per-category accuracy — the spread that headlines hide
 # ---------------------------------------------------------------------------
 
+class TicketCategories(NamedTuple):
+    """One category per ticket, with the tickets whose pages disagreed."""
+
+    gold: dict[str, str | None]
+    pipeline: dict[str, str | None]
+    sarvam: dict[str, str | None]
+    ambiguous_sarvam: set[str]
+    ambiguous_pipeline: set[str]
+
+
+def aggregate_ticket_categories(pages: Sequence[PageRecord]) -> TicketCategories:
+    """Collapse per-page categories to one value per ticket.
+
+    Category is a property of the grievance, not of a page. Extract is invoked
+    per page (``sarvam_evaluate.py:604``) and schema v2 makes
+    ``grievance_category`` ``required``, so every page must answer — including
+    cover sheets and attachments that have no category to give.
+
+    **Disagreement is recorded, never resolved by position.** Keeping the first
+    non-null answer lets a forced guess on page one mask a correct answer on
+    the grievance-bearing page. Majority is no better: it favours whichever
+    page type is most numerous, usually the attachments. Without knowing which
+    page bears the grievance there is no defensible winner, so a ticket whose
+    pages disagree is returned with ``None`` and named in the ambiguous sets.
+
+    Both the headline metric and ``per_category_table`` must go through this.
+    They had separate copies of this loop, and fixing only one made the
+    per-category rows contradict the headline for the same ticket.
+    """
+    gold: dict[str, str | None] = {}
+    pipeline: dict[str, str | None] = {}
+    sarvam: dict[str, str | None] = {}
+    seen_pipeline: dict[str, set[str]] = defaultdict(set)
+    seen_sarvam: dict[str, set[str]] = defaultdict(set)
+
+    for p in pages:
+        for target, seen, val in [
+            (gold, None, p.gold_category),
+            (pipeline, seen_pipeline, p.pipeline_category),
+            (sarvam, seen_sarvam, p.sarvam_category),
+        ]:
+            key = category_key(val)
+            if seen is not None and key is not None:
+                seen[p.ticket].add(key)
+            if p.ticket not in target:
+                target[p.ticket] = val
+            elif target[p.ticket] is None and val is not None:
+                target[p.ticket] = val
+
+    ambiguous_sarvam = {t for t, vals in seen_sarvam.items() if len(vals) > 1}
+    ambiguous_pipeline = {t for t, vals in seen_pipeline.items() if len(vals) > 1}
+    for ticket in ambiguous_sarvam:
+        sarvam[ticket] = None
+    for ticket in ambiguous_pipeline:
+        pipeline[ticket] = None
+    return TicketCategories(gold, pipeline, sarvam, ambiguous_sarvam, ambiguous_pipeline)
+
+
 def per_category_table(pages: list[PageRecord]) -> dict[str, dict[str, Any]]:
     """Per-category accuracy for pipeline vs Sarvam, grouped by gold label.
 
     One row per gold_category value (e.g. Police 0.85 vs Welfare 0.51).
-    De-duplicated by ticket like the headline metric (one category per
-    ticket). Tickets without a gold label are omitted.
+    De-duplicated by ticket through :func:`aggregate_ticket_categories`, the
+    same path the headline uses, so a ticket cannot be ambiguous in one and
+    correct in the other. Tickets without a gold label are omitted.
 
     Returns mapping category -> {n_tickets, pipeline_accuracy,
     sarvam_accuracy, pipeline_correct, sarvam_correct, difference}.
     """
-    ticket_gold: dict[str, str | None] = {}
-    ticket_pipe: dict[str, str | None] = {}
-    ticket_sarvam: dict[str, str | None] = {}
-    for p in pages:
-        for d, val in [
-            (ticket_gold, p.gold_category),
-            (ticket_pipe, p.pipeline_category),
-            (ticket_sarvam, p.sarvam_category),
-        ]:
-            if p.ticket not in d:
-                d[p.ticket] = val
-            elif d[p.ticket] is None and val is not None:
-                d[p.ticket] = val
+    aggregated = aggregate_ticket_categories(pages)
+    ticket_gold = aggregated.gold
+    ticket_pipe = aggregated.pipeline
+    ticket_sarvam = aggregated.sarvam
     # Group tickets by gold category. The row label is the readable form, so
     # escaped and unescaped spellings of one category are a single row.
     groups: dict[str, list[str]] = defaultdict(list)
@@ -577,53 +627,16 @@ def build_scorecard(
     n_pages = len(pages)
     n_tickets = len({p.ticket for p in pages})
 
-    # Category arm — paired, ticket-clustered. Category is a property of the
-    # grievance, not of a page, so it is de-duplicated to one value per ticket.
-    #
-    # **Disagreement between pages is recorded, never resolved by position.**
-    # This used to keep the first non-null answer and `pass` on any later
-    # value that differed. That was survivable while a page with no grievance
-    # content could return null and let a later page's answer through. Schema
-    # v2 makes `grievance_category` `required`, and Extract is invoked per page
-    # (sarvam_evaluate.py:604), so every page must now answer — including cover
-    # sheets and attachments that have no category to give. First-wins then
-    # lets a forced guess on page one mask a correct answer on the
-    # grievance-bearing page, silently, in the primary outcome.
-    #
-    # Picking a different page is not a fix either: majority favours whichever
-    # page type is most numerous, which for a multi-page grievance is usually
-    # the attachments. Without knowing which page bears the grievance there is
-    # no defensible winner, so a ticket whose pages disagree is marked
-    # ambiguous and excluded from accuracy, with the count reported. The real
-    # fix is to extract once per grievance rather than per page.
-    ticket_gold: dict[str, str | None] = {}
-    ticket_pipe: dict[str, str | None] = {}
-    ticket_sarvam: dict[str, str | None] = {}
-    # ticket -> set of distinct non-null answers seen, per field
-    seen_gold: dict[str, set[str]] = defaultdict(set)
-    seen_pipe: dict[str, set[str]] = defaultdict(set)
-    seen_sarvam: dict[str, set[str]] = defaultdict(set)
-    for p in pages:
-        for d, seen, val in [
-            (ticket_gold, seen_gold, p.gold_category),
-            (ticket_pipe, seen_pipe, p.pipeline_category),
-            (ticket_sarvam, seen_sarvam, p.sarvam_category),
-        ]:
-            key = category_key(val)
-            if key is not None:
-                seen[p.ticket].add(key)
-            if p.ticket not in d:
-                d[p.ticket] = val
-            elif d[p.ticket] is None and val is not None:
-                d[p.ticket] = val
-
-    # A ticket whose pages gave two different answers has no usable value.
-    ambiguous_sarvam = {t for t, vals in seen_sarvam.items() if len(vals) > 1}
-    ambiguous_pipeline = {t for t, vals in seen_pipe.items() if len(vals) > 1}
-    for ticket in ambiguous_sarvam:
-        ticket_sarvam[ticket] = None
-    for ticket in ambiguous_pipeline:
-        ticket_pipe[ticket] = None
+    # Category arm — paired, ticket-clustered. One value per ticket via the
+    # shared aggregator, which records page disagreement rather than resolving
+    # it by position. per_category_table uses the same call, so a ticket cannot
+    # be ambiguous in the headline and correct in the per-category rows.
+    _agg = aggregate_ticket_categories(pages)
+    ticket_gold = _agg.gold
+    ticket_pipe = _agg.pipeline
+    ticket_sarvam = _agg.sarvam
+    ambiguous_sarvam = _agg.ambiguous_sarvam
+    ambiguous_pipeline = _agg.ambiguous_pipeline
 
     # Only tickets with a gold label contribute to paired accuracy
     # Arm-aware: digitise-only does not score category (gold Category requires Extract)

--- a/scripts/benchmark_pipeline.py
+++ b/scripts/benchmark_pipeline.py
@@ -871,6 +871,105 @@ def _get_git_sha() -> str | None:
     return None
 
 
+def _probe_tesseract() -> tuple[str, list[str] | str]:
+    """Best-effort (version, sorted available languages) for tesseract.
+
+    Resolves the binary exactly as the real OCR stage does —
+    ``pytesseract_backend._configure_tesseract()``, which checks
+    ``TESSERACT_CMD``/PATH/the bundled ``~/.local/tesseract`` install in that
+    order — not a naive PATH lookup, so a box using the bundled install is
+    reported accurately. Never raises: returns ``("unavailable",
+    "unavailable")`` if tesseract, or even the ``pipeline-core`` extra
+    itself, is unavailable. The two probes are independent (a broken version
+    call must not blank out a working language list, or vice versa).
+    """
+    version: str = "unavailable"
+    langs: list[str] | str = "unavailable"
+    try:
+        import pytesseract
+        from janasunani.pipeline.stages.ocr_extraction.pytesseract_backend import (
+            _configure_tesseract,
+        )
+
+        _configure_tesseract()
+        try:
+            version = str(pytesseract.get_tesseract_version())
+        except Exception:
+            pass
+        try:
+            langs = sorted(pytesseract.get_languages(config=""))
+        except Exception:
+            pass
+    except Exception:
+        pass
+    return version, langs
+
+
+def _probe_poppler_version() -> str:
+    """Best-effort poppler/pdftoppm version banner.
+
+    Resolves the binary exactly as ``page_renderer`` does —
+    ``page_renderer.POPPLER_PATH`` (the bundled ``~/.local/poppler`` install,
+    falling back to ``/usr/bin``, falling back to plain PATH) — the same
+    value ``render_page`` passes to ``pdf2image``. Never raises: returns
+    ``"unavailable"`` if pdftoppm cannot be run at all (missing binary,
+    ``pipeline-core`` extra absent, etc).
+    """
+    try:
+        from janasunani.pipeline.stages.ocr_extraction import page_renderer
+
+        pdftoppm_cmd = (
+            str(Path(page_renderer.POPPLER_PATH) / "pdftoppm")
+            if page_renderer.POPPLER_PATH
+            else "pdftoppm"
+        )
+        result = subprocess.run(
+            [pdftoppm_cmd, "-v"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        # pdftoppm prints its version banner ("pdftoppm version X.YY.Z") to
+        # stderr regardless of exit code; take the first line either stream
+        # produced rather than trusting the exit code.
+        banner = (result.stderr or result.stdout or "").strip().splitlines()
+        if banner:
+            return banner[0].strip()
+    except Exception:
+        pass
+    return "unavailable"
+
+
+def _probe_ocr_toolchain() -> dict[str, Any]:
+    """Best-effort provenance for the OCR toolchain this run would use.
+
+    Two artifacts from the same corpus, produced by different tesseract
+    versions (a laptop's 5.5.1 vs. a freshly-provisioned box's 5.3.4), or by
+    one machine silently missing the Odia (`ori`) traineddata, must not be
+    indistinguishable in ``benchmark_context`` — a missing language pack is a
+    null-scored-as-zero: OCR quietly degrades with no error and no trace in
+    the artifact.
+
+    Never raises (composes ``_probe_tesseract``/``_probe_poppler_version``,
+    both independently defensive). A machine with no tesseract/poppler
+    installed, or missing the ``pipeline-core`` extra entirely (e.g. plain
+    CI), must not crash the harness on import or on the synthetic
+    (``--fake``) path — this is called unconditionally for every run. Each
+    field is the real value or the literal string ``"unavailable"``: never
+    omitted, so an absent key is never mistaken for "not recorded" when it
+    means "checked and absent". This is an environment probe, not a
+    measurement — called outside ``run_benchmark``/``_measure_with_processor``
+    entirely, nowhere near a stage timer.
+    """
+    tesseract_version, tesseract_langs = _probe_tesseract()
+    return {
+        "tesseract_version": tesseract_version,
+        "tesseract_langs": tesseract_langs,
+        "poppler_version": _probe_poppler_version(),
+    }
+
+
 def _measure_with_processor(
     variant: str,
     docs: list[dict[str, Any]],
@@ -1639,6 +1738,25 @@ def main(argv: list[str] | None = None) -> int:
                 startup["seconds"] = time.perf_counter() - started
             return warmed["processor"]
 
+    # Probed once — the OCR toolchain does not vary per variant within a
+    # single process — and merged into every variant's benchmark_context
+    # below (additive keys, both the real-document and synthetic paths) so
+    # two artifacts from different machines are distinguishable by tesseract
+    # version and available language packs, not just by host_label.
+    # _probe_ocr_toolchain() is already internally defensive (never raises),
+    # but this call site adds an outer belt-and-suspenders catch: an
+    # environment probe must never be the reason the harness — including the
+    # synthetic/--fake path, which has no OCR dependency of its own — fails
+    # to run at all.
+    try:
+        ocr_toolchain = _probe_ocr_toolchain()
+    except Exception:
+        ocr_toolchain = {
+            "tesseract_version": "unavailable",
+            "tesseract_langs": "unavailable",
+            "poppler_version": "unavailable",
+        }
+
     results: dict[str, dict[str, Any]] = {}
     for variant in variants:
         try:
@@ -1681,6 +1799,7 @@ def main(argv: list[str] | None = None) -> int:
                 "sample_document_count": len(loaded_docs),
                 "sample_digest": sample_digest,
                 "sample_manifest_complete": sample_manifest_complete,
+                **ocr_toolchain,
             }
         else:
             result["benchmark_context"] = {
@@ -1689,6 +1808,7 @@ def main(argv: list[str] | None = None) -> int:
                 "fixture": "deterministic synthetic grievances without citizen data",
                 "sample_provenance": SYNTHETIC_PROVENANCE,
                 "execution": "sequential single-process execution",
+                **ocr_toolchain,
             }
         results[variant] = result
         e2e = result["stages"][E2E_KEY]

--- a/scripts/benchmark_pipeline.py
+++ b/scripts/benchmark_pipeline.py
@@ -467,8 +467,47 @@ def staged_sample_coverage(
     return sorted(listed - staged), sorted(staged - listed)
 
 
+class StaleDocumentBytesError(RuntimeError):
+    """A staged document's bytes changed after the sample was fingerprinted.
+
+    ``main()`` fingerprints the staged sample (``sample_digest`` /
+    ``_document_sample_file_hashes``) once, before the run starts.
+    ``_measure_with_processor`` then reads each document's actual bytes
+    lazily — one document at a time, potentially much later for a large
+    corpus (see #308) — to keep memory bounded. That gap is a real window: a
+    file rewritten mid-run (e.g. a corpus still hydrating from Box while the
+    benchmark is already running against it) is read with content the
+    published ``sample_digest`` never claimed. Raised eagerly, outside the
+    per-attempt failure tracking in ``_measure_with_processor`` — a silently
+    wrong provenance digest on a publishable artifact is exactly the defect
+    this guards against, not a processing failure to count and continue
+    past.
+    """
+
+
+def _document_sample_file_hashes(directory: Path) -> dict[str, str]:
+    """SHA-256 hex digest of each staged document's current bytes, by name.
+
+    Reads every file once, the same work ``_document_sample_digest`` already
+    folds into its aggregate digest — exposed per-file so a caller can
+    fingerprint the sample up front and later verify individual documents
+    against that snapshot at the point they are actually read (see
+    ``StaleDocumentBytesError`` and ``run_benchmark``'s
+    ``expected_file_hashes``), without a second full pass over the
+    directory. Bytes are hashed and discarded one file at a time — nothing
+    beyond one file's bytes is ever resident, same as the eager-read fix in
+    #308.
+    """
+    return {
+        path.name: hashlib.sha256(path.read_bytes()).hexdigest()
+        for path in _staged_document_paths(directory)
+    }
+
+
 def _document_sample_digest(
-    directory: Path, manifest: Mapping[str, Any] | None
+    directory: Path,
+    manifest: Mapping[str, Any] | None,
+    file_hashes: Mapping[str, str] | None = None,
 ) -> str:
     """Stable digest identifying the on-disk sample, for provenance.
 
@@ -484,13 +523,20 @@ def _document_sample_digest(
     the manifest never claimed. Hashing filename + content per file (not
     the full path) keeps the re-stage stability the manifest-only version
     had, while an equal-count substitution now moves the digest.
+
+    ``file_hashes``, when given, must be ``_document_sample_file_hashes``'s
+    output for the same ``directory`` — reused so a caller that also wants
+    the per-file map (e.g. ``main()``, to pass as ``run_benchmark``'s
+    ``expected_file_hashes``) reads each file once, not twice.
     """
+    if file_hashes is None:
+        file_hashes = _document_sample_file_hashes(directory)
     hasher = hashlib.sha256()
     if manifest is not None:
         hasher.update(json.dumps(manifest, sort_keys=True).encode("utf-8"))
-    for path in _staged_document_paths(directory):
-        hasher.update(path.name.encode("utf-8"))
-        hasher.update(hashlib.sha256(path.read_bytes()).digest())
+    for name in sorted(file_hashes):
+        hasher.update(name.encode("utf-8"))
+        hasher.update(bytes.fromhex(file_hashes[name]))
     return hasher.hexdigest()
 
 
@@ -832,6 +878,7 @@ def _measure_with_processor(
     discard_warm: bool,
     processor_factory: Callable[[str], Any] | None,
     sleep_fake: bool = False,
+    expected_file_hashes: Mapping[str, str] | None = None,
 ) -> dict[str, Any]:
     """Run processor over docs repeats times, collect per-stage wall seconds.
 
@@ -844,6 +891,17 @@ def _measure_with_processor(
     method with the same signature as ``PipelineGrievanceProcessor.process``.
     The factory is called once per variant (models warmed once). If it is
     None, fake timings are used (no real processor).
+
+    ``expected_file_hashes`` (filename -> sha256 hex, from
+    ``_document_sample_file_hashes``) is the fingerprint taken before this
+    run started. When given, every document read from ``document_path``
+    below is re-hashed and checked against it, raising
+    ``StaleDocumentBytesError`` on any mismatch — closing the window between
+    that snapshot and this function's lazy, one-document-at-a-time read
+    (#308) during which a file could be rewritten out from under the run,
+    e.g. by a corpus still hydrating from Box. ``None`` (the default) skips
+    the check, which is correct for synthetic docs and any caller that never
+    took a snapshot to check against.
     """
     per_stage_times: dict[str, list[float]] = {k: [] for k in ALL_KEYS}
     per_stage_tickets: dict[str, list[str]] = {k: [] for k in ALL_KEYS}
@@ -879,7 +937,27 @@ def _measure_with_processor(
         document_bytes = doc.get("document_bytes")
         document_path = doc.get("document_path")
         if document_bytes is None and document_path is not None and processor is not None:
-            document_bytes = Path(document_path).read_bytes()
+            resolved_path = Path(document_path)
+            document_bytes = resolved_path.read_bytes()
+            if expected_file_hashes is not None:
+                # Verification stays here too — after the read, still before
+                # the per-repeat timer loop below. One sha256 over bytes
+                # already in memory is cheap next to OCR, and it must never
+                # be silently skipped: a document missing from the snapshot
+                # (staged after fingerprinting) is exactly as stale as one
+                # whose hash no longer matches.
+                actual_hash = hashlib.sha256(document_bytes).hexdigest()
+                expected_hash = expected_file_hashes.get(resolved_path.name)
+                if expected_hash is None or actual_hash != expected_hash:
+                    raise StaleDocumentBytesError(
+                        f"{resolved_path.name} does not match the "
+                        "sample_digest snapshot taken before this run "
+                        f"started (expected sha256 {expected_hash!r}, got "
+                        f"{actual_hash!r}). The file changed on disk between "
+                        "fingerprinting and being read — e.g. a corpus still "
+                        "hydrating from Box. Re-stage the sample (or wait "
+                        "for hydration to finish) before benchmarking it."
+                    )
         for r in range(repeats):
             attempts += 1
             is_warm = discard_warm and r == 0
@@ -986,6 +1064,7 @@ def run_benchmark(
     seed: int = 42,
     sleep_fake: bool = False,
     is_fake: bool | None = None,
+    expected_file_hashes: Mapping[str, str] | None = None,
 ) -> dict[str, Any]:
     """Run one benchmark variant and return structured results.
 
@@ -1002,6 +1081,11 @@ def run_benchmark(
             is non-zero for manual checks; default False for fast tests.
         is_fake: whether this result is synthetic fake timing (non-publishable).
             If None, inferred from processor_factory is None.
+        expected_file_hashes: filename -> sha256 hex fingerprint taken before
+            this run started (see ``_document_sample_file_hashes``). Passed
+            straight to ``_measure_with_processor``, which raises
+            ``StaleDocumentBytesError`` if a document's bytes no longer match
+            when actually read. ``None`` (the default) skips the check.
 
     Returns dict with keys variant, n_docs, repeats, warm_discarded,
     git_sha, timestamp, stages (per-stage stats), is_fake_timing, etc.
@@ -1030,6 +1114,7 @@ def run_benchmark(
         discard_warm=discard_warm,
         processor_factory=processor_factory,
         sleep_fake=sleep_fake,
+        expected_file_hashes=expected_file_hashes,
     )
     per_stage_times: dict[str, list[float]] = raw["times"]  # type: ignore[assignment]
     per_stage_tickets: dict[str, list[str]] = raw["tickets"]  # type: ignore[assignment]
@@ -1385,6 +1470,7 @@ def main(argv: list[str] | None = None) -> int:
     sample_slice: str | None = None
     sample_digest: str | None = None
     sample_manifest_complete = False
+    sample_file_hashes: dict[str, str] | None = None
     if args.documents_dir is not None:
         if args.n_docs is not None or args.n_image_docs is not None:
             parser.error(
@@ -1417,7 +1503,15 @@ def main(argv: list[str] | None = None) -> int:
                 "the sample you meant."
             )
         sample_slice = args.slice or manifest_slice or "unspecified"
-        sample_digest = _document_sample_digest(args.documents_dir, sample_manifest)
+        # Fingerprint the sample once, here, before the run reads anything --
+        # sample_file_hashes is threaded into run_benchmark below so each
+        # document's later, lazy read (#308) is checked against this exact
+        # snapshot rather than trusted blind. file_hashes= reuses that same
+        # read for sample_digest instead of a second pass over the directory.
+        sample_file_hashes = _document_sample_file_hashes(args.documents_dir)
+        sample_digest = _document_sample_digest(
+            args.documents_dir, sample_manifest, file_hashes=sample_file_hashes
+        )
         # load_staged_documents has already refused a manifest that lists a
         # document nobody staged. What is left is the other direction —
         # staged files the manifest does not account for, and the no-manifest
@@ -1547,18 +1641,26 @@ def main(argv: list[str] | None = None) -> int:
 
     results: dict[str, dict[str, Any]] = {}
     for variant in variants:
-        result = run_benchmark(
-            variant=variant,
-            n_text=0 if loaded_docs is not None else args.n_docs,
-            n_image=0 if loaded_docs is not None else args.n_image_docs,
-            docs=loaded_docs,
-            repeats=args.repeats,
-            discard_warm=discard_warm,
-            seed=args.seed,
-            sleep_fake=args.sleep_fake,
-            processor_factory=processor_factory,
-            is_fake=is_fake,
-        )
+        try:
+            result = run_benchmark(
+                variant=variant,
+                n_text=0 if loaded_docs is not None else args.n_docs,
+                n_image=0 if loaded_docs is not None else args.n_image_docs,
+                docs=loaded_docs,
+                repeats=args.repeats,
+                discard_warm=discard_warm,
+                seed=args.seed,
+                sleep_fake=args.sleep_fake,
+                processor_factory=processor_factory,
+                is_fake=is_fake,
+                expected_file_hashes=sample_file_hashes,
+            )
+        except StaleDocumentBytesError as exc:
+            # A staged document changed under us mid-run (e.g. a corpus
+            # still hydrating from Box) — fail loudly with the filename
+            # rather than publish a sample_digest that no longer describes
+            # what was actually measured.
+            parser.error(str(exc))
         result["processor_startup_seconds"] = startup.get("seconds")
         if loaded_docs is not None:
             # Real-document path: this is the actual defect being fixed —

--- a/scripts/benchmark_pipeline.py
+++ b/scripts/benchmark_pipeline.py
@@ -227,8 +227,12 @@ def _document_kind(doc: Mapping[str, Any]) -> str:
     "document" path to have measurements, and none were ever attributed to
     it. The loader already knows what it built: bytes present means a
     scanned document, text present (and no bytes) means free text.
+    ``document_path`` counts the same as ``document_bytes`` here —
+    ``load_staged_documents`` hands back a path instead of pre-read bytes
+    (see #308) so a document is still a "document" before its bytes are
+    ever read.
     """
-    if doc.get("document_bytes") is not None:
+    if doc.get("document_bytes") is not None or doc.get("document_path") is not None:
         return "document"
     if doc.get("text") is not None:
         return "text"
@@ -496,11 +500,22 @@ def load_staged_documents(
 ) -> list[dict[str, Any]]:
     """Load a real staged document sample for benchmarking.
 
-    Returns the same dict shape as ``synthesize_documents``: ticket, text
-    (always None here — these are scanned documents, not free text),
-    document_name, document_bytes, district. Reading real bytes means the
-    OCR stage actually runs against real scans, unlike the text-only half
-    of the synthetic fixture.
+    Returns dicts shaped like ``synthesize_documents``'s (ticket, text,
+    document_name, document_bytes, district) plus one extra key,
+    ``document_path``. Unlike ``synthesize_documents`` — whose synthetic
+    bytes are already in memory, generated, not read — a staged sample's
+    bytes live on disk, and a real slice-sized draw is large enough that
+    reading every file up front is not free: the staged Sambalpur/2024
+    sample alone averages 627 KB/document, and #308 was filed when a
+    69,844-document, 60 GB corpus made that arithmetic a bounded-RAM problem
+    rather than a theoretical one. So ``document_bytes`` here is always
+    ``None`` and ``document_path`` carries the file instead; the actual read
+    happens later, one document at a time, in
+    ``_measure_with_processor`` — deliberately outside every per-stage
+    timer, so disk I/O is never attributed to a model stage (see that
+    function for where). Reading real bytes (whenever it happens) means the
+    OCR stage actually runs against real scans, unlike the text-only half of
+    the synthetic fixture.
 
     ``directory`` is a flat staging directory of supported document files
     (see ``SUPPORTED_DOCUMENT_SUFFIXES``) named
@@ -650,7 +665,8 @@ def load_staged_documents(
                 "ticket": ticket,
                 "text": None,
                 "document_name": path.name,
-                "document_bytes": path.read_bytes(),
+                "document_bytes": None,
+                "document_path": path,
                 "district": district,
             }
         )
@@ -847,6 +863,23 @@ def _measure_with_processor(
     for doc in docs:
         ticket = doc["ticket"]
         kind = _document_kind(doc)
+        # Resolve this document's bytes once, here — before the per-repeat
+        # loop and its perf_counter() calls below, never inside them. A read
+        # inside the timed region would land inside whichever stage runs
+        # first (ocr) and inflate its measured latency with disk I/O that
+        # has nothing to do with the model (#308). load_staged_documents()
+        # hands back document_path instead of pre-read bytes for exactly
+        # this reason: reading here, one document at a time, keeps at most
+        # one document's bytes resident rather than the whole staged
+        # sample. Read once and reuse for every repeat of this document
+        # (not re-read per repeat) — still outside the timer either way,
+        # but no reason to hit disk more than once for the same file. The
+        # fake path (processor is None) never touches document bytes, so
+        # the read is skipped entirely there.
+        document_bytes = doc.get("document_bytes")
+        document_path = doc.get("document_path")
+        if document_bytes is None and document_path is not None and processor is not None:
+            document_bytes = Path(document_path).read_bytes()
         for r in range(repeats):
             attempts += 1
             is_warm = discard_warm and r == 0
@@ -865,7 +898,7 @@ def _measure_with_processor(
                         ticket_no=ticket,
                         text=doc.get("text"),
                         document_name=doc.get("document_name"),
-                        document_bytes=doc.get("document_bytes"),
+                        document_bytes=document_bytes,
                         district=doc.get("district"),
                     )
                 except Exception as exc:  # noqa: BLE001

--- a/scripts/benchmark_pipeline.py
+++ b/scripts/benchmark_pipeline.py
@@ -485,7 +485,30 @@ class StaleDocumentBytesError(RuntimeError):
     """
 
 
-def _document_sample_file_hashes(directory: Path) -> dict[str, str]:
+class SampleFingerprintDriftError(RuntimeError):
+    """The fingerprinted file set differs from the documents actually loaded.
+
+    ``load_staged_documents`` and ``_document_sample_file_hashes`` each list
+    ``directory`` independently by default (two separate ``iterdir()``
+    calls). A file staged between those two scans — the same live-hydration
+    scenario ``StaleDocumentBytesError`` guards against, just at the
+    directory-listing level instead of a single file's bytes — could end up
+    fingerprinted into ``sample_digest`` without ever being loaded (and
+    therefore never benchmarked or verified), or loaded without ever being
+    fingerprinted. Either way the published digest would describe a file set
+    the run never actually measured. ``main()`` closes the race at the
+    source: it derives the file list to fingerprint from ``loaded_docs``'
+    own ``document_path`` entries (a single directory scan, inside
+    ``load_staged_documents``) rather than a second, independent scan. This
+    error is the cheap, explicit insurance on top of that — checked, not
+    assumed — for any caller (present or future) that fingerprints from an
+    independently-scanned file list instead.
+    """
+
+
+def _document_sample_file_hashes(
+    directory: Path, files: list[Path] | None = None
+) -> dict[str, str]:
     """SHA-256 hex digest of each staged document's current bytes, by name.
 
     Reads every file once, the same work ``_document_sample_digest`` already
@@ -497,11 +520,50 @@ def _document_sample_file_hashes(directory: Path) -> dict[str, str]:
     directory. Bytes are hashed and discarded one file at a time — nothing
     beyond one file's bytes is ever resident, same as the eager-read fix in
     #308.
+
+    ``files``, when given, is hashed as-is instead of scanning ``directory``
+    independently. ``main()`` passes the ``document_path`` values from
+    ``load_staged_documents``'s own return, so the fingerprint covers
+    exactly the documents that were actually loaded (see
+    ``SampleFingerprintDriftError``) rather than whatever a second,
+    independent directory listing happens to see — a real difference while a
+    staging directory is actively being hydrated. The default (``None``)
+    scans fresh, which is correct for a standalone call with no
+    already-loaded document list to reuse.
     """
+    if files is None:
+        files = _staged_document_paths(directory)
     return {
-        path.name: hashlib.sha256(path.read_bytes()).hexdigest()
-        for path in _staged_document_paths(directory)
+        path.name: hashlib.sha256(path.read_bytes()).hexdigest() for path in files
     }
+
+
+def _check_fingerprint_matches_loaded_documents(
+    loaded_docs: list[dict[str, Any]],
+    file_hashes: Mapping[str, str],
+) -> None:
+    """Raise ``SampleFingerprintDriftError`` if the two file sets disagree.
+
+    Cheap insurance on top of ``main()`` deriving ``_document_sample_file_hashes``'s
+    ``files=`` from ``loaded_docs`` itself: an explicit, fast check rather
+    than trusting that derivation silently. ``loaded_docs`` is what
+    ``run_benchmark`` will actually iterate and measure; ``file_hashes``'
+    keys are what ``sample_digest`` claims to describe. They must name
+    exactly the same documents.
+    """
+    loaded_names = {doc["document_name"] for doc in loaded_docs}
+    hashed_names = set(file_hashes)
+    if loaded_names != hashed_names:
+        only_hashed = sorted(hashed_names - loaded_names)
+        only_loaded = sorted(loaded_names - hashed_names)
+        raise SampleFingerprintDriftError(
+            "sample_digest's file set does not match the documents loaded "
+            f"for benchmarking (fingerprinted but never loaded, so never "
+            f"measured: {only_hashed}; loaded but never fingerprinted: "
+            f"{only_loaded}). The staged directory likely changed between "
+            "listing and fingerprinting — re-run once staging/hydration has "
+            "settled."
+        )
 
 
 def _document_sample_digest(
@@ -593,6 +655,15 @@ def load_staged_documents(
     completeness check, or protection against the hierarchical-ticket
     collision above (and ``main`` will refuse to mark such a run
     publication-ready).
+
+    ``main()`` fingerprints this same directory afterward
+    (``_document_sample_file_hashes``) for ``sample_digest``, from the
+    ``document_path`` this function already put in each returned dict —
+    not a second, independent directory scan. Two independent scans of a
+    staging directory that is actively being hydrated can each see a
+    different file set (see ``SampleFingerprintDriftError``); deriving the
+    fingerprint's file list from what was actually loaded here closes that
+    race at the source instead of trusting two scans to agree.
 
     Raises:
         FileNotFoundError: ``directory`` does not exist or is not a
@@ -1607,7 +1678,26 @@ def main(argv: list[str] | None = None) -> int:
         # document's later, lazy read (#308) is checked against this exact
         # snapshot rather than trusted blind. file_hashes= reuses that same
         # read for sample_digest instead of a second pass over the directory.
-        sample_file_hashes = _document_sample_file_hashes(args.documents_dir)
+        #
+        # The file list to hash comes from loaded_docs' own document_path
+        # entries, not a fresh directory scan: load_staged_documents() above
+        # already scanned the directory once. A second, independent scan
+        # here (the original shape) can see a different file set while a
+        # staging directory is actively being hydrated -- a file staged in
+        # between could be fingerprinted into sample_digest without ever
+        # being loaded (and therefore never benchmarked or verified), or the
+        # reverse. Reusing the already-loaded paths closes that race at the
+        # source; _check_fingerprint_matches_loaded_documents below is the
+        # cheap, explicit check on top, in case a future change reintroduces
+        # an independent scan somewhere in this path.
+        staged_files = [doc["document_path"] for doc in loaded_docs]
+        sample_file_hashes = _document_sample_file_hashes(
+            args.documents_dir, files=staged_files
+        )
+        try:
+            _check_fingerprint_matches_loaded_documents(loaded_docs, sample_file_hashes)
+        except SampleFingerprintDriftError as exc:
+            parser.error(str(exc))
         sample_digest = _document_sample_digest(
             args.documents_dir, sample_manifest, file_hashes=sample_file_hashes
         )

--- a/tests/test_benchmark_pipeline.py
+++ b/tests/test_benchmark_pipeline.py
@@ -11,6 +11,7 @@ import json
 import os
 import subprocess
 import sys
+import tracemalloc
 from pathlib import Path, PurePosixPath
 
 import pytest
@@ -179,12 +180,16 @@ def test_load_staged_documents_without_manifest(tmp_path):
     tickets = {d["ticket"] for d in docs}
     assert tickets == {"CMO20241020862", "CMO2024483790"}
     for doc in docs:
-        # Same shape as synthesize_documents(): ticket, text, document_name,
-        # document_bytes, district.
+        # Same shape as synthesize_documents() (ticket, text, document_name,
+        # document_bytes, district) plus document_path. Bytes are not read
+        # here (#308) — document_bytes stays None and document_path carries
+        # the file; _measure_with_processor reads it lazily, one document at
+        # a time, outside every stage timer.
         assert doc["text"] is None
         assert doc["document_name"]
-        assert isinstance(doc["document_bytes"], bytes)
-        assert len(doc["document_bytes"]) > 0
+        assert doc["document_bytes"] is None
+        assert doc["document_path"].is_file()
+        assert len(doc["document_path"].read_bytes()) > 0
         # No manifest present, so district falls back to a stable label
         # rather than crashing or silently using None.
         assert doc["district"] == "unspecified"
@@ -623,8 +628,10 @@ def test_document_sample_digest_stable_across_restage_to_new_path(tmp_path):
 
 
 def test_run_benchmark_over_loaded_real_documents(tmp_path):
-    # The measurement loop needs no change: docs from load_staged_documents
-    # flow through run_benchmark exactly like any other custom doc list.
+    # No processor_factory here, so this exercises the fake timing path,
+    # which never touches document_bytes/document_path — docs from
+    # load_staged_documents flow through run_benchmark exactly like any
+    # other custom doc list.
     _stage_document(tmp_path, "CMO20241020862")
     _stage_document(tmp_path, "CMO2024483790", suffix=".jpeg")
     docs = load_staged_documents(tmp_path)
@@ -633,6 +640,121 @@ def test_run_benchmark_over_loaded_real_documents(tmp_path):
     assert result["n_docs"] == 2
     assert result["stages"]["e2e"]["n"] == 4
     assert {"CMO20241020862", "CMO2024483790"} == set(result["_raw"]["tickets"]["e2e"])
+
+
+# ---------------------------------------------------------------------------
+# #308 — streaming: only one document's bytes resident/read at a time
+# ---------------------------------------------------------------------------
+
+
+def test_load_staged_documents_streams_bytes_bounded_memory(tmp_path):
+    """load_staged_documents() used to call path.read_bytes() for every
+    staged file and hold the whole list before run_benchmark started, so an
+    n-document sample cost roughly n * average_document_size resident on top
+    of the loaded models — ~630 MB for the 627 KB/doc Sambalpur/2024 sample
+    at n=1,000, ~44 GB for the 69,844-document corpus this harness is about
+    to run over (see #308). It now hands back a document_path per document,
+    and the real bytes are read lazily by _measure_with_processor, one
+    document at a time. Build documents large enough that eager loading
+    would clearly show up in peak traced memory, and confirm streaming keeps
+    the peak near a single document's size instead of scaling with n.
+    """
+    n_docs = 8
+    doc_size = 3_000_000  # ~3 MB filler; deterministic, no citizen data
+    filler = b"%PDF-1.4\n" + (b"A" * doc_size)
+    for i in range(n_docs):
+        path = tmp_path / f"CMO2024{i:07d}_complaint_20250715_234307.pdf"
+        path.write_bytes(filler)
+
+    docs = load_staged_documents(tmp_path)
+    assert len(docs) == n_docs
+    # Nothing has been read yet — the loader only records paths.
+    assert all(doc["document_bytes"] is None for doc in docs)
+    assert all(doc["document_path"] is not None for doc in docs)
+
+    class Processor:
+        _timing_sink = None
+
+        def process(self, **kwargs):
+            document_bytes = kwargs["document_bytes"]
+            assert document_bytes is not None
+            assert len(document_bytes) == len(filler)
+            self._timing_sink({"redact": 0.001, "e2e": 0.002, "ok": 1.0})
+
+    tracemalloc.start()
+    try:
+        run_benchmark(
+            variant="standard",
+            docs=docs,
+            repeats=1,
+            discard_warm=False,
+            processor_factory=lambda _variant: Processor(),
+        )
+        _current, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+
+    # Eager loading (the bug) would resident roughly n_docs * doc_size here
+    # (~24 MB for 8 x 3 MB). Streaming should keep the traced peak within a
+    # small multiple of one document, not scale with the sample size.
+    assert peak < doc_size * 3, (
+        f"peak traced memory {peak} bytes suggests more than one document's "
+        f"bytes were resident at once (n_docs={n_docs}, doc_size={doc_size})"
+    )
+
+
+def test_measure_with_processor_reads_each_document_once_not_per_repeat(tmp_path, monkeypatch):
+    # Bounded reads, not just bounded memory: a document's bytes must be
+    # read once and reused across its repeats, not re-read from disk every
+    # repeat (which would still be correct memory-wise but wasteful I/O).
+    _stage_document(tmp_path, "CMO20241020862")
+    _stage_document(tmp_path, "CMO2024483790", suffix=".jpeg")
+    docs = load_staged_documents(tmp_path)
+
+    read_calls: list[Path] = []
+    original_read_bytes = Path.read_bytes
+
+    def counting_read_bytes(self):
+        read_calls.append(self)
+        return original_read_bytes(self)
+
+    monkeypatch.setattr(Path, "read_bytes", counting_read_bytes)
+
+    class Processor:
+        _timing_sink = None
+
+        def process(self, **kwargs):
+            self._timing_sink({"redact": 0.001, "e2e": 0.002, "ok": 1.0})
+
+    run_benchmark(
+        variant="standard",
+        docs=docs,
+        repeats=3,
+        discard_warm=False,
+        processor_factory=lambda _variant: Processor(),
+    )
+
+    # 2 documents x 3 repeats: without the fix this would be up to 6 reads
+    # from inside the loop (or reads already done eagerly by the loader).
+    # Reading once per document and reusing it across repeats caps this at 2.
+    assert len(read_calls) == 2
+    assert {p.name for p in read_calls} == {d["document_path"].name for d in docs}
+
+
+def test_run_benchmark_fake_path_never_reads_staged_bytes(tmp_path, monkeypatch):
+    # The fake timing path (no processor_factory) never calls process(), so
+    # it has no use for document bytes at all; the lazy read must not fire
+    # just because a real staged sample happens to be on disk.
+    _stage_document(tmp_path, "CMO20241020862")
+    docs = load_staged_documents(tmp_path)
+
+    def failing_read_bytes(self):
+        raise AssertionError(f"fake timing path must not read {self}")
+
+    monkeypatch.setattr(Path, "read_bytes", failing_read_bytes)
+
+    result = run_benchmark(variant="standard", docs=docs, repeats=2, discard_warm=False)
+    assert result["n_docs"] == 1
 
 
 def test_document_kind_reads_the_doc_not_the_ticket_string():

--- a/tests/test_benchmark_pipeline.py
+++ b/tests/test_benchmark_pipeline.py
@@ -7,6 +7,7 @@ for the four variants standard / sarvam_digitise / sarvam_extract / sarvam_both.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import subprocess
@@ -23,9 +24,11 @@ from scripts.benchmark_pipeline import (
     STAGES,
     SUPPORTED_DOCUMENT_SUFFIXES,
     VALID_VARIANTS,
+    StaleDocumentBytesError,
     _clustered_se,
     _document_kind,
     _document_sample_digest,
+    _document_sample_file_hashes,
     _fake_process,
     _percentile,
     _single_page_text_pdf,
@@ -625,6 +628,183 @@ def test_document_sample_digest_stable_across_restage_to_new_path(tmp_path):
     }
 
     assert _document_sample_digest(dir1, manifest) == _document_sample_digest(dir2, manifest)
+
+
+# ---------------------------------------------------------------------------
+# #315 Codex follow-up — bind sample_digest to the bytes actually benchmarked
+# ---------------------------------------------------------------------------
+
+
+def test_document_sample_file_hashes_matches_per_file_digest_inputs(tmp_path):
+    _stage_document(tmp_path, "CMO20241020862")
+    _stage_document(tmp_path, "CMO2024483790", suffix=".jpeg")
+
+    hashes = _document_sample_file_hashes(tmp_path)
+
+    names = {d.name for d in tmp_path.iterdir() if d.suffix.lower() in SUPPORTED_DOCUMENT_SUFFIXES}
+    assert set(hashes) == names
+    for name, digest in hashes.items():
+        expected = hashlib.sha256((tmp_path / name).read_bytes()).hexdigest()
+        assert digest == expected
+    # _document_sample_digest(..., file_hashes=hashes) must be reusable
+    # without a second read — same result as computing it fresh.
+    assert _document_sample_digest(tmp_path, None, file_hashes=hashes) == _document_sample_digest(
+        tmp_path, None
+    )
+
+
+def test_run_benchmark_detects_document_mutated_after_fingerprint(tmp_path):
+    # This is the actual race #308's lazy read opened: sample_digest is
+    # fingerprinted once, before the run starts; _measure_with_processor then
+    # reads each document lazily, potentially much later. Stage a directory,
+    # fingerprint it (as main() does before run_benchmark starts), mutate one
+    # file on disk exactly like a corpus still hydrating from Box would, and
+    # confirm the run refuses to silently benchmark content the fingerprint
+    # never saw.
+    mutated_path = _stage_document(tmp_path, "CMO20241020862")
+    _stage_document(tmp_path, "CMO2024483790", suffix=".jpeg")
+    file_hashes = _document_sample_file_hashes(tmp_path)
+    docs = load_staged_documents(tmp_path)
+
+    # Simulate the mid-run rewrite: different bytes land on disk after the
+    # fingerprint but before run_benchmark's lazy read.
+    mutated_path.write_bytes(_single_page_text_pdf("A completely different scan"))
+
+    with pytest.raises(StaleDocumentBytesError, match=mutated_path.name):
+        run_benchmark(
+            variant="standard",
+            docs=docs,
+            repeats=1,
+            discard_warm=False,
+            processor_factory=lambda _variant: type(
+                "Processor",
+                (),
+                {
+                    "_timing_sink": None,
+                    "process": lambda self, **kwargs: self._timing_sink(
+                        {"redact": 0.1, "e2e": 0.2, "ok": 1.0}
+                    ),
+                },
+            )(),
+            expected_file_hashes=file_hashes,
+        )
+
+
+def test_run_benchmark_missing_from_fingerprint_also_fails_loudly(tmp_path):
+    # A file staged after the fingerprint was taken is exactly as stale as
+    # one whose content changed — both mean the run is about to measure
+    # bytes the published sample_digest never claimed. Must not be treated
+    # as "no opinion, so allow it".
+    file_hashes = _document_sample_file_hashes(tmp_path)  # empty snapshot
+    _stage_document(tmp_path, "CMO20241020862")
+    docs = load_staged_documents(tmp_path)
+
+    with pytest.raises(StaleDocumentBytesError, match="CMO20241020862"):
+        run_benchmark(
+            variant="standard",
+            docs=docs,
+            repeats=1,
+            discard_warm=False,
+            processor_factory=lambda _variant: type(
+                "Processor",
+                (),
+                {
+                    "_timing_sink": None,
+                    "process": lambda self, **kwargs: self._timing_sink(
+                        {"redact": 0.1, "e2e": 0.2, "ok": 1.0}
+                    ),
+                },
+            )(),
+            expected_file_hashes=file_hashes,
+        )
+
+
+def test_run_benchmark_happy_path_with_matching_fingerprint_still_passes(tmp_path):
+    # The verification must not get in its own way when nothing changed —
+    # this is the common case (no hydration race) and must behave exactly
+    # like passing no expected_file_hashes at all.
+    _stage_document(tmp_path, "CMO20241020862")
+    _stage_document(tmp_path, "CMO2024483790", suffix=".jpeg")
+    file_hashes = _document_sample_file_hashes(tmp_path)
+    docs = load_staged_documents(tmp_path)
+
+    result = run_benchmark(
+        variant="standard",
+        docs=docs,
+        repeats=2,
+        discard_warm=False,
+        processor_factory=lambda _variant: type(
+            "Processor",
+            (),
+            {
+                "_timing_sink": None,
+                "process": lambda self, **kwargs: self._timing_sink(
+                    {"redact": 0.1, "e2e": 0.2, "ok": 1.0}
+                ),
+            },
+        )(),
+        expected_file_hashes=file_hashes,
+    )
+    assert result["n_docs"] == 2
+    assert result["failed_attempts"] == 0
+    assert result["stages"]["e2e"]["n"] == 4
+
+
+def test_run_benchmark_fake_path_skips_fingerprint_check(tmp_path):
+    # The fake timing path never reads document bytes at all (see #308's
+    # fake-path test), so it must not fail even when expected_file_hashes is
+    # stale — there is nothing to verify because nothing gets read.
+    mutated_path = _stage_document(tmp_path, "CMO20241020862")
+    file_hashes = _document_sample_file_hashes(tmp_path)
+    docs = load_staged_documents(tmp_path)
+    mutated_path.write_bytes(_single_page_text_pdf("A completely different scan"))
+
+    result = run_benchmark(
+        variant="standard",
+        docs=docs,
+        repeats=2,
+        discard_warm=False,
+        expected_file_hashes=file_hashes,  # no processor_factory -> fake path
+    )
+    assert result["n_docs"] == 1
+
+
+def test_cli_documents_dir_stale_document_bytes_fails_loudly(tmp_path, monkeypatch, capsys):
+    # CLI wiring: main() must convert a StaleDocumentBytesError raised deep
+    # inside run_benchmark into a loud, non-zero-exit CLI failure that names
+    # the file, not a silently-written latency.json. run_benchmark itself is
+    # stubbed here — the detection logic is exercised for real above; this
+    # test is only about main()'s try/except around the call.
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    _stage_document(staging, "CMO20241020862")
+    out = tmp_path / "latency.json"
+
+    def fake_run_benchmark(*_args, **_kwargs):
+        raise StaleDocumentBytesError(
+            "CMO20241020862_complaint_20250715_234307.pdf does not match "
+            "the sample_digest snapshot taken before this run started"
+        )
+
+    monkeypatch.setattr(bench_mod, "run_benchmark", fake_run_benchmark)
+
+    with pytest.raises(SystemExit) as exc:
+        bench_mod.main(
+            [
+                "--fake",
+                "--documents-dir",
+                str(staging),
+                "--repeats",
+                "2",
+                "--output",
+                str(out),
+            ]
+        )
+    assert exc.value.code == 2
+    assert not out.exists()
+    err = capsys.readouterr().err
+    assert "CMO20241020862_complaint_20250715_234307.pdf" in err
+    assert "sample_digest snapshot" in err
 
 
 def test_run_benchmark_over_loaded_real_documents(tmp_path):

--- a/tests/test_benchmark_pipeline.py
+++ b/tests/test_benchmark_pipeline.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tracemalloc
@@ -1463,8 +1464,20 @@ def test_probe_ocr_toolchain_populates_real_values_when_installed():
     # must report real values: two machines with different tesseract
     # versions or a missing Odia (ori) pack must be distinguishable from
     # this output, which is the entire point of #315's follow-up.
+    #
+    # The importorskips gate on the Python wrappers; the assertions below
+    # need the system binaries those wrappers shell out to. They are
+    # separately installable, so `pip install pytesseract` on a host with no
+    # `tesseract` on PATH satisfies the import and still probes
+    # "unavailable" — correct behaviour that used to fail this test, and so
+    # the repo's required test command, on a legitimate environment. Gate on
+    # what is actually asserted.
     pytest.importorskip("pytesseract")
     pytest.importorskip("pdf2image")
+    if shutil.which("tesseract") is None:
+        pytest.skip("tesseract binary not on PATH; _probe_tesseract has its own test")
+    if shutil.which("pdftoppm") is None:
+        pytest.skip("poppler (pdftoppm) not on PATH; _probe_poppler_version has its own test")
 
     toolchain = bench_mod._probe_ocr_toolchain()
 

--- a/tests/test_benchmark_pipeline.py
+++ b/tests/test_benchmark_pipeline.py
@@ -1512,12 +1512,22 @@ def test_probe_ocr_toolchain_records_unavailable_when_tesseract_probe_fails(monk
         "janasunani.pipeline.stages.ocr_extraction.pytesseract_backend._configure_tesseract",
         boom,
     )
+    # Poppler is stubbed rather than skipped on. The claim under test is that
+    # a tesseract failure does not reach poppler's result, and asserting
+    # `!= "unavailable"` tested that only where the pdftoppm *binary* happens
+    # to be installed -- so on a box with pipeline-core but no poppler this
+    # failed the required suite for a reason that has nothing to do with the
+    # behaviour it describes. A sentinel makes the independence exact:
+    # whatever poppler returned has to arrive untouched.
+    monkeypatch.setattr(
+        bench_mod, "_probe_poppler_version", lambda: "pdftoppm 99.99 (sentinel)"
+    )
 
     toolchain = bench_mod._probe_ocr_toolchain()
 
     assert toolchain["tesseract_version"] == "unavailable"
     assert toolchain["tesseract_langs"] == "unavailable"
-    assert toolchain["poppler_version"] != "unavailable"  # unaffected
+    assert toolchain["poppler_version"] == "pdftoppm 99.99 (sentinel)"  # unaffected
 
 
 def test_probe_ocr_toolchain_composes_independent_tesseract_and_poppler_probes():

--- a/tests/test_benchmark_pipeline.py
+++ b/tests/test_benchmark_pipeline.py
@@ -1274,11 +1274,13 @@ def test_cli_synthetic_path_benchmark_context_fixture_is_unchanged(tmp_path):
     ctx = data["benchmark_context"]
     assert ctx["fixture"] == "deterministic synthetic grievances without citizen data"
     assert ctx["execution"] == "sequential single-process execution"
-    # No document-sample keys leak onto the synthetic path. `sample_provenance`
-    # is the declaration that there is no sample, not a sample key: the gate
-    # requires it because a context that says nothing cannot be shown to be
-    # synthetic, and a real measurement must not inherit that benefit of the
-    # doubt.
+    # No document-sample keys leak onto the synthetic path. Two kinds of key
+    # are nonetheless expected here. `sample_provenance` is the declaration
+    # that there is no sample, not a sample key: the gate requires it because
+    # a context that says nothing cannot be shown to be synthetic, and a real
+    # measurement must not inherit that benefit of the doubt. The OCR
+    # toolchain keys (#315 follow-up) are additive and present on every path,
+    # including synthetic — see test_cli_synthetic_path_records_ocr_toolchain.
     assert ctx["sample_provenance"] == "synthetic"
     assert set(ctx) == {
         "host_label",
@@ -1286,7 +1288,111 @@ def test_cli_synthetic_path_benchmark_context_fixture_is_unchanged(tmp_path):
         "fixture",
         "execution",
         "sample_provenance",
+        "tesseract_version",
+        "tesseract_langs",
+        "poppler_version",
     }
+
+
+# ---------------------------------------------------------------------------
+# #315 Codex follow-up — OCR toolchain provenance in benchmark_context
+# ---------------------------------------------------------------------------
+
+
+def test_probe_ocr_toolchain_populates_real_values_when_installed():
+    # Real code path, no mocking of pytesseract/poppler: the pipeline-core
+    # test gate (tests/README.md) requires tesseract and poppler installed
+    # locally, so this must report real values, not "unavailable"
+    # placeholders. Two machines with different tesseract versions or a
+    # missing Odia (ori) pack must be distinguishable from this output.
+    toolchain = bench_mod._probe_ocr_toolchain()
+
+    assert set(toolchain) == {"tesseract_version", "tesseract_langs", "poppler_version"}
+    assert toolchain["tesseract_version"] != "unavailable"
+    assert toolchain["tesseract_version"][0].isdigit()
+    assert isinstance(toolchain["tesseract_langs"], list)
+    assert toolchain["tesseract_langs"] == sorted(toolchain["tesseract_langs"])
+    assert "eng" in toolchain["tesseract_langs"]
+    assert toolchain["poppler_version"] != "unavailable"
+    assert "pdftoppm" in toolchain["poppler_version"].lower()
+
+
+def test_probe_ocr_toolchain_records_unavailable_when_tesseract_probe_fails(monkeypatch):
+    # Simulate a box where tesseract cannot be located/configured (e.g. no
+    # binary installed at all). The probe must not raise, must not silently
+    # omit the keys, and must not let a tesseract failure take poppler's
+    # (independently probed) result down with it.
+    def boom():
+        raise RuntimeError("tesseract not installed on this box")
+
+    monkeypatch.setattr(
+        "janasunani.pipeline.stages.ocr_extraction.pytesseract_backend._configure_tesseract",
+        boom,
+    )
+
+    toolchain = bench_mod._probe_ocr_toolchain()
+
+    assert toolchain["tesseract_version"] == "unavailable"
+    assert toolchain["tesseract_langs"] == "unavailable"
+    assert toolchain["poppler_version"] != "unavailable"  # unaffected
+
+
+def test_probe_ocr_toolchain_composes_independent_tesseract_and_poppler_probes():
+    # _probe_ocr_toolchain() itself has no per-field try/except — it trusts
+    # _probe_tesseract()/_probe_poppler_version() to each be defensive on
+    # their own (tested directly above/below). What it must get right is
+    # composition: both fields present, independently sourced.
+    toolchain = bench_mod._probe_ocr_toolchain()
+    tesseract_version, tesseract_langs = bench_mod._probe_tesseract()
+    assert toolchain["tesseract_version"] == tesseract_version
+    assert toolchain["tesseract_langs"] == tesseract_langs
+    assert toolchain["poppler_version"] == bench_mod._probe_poppler_version()
+
+
+def test_probe_poppler_version_never_raises_when_subprocess_fails(monkeypatch):
+    # One level lower than the test above: exercises _probe_poppler_version
+    # itself (not the composite _probe_ocr_toolchain) against the exact
+    # failure it is written to catch — subprocess.run raising because
+    # pdftoppm isn't installed.
+    def boom(*_args, **_kwargs):
+        raise FileNotFoundError("pdftoppm not found")
+
+    monkeypatch.setattr(bench_mod.subprocess, "run", boom)
+
+    assert bench_mod._probe_poppler_version() == "unavailable"
+
+
+def test_cli_synthetic_path_records_ocr_toolchain(tmp_path):
+    out = tmp_path / "latency.json"
+    rc = bench_mod.main(
+        ["--fake", "--n-docs", "2", "--repeats", "2", "--output", str(out)]
+    )
+    assert rc == 0
+    ctx = json.loads(out.read_text())["benchmark_context"]
+    for key in ("tesseract_version", "tesseract_langs", "poppler_version"):
+        assert key in ctx
+
+
+def test_cli_harness_still_runs_when_ocr_toolchain_probe_itself_raises(tmp_path, monkeypatch):
+    # Belt-and-suspenders: even if _probe_ocr_toolchain's own internal
+    # defensiveness were ever broken by a future change, main()'s outer
+    # catch must still keep the synthetic (--fake) path — which has no OCR
+    # dependency of its own — running to completion rather than crashing on
+    # an environment probe.
+    def boom():
+        raise RuntimeError("unexpected probe failure")
+
+    monkeypatch.setattr(bench_mod, "_probe_ocr_toolchain", boom)
+
+    out = tmp_path / "latency.json"
+    rc = bench_mod.main(
+        ["--fake", "--n-docs", "2", "--repeats", "2", "--output", str(out)]
+    )
+    assert rc == 0
+    ctx = json.loads(out.read_text())["benchmark_context"]
+    assert ctx["tesseract_version"] == "unavailable"
+    assert ctx["tesseract_langs"] == "unavailable"
+    assert ctx["poppler_version"] == "unavailable"
 
 
 def test_run_benchmark_standard_variant_basic():

--- a/tests/test_benchmark_pipeline.py
+++ b/tests/test_benchmark_pipeline.py
@@ -24,7 +24,9 @@ from scripts.benchmark_pipeline import (
     STAGES,
     SUPPORTED_DOCUMENT_SUFFIXES,
     VALID_VARIANTS,
+    SampleFingerprintDriftError,
     StaleDocumentBytesError,
+    _check_fingerprint_matches_loaded_documents,
     _clustered_se,
     _document_kind,
     _document_sample_digest,
@@ -807,6 +809,158 @@ def test_cli_documents_dir_stale_document_bytes_fails_loudly(tmp_path, monkeypat
     assert "sample_digest snapshot" in err
 
 
+# ---------------------------------------------------------------------------
+# #315 Codex follow-up round 2 — fingerprint file set must match what was
+# actually loaded (a file added/removed between two independent directory
+# scans could be fingerprinted without being benchmarked, or vice versa)
+# ---------------------------------------------------------------------------
+
+
+def test_check_fingerprint_matches_loaded_documents_passes_when_sets_agree():
+    loaded_docs = [
+        {"document_name": "a.pdf"},
+        {"document_name": "b.pdf"},
+    ]
+    file_hashes = {"a.pdf": "hash-a", "b.pdf": "hash-b"}
+    # Must not raise.
+    _check_fingerprint_matches_loaded_documents(loaded_docs, file_hashes)
+
+
+def test_check_fingerprint_matches_loaded_documents_raises_on_extra_hash():
+    # A file fingerprinted but never loaded is the dangerous direction:
+    # sample_digest would cover bytes nothing in the run ever measured.
+    loaded_docs = [{"document_name": "a.pdf"}]
+    file_hashes = {"a.pdf": "hash-a", "stowaway.pdf": "hash-b"}
+
+    with pytest.raises(SampleFingerprintDriftError, match="stowaway.pdf"):
+        _check_fingerprint_matches_loaded_documents(loaded_docs, file_hashes)
+
+
+def test_check_fingerprint_matches_loaded_documents_raises_on_missing_hash():
+    loaded_docs = [{"document_name": "a.pdf"}, {"document_name": "b.pdf"}]
+    file_hashes = {"a.pdf": "hash-a"}
+
+    with pytest.raises(SampleFingerprintDriftError, match="b.pdf"):
+        _check_fingerprint_matches_loaded_documents(loaded_docs, file_hashes)
+
+
+def test_fingerprint_race_between_independent_scans_is_real_and_caught(tmp_path):
+    # Reproduces the actual race Codex found: load_staged_documents() and
+    # _document_sample_file_hashes() each independently list the directory
+    # by default (two directory.iterdir() calls, not one). A file staged in
+    # between -- e.g. a corpus still hydrating into this directory -- lands
+    # in the second scan's hashes without ever having been loaded. This is
+    # exactly what main() no longer does (it derives the hash target list
+    # from loaded_docs' own document_path, not a second scan -- see the
+    # tests below), but the two independently-scanning functions still
+    # exist on their own and the mismatch they can produce must be caught,
+    # not silently published.
+    _stage_document(tmp_path, "CMO20241020862")
+    loaded_docs = load_staged_documents(tmp_path)  # scan #1
+
+    # Simulate a file landing mid-hydration, after scan #1.
+    _stage_document(tmp_path, "CMO2024483790", suffix=".jpeg")
+
+    file_hashes = _document_sample_file_hashes(tmp_path)  # independent scan #2
+    assert "CMO2024483790_complaint_20250715_234307.jpeg" in file_hashes  # premise: the race is real
+
+    with pytest.raises(
+        SampleFingerprintDriftError, match="CMO2024483790_complaint_20250715_234307.jpeg"
+    ):
+        _check_fingerprint_matches_loaded_documents(loaded_docs, file_hashes)
+
+
+def test_document_sample_file_hashes_with_explicit_files_ignores_later_directory_changes(
+    tmp_path,
+):
+    # This is the actual fix: an explicit files= snapshot is hashed as-is,
+    # so a file appearing after the snapshot was taken cannot silently
+    # enter the fingerprint no matter when _document_sample_file_hashes
+    # happens to run relative to the directory changing.
+    _stage_document(tmp_path, "CMO20241020862")
+    files = bench_mod._staged_document_paths(tmp_path)
+
+    _stage_document(tmp_path, "CMO2024483790", suffix=".jpeg")  # lands after the snapshot
+
+    hashes = _document_sample_file_hashes(tmp_path, files=files)
+    assert set(hashes) == {"CMO20241020862_complaint_20250715_234307.pdf"}
+
+
+def test_cli_documents_dir_fingerprint_derives_from_loaded_documents_not_a_rescan(tmp_path):
+    # Integration-level regression guard for the actual fix in main(): the
+    # file list handed to _document_sample_file_hashes comes from
+    # loaded_docs' own document_path values, not a fresh directory scan. A
+    # file staged after load_staged_documents() has already run (simulated
+    # here by writing it right after staging the first two, before main()
+    # runs at all -- main() only ever sees the directory once) must not
+    # appear in sample_digest's file set unless it was actually loaded.
+    # (The full race -- a file appearing *during* main()'s own run, between
+    # its load and fingerprint steps -- can no longer happen by
+    # construction, which is exactly what this test is standing in for:
+    # there is only one directory scan for main() to race against itself.)
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    _stage_document(staging, "CMO20241020862")
+    _stage_document(staging, "CMO2024483790", suffix=".jpeg")
+    out = tmp_path / "latency.json"
+
+    rc = bench_mod.main(
+        [
+            "--fake",
+            "--documents-dir",
+            str(staging),
+            "--repeats",
+            "2",
+            "--output",
+            str(out),
+        ]
+    )
+    assert rc == 0
+    data = json.loads(out.read_text())
+    assert data["n_docs"] == 2
+    assert data["benchmark_context"]["sample_digest"]
+
+
+def test_cli_documents_dir_fingerprint_drift_fails_loudly(tmp_path, monkeypatch, capsys):
+    # CLI wiring: main() must convert a SampleFingerprintDriftError raised
+    # by the insurance check into a loud, non-zero-exit CLI failure, not a
+    # silently-written latency.json whose sample_digest overclaims what was
+    # measured. The detection logic itself is exercised for real above;
+    # this test is only about main()'s try/except around the call.
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    _stage_document(staging, "CMO20241020862")
+    out = tmp_path / "latency.json"
+
+    def fake_check(*_args, **_kwargs):
+        raise SampleFingerprintDriftError(
+            "sample_digest's file set does not match the documents loaded "
+            "for benchmarking (fingerprinted but never loaded, so never "
+            "measured: ['stowaway.pdf']; loaded but never fingerprinted: [])"
+        )
+
+    monkeypatch.setattr(
+        bench_mod, "_check_fingerprint_matches_loaded_documents", fake_check
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        bench_mod.main(
+            [
+                "--fake",
+                "--documents-dir",
+                str(staging),
+                "--repeats",
+                "2",
+                "--output",
+                str(out),
+            ]
+        )
+    assert exc.value.code == 2
+    assert not out.exists()
+    err = capsys.readouterr().err
+    assert "stowaway.pdf" in err
+
+
 def test_run_benchmark_over_loaded_real_documents(tmp_path):
     # No processor_factory here, so this exercises the fake timing path,
     # which never touches document_bytes/document_path — docs from
@@ -1300,11 +1454,18 @@ def test_cli_synthetic_path_benchmark_context_fixture_is_unchanged(tmp_path):
 
 
 def test_probe_ocr_toolchain_populates_real_values_when_installed():
-    # Real code path, no mocking of pytesseract/poppler: the pipeline-core
-    # test gate (tests/README.md) requires tesseract and poppler installed
-    # locally, so this must report real values, not "unavailable"
-    # placeholders. Two machines with different tesseract versions or a
-    # missing Odia (ori) pack must be distinguishable from this output.
+    # Real code path, no mocking of pytesseract/poppler. Base CI
+    # (pipeline.yml) deliberately runs `uv sync --all-groups --extra
+    # serving` without pipeline-core, so pytesseract/pdf2image are not
+    # importable there and this test must skip rather than assert on
+    # "unavailable" — that path has its own test below. Locally, with
+    # pipeline-core installed (tests/README.md's gate requirement), this
+    # must report real values: two machines with different tesseract
+    # versions or a missing Odia (ori) pack must be distinguishable from
+    # this output, which is the entire point of #315's follow-up.
+    pytest.importorskip("pytesseract")
+    pytest.importorskip("pdf2image")
+
     toolchain = bench_mod._probe_ocr_toolchain()
 
     assert set(toolchain) == {"tesseract_version", "tesseract_langs", "poppler_version"}
@@ -1318,10 +1479,19 @@ def test_probe_ocr_toolchain_populates_real_values_when_installed():
 
 
 def test_probe_ocr_toolchain_records_unavailable_when_tesseract_probe_fails(monkeypatch):
-    # Simulate a box where tesseract cannot be located/configured (e.g. no
-    # binary installed at all). The probe must not raise, must not silently
-    # omit the keys, and must not let a tesseract failure take poppler's
+    # Simulate a box where tesseract is importable but misbehaves at runtime
+    # (as opposed to not being installed at all, which base CI already
+    # exercises for real — see test_probe_ocr_toolchain_composes_independent_
+    # tesseract_and_poppler_probes, which asserts nothing about availability
+    # and so passes either way). monkeypatch.setattr's string-path form has
+    # to import pytesseract_backend to resolve the target, and that module
+    # does `import pytesseract` at module scope, so this needs pytesseract
+    # importable too — skip in base CI rather than error out on the mock
+    # setup itself. The probe must not raise, must not silently omit the
+    # keys, and must not let a tesseract failure take poppler's
     # (independently probed) result down with it.
+    pytest.importorskip("pytesseract")
+
     def boom():
         raise RuntimeError("tesseract not installed on this box")
 

--- a/tests/test_sarvam_evaluate.py
+++ b/tests/test_sarvam_evaluate.py
@@ -1209,9 +1209,9 @@ def test_schema_v2_constrains_the_category_and_drops_district():
     """v1's category had no enum, so the model had nothing to choose from.
 
     The 2026-08-25 Sambalpur/2024 run billed 200 Extract pages and got
-    free-text subject lines back: "Sanction of new AWC buildings" against a
-    gold label of ICDS. It matched gold on 0 of the 11 grievances where it
-    answered at all, which measured the schema rather than the provider.
+    free-text subject lines back — the specific relief each petitioner asked
+    for, not a taxonomy label. It matched gold on 0 of the 11 grievances where
+    it answered at all, which measured the schema rather than the provider.
     """
     from janasunani.evaluation.sarvam_grievance_schema import (
         GRIEVANCE_CATEGORIES,

--- a/tests/test_sarvam_evaluate.py
+++ b/tests/test_sarvam_evaluate.py
@@ -1246,3 +1246,50 @@ def test_schema_v2_passes_the_provider_preflight():
 
     _validate_extract_schema(get_schema("v2"))
     _validate_extract_schema(get_schema("v1"))
+
+
+def test_v2_requires_the_category_but_v1_stays_reproducible():
+    """The declared primary outcome must not be optional in v2.
+
+    JSON Schema properties are optional unless listed under `required`, so the
+    enum alone constrains what the model may answer without obliging it to
+    answer at all. The 2026-08-25 run returned a category on 11 of 87
+    grievances; a corrected run must not be able to repeat that and still be
+    well-formed.
+
+    v1 must keep no `required`, or the run it exists to reproduce stops being
+    reproducible.
+    """
+    from janasunani.evaluation.sarvam_grievance_schema import (
+        GRIEVANCE_EXTRACT_SCHEMA_V1,
+        GRIEVANCE_EXTRACT_SCHEMA_V2,
+        get_schema,
+    )
+
+    assert GRIEVANCE_EXTRACT_SCHEMA_V2["required"] == ["grievance_category"]
+    assert get_schema("v2")["required"] == ["grievance_category"]
+
+    # The other two stay optional: a page with no legible prose returning no
+    # grievance_text is a real outcome, not a malformed response.
+    assert "summary" not in GRIEVANCE_EXTRACT_SCHEMA_V2["required"]
+    assert "grievance_text" not in GRIEVANCE_EXTRACT_SCHEMA_V2["required"]
+
+    assert "required" not in GRIEVANCE_EXTRACT_SCHEMA_V1
+    assert "required" not in get_schema("v1")
+
+
+def test_a_response_missing_the_category_is_invalid_under_v2():
+    """Exercise the constraint against a validator, not just the dict shape."""
+    jsonschema = pytest.importorskip("jsonschema")
+
+    from janasunani.evaluation.sarvam_grievance_schema import get_schema
+
+    schema = get_schema("v2")
+    jsonschema.validate({"grievance_category": "ICDS", "summary": "x"}, schema)
+
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate({"summary": "x", "grievance_text": "y"}, schema)
+
+    # And the enum still binds what it may say.
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate({"grievance_category": "Sanction of new buildings"}, schema)

--- a/tests/test_sarvam_evaluate.py
+++ b/tests/test_sarvam_evaluate.py
@@ -22,8 +22,11 @@ def test_grievance_schema_is_pinned_and_versioned():
         get_schema,
     )
 
-    assert SCHEMA_VERSION == "v1"
+    # The default moved to v2 when v1 proved unable to answer its own primary
+    # outcome. v1 stays pinned and reachable so the 2026-08-25 run reproduces.
+    assert SCHEMA_VERSION == "v2"
     assert "v1" in SUPPORTED_SCHEMA_VERSIONS
+    assert "v2" in SUPPORTED_SCHEMA_VERSIONS
     assert SUPPORTED_SCHEMA_VERSIONS["v1"] is GRIEVANCE_EXTRACT_SCHEMA_V1
     schema = get_schema("v1")
     assert schema is GRIEVANCE_EXTRACT_SCHEMA_V1
@@ -205,10 +208,14 @@ def test_evaluate_dry_run_digitise_arm(tmp_path: Path):
     md_path = out / "sarvam_scorecard.md"
     assert json_path.is_file()
     assert md_path.is_file()
+    from janasunani.evaluation.sarvam_grievance_schema import SCHEMA_VERSION
+
     data = json.loads(json_path.read_text())
     assert data["n_pages"] == 2
     assert data["arm"] == "digitise"
-    assert data["schema_version"] == "v1"
+    # Whatever the default is, the scorecard records it, so a headline number
+    # can always be traced back to the schema that produced it.
+    assert data["schema_version"] == SCHEMA_VERSION
     assert data["cost_rupees"] == 0.0  # dry-run
     assert "summary_divergence" in data
     progress_path = out / "sarvam_progress.json"
@@ -1196,3 +1203,46 @@ def test_save_records_destination_rejects_traversal_after_resolution():
     escaped = DATA_DIR / "external" / ".." / ".." / "docs" / "leak.jsonl"
     with pytest.raises(ValueError, match="governed data tree"):
         _checked_record_destination(escaped)
+
+
+def test_schema_v2_constrains_the_category_and_drops_district():
+    """v1's category had no enum, so the model had nothing to choose from.
+
+    The 2026-08-25 Sambalpur/2024 run billed 200 Extract pages and got
+    free-text subject lines back: "Sanction of new AWC buildings" against a
+    gold label of ICDS. It matched gold on 0 of the 11 grievances where it
+    answered at all, which measured the schema rather than the provider.
+    """
+    from janasunani.evaluation.sarvam_grievance_schema import (
+        GRIEVANCE_CATEGORIES,
+        SCHEMA_VERSION,
+        get_schema,
+    )
+
+    v2 = get_schema("v2")
+    category = v2["properties"]["grievance_category"]
+    assert category["enum"] == list(GRIEVANCE_CATEGORIES)
+    assert len(GRIEVANCE_CATEGORIES) == 35
+
+    # District is a structured column on `complaints`, known at intake for
+    # every grievance. Paying an extraction endpoint to read it off a scan
+    # buys nothing, and in the run it crowded out the field we needed.
+    assert "district" not in v2["properties"]
+    assert "district" in get_schema("v1")["properties"]
+
+    # The stored taxonomy carries a double-escaped label; the enum must offer
+    # the readable form, not the HTML entity.
+    assert "Scheme & Benefits" in GRIEVANCE_CATEGORIES
+    assert not any("&amp;" in c for c in GRIEVANCE_CATEGORIES)
+
+    # New runs must not silently select the schema that cannot answer.
+    assert SCHEMA_VERSION == "v2"
+
+
+def test_schema_v2_passes_the_provider_preflight():
+    """An enum must not trip the guard that catches HTTP-400 shapes."""
+    from janasunani.egress.sarvam import _validate_extract_schema
+    from janasunani.evaluation.sarvam_grievance_schema import get_schema
+
+    _validate_extract_schema(get_schema("v2"))
+    _validate_extract_schema(get_schema("v1"))

--- a/tests/test_sarvam_scorecard.py
+++ b/tests/test_sarvam_scorecard.py
@@ -489,3 +489,79 @@ def test_render_markdown_and_write_outputs():
         assert "summary_divergence" in data
         md2 = paths["markdown"].read_text()
         assert md2 == md
+
+
+def test_escaped_gold_label_scores_a_correct_prediction_as_correct():
+    """``Scheme & Benefits`` is stored double-escaped; the enum offers it readable.
+
+    Exact-equality scoring counted every correct prediction for that category
+    as wrong, so the one category whose stored label carries an HTML entity
+    would have read 0% accuracy in a paid benchmark for a formatting reason.
+    """
+    from janasunani.evaluation.sarvam_scorecard import (
+        PageRecord,
+        build_scorecard,
+        per_category_table,
+    )
+
+    stored = "Scheme &amp;amp; Benefits"
+    readable = "Scheme & Benefits"
+    pages = [
+        PageRecord(
+            ticket=f"SCH{i}",
+            page_id=f"SCH{i}P1",
+            gold_category=stored,
+            pipeline_category=readable,
+            sarvam_category=readable,
+        )
+        for i in range(10)
+    ]
+
+    table = per_category_table(pages)
+    # The row is labelled readably, not with the entity.
+    assert readable in table
+    assert stored not in table
+    assert table[readable]["n_tickets"] == 10
+    assert table[readable]["pipeline_accuracy"] == 1.0
+    assert table[readable]["sarvam_accuracy"] == 1.0
+
+    report = build_scorecard(pages)
+    assert report.category is not None
+    assert report.category["pipeline_accuracy"] == 1.0
+    assert report.category["sarvam_accuracy"] == 1.0
+
+
+def test_label_normalisation_does_not_make_different_categories_match():
+    """Unescaping must not collapse genuinely different labels."""
+    from janasunani.evaluation.sarvam_scorecard import (
+        PageRecord,
+        build_scorecard,
+        category_key,
+        unescape_label,
+    )
+
+    assert unescape_label("Scheme &amp;amp; Benefits") == "Scheme & Benefits"
+    assert unescape_label("Scheme &amp; Benefits") == "Scheme & Benefits"
+    assert unescape_label("Scheme & Benefits") == "Scheme & Benefits"
+    assert unescape_label("  Land   Matters ") == "Land Matters"
+    assert unescape_label(None) is None
+    assert unescape_label("   ") is None
+
+    # Case-insensitive match, but distinct categories stay distinct.
+    assert category_key("land matters") == category_key("Land Matters")
+    assert category_key("Land Matters") != category_key("Legal")
+
+    # A missing prediction never matches a present gold label.
+    pages = [
+        PageRecord(
+            ticket="T1",
+            page_id="T1P1",
+            gold_category="Land Matters",
+            pipeline_category="Legal",
+            sarvam_category=None,
+        )
+    ]
+    report = build_scorecard(pages)
+    assert report.category is not None
+    assert report.category["pipeline_accuracy"] == 0.0
+    assert report.category["sarvam_accuracy"] == 0.0

--- a/tests/test_sarvam_scorecard.py
+++ b/tests/test_sarvam_scorecard.py
@@ -565,3 +565,67 @@ def test_label_normalisation_does_not_make_different_categories_match():
     assert report.category is not None
     assert report.category["pipeline_accuracy"] == 0.0
     assert report.category["sarvam_accuracy"] == 0.0
+
+
+def test_pages_disagreeing_on_category_are_ambiguous_not_first_wins():
+    """A forced guess on page one must not mask the grievance page's answer.
+
+    Schema v2 makes `grievance_category` required and Extract runs per page,
+    so cover sheets and attachments must now answer even though they carry no
+    category. The old first-non-null rule let that guess win silently.
+    """
+    from janasunani.evaluation.sarvam_scorecard import PageRecord, build_scorecard
+
+    pages = [
+        # Page 1 is a cover sheet: forced to guess, and guesses wrong.
+        PageRecord(
+            ticket="T1", page_id="T1:1", gold_category="ICDS",
+            pipeline_category="ICDS", sarvam_category="Housing",
+        ),
+        # Page 2 actually bears the grievance and gets it right.
+        PageRecord(
+            ticket="T1", page_id="T1:2", gold_category="ICDS",
+            pipeline_category="ICDS", sarvam_category="ICDS",
+        ),
+    ]
+    report = build_scorecard(pages)
+    assert report.category is not None
+    # Not scored as correct on a lucky later page, and not scored as correct
+    # on a wrong first page: the ticket is ambiguous and counts against.
+    assert report.category["sarvam_accuracy"] == 0.0
+    assert report.category["sarvam_ambiguous_tickets"] == 1
+    # The pipeline agreed across pages, so it is unaffected.
+    assert report.category["pipeline_accuracy"] == 1.0
+    assert report.category["pipeline_ambiguous_tickets"] == 0
+
+
+def test_pages_agreeing_across_pages_still_score_normally():
+    """Ambiguity handling must not penalise a consistent multi-page answer."""
+    from janasunani.evaluation.sarvam_scorecard import PageRecord, build_scorecard
+
+    pages = [
+        PageRecord(ticket=f"T{i}", page_id=f"T{i}:{p}", gold_category="Housing",
+                   pipeline_category="Housing", sarvam_category="Housing")
+        for i in range(5) for p in (1, 2, 3)
+    ]
+    report = build_scorecard(pages)
+    assert report.category is not None
+    assert report.category["sarvam_accuracy"] == 1.0
+    assert report.category["sarvam_ambiguous_tickets"] == 0
+    assert report.category["n_tickets"] == 5
+
+
+def test_escaped_and_unescaped_spellings_are_not_a_disagreement():
+    """Two spellings of one category must not be scored as pages disagreeing."""
+    from janasunani.evaluation.sarvam_scorecard import PageRecord, build_scorecard
+
+    pages = [
+        PageRecord(ticket="T1", page_id="T1:1", gold_category="Scheme &amp;amp; Benefits",
+                   pipeline_category="Scheme & Benefits", sarvam_category="Scheme & Benefits"),
+        PageRecord(ticket="T1", page_id="T1:2", gold_category="Scheme &amp;amp; Benefits",
+                   pipeline_category="Scheme &amp;amp; Benefits", sarvam_category="scheme & benefits"),
+    ]
+    report = build_scorecard(pages)
+    assert report.category is not None
+    assert report.category["sarvam_ambiguous_tickets"] == 0
+    assert report.category["sarvam_accuracy"] == 1.0

--- a/tests/test_sarvam_scorecard.py
+++ b/tests/test_sarvam_scorecard.py
@@ -629,3 +629,62 @@ def test_escaped_and_unescaped_spellings_are_not_a_disagreement():
     assert report.category is not None
     assert report.category["sarvam_ambiguous_tickets"] == 0
     assert report.category["sarvam_accuracy"] == 1.0
+
+
+def test_per_category_table_agrees_with_the_headline_on_ambiguity():
+    """The two paths must not disagree about the same ticket.
+
+    They had separate copies of the ticket-collapsing loop. Fixing only the
+    headline left `per_category_table` on first-wins, so a ticket whose page
+    one happened to match gold scored incorrect in the headline and correct in
+    the per-category row for that very category.
+    """
+    from janasunani.evaluation.sarvam_scorecard import (
+        PageRecord,
+        build_scorecard,
+        per_category_table,
+    )
+
+    pages = [
+        # Page one matches gold; page two disagrees. First-wins would call
+        # this correct. It is ambiguous, so both paths must call it wrong.
+        PageRecord(ticket="T1", page_id="T1:1", gold_category="ICDS",
+                   pipeline_category="ICDS", sarvam_category="ICDS"),
+        PageRecord(ticket="T1", page_id="T1:2", gold_category="ICDS",
+                   pipeline_category="ICDS", sarvam_category="Housing"),
+    ]
+
+    headline = build_scorecard(pages).category
+    table = per_category_table(pages)
+
+    assert headline is not None
+    assert headline["sarvam_accuracy"] == 0.0
+    assert headline["sarvam_ambiguous_tickets"] == 1
+    # The per-category row for ICDS must say the same thing.
+    assert table["ICDS"]["sarvam_correct"] == 0
+    assert table["ICDS"]["sarvam_accuracy"] == 0.0
+    # And the pipeline, which agreed across pages, is correct in both.
+    assert headline["pipeline_accuracy"] == 1.0
+    assert table["ICDS"]["pipeline_accuracy"] == 1.0
+
+
+def test_both_paths_share_one_aggregator():
+    """Guard against the duplicate loop coming back."""
+    from janasunani.evaluation.sarvam_scorecard import (
+        PageRecord,
+        aggregate_ticket_categories,
+    )
+
+    pages = [
+        PageRecord(ticket="T1", page_id="T1:1", gold_category="Legal",
+                   pipeline_category="Legal", sarvam_category="Legal"),
+        PageRecord(ticket="T1", page_id="T1:2", gold_category="Legal",
+                   pipeline_category="Traffic", sarvam_category="Legal"),
+    ]
+    agg = aggregate_ticket_categories(pages)
+    assert agg.gold["T1"] == "Legal"
+    assert agg.sarvam["T1"] == "Legal"
+    assert agg.ambiguous_sarvam == set()
+    # The pipeline disagreed with itself across pages.
+    assert agg.pipeline["T1"] is None
+    assert agg.ambiguous_pipeline == {"T1"}


### PR DESCRIPTION
The presentation is finished, so #313 and #315 are being retired. Both carried real non-deck code that has nothing to do with slides, and this recovers it.

## What was extracted

Eleven commits, cherry-picked with `-x` so each keeps its original message and reasoning.

From **#315** (`fix/benchmark-stream-documents`) — all five commits were already deck-free:

- streaming staged document bytes instead of eager-loading them
- `StaleDocumentBytesError` and `_document_sample_file_hashes`, binding `sample_digest` to the bytes actually benchmarked
- OCR toolchain provenance in `benchmark_context`
- the base-CI skip and fingerprint-drift close
- the OCR probe test gated on the system binary, not just the Python wrapper

From **#313** (`fix/sarvam-schema-v2-and-benchmark-slide`) — six of eight commits:

- Extract schema v2: `district` dropped, category enumerated and required
- category label normalisation before scoring (the HTML-entity unescape)
- per-page disagreement recorded instead of page one winning
- one aggregator for both category paths
- the roadmap/DELIVERY record of the paid run

Its two deck-only commits (`6fdbba2`, `d181e30`) were skipped, and the deck hunks were stripped from the four mixed commits. **No file under `docs/presentations/` is touched by this branch.**

## Why the base is this branch and not main

Neither PR applies to `main`. Both build on the real-document input path that reaches main only through #326, and a cherry-pick of the first #315 commit onto main conflicts immediately. #326 already carries `docs/timing-quality-briefing` in full, so it is the one path these changes have.

## On #306

It needs no salvage at all: `docs/timing-quality-briefing` is entirely contained in #326 (`git merge-base --is-ancestor` confirms, 0 commits ahead). Every one of its commits already reaches main. It can be closed.

## Conflicts

Four, all additive — the two branches added code at the same points in `benchmark_pipeline.py`. Three were "keep both". The fourth was a real merge: `sample_digest` now comes from #315's `file_hashes=` form so it hashes the same bytes the run later verifies against, while keeping the `--slice`/manifest-conflict check and the coverage block from the review rounds on #326.

## Verification

`2013 passed, 19 skipped`, ruff clean — against 1980 on the base branch. The 33 additional tests are exactly the ones #313 and #315 shipped, passing against the merged code, which is what shows the strip dropped nothing and the conflict resolutions are right.

`Makefile` shows as differing from both retired branches; it is identical to `main`. That difference belongs to the deck branch and is already carried by #326.