### PR TITLE
fix(rehearsal): guard the preflight argv against set -u on bash 3.2

### DIFF
--- a/docs/DEMO.md
+++ b/docs/DEMO.md
@@ -206,8 +206,6 @@ The **13 August freeze** is gated by a single laptop command that proves every [
 ```bash
 make rehearsal
 # runs scripts/demo_rehearsal.sh — see docs/plans/2026-08-08-demo-integration-rehearsal.md Part 2
-# Note: the Make target and script land in PR #203 (chore/demo-rehearsal-script);
-# until that merges, run the individual Phase A–C checks from the plan directly.
 ```
 
 What it checks (four phases, fail-fast):
@@ -222,7 +220,7 @@ Run it **the night before the demo** (see [DEMO_SCRIPT.md](DEMO_SCRIPT.md#pre-de
 | Artifact | Where |
 |---|---|
 | Timed walkthrough (Scenes 0–6) | [DEMO_SCRIPT.md](DEMO_SCRIPT.md) |
-| Automated gate | [`scripts/demo_rehearsal.sh`](../scripts/demo_rehearsal.sh) (via PR #203) |
+| Automated gate | [`scripts/demo_rehearsal.sh`](../scripts/demo_rehearsal.sh) |
 | Integration plan (gates, Table 2, three Sarvam arms) | [`docs/plans/2026-08-08-demo-integration-rehearsal.md`](plans/2026-08-08-demo-integration-rehearsal.md) |
 | Delivery scope & benchmark Table 2 | [DELIVERY.md](DELIVERY.md) Table 1 & 2 |
 

--- a/scripts/demo_rehearsal.sh
+++ b/scripts/demo_rehearsal.sh
@@ -128,7 +128,16 @@ phase_a_static() {
   if [ "$REHEARSAL_STRICT" = "1" ]; then
     PREFLIGHT_ARGS+=(--strict)
   fi
-  if ! uv run --extra demo janasunani-demo-preflight "${PREFLIGHT_ARGS[@]}"; then
+  # bash 3.2 -- the system bash on the macOS demo laptop -- treats "${A[@]}" on
+  # an empty array as an unbound variable under `set -u`, so the unguarded
+  # expansion aborts the whole rehearsal whenever REHEARSAL_STRICT is unset.
+  # Build the command instead; the same guard already protects PYTEST_FILES.
+  if [ "${#PREFLIGHT_ARGS[@]}" -gt 0 ]; then
+    PREFLIGHT_CMD=(uv run --extra demo janasunani-demo-preflight "${PREFLIGHT_ARGS[@]}")
+  else
+    PREFLIGHT_CMD=(uv run --extra demo janasunani-demo-preflight)
+  fi
+  if ! "${PREFLIGHT_CMD[@]}"; then
     # Preflight exits 1 on FAIL; advisory WARN still exits 0. In strict mode
     # a WARN becomes FAIL, so failure here is real.
     fail "janasunani-demo-preflight failed"

--- a/tests/test_deploy_stack.py
+++ b/tests/test_deploy_stack.py
@@ -1261,6 +1261,73 @@ def test_rehearsal_scripts_are_valid_shell():
         assert result.returncode == 0, f"{path.name} failed bash -n: {result.stderr}"
 
 
+def _extract_preflight_command_block() -> str:
+    """The real PREFLIGHT_ARGS/PREFLIGHT_CMD region of the shipped script.
+
+    Read off disk so these tests exercise the text the operator actually runs,
+    not a copy that can drift away from it.
+    """
+    lines = REHEARSAL_SH_PATH.read_text().splitlines()
+    start = next(i for i, line in enumerate(lines) if line.strip() == "PREFLIGHT_ARGS=()")
+    end = next(
+        i for i, line in enumerate(lines[start:], start)
+        if line.strip().startswith('if ! "${PREFLIGHT_CMD[@]}"')
+    )
+    return "\n".join(lines[start:end])
+
+
+@pytest.mark.parametrize(
+    ("strict", "expect_strict_flag"),
+    [("0", False), ("1", True)],
+)
+def test_demo_rehearsal_preflight_command_survives_set_u(strict, expect_strict_flag):
+    """#331-adjacent: the preflight invocation must not die on an empty array.
+
+    `set -euo pipefail` plus bash 3.2 -- the system bash on the macOS demo
+    laptop -- treats "${PREFLIGHT_ARGS[@]}" on an empty array as an unbound
+    variable, so an unguarded expansion aborted the whole rehearsal in the
+    common (non-strict) case. Run the script's own block and assert the command
+    it builds is right in both modes.
+    """
+    harness = "\n".join(
+        [
+            "set -euo pipefail",
+            f'REHEARSAL_STRICT="{strict}"',
+            _extract_preflight_command_block(),
+            'printf "%s\\n" "${PREFLIGHT_CMD[@]}"',
+        ]
+    )
+    result = subprocess.run(
+        ["bash", "-c", harness], capture_output=True, text=True
+    )
+    assert result.returncode == 0, f"preflight block failed under set -u: {result.stderr}"
+    argv = result.stdout.split()
+    assert argv[:1] == ["uv"], argv
+    assert "janasunani-demo-preflight" in argv, argv
+    assert ("--strict" in argv) is expect_strict_flag, argv
+
+
+def test_demo_rehearsal_empty_arrays_are_length_guarded():
+    """Portability invariant, checkable on any bash.
+
+    CI runs bash 5, where expanding an empty array under `set -u` is legal, so
+    executing the block cannot catch a regression on its own. Require instead
+    that every array the script initialises empty -- the only ones that can
+    actually be empty at expansion time -- is read through a "${#NAME[@]}"
+    length guard. That is the property that makes it safe on bash 3.2.
+    """
+    text = REHEARSAL_SH_PATH.read_text()
+    starts_empty = set(re.findall(r"^\s*([A-Z_]+)=\(\)\s*$", text, re.MULTILINE))
+    assert starts_empty, "expected the script to build argv arrays"
+    guarded = set(re.findall(r'"\$\{#([A-Z_]+)\[@\]\}"', text))
+    unguarded = starts_empty - guarded
+    assert not unguarded, (
+        f"arrays initialised empty but expanded without a length guard: "
+        f"{sorted(unguarded)}. Under set -u on bash 3.2 an empty expansion is "
+        "an unbound variable and aborts the rehearsal."
+    )
+
+
 def test_demo_rehearsal_script_covers_required_phases():
     """Static content check: the rehearsal script must implement Phases A-D
     from the plan (ruff+pytest, health curl, supervisor/history, frontend,


### PR DESCRIPTION
Salvage from `chore/demo-integration-freeze` before that branch is deleted. That branch was one commit, 231 behind `main`, with its remote already gone. Its content split three ways: the `outputs/benchmark/` `.gitignore` rules had already reached `main` independently, the freeze-tag rows are obsolete now that the 14 August demo has been delivered, and these two fixes had never landed anywhere.

## The bug

`scripts/demo_rehearsal.sh` runs under `set -euo pipefail`. It builds `PREFLIGHT_ARGS` as an empty array, appends `--strict` only when `REHEARSAL_STRICT=1`, then expanded it unguarded:

```bash
PREFLIGHT_ARGS=()
if [ "$REHEARSAL_STRICT" = "1" ]; then
  PREFLIGHT_ARGS+=(--strict)
fi
if ! uv run --extra demo janasunani-demo-preflight "${PREFLIGHT_ARGS[@]}"; then
```

On bash 3.2 — the system bash on the macOS demo laptop — expanding an empty array under `set -u` is an unbound variable:

```
$ /bin/bash -c 'set -u; A=(); printf "%s\n" "${A[@]}"'
/bin/bash: A[@]: unbound variable
```

So `make rehearsal` aborted before preflight ever ran, in the *common* case — non-strict. `PYTEST_FILES` two blocks earlier already had the length guard; this one did not.

## The fix

Build the command into `PREFLIGHT_CMD` behind a length check, mirroring the existing `PYTEST_FILES` guard.

## Tests

Both read the script off disk, so they track the file the operator actually runs rather than a copy that can drift.

- `test_demo_rehearsal_preflight_command_survives_set_u` executes the script's own `PREFLIGHT` block under `set -euo pipefail` and asserts the argv it builds, parametrised over both modes: `--strict` present when `REHEARSAL_STRICT=1`, absent otherwise.
- `test_demo_rehearsal_empty_arrays_are_length_guarded` states the portability invariant — every array the script initialises empty is read through a `"${#NAME[@]}"` guard. This one earns its place: CI runs bash 5, where the empty expansion is perfectly legal, so executing the block cannot catch a regression on its own.

Both fail against the previous script and pass against this one, verified by reverting the script and re-running.

## Also

Drops two stale references in `docs/DEMO.md` (lines 209 and 225) telling the reader that `make rehearsal` and `scripts/demo_rehearsal.sh` are still pending in PR #203. Both have been on `main` for weeks.

## Validation

- `uv run ruff check .` — clean
- `uv run --extra serving --extra pipeline-core pytest` — 1965 passed, 19 skipped
- `bash -n scripts/demo_rehearsal.sh` — clean
- the shipped block executed under real `/bin/bash` 3.2.57, which is where the bug bites: now builds `uv run --extra demo janasunani-demo-preflight`