### PR TITLE
feat(evaluation): verified DSI corpus draws and a benchmark that names its sample

### DIFF
--- a/janasunani/evaluation/dsi_sample.py
+++ b/janasunani/evaluation/dsi_sample.py
@@ -1,0 +1,594 @@
+"""Nested stratified draws over the DSI clinic reference corpus.
+
+The DSI clinic's ``large_sample`` is the corpus their reported numbers were
+measured on: **70,029 documents across 69,977 tickets**, drawn from 100,000
+complaints at seed 1337 (see :mod:`janasunani.samples`, which pins it).
+Reproducing anything of theirs means working from it rather than from a slice
+of our own choosing.
+
+69,844 is *not* this number. It is the count in the known-short Box copy,
+which is missing 189 documents that S3 has, and it appears in this file only as
+the failure that :func:`load_corpus`'s manifest comparison exists to catch.
+Passing it as the largest tier's budget would make ``_draw`` sample 185
+documents out of the verified population instead of returning it whole, and
+every nested tier would then descend from an incomplete corpus --- the same
+wrong-population failure, arrived at through the budget rather than the disk.
+
+It is also 60 GB, and a single pipeline pass over all of it is days of compute.
+So the work is tiered, and the tiers must nest:
+
+    latency  (few hundred)  subset of
+    quality  (few thousand) subset of
+    corpus   (len(corpus), never a copied constant)
+
+**Nesting is by construction, never by re-seeding.** A seeded re-draw at a
+smaller budget is not a subset of the larger one: ``allocate`` apportions a
+per-category floor first and then the remainder by largest remainder, so
+changing the budget reshuffles which categories get headroom and the two draws
+share only what they happen to share. This module therefore draws the largest
+tier from the corpus, then each smaller tier *from the tier above it*. That is
+the only way the latency numbers and the quality numbers describe the same
+documents, which is the whole point of doing it this way.
+
+The stratifier is ``sarvam_sample_builder.allocate``, reused rather than
+reimplemented. Its docstring records three failures it already survived; a
+second copy here would get to rediscover them.
+
+Reads only the paths it is given. Emits manifests of ticket ids, categories and
+filenames -- never document text.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import random
+import re
+import unicodedata
+from collections import Counter
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from janasunani.evaluation.sarvam_sample_builder import allocate
+
+#: Frozen so a redraw is reproducible. Distinct from the DSI corpus seed (1337)
+#: and from the Sambalpur slice seed (20260824) so the three cannot be confused
+#: in a manifest.
+DEFAULT_SEED = 20260825
+
+#: Per-category minimum. The corpus has 35 categories with a very long tail --
+#: Traffic has 12 rows against Housing's 17,103 -- so without a floor the rare
+#: categories vanish and per-category accuracy is unreportable for most of the
+#: taxonomy.
+DEFAULT_FLOOR = 3
+
+#: Category recorded as absent. Kept as an explicit bucket rather than dropped,
+#: because "how many documents have no category at all" is itself a finding and
+#: silently excluding them would overstate coverage.
+UNCATEGORISED = "__uncategorised__"
+
+
+@dataclass(frozen=True)
+class DocumentRecord:
+    """One document on disk, joined to its complaint's recorded category."""
+
+    ticket: str
+    filename: str
+    category: str
+    size_bytes: int
+
+    @property
+    def is_categorised(self) -> bool:
+        return self.category != UNCATEGORISED
+
+
+def _norm_category(value: Any) -> str:
+    """Readable category, or the explicit uncategorised bucket.
+
+    Whitespace and Unicode form only. The DSI corpus stores its 34 categories
+    cleanly -- checked on 2026-08-25, the only ampersands are the literal ones
+    in ``Agriculture & Farming`` and ``School & College``.
+
+    Our own lake is different: it holds ``Scheme & Benefits`` double-escaped as
+    ``Scheme &amp;amp; Benefits``, and a stratifier keying on the raw string
+    would split one category into two strata. That does not happen here, so
+    rather than carry a second copy of the scoring-side unescaper this raises
+    if the assumption ever stops holding. Silently coping would hide a corpus
+    swap; the scoring path has ``sarvam_scorecard.unescape_label`` for the
+    case where escaping is expected.
+    """
+    if value is None:
+        return UNCATEGORISED
+    text = unicodedata.normalize("NFC", str(value))
+    text = re.sub(r"\s+", " ", text).strip()
+    if not text:
+        return UNCATEGORISED
+    if "&amp;" in text or "&lt;" in text or "&gt;" in text or "&quot;" in text:
+        raise ValueError(
+            f"category {text!r} carries an HTML entity, so this corpus needs "
+            "unescaping before stratification or one category will split into "
+            "two strata. Use sarvam_scorecard.unescape_label and update this "
+            "function's assumption."
+        )
+    return text
+
+
+@dataclass(frozen=True)
+class ManifestEntry:
+    """One row of the pinned reference manifest."""
+
+    ticket: str
+    size_bytes: int | None
+    md5: str | None
+
+
+def load_reference_manifest(path: Path | str) -> dict[str, ManifestEntry]:
+    """``{s3_key: ManifestEntry}`` from the pinned DSI reference manifest (TSV).
+
+    Columns are ``ticket``, ``s3_key``, ``size_bytes``, ``md5``. The key is
+    the object key in ``janasunani-documents-dsi-reference``, which is also
+    the path relative to the corpus root once synced -- so it is directly
+    comparable to what :func:`load_corpus` walks.
+
+    Every row must carry a nonblank ``s3_key`` and ``ticket``, and the ticket
+    must equal the key's prefix before ``_complaint_``: the format makes it
+    derivable, and :func:`load_corpus` trusts the manifest over the parse, so
+    a contradicting row files the document under the wrong ticket. A blank key
+    would silently leave the expected-key set and let an equally absent
+    document compare equal; a blank ticket would be emitted in place of the
+    path parse that would have been right.
+
+    A repeated ``s3_key`` raises: the surviving row would decide the ticket,
+    the category and the provenance for that document, so a duplicate makes
+    stratification depend on manifest order.
+
+    ``size_bytes`` and ``md5`` are kept, not discarded. A key comparison
+    alone proves only that a file with the right name is present; a
+    truncated, stale or replaced document under the expected key passes it,
+    and ``draw_nested`` then emits well-formed tier manifests for altered
+    bytes. See ``verify`` in :func:`load_corpus`.
+
+    The md5 column is a true content hash for every object in the reference
+    bucket, including the 80 over 8 MB: they arrived multipart in the source
+    bucket, where the etag is not an MD5, and the server-side copy rewrote
+    them single-part.
+    """
+    import csv
+
+    path = Path(path)
+    entries: dict[str, ManifestEntry] = {}
+    with path.open(newline="") as handle:
+        reader = csv.DictReader(handle, delimiter="\t")
+        missing = {"ticket", "s3_key"} - set(reader.fieldnames or ())
+        if missing:
+            raise ValueError(
+                f"{path} is not a reference manifest: missing column(s) "
+                f"{sorted(missing)}. Expected ticket, s3_key, size_bytes, md5."
+            )
+        duplicated: list[str] = []
+        blank: list[str] = []
+        mismatched: list[str] = []
+        for row in reader:
+            key = (row.get("s3_key") or "").strip()
+            ticket = (row.get("ticket") or "").strip()
+            # Neither identity may be blank, and neither may be skipped.
+            #
+            # A blank key silently shrank the expected-key set, so if that
+            # document was also absent on disk the set comparison in
+            # `load_corpus` passed and certified a smaller corpus -- the
+            # known-short-copy failure this manifest exists to catch, caused
+            # by the manifest itself.
+            #
+            # A blank ticket was worse than it looks: `load_corpus` prefers
+            # the manifest's ticket over the one parsed from the path,
+            # because the record beats a derivation. A blank one is not a
+            # record, so the document was emitted under an empty ticket and
+            # landed in the uncategorised stratum, overriding a path parse
+            # that would have been right.
+            if not key or not ticket:
+                blank.append(
+                    f"line {reader.line_num}: "
+                    + ("no s3_key" if not key else f"{key!r} has no ticket")
+                )
+                continue
+            # The ticket is derivable from the key exactly -- the key is
+            # `<ticket>_complaint_<timestamp>.<ext>`, hierarchical tickets
+            # included -- and `load_corpus` prefers the manifest's ticket over
+            # that parse. So a row pairing a valid key with a different
+            # nonblank ticket passes every key, size and hash check and still
+            # files the document under the wrong ticket, taking its category
+            # and its emitted provenance with it. Requiring the two to agree
+            # is asserting an invariant the format already guarantees.
+            if "_complaint_" in key and key.split("_complaint_")[0] != ticket:
+                mismatched.append(
+                    f"line {reader.line_num}: {key!r} carries ticket {ticket!r}"
+                )
+                continue
+            # A repeated key is a broken manifest, not a last-one-wins
+            # question. The disk-versus-manifest set comparison in
+            # `load_corpus` still passes on a duplicate, but the surviving
+            # row supplies the ticket used for category lookup and emitted
+            # provenance -- so two rows for one key silently make
+            # stratification depend on manifest order.
+            if key in entries:
+                duplicated.append(key)
+                continue
+            raw_size = (row.get("size_bytes") or "").strip()
+            entries[key] = ManifestEntry(
+                ticket=ticket,
+                size_bytes=int(raw_size) if raw_size.isdigit() else None,
+                md5=(row.get("md5") or "").strip() or None,
+            )
+    if blank:
+        raise ValueError(
+            f"{path} has {len(blank)} row(s) with a blank identity: "
+            f"{blank[:5]}"
+            + (", ..." if len(blank) > 5 else "")
+            + ". A row with no s3_key silently leaves the expected-key set, "
+            "so an equally absent document still compares equal; a row with "
+            "no ticket is emitted under an empty one and overrides the path "
+            "parse that would have been right."
+        )
+    if not entries and not blank and not duplicated and not mismatched:
+        raise ValueError(
+            f"{path} parsed zero rows. A manifest with no documents verifies "
+            "vacuously against any corpus -- including an empty directory -- "
+            "and load_corpus would then return that emptiness as a verified "
+            "population. Re-pull the manifest from DVC."
+        )
+    if mismatched:
+        raise ValueError(
+            f"{path} has {len(mismatched)} row(s) whose ticket contradicts "
+            f"the s3_key: {mismatched[:5]}"
+            + (", ..." if len(mismatched) > 5 else "")
+            + ". The key encodes the ticket, and load_corpus prefers the "
+            "manifest's ticket over the parse, so such a row files the "
+            "document under the wrong ticket and inherits the wrong category."
+        )
+    if duplicated:
+        raise ValueError(
+            f"{path} lists {len(duplicated)} s3_key(s) more than once: "
+            f"{sorted(set(duplicated))[:5]}"
+            + (", ..." if len(set(duplicated)) > 5 else "")
+            + ". The key comparison in load_corpus still passes on a "
+            "duplicate, so the row that happens to come last would decide "
+            "the ticket, the category and the provenance for that document."
+        )
+    return entries
+
+
+def load_corpus(
+    documents_dir: Path | str,
+    complaints_path: Path | str,
+    *,
+    ticket_column: str = "ticket_no",
+    category_column: str = "category",
+    manifest: Mapping[str, "ManifestEntry"] | None = None,
+    verify: str = "size",
+    expected_documents: int | None = None,
+) -> list[DocumentRecord]:
+    """Join documents on disk to their complaint category.
+
+    Object keys are ``<ticket>_complaint_<timestamp>.<ext>`` and the ticket may
+    itself contain slashes: 1,446 of the corpus's 70,029 documents (2.06%)
+    belong to tickets like ``OR159/P/2021/00535``. The reference bucket stores
+    them under the full key, so a synced copy has those documents in nested
+    directories.
+
+    The walk is therefore recursive and the ticket comes from the path
+    **relative to** ``documents_dir``, which reconstructs the object key
+    exactly. A flat ``iterdir()`` did not mis-parse those documents, it never
+    reached them: they sat one directory down and were silently absent from
+    the corpus, and so from every tier drawn out of it. Taking the basename
+    instead would be the other failure -- ``00535_complaint_...`` parses to
+    ``00535``, which matches no complaint and collapses distinct tickets that
+    share a trailing segment.
+
+    A ticket may carry more than one document; each is its own record, because
+    the pipeline processes documents and the latency measurement is per
+    document.
+
+    Documents whose ticket is absent from the complaints table, or whose
+    complaint has no category, land in :data:`UNCATEGORISED` rather than being
+    dropped.
+
+    ``manifest`` is the pinned reference manifest
+    (``load_reference_manifest``), and passing it is what makes the corpus
+    *verified* rather than *whatever happens to be on disk*. Without it this
+    walks any directory and hands the result to ``draw_nested``, which then
+    produces valid-looking tier manifests for a different population -- the
+    known-short Box copy (69,844 files against 70,029, see
+    ``janasunani.samples``) being the case that already exists. With it, a
+    key on disk that the manifest does not list, or a key the manifest lists
+    that is not on disk, stops the draw.
+
+    Ticket ids come from the manifest where it is given, rather than being
+    re-parsed from the path. They are the same by construction -- the key is
+    ``<ticket>_complaint_<timestamp>.<ext>`` -- but the manifest is the
+    pinned record and the parser is a derivation, so where both exist the
+    record wins.
+
+    Raises:
+        ValueError: a file does not carry the ``_complaint_`` marker and so
+            has no ticket (including it as a document named after itself is
+            how a stray ``manifest.tsv`` becomes a stratum of one), or the
+            staged corpus does not match ``manifest``.
+    """
+    import polars as pl
+
+    documents_dir = Path(documents_dir)
+    frame = pl.read_parquet(complaints_path, columns=[ticket_column, category_column])
+    categories: dict[str, str] = {}
+    for ticket, category in zip(
+        frame[ticket_column].cast(pl.Utf8).to_list(),
+        frame[category_column].to_list(),
+        strict=True,
+    ):
+        if ticket:
+            categories[str(ticket)] = _norm_category(category)
+
+    records: list[DocumentRecord] = []
+    unparsed: list[str] = []
+    for path in sorted(documents_dir.rglob("*")):
+        if not path.is_file():
+            continue
+        relative = path.relative_to(documents_dir)
+        # Hidden anywhere in the path, not just the basename: a synced corpus
+        # carries .dvc/ and .DS_Store, and neither is a document.
+        if any(part.startswith(".") for part in relative.parts):
+            continue
+        key = relative.as_posix()
+        if "_complaint_" not in key:
+            unparsed.append(key)
+            continue
+        parsed = key.split("_complaint_")[0]
+        entry = manifest.get(key) if manifest else None
+        ticket = entry.ticket if entry is not None else parsed
+        records.append(
+            DocumentRecord(
+                ticket=ticket,
+                filename=key,
+                category=categories.get(ticket, UNCATEGORISED),
+                size_bytes=path.stat().st_size,
+            )
+        )
+
+    if manifest is not None:
+        # A manifest and a corpus can agree with each other and still both be
+        # wrong. The set comparison below is symmetric, so a strict subset of
+        # the pinned population -- the same 100 documents listed and staged,
+        # or a header-only manifest beside an empty directory -- passes it
+        # vacuously, and draw_nested then emits well-formed tier manifests for
+        # a fraction of the corpus. Only a count known independently of both
+        # can catch that, so callers drawing the pinned reference corpus pass
+        # `expected_documents` (70,029; see janasunani.samples).
+        if expected_documents is not None and len(manifest) != expected_documents:
+            raise ValueError(
+                f"the pinned manifest lists {len(manifest)} document(s), not "
+                f"the expected {expected_documents}. A manifest and a corpus "
+                "that agree with each other can still both be a subset of the "
+                "population the numbers are supposed to describe, and the "
+                "disk-versus-manifest comparison cannot see that."
+            )
+        if verify not in {"keys", "size", "md5"}:
+            raise ValueError(
+                f"verify must be 'keys', 'size' or 'md5', got {verify!r}"
+            )
+        on_disk = {r.filename for r in records}
+        listed = set(manifest)
+        missing = sorted(listed - on_disk)
+        extra = sorted(on_disk - listed)
+        if missing or extra:
+            raise ValueError(
+                f"the corpus under {documents_dir} does not match the pinned "
+                f"reference manifest: {len(missing)} listed document(s) are "
+                f"absent and {len(extra)} present document(s) are not listed "
+                f"(missing e.g. {missing[:3]}, extra e.g. {extra[:3]}). "
+                "Drawing tiers from it would produce valid-looking manifests "
+                "for a different population -- the Box copy is 185 documents "
+                "short of S3 in exactly this way. Re-sync from "
+                "janasunani-documents-dsi-reference."
+            )
+
+        # Keys matching is not bytes matching. A truncated, stale or replaced
+        # document under the expected key passes the set comparison above,
+        # and draw_nested then emits well-formed tier manifests for altered
+        # bytes -- the same class of silent-wrong-population failure, one
+        # level down.
+        #
+        # Size is the default because it is a stat() per file: free at 70,029
+        # documents, and it catches truncation and replacement, which is what
+        # a partial sync actually produces. md5 is exact and reads all 56 GB,
+        # so it is opt-in for when the corpus is being certified rather than
+        # used. keys is the escape hatch for a manifest without the columns.
+        if verify != "keys":
+            # The requested tier must actually be available. `size_bytes` is
+            # None for a blank or non-numeric column and `md5` is None for a
+            # blank one, and both checks below are written as "compare it if
+            # we have it" -- so a truncated or malformed manifest silently
+            # downgraded verify="size" and verify="md5" to the key comparison
+            # while the caller believed they had asked for bytes. That is the
+            # certify-altered-documents failure this function exists to stop.
+            # `keys` is the explicit escape hatch for a manifest without the
+            # columns; it should not be reachable by accident.
+            column = "size_bytes" if verify == "size" else "md5"
+            unusable = sorted(
+                record.filename
+                for record in records
+                if getattr(manifest[record.filename], column) is None
+            )
+            if unusable:
+                raise ValueError(
+                    f"verify={verify!r} needs a {column} for every document, "
+                    f"and the pinned manifest has none for {len(unusable)} of "
+                    f"them: {unusable[:3]}"
+                    + (", ..." if len(unusable) > 3 else "")
+                    + ". Comparing only the keys that do carry one would "
+                    "certify the rest on their names alone. Re-sync the "
+                    "manifest, or pass verify='keys' to say so deliberately."
+                )
+
+            corrupt: list[str] = []
+            for record in records:
+                entry = manifest[record.filename]
+                if entry.size_bytes is not None and record.size_bytes != entry.size_bytes:
+                    corrupt.append(
+                        f"{record.filename} (size {record.size_bytes} != "
+                        f"{entry.size_bytes})"
+                    )
+                    continue
+                if verify == "md5" and entry.md5:
+                    digest = hashlib.md5()  # noqa: S324 - matching S3 etags, not security
+                    with (documents_dir / record.filename).open("rb") as stream:
+                        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                            digest.update(chunk)
+                    if digest.hexdigest() != entry.md5:
+                        corrupt.append(f"{record.filename} (md5 mismatch)")
+            if corrupt:
+                raise ValueError(
+                    f"{len(corrupt)} document(s) under {documents_dir} do not "
+                    f"match the pinned manifest's recorded bytes: "
+                    f"{corrupt[:3]}"
+                    + (", ..." if len(corrupt) > 3 else "")
+                    + ". The keys are right and the content is not, so a draw "
+                    "from this corpus would carry the manifest's identity and "
+                    "different documents. Re-sync from "
+                    "janasunani-documents-dsi-reference."
+                )
+
+    if unparsed:
+        raise ValueError(
+            f"{len(unparsed)} file(s) under {documents_dir} carry no "
+            f"'_complaint_' marker and so have no ticket: {unparsed[:5]}"
+            + (", ..." if len(unparsed) > 5 else "")
+            + ". Move non-document files out of the corpus directory. Kept as "
+            "documents they would each become their own uncategorised "
+            "stratum and take a floor allocation from a real category."
+        )
+    return records
+
+
+def _draw(
+    pool: Sequence[DocumentRecord],
+    budget: int,
+    floor: int,
+    rng: random.Random,
+) -> list[DocumentRecord]:
+    """Stratified draw of *budget* documents from *pool*.
+
+    Categories are shuffled independently so the choice within a stratum is
+    random, while the allocation across strata stays deterministic given the
+    counts. Sorting the pool first makes the shuffle depend on the seed rather
+    than on filesystem order.
+    """
+    if budget >= len(pool):
+        return sorted(pool, key=lambda r: r.filename)
+
+    by_category: dict[str, list[DocumentRecord]] = {}
+    for record in sorted(pool, key=lambda r: r.filename):
+        by_category.setdefault(record.category, []).append(record)
+
+    counts = {c: len(rs) for c, rs in by_category.items()}
+    quota = allocate(counts, budget=budget, floor=floor)
+
+    chosen: list[DocumentRecord] = []
+    for category in sorted(by_category):
+        candidates = list(by_category[category])
+        rng.shuffle(candidates)
+        chosen.extend(candidates[: quota[category]])
+    return sorted(chosen, key=lambda r: r.filename)
+
+
+def manifest_digest(records: Sequence[DocumentRecord]) -> str:
+    """Stable digest over the drawn set: ticket, filename and size.
+
+    Size is included so that re-hydrating a document as a different file is
+    visible as a different sample rather than silently reusing the id.
+    """
+    payload = "\n".join(f"{r.ticket}\t{r.filename}\t{r.size_bytes}" for r in sorted(records, key=lambda r: r.filename))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def summarise(records: Sequence[DocumentRecord]) -> dict[str, Any]:
+    counts = Counter(r.category for r in records)
+    categorised = [r for r in records if r.is_categorised]
+    return {
+        "documents": len(records),
+        "tickets": len({r.ticket for r in records}),
+        "categorised_documents": len(categorised),
+        "distinct_categories": len({r.category for r in categorised}),
+        "bytes": sum(r.size_bytes for r in records),
+        "per_category": dict(sorted(counts.items())),
+        "digest": manifest_digest(records),
+    }
+
+
+def draw_nested(
+    corpus: Sequence[DocumentRecord],
+    tiers: Mapping[str, int],
+    *,
+    seed: int = DEFAULT_SEED,
+    floor: int = DEFAULT_FLOOR,
+) -> dict[str, list[DocumentRecord]]:
+    """Draw each tier from the tier above it, largest first.
+
+    ``tiers`` maps a name to a document budget, e.g.
+    ``{"quality": 10_000, "latency": 500}``. They are sorted descending and
+    each draw uses the previous tier as its pool, so the result is a strict
+    chain of subsets. Verify it with :func:`assert_nested` rather than trusting
+    it: this is the property that a re-seeded redraw silently breaks.
+
+    For a tier meant to be the whole corpus, pass ``len(corpus)`` --- a budget
+    at or above the pool returns it whole, while a copied constant that has
+    drifted below the true count silently samples instead, and every smaller
+    tier then descends from that shortfall.
+    """
+    ordered = sorted(tiers.items(), key=lambda kv: -kv[1])
+    out: dict[str, list[DocumentRecord]] = {}
+    pool: Sequence[DocumentRecord] = corpus
+    for index, (name, budget) in enumerate(ordered):
+        # A distinct stream per tier, derived from one seed, so adding a tier
+        # does not perturb the tiers above it.
+        rng = random.Random(f"{seed}:{name}:{index}")
+        drawn = _draw(pool, budget=budget, floor=floor, rng=rng)
+        out[name] = drawn
+        pool = drawn
+    return out
+
+
+def assert_nested(tiers: Mapping[str, Sequence[DocumentRecord]]) -> None:
+    """Raise unless every smaller tier is a subset of every larger one."""
+    ordered = sorted(tiers.items(), key=lambda kv: -len(kv[1]))
+    for (outer_name, outer), (inner_name, inner) in zip(ordered, ordered[1:], strict=False):
+        outer_files = {r.filename for r in outer}
+        stray = sorted({r.filename for r in inner} - outer_files)
+        if stray:
+            raise ValueError(
+                f"{inner_name} is not a subset of {outer_name}: "
+                f"{len(stray)} document(s) absent from the larger tier, "
+                f"first {stray[0]!r}"
+            )
+
+
+def write_manifest(
+    records: Sequence[DocumentRecord],
+    path: Path | str,
+    *,
+    name: str,
+    seed: int,
+    floor: int,
+    source: str,
+) -> Path:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    body = {
+        "name": name,
+        "source": source,
+        "seed": seed,
+        "floor_per_category": floor,
+        **summarise(records),
+        "documents_list": [asdict(r) for r in records],
+    }
+    path.write_text(json.dumps(body, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path

--- a/janasunani/evaluation/sarvam_evaluate.py
+++ b/janasunani/evaluation/sarvam_evaluate.py
@@ -26,8 +26,10 @@ from __future__ import annotations
 
 import argparse
 from collections import Counter
+from dataclasses import asdict
 from datetime import UTC, datetime
 import hashlib
+import contextlib
 import json
 import os
 import sys
@@ -337,9 +339,155 @@ def _load_metadata_join(
     return mapping
 
 
+def _checked_record_destination(path: Path) -> Path:
+    """Resolve ``--save-records`` and refuse anywhere outside ``data/``.
+
+    The dump is **unredacted**: every record carries the citizen's own words
+    plus whatever the provider returned. ``data/`` is the one tree the data
+    policy governs and the one git ignores wholesale, so a dump landing
+    anywhere else is a file nobody is watching. ``docs/records.jsonl`` or a
+    bare ``records.jsonl`` at the repo root would previously have been created
+    without complaint and would then sit in `git status` waiting to be added.
+
+    Resolved before comparison so ``data/../docs/x.jsonl`` and a symlink into
+    the tree are both rejected rather than passing a prefix check.
+    """
+    from janasunani.config import DATA_DIR
+
+    resolved = Path(path).expanduser().resolve()
+    root = DATA_DIR.resolve()
+    if not resolved.is_relative_to(root):
+        raise ValueError(
+            f"--save-records must write inside {root} (the governed data tree), "
+            f"not {resolved}. The dump is unredacted citizen text: it may not be "
+            "written where it could be committed or shared by accident."
+        )
+    return resolved
+
+
+def _probe_record_destination(destination: Path) -> None:
+    """Fail now if the dump could not be written, without destroying anything.
+
+    Writability is a property of the directory plus, where the target already
+    exists, of that file. Neither can be established from the path alone --
+    ``_checked_record_destination`` proves only that the location is
+    permitted -- and finding out at the write costs a whole paid run.
+
+    Never truncates. An existing dump from a previous run is evidence; the
+    probe checks it and leaves the bytes alone. Either way it creates and
+    removes a uniquely named sibling, which tests the directory the real write
+    will use without inventing a partial file at the destination.
+
+    The sibling probe runs *whether or not the destination exists*, and that
+    is not redundant. ``_write_record_dump`` no longer opens the destination:
+    it writes a temporary sibling and ``os.replace``s it into position, so the
+    write needs the parent directory to be writable even when the target file
+    already is. Returning early on an existing dump therefore passed a
+    writable file sitting in a read-only directory, every paid page ran, and
+    the write then failed creating its sibling -- the exact outcome this probe
+    exists to prevent, reintroduced by the change that made the write atomic.
+
+    The ``W_OK`` check on an existing file is kept as well, though a POSIX
+    rename does not strictly need it: it costs nothing, and a destination the
+    operator cannot write is worth refusing before a paid run rather than
+    relying on rename semantics holding everywhere.
+    """
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if destination.exists():
+        if not destination.is_file():
+            raise OSError(f"{destination} exists and is not a regular file")
+        if not os.access(destination, os.W_OK):
+            raise OSError(f"{destination} exists and is not writable")
+    probe = destination.parent / f".{destination.name}.probe-{os.getpid()}"
+    try:
+        fd = os.open(probe, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        os.close(fd)
+    finally:
+        try:
+            probe.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _write_record_dump(destination: Path, records: Any) -> Path:
+    """Write the unredacted per-page dump, 0600 from the moment it exists.
+
+    The mode has to be applied at creation, not after the write. Under the
+    usual ``022`` umask ``Path.open("w")`` creates the file ``0644``, so the
+    citizen text was world-readable on the host for the entire write and was
+    narrowed only once the last record had landed -- a window that grows with
+    the run. An interrupt before the ``chmod`` left it ``0644`` permanently.
+
+    ``os.open`` applies the mode as the file is created. ``fchmod`` covers the
+    other half: if the path already exists, ``O_CREAT``'s mode argument is
+    ignored, so a dump overwriting a previously world-readable file would
+    otherwise keep those permissions.
+
+    The write goes to a temporary sibling and is renamed into place only once
+    every record has landed. Writing ``O_TRUNC`` straight onto the destination
+    destroyed the previous dump the instant the new one opened, so a
+    serialisation error or an interrupt mid-run left a truncated file where
+    complete evidence had been -- and this is unredacted per-page output that
+    a paid run produced, not something a retry reconstructs for free. The
+    startup probe is deliberately non-destructive for the same reason; this
+    closes the other half of it.
+
+    The sibling shares the destination's directory so the rename is on one
+    filesystem and therefore atomic, and it is created 0600 like the final
+    file: it holds the same citizen text.
+    """
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    # `mkstemp` opens with O_CREAT|O_EXCL at 0600, so it cannot follow or
+    # reuse anything already at the path. The first version of this used a
+    # predictable `.<name>.<pid>.partial` with O_TRUNC: a local process able
+    # to pre-create that path as a symlink would have had this write follow
+    # it, putting unredacted citizen text outside the tree
+    # `_checked_record_destination` validated, and then `os.replace` would
+    # have installed the symlink itself as the dump. Unguessable and
+    # exclusive closes both halves.
+    fd, tmp_name = tempfile.mkstemp(
+        dir=destination.parent, prefix=f".{destination.name}.", suffix=".partial"
+    )
+    tmp = Path(tmp_name)
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            for record in records:
+                handle.write(json.dumps(asdict(record), default=str) + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, destination)
+    except BaseException:
+        # Including KeyboardInterrupt: a Ctrl-C is the interrupt this exists
+        # to survive, and leaving the partial behind would strand unredacted
+        # text at a path nothing later cleans up. Only ever this invocation's
+        # own file, which mkstemp guarantees we created.
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise
+    return destination
+
+
 def _unwrap_extract_result(payload: Any) -> dict[str, Any]:
-    """Unwrap the various shapes ``adapter.extract`` may return."""
+    """Unwrap the various shapes ``adapter.extract`` may return.
+
+    ``result`` (singular) is the shape the live API actually returns and is
+    checked first. GET /doc-ai/v1/job/{job_id}/results answers with the
+    envelope ``{job_id, type, status, usage, result, annotations, version}``
+    and the schema's fields live under ``result``.
+
+    Omitting it was silent rather than loud: the final ``return payload``
+    fallback handed back the envelope, and the caller's
+    ``payload.get("grievance_category")`` then read one level too high and
+    got ``None``. The 2026-08-25 Sambalpur/2024 run billed 200 Extract pages
+    and recorded ``sarvam_category`` as null on all 198 scored pages for
+    exactly this reason, which scored as 0.000 accuracy rather than as a
+    missing measurement. A shape this function does not recognise must not
+    look like a confident empty answer.
+    """
     if isinstance(payload, dict):
+        if isinstance(payload.get("result"), dict):
+            return payload["result"]
         if "results" in payload and isinstance(payload["results"], list) and payload["results"]:
             first = payload["results"][0]
             if isinstance(first, dict):
@@ -385,6 +533,18 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--audit-db", type=Path, default=None, help="Sarvam egress audit log (default: <out>/sarvam_audit.sqlite).")
     parser.add_argument("--dry-run", action="store_true", help="Render and run pytesseract only. No Sarvam call, no spend.")
     parser.add_argument("--dump-text", action="store_true", help="Print both transcripts. Debugging only; refuses more than one page.")
+    parser.add_argument(
+        "--save-records",
+        type=Path,
+        default=None,
+        help=(
+            "Persist one JSON line per scored page (ticket, page id, pytesseract "
+            "text, Sarvam markdown/category/summary, pipeline category/summary, "
+            "gold category, handwritten, language) to this path. Unredacted and "
+            "carries real ticket ids and grievance text — write it under a "
+            "controlled data/ location only, never under outputs/ or git."
+        ),
+    )
     return parser
 
 
@@ -398,6 +558,32 @@ def main(argv: list[str] | None = None) -> int:
     if not input_dir.is_dir():
         logger.error(f"input dir not found: {input_dir}")
         return 1
+
+    # Resolved here rather than at the write, which is after every page has
+    # been rendered, sent to a paid provider and scored. A bad path is knowable
+    # at startup, and finding out at the end costs the whole run — the command
+    # then returned 1 before writing the aggregate outputs too, so the money
+    # bought nothing. Held for the actual write below.
+    record_destination: Path | None = None
+    if args.save_records:
+        try:
+            record_destination = _checked_record_destination(args.save_records)
+            # Prove it can actually be written, not merely that it sits in a
+            # permitted directory. A parent that is an existing file, a
+            # read-only directory or a bad permission all pass the location
+            # check and then raise inside _write_record_dump -- after every
+            # page has been rendered, submitted to a paid provider and
+            # scored.
+            #
+            # Non-destructively. The first version of this probe called
+            # _write_record_dump directly, which opens O_TRUNC: pointing
+            # --save-records at a previous run's dump erased it before any
+            # other check ran, and an early return then left neither the old
+            # evidence nor a replacement.
+            _probe_record_destination(record_destination)
+        except (ValueError, OSError) as exc:
+            logger.error(f"--save-records destination is unusable: {exc}")
+            return 1
 
     try:
         schema = get_schema(args.schema_version)
@@ -679,6 +865,17 @@ def main(argv: list[str] | None = None) -> int:
     # Pass arm + slice so scorecard correctly hides non-measured arms (digitise vs extract)
     # and renders the selected slice (not demo constant).
     report = build_scorecard(records, slice_label=args.slice, arm=args.arm)
+
+    # Optional per-page record dump. The aggregate path deliberately keeps no
+    # provider payloads (`contains_text_or_provider_payloads: False` in the
+    # checkpoint), so without this the transcripts, categories and summaries are
+    # computed, scored and discarded. Reference examples need them kept, and the
+    # help text is explicit that the file is unredacted.
+    if record_destination is not None:
+        _write_record_dump(record_destination, records)
+        logger.success(
+            f"records -> {record_destination} ({len(records)} pages, unredacted)"
+        )
 
     # Write markdown + base scorecard first, then overwrite JSON with enriched payload
     try:

--- a/scripts/benchmark_pipeline.py
+++ b/scripts/benchmark_pipeline.py
@@ -42,8 +42,13 @@ import time
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from pathlib import Path
-from typing import Any, Callable
+from pathlib import Path, PurePosixPath
+from typing import Any, Callable, Iterable, Mapping
+
+from loguru import logger
+
+from janasunani.evaluation.sarvam_sample_builder import IMAGE_SUFFIXES
+from janasunani.pipeline.ticket import ticket_from_relpath
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -80,6 +85,12 @@ DEFAULT_REPEATS = 3
 # Output location (relative to repo root)
 DEFAULT_OUTPUT = Path("outputs/benchmark/latency.json")
 LATENCY_SCHEMA_VERSION = "janasunani.pipeline-latency/v1"
+
+# What the run measured. The publication gate requires one of these to be
+# stated: a context that declares nothing cannot be shown to be synthetic,
+# and a real measurement must not inherit that benefit of the doubt.
+SYNTHETIC_PROVENANCE = "synthetic"
+STAGED_PROVENANCE = "staged-documents"
 
 # Fake per-stage mean seconds (CPU laptop, no GPU). These are not
 # performance claims — they are deterministic stand-ins so the harness
@@ -204,30 +215,44 @@ def compute_stage_stats(
     }
 
 
-def _input_kind(ticket: str) -> str:
-    if ticket.startswith("SYN-TXT-"):
-        return "text"
-    if ticket.startswith("SYN-IMG-"):
+def _document_kind(doc: Mapping[str, Any]) -> str:
+    """What kind of input a document dict represents.
+
+    Read off the doc's own fields, not its ticket string. This used to be
+    ``_input_kind(ticket)``, matching on a ``"SYN-TXT-"``/``"SYN-IMG-"``
+    prefix — a fixture-generator convention, not a property of the input.
+    Every real ticket (``CMO20241020862``, ...) fell through to
+    "unspecified", which made ``has_clean_full_path_coverage`` below
+    structurally unsatisfiable for a real-document run: it requires the
+    "document" path to have measurements, and none were ever attributed to
+    it. The loader already knows what it built: bytes present means a
+    scanned document, text present (and no bytes) means free text.
+    """
+    if doc.get("document_bytes") is not None:
         return "document"
+    if doc.get("text") is not None:
+        return "text"
     return "unspecified"
 
 
 def _stats_by_input(
     times_by_stage: dict[str, list[float]],
     tickets_by_stage: dict[str, list[str]],
+    kinds_by_stage: dict[str, list[str]],
 ) -> dict[str, dict[str, dict[str, Any]]]:
     result: dict[str, dict[str, dict[str, Any]]] = {}
     kinds = sorted(
-        {_input_kind(ticket) for tickets in tickets_by_stage.values() for ticket in tickets}
+        {kind for stage_kinds in kinds_by_stage.values() for kind in stage_kinds}
     )
     for kind in kinds:
         result[kind] = {}
         for stage, times in times_by_stage.items():
             tickets = tickets_by_stage.get(stage, [])
+            stage_kinds = kinds_by_stage.get(stage, [])
             selected = [
                 (seconds, ticket)
-                for seconds, ticket in zip(times, tickets)
-                if _input_kind(ticket) == kind
+                for seconds, ticket, doc_kind in zip(times, tickets, stage_kinds)
+                if doc_kind == kind
             ]
             result[kind][stage] = compute_stage_stats(
                 [seconds for seconds, _ in selected],
@@ -303,6 +328,355 @@ def synthesize_documents(
         )
     # Deterministic shuffle so order is not fixture-grouped
     rng.shuffle(docs)
+    return docs
+
+
+# ---------------------------------------------------------------------------
+# Real-document fixtures — a staged sample, not synthetic text
+# ---------------------------------------------------------------------------
+
+# Documents this loader accepts: PDFs plus the image types
+# ``sarvam_sample_builder`` also treats as one-page documents. A staging
+# directory is expected to hold only these plus, optionally,
+# ``sample_manifest.json``.
+SUPPORTED_DOCUMENT_SUFFIXES: frozenset[str] = frozenset({".pdf"}) | IMAGE_SUFFIXES
+
+
+def _staged_document_paths(directory: Path) -> list[Path]:
+    """Supported document files directly under ``directory``, sorted.
+
+    Sorted so the file list — and therefore the fallback digest in
+    ``_document_sample_digest`` — does not depend on filesystem iteration
+    order.
+    """
+    return sorted(
+        path
+        for path in directory.iterdir()
+        if path.is_file() and path.suffix.lower() in SUPPORTED_DOCUMENT_SUFFIXES
+    )
+
+
+def staged_sample_coverage(
+    manifest: Mapping[str, Any] | None, staged_names: Iterable[str]
+) -> tuple[list[str], list[str]]:
+    """Compare what the manifest says was drawn with what is on disk.
+
+    Returns ``(missing, unlisted)``: manifest documents that were not staged,
+    and staged documents the manifest does not account for. Both are sorted.
+
+    The two halves are not symmetric, and the callers treat them differently.
+    A *missing* document means the sample measured is a strict subset of the
+    sample drawn while still being labelled with the manifest's slice, seed
+    and digest — the artifact would name a draw it did not run on, which is
+    the defect this whole input path exists to close. An *unlisted* document
+    means the reverse, and cannot be an error here: a manifest is allowed to
+    cover only some of the staged files (the ticket for the rest falls back
+    to filename parsing, deliberately, see ``load_staged_documents``). It
+    still means the measured set is not the drawn set, so it blocks
+    publication rather than the run.
+
+    Raises ``ValueError`` if a filename is listed more than once. That is a
+    broken manifest rather than a coverage question, and collapsing it into
+    the set made it invisible in the worst way -- see the check below.
+
+    Manifest entries without a ``file`` key are simply not counted as
+    coverage. The explicit-manifest call path allows ``{"ticket": ...}``
+    alone, so such a manifest still *loads* — it just cannot claim the staged
+    files are the drawn ones, because it ties no identity to any of them. A
+    row carrying *neither* identity is not that exception, it is a junk row,
+    and it raises: counting it as nothing left coverage perfect. An
+    earlier version absorbed one unlisted file per unkeyed entry, on the
+    reasoning that the count was the most that could be claimed. That was
+    wrong: a count is not an identity, and it let a one-file staging beside
+    ``{"documents": [{"ticket": "CMO1"}]}`` report perfect coverage while
+    nothing connected the two.
+    """
+    entries = (manifest or {}).get("documents")
+    if not isinstance(entries, list):
+        return [], []
+
+    listed: set[str] = set()
+    duplicated: list[str] = []
+    malformed: list[str] = []
+    for position, entry in enumerate(entries):
+        # A non-mapping row is not a manifest entry at all. Skipping it let a
+        # manifest with valid rows for every staged file plus one junk row
+        # report a perfect match and publish.
+        if not isinstance(entry, Mapping):
+            malformed.append(f"entry {position}: not an object ({type(entry).__name__})")
+            continue
+        file_name = entry.get("file")
+        ticket = entry.get("ticket")
+        has_file = isinstance(file_name, str) and file_name.strip()
+        has_ticket = isinstance(ticket, str) and ticket.strip()
+        # A row naming a file but no ticket is the dangerous half of the
+        # asymmetry: it counts as coverage while `load_staged_documents`
+        # silently falls back to basename parsing, which is lossy for the
+        # hierarchical tickets (~2% of complaints) it exists to protect.
+        if has_file and not has_ticket:
+            malformed.append(f"entry {position}: {file_name!r} has no ticket")
+            continue
+        # Neither identity is the same junk row as a non-mapping, one level
+        # in: `{}` is a Mapping, so it passed every check above, counted as
+        # nothing, and left coverage perfect. A manifest with valid rows for
+        # every staged file plus one empty object still reported a complete
+        # sample and published.
+        if not has_file and not has_ticket:
+            malformed.append(f"entry {position}: names neither a file nor a ticket")
+            continue
+        # The other half is fine and is relied on: a row with a ticket and no
+        # file cannot be matched by name, so it simply does not count as
+        # coverage and the run is not publishable. That is the explicit-
+        # manifest call path, and it is tested.
+        if has_file:
+            if file_name in listed:
+                duplicated.append(file_name)
+            listed.add(file_name)
+
+    if malformed:
+        raise ValueError(
+            f"sample manifest has {len(malformed)} malformed entr(ies): "
+            f"{malformed[:5]}"
+            + (", ..." if len(malformed) > 5 else "")
+            + ". A row that cannot be read is not coverage, and skipping it "
+            "let a manifest with one junk row still report a perfect match."
+        )
+
+    # A repeated `file` is a broken manifest, not a coverage question, so it
+    # raises rather than being folded into `missing`/`unlisted`. Collapsed
+    # into the set it was invisible: a manifest claiming `one.pdf` for both
+    # T1 and T2 against a one-file staging reported nothing missing and
+    # nothing unlisted -- a perfect match -- while `file_to_ticket` kept only
+    # the last entry and the run measured one document under a manifest
+    # claiming two.
+    if duplicated:
+        raise ValueError(
+            f"sample manifest lists {len(duplicated)} filename(s) more than "
+            f"once: {sorted(set(duplicated))[:5]}"
+            + (", ..." if len(set(duplicated)) > 5 else "")
+            + ". Each staged file must appear once, or the ticket it is "
+            "attributed to depends on entry order and the document count "
+            "the manifest claims is not the count that runs."
+        )
+
+    staged = set(staged_names)
+    return sorted(listed - staged), sorted(staged - listed)
+
+
+def _document_sample_digest(
+    directory: Path, manifest: Mapping[str, Any] | None
+) -> str:
+    """Stable digest identifying the on-disk sample, for provenance.
+
+    Two components go in, for two different jobs. The manifest (when
+    present) gives *identity* — the draw/seed/slice — and is stable across
+    a re-stage to a different path. Every staged file's actual bytes give
+    *integrity*. Hashing only the manifest (the original version of this
+    function) made a content change on disk invisible: a bad re-download, a
+    swapped page, or a stale manifest sitting beside different bytes than
+    it describes all left the digest — and the manifest-count cross-check
+    in ``load_staged_documents`` — unchanged as long as filenames and
+    counts still lined up, even though the processor would read something
+    the manifest never claimed. Hashing filename + content per file (not
+    the full path) keeps the re-stage stability the manifest-only version
+    had, while an equal-count substitution now moves the digest.
+    """
+    hasher = hashlib.sha256()
+    if manifest is not None:
+        hasher.update(json.dumps(manifest, sort_keys=True).encode("utf-8"))
+    for path in _staged_document_paths(directory):
+        hasher.update(path.name.encode("utf-8"))
+        hasher.update(hashlib.sha256(path.read_bytes()).digest())
+    return hasher.hexdigest()
+
+
+def load_staged_documents(
+    directory: Path | str,
+    manifest: Mapping[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Load a real staged document sample for benchmarking.
+
+    Returns the same dict shape as ``synthesize_documents``: ticket, text
+    (always None here — these are scanned documents, not free text),
+    document_name, document_bytes, district. Reading real bytes means the
+    OCR stage actually runs against real scans, unlike the text-only half
+    of the synthetic fixture.
+
+    ``directory`` is a flat staging directory of supported document files
+    (see ``SUPPORTED_DOCUMENT_SUFFIXES``) named
+    ``"<ticket>_complaint_<timestamp>.<ext>"`` — the layout
+    ``janasunani.evaluation.sarvam_sample_builder.build_sample`` writes.
+
+    Ticket ids come from the manifest's ``documents`` array (each entry has
+    ``ticket``/``s3_key``/``file``) when one is available, matched by
+    filename; only a file the manifest does not cover falls back to
+    ``janasunani.pipeline.ticket.ticket_from_relpath`` on the bare filename
+    (the same parser the pipeline itself uses, so a fallback ticket here
+    still clusters with the same key it would downstream). The fallback is
+    lossy for hierarchical tickets: ~2% of complaints have a ticket like
+    ``OR159/P/2021/00535``, but ``sarvam_sample_builder`` stages files under
+    ``Path(key).name`` — the directory part of the ticket is discarded
+    before the file ever reaches disk, so without a manifest entry the
+    parser can only recover the trailing segment (``00535``). Two distinct
+    complaints that happen to share that trailing segment then collapse
+    into one ticket, and therefore one cluster, corrupting the
+    ticket-clustered SEs this harness exists to report. Stage with the
+    manifest to avoid this; the fallback is a best-effort floor, not a fix.
+
+    If ``manifest`` is not given and ``directory/sample_manifest.json``
+    exists, it is loaded and used for: per-file ticket ids (above), the
+    sample's district (from its ``"slice"`` field, formatted
+    ``"<district>/<year>"``), and a completeness check against what is
+    actually staged. A missing manifest is not an error — the loader still
+    works from the directory's filenames alone, just without a district, the
+    completeness check, or protection against the hierarchical-ticket
+    collision above (and ``main`` will refuse to mark such a run
+    publication-ready).
+
+    Raises:
+        FileNotFoundError: ``directory`` does not exist or is not a
+            directory.
+        ValueError: the directory has no supported documents, a filename
+            cannot be parsed into a ticket, or the manifest lists a document
+            that is not staged. An empty document list must never reach
+            ``run_benchmark`` silently — its own "no documents" error talks
+            about ``n_text + n_image``, which would misdescribe a directory
+            problem as a document-count-flag problem. A partially staged
+            sample must not run at all: it would measure a subset of the
+            draw under the full draw's label.
+    """
+    directory = Path(directory)
+    if not directory.is_dir():
+        raise FileNotFoundError(
+            f"--documents-dir {directory} does not exist or is not a directory"
+        )
+
+    if manifest is None:
+        manifest_path = directory / "sample_manifest.json"
+        if manifest_path.is_file():
+            manifest = json.loads(manifest_path.read_text())
+
+    files = _staged_document_paths(directory)
+    if not files:
+        raise ValueError(
+            f"no supported documents ({sorted(SUPPORTED_DOCUMENT_SUFFIXES)}) "
+            f"found in {directory}; refusing to silently benchmark an empty "
+            "sample. Point --documents-dir at a staged sample, e.g. one "
+            "written by janasunani-build-sarvam-sample."
+        )
+
+    district: str | None = None
+    if manifest:
+        slice_label = manifest.get("slice")
+        if slice_label:
+            district = str(slice_label).split("/", 1)[0]
+    if not district:
+        district = "unspecified"
+
+    # The manifest's own ticket, keyed by staged filename, is authoritative
+    # where it exists: it is the ticket that was actually drawn, before
+    # sarvam_sample_builder's Path(key).name staging step discarded any
+    # directory prefix. Only a file missing from the manifest (or no
+    # manifest at all) falls back to parsing the filename itself.
+    file_to_ticket: dict[str, str] = {}
+    contradicted: list[str] = []
+    if manifest is not None:
+        manifest_documents = manifest.get("documents")
+        if isinstance(manifest_documents, list):
+            for entry in manifest_documents:
+                if not isinstance(entry, Mapping):
+                    continue
+                file_name = entry.get("file")
+                manifest_ticket = entry.get("ticket")
+                if not (file_name and manifest_ticket):
+                    continue
+                # Where the row carries the source key, it decides both other
+                # fields: the builder writes `file` as Path(key).name and the
+                # key is `<ticket>_complaint_<timestamp>.<ext>`. Taking the
+                # row's ticket as authoritative without checking it let a row
+                # pair a staged file with the wrong complaint -- coverage
+                # still reported a complete match, so the run clustered under
+                # that complaint and could still be published.
+                source_key = entry.get("s3_key")
+                if isinstance(source_key, str) and source_key.strip():
+                    key = source_key.strip()
+                    # A key with no `_complaint_` marker names no ticket, and
+                    # skipping the comparison there was the wrong reading of
+                    # "validate where we can": the manifest mapping bypasses
+                    # filename parsing entirely, so `{file: "one.pdf", ticket:
+                    # "WRONG", s3_key: "one.pdf"}` loaded under WRONG, reported
+                    # complete coverage and stayed publishable. A supplied key
+                    # must be a key.
+                    if "_complaint_" not in key:
+                        contradicted.append(
+                            f"{file_name!r}: s3_key {key!r} carries no "
+                            "'_complaint_' marker, so it names no ticket"
+                        )
+                        continue
+                    key_ticket = key.split("_complaint_")[0]
+                    if key_ticket != manifest_ticket:
+                        contradicted.append(
+                            f"{file_name!r}: s3_key names ticket {key_ticket!r}, "
+                            f"row says {manifest_ticket!r}"
+                        )
+                        continue
+                    if PurePosixPath(key).name != file_name:
+                        contradicted.append(
+                            f"{file_name!r}: s3_key basename is "
+                            f"{PurePosixPath(key).name!r}"
+                        )
+                        continue
+                file_to_ticket[file_name] = manifest_ticket
+
+    if contradicted:
+        raise ValueError(
+            f"sample manifest has {len(contradicted)} row(s) whose s3_key "
+            f"contradicts the row: {contradicted[:5]}"
+            + (", ..." if len(contradicted) > 5 else "")
+            + ". The key carries both the ticket and the staged filename, so "
+            "a row that disagrees with it would cluster the run under the "
+            "wrong complaint while coverage still reported a complete match."
+        )
+
+    docs: list[dict[str, Any]] = []
+    unparsed: list[str] = []
+    for path in files:
+        ticket = file_to_ticket.get(path.name) or ticket_from_relpath(path.name)
+        if ticket is None:
+            unparsed.append(path.name)
+            continue
+        docs.append(
+            {
+                "ticket": ticket,
+                "text": None,
+                "document_name": path.name,
+                "document_bytes": path.read_bytes(),
+                "district": district,
+            }
+        )
+    if unparsed:
+        raise ValueError(
+            f"{len(unparsed)} file(s) in {directory} do not match the staged "
+            "naming convention '<ticket>_complaint_<timestamp>.<ext>' and "
+            f"cannot be assigned a ticket: {unparsed[:5]}"
+            + (", ..." if len(unparsed) > 5 else "")
+        )
+
+    missing, _unlisted = staged_sample_coverage(
+        manifest, (doc["document_name"] for doc in docs)
+    )
+    if missing:
+        raise ValueError(
+            f"{len(missing)} document(s) listed in the sample manifest at "
+            f"{directory} are not staged there: {missing[:5]}"
+            + (", ..." if len(missing) > 5 else "")
+            + ". Benchmarking the remainder would measure a strict subset of "
+            "the drawn sample while labelling the artifact with the "
+            "manifest's slice, seed and digest. Re-stage the sample (a "
+            "failed Glacier restore is the usual cause) or point "
+            "--documents-dir at a directory whose manifest matches it."
+        )
+
     return docs
 
 
@@ -457,6 +831,7 @@ def _measure_with_processor(
     """
     per_stage_times: dict[str, list[float]] = {k: [] for k in ALL_KEYS}
     per_stage_tickets: dict[str, list[str]] = {k: [] for k in ALL_KEYS}
+    per_stage_kinds: dict[str, list[str]] = {k: [] for k in ALL_KEYS}
     temperature_times: dict[str, list[float]] = {"cold": [], "warm": []}
     temperature_tickets: dict[str, list[str]] = {"cold": [], "warm": []}
     has_completed_request = False
@@ -471,6 +846,7 @@ def _measure_with_processor(
 
     for doc in docs:
         ticket = doc["ticket"]
+        kind = _document_kind(doc)
         for r in range(repeats):
             attempts += 1
             is_warm = discard_warm and r == 0
@@ -525,9 +901,11 @@ def _measure_with_processor(
                 for stage_name, seconds in captured.items():
                     per_stage_times.setdefault(stage_name, []).append(seconds)
                     per_stage_tickets.setdefault(stage_name, []).append(ticket)
+                    per_stage_kinds.setdefault(stage_name, []).append(kind)
                 if E2E_KEY not in captured:
                     per_stage_times[E2E_KEY].append(elapsed)
                     per_stage_tickets[E2E_KEY].append(ticket)
+                    per_stage_kinds[E2E_KEY].append(kind)
             else:
                 # Fake timing path — deterministic, fast, no sleep unless
                 # BENCHMARK_FAKE_SLEEP is set (for manual wall-clock checks).
@@ -544,14 +922,17 @@ def _measure_with_processor(
                     continue
                 per_stage_times[E2E_KEY].append(timings.e2e)
                 per_stage_tickets[E2E_KEY].append(ticket)
+                per_stage_kinds[E2E_KEY].append(kind)
                 for stage in STAGES:
                     per_stage_times[stage].append(timings.per_stage[stage])
                     per_stage_tickets[stage].append(ticket)
+                    per_stage_kinds[stage].append(kind)
 
     # Return merged structure for compute_stage_stats
     return {
         "times": per_stage_times,  # type: ignore[return-value]
         "tickets": per_stage_tickets,  # type: ignore[return-value]
+        "kinds": per_stage_kinds,  # type: ignore[return-value]
         "attempts": attempts,
         "completed_attempts": completed_attempts,
         "failed_attempts": attempts - completed_attempts,
@@ -619,6 +1000,7 @@ def run_benchmark(
     )
     per_stage_times: dict[str, list[float]] = raw["times"]  # type: ignore[assignment]
     per_stage_tickets: dict[str, list[str]] = raw["tickets"]  # type: ignore[assignment]
+    per_stage_kinds: dict[str, list[str]] = raw["kinds"]  # type: ignore[assignment]
 
     stages_stats: dict[str, dict[str, Any]] = {}
     for key in per_stage_times:
@@ -647,7 +1029,7 @@ def run_benchmark(
         "timestamp": timestamp,
         "git_sha": git_sha,
         "stages": stages_stats,
-        "input_paths": _stats_by_input(per_stage_times, per_stage_tickets),
+        "input_paths": _stats_by_input(per_stage_times, per_stage_tickets, per_stage_kinds),
         "temperature_e2e": {
             temperature: compute_stage_stats(
                 raw["temperature_times"][temperature],
@@ -702,6 +1084,40 @@ def latency_json_payload(
     def nonblank(value: object) -> bool:
         return isinstance(value, str) and bool(value.strip())
 
+    def has_sample_verdict(context: dict[str, Any]) -> bool:
+        """The artifact must say what it ran on, and absence is not an answer.
+
+        Keying off the presence of `sample_slice` was the earlier mistake: a
+        real-document run assembled through the public
+        `load_staged_documents` -> `run_benchmark` -> `write_latency_json`
+        path can carry only the host and model labels, and treating that
+        silence as "synthetic, therefore fine" published a real measurement
+        with no manifest and no slice.
+
+        So the context declares which it is. Synthetic needs nothing further.
+        A staged-document run must both name its draw -- "unspecified" is the
+        fallback when neither --slice nor the manifest supplies one, and it
+        names nothing -- and carry a manifest that accounted for every staged
+        file. Anything else, including a context that declares nothing, is
+        not publishable.
+        """
+        provenance = context.get("sample_provenance")
+        if provenance == SYNTHETIC_PROVENANCE:
+            return True
+        if provenance != STAGED_PROVENANCE:
+            return False
+        # The slice names the district and year, not the draw. Two different
+        # staged sets from Sambalpur/2024 are indistinguishable by slice alone,
+        # which is what `_document_sample_digest` exists to settle: it binds
+        # the manifest to the bytes actually measured. A staged verdict without
+        # it identifies a population but not the sample.
+        return (
+            context.get("sample_manifest_complete") is True
+            and nonblank(context.get("sample_slice"))
+            and context["sample_slice"] != "unspecified"
+            and nonblank(context.get("sample_digest"))
+        )
+
     def has_cold_and_warm(result: dict[str, Any]) -> bool:
         temperatures = result.get("temperature_e2e")
         return isinstance(temperatures, dict) and all(
@@ -711,14 +1127,34 @@ def latency_json_payload(
         )
 
     def has_clean_full_path_coverage(result: dict[str, Any]) -> bool:
+        # This used to hardcode requiring BOTH "text" and "document" paths
+        # to have clean e2e coverage, which matched the synthetic default
+        # (always mixes text grievances and image documents) but made a
+        # --documents-dir run structurally unpublishable: real staged
+        # scans are all "document" kind, so there is legitimately no
+        # "text" path, and the gate could never pass regardless of how
+        # clean the run was. The gate should require clean coverage for
+        # whatever input kinds this run actually exercised — every one of
+        # them, not a fixed pair. A mixed run (synthetic default) still has
+        # to show clean "text" and "document" coverage; a document-only run
+        # only has to show it for "document".
+        #
+        # "unspecified" never counts as coverage, whether or not other
+        # kinds are also present: it means at least one measurement's input
+        # kind (see _document_kind) could not be determined, which is
+        # exactly the provenance gap this gate exists to catch.
         if result.get("failed_attempts") != 0:
             return False
         input_paths = result.get("input_paths")
-        return isinstance(input_paths, dict) and all(
-            isinstance(input_paths.get(path_name), dict)
-            and isinstance(input_paths[path_name].get("e2e"), dict)
-            and input_paths[path_name]["e2e"].get("n", 0) > 0
-            for path_name in ("text", "document")
+        if not isinstance(input_paths, dict) or not input_paths:
+            return False
+        if "unspecified" in input_paths:
+            return False
+        return all(
+            isinstance(stats, dict)
+            and isinstance(stats.get("e2e"), dict)
+            and stats["e2e"].get("n", 0) > 0
+            for stats in input_paths.values()
         )
 
     publication_ready = bool(variants_payload) and all(
@@ -731,6 +1167,13 @@ def latency_json_payload(
         and isinstance(result.get("benchmark_context"), dict)
         and nonblank(result["benchmark_context"].get("host_label"))
         and nonblank(result["benchmark_context"].get("model_release_id"))
+        # Absent on the synthetic path, which has no sample to be
+        # incomplete; only an explicit False blocks. False means the
+        # measured document set is not the drawn document set — no
+        # manifest at all, or staged files the manifest does not account
+        # for — so the recorded slice and digest would name a draw that is
+        # not what ran.
+        and has_sample_verdict(result["benchmark_context"])
         and nonblank(result.get("git_sha"))
         for result in variants_payload.values()
     )
@@ -802,14 +1245,45 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--n-docs",
         type=int,
-        default=DEFAULT_N_TEXT,
-        help="Number of synthetic text grievances (default: 20).",
+        default=None,
+        help=(
+            "Number of synthetic text grievances (default: 20 when "
+            "--documents-dir is not given). Mutually exclusive with "
+            "--documents-dir, which determines its own document count."
+        ),
     )
     parser.add_argument(
         "--n-image-docs",
         type=int,
-        default=DEFAULT_N_IMAGE,
-        help="Number of synthetic image documents (default: 10).",
+        default=None,
+        help=(
+            "Number of synthetic image documents (default: 10 when "
+            "--documents-dir is not given). Mutually exclusive with "
+            "--documents-dir, which determines its own document count."
+        ),
+    )
+    parser.add_argument(
+        "--documents-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Directory of a real staged document sample to benchmark "
+            "instead of the synthetic fixture (see load_staged_documents). "
+            "Mutually exclusive with --n-docs/--n-image-docs. If the "
+            "directory has a sample_manifest.json (written by "
+            "janasunani-build-sarvam-sample), it supplies district/slice "
+            "and a document-count cross-check."
+        ),
+    )
+    parser.add_argument(
+        "--slice",
+        default=None,
+        help=(
+            "Label for the staged sample's slice (e.g. 'Sambalpur/2024'), "
+            "recorded in benchmark_context. Only used with --documents-dir; "
+            "defaults to the sample_manifest.json 'slice' field, or "
+            "'unspecified' if there is no manifest."
+        ),
     )
     parser.add_argument(
         "--repeats",
@@ -866,10 +1340,131 @@ def main(argv: list[str] | None = None) -> int:
     # Validate repeats
     if args.repeats < 1:
         parser.error("--repeats must be >= 1")
-    if args.n_docs < 0 or args.n_image_docs < 0:
-        parser.error("--n-docs and --n-image-docs must be >= 0")
-    if args.n_docs + args.n_image_docs == 0:
-        parser.error("at least one of --n-docs or --n-image-docs must be > 0")
+
+    # --documents-dir (real staged sample) and --n-docs/--n-image-docs
+    # (synthetic fixture counts) configure two different document sources;
+    # letting both through would silently pick one and ignore the other.
+    # --n-docs/--n-image-docs default to None (not DEFAULT_N_TEXT/
+    # DEFAULT_N_IMAGE) precisely so this can tell "not passed" from
+    # "explicitly passed the default value".
+    loaded_docs: list[dict[str, Any]] | None = None
+    sample_manifest: dict[str, Any] | None = None
+    sample_slice: str | None = None
+    sample_digest: str | None = None
+    sample_manifest_complete = False
+    if args.documents_dir is not None:
+        if args.n_docs is not None or args.n_image_docs is not None:
+            parser.error(
+                "--documents-dir is mutually exclusive with --n-docs/"
+                "--n-image-docs: the staged sample determines its own "
+                "document count, so passing both is contradictory."
+            )
+        manifest_path = args.documents_dir / "sample_manifest.json"
+        if manifest_path.is_file():
+            sample_manifest = json.loads(manifest_path.read_text())
+        try:
+            loaded_docs = load_staged_documents(
+                args.documents_dir, manifest=sample_manifest
+            )
+        except (FileNotFoundError, ValueError) as exc:
+            parser.error(str(exc))
+        manifest_slice = (sample_manifest or {}).get("slice")
+        # A conflicting --slice is refused, not preferred. The override exists
+        # to *supply* a label the manifest does not carry, not to rename a
+        # draw: taking the CLI value while the manifest still counted as
+        # complete produced an artifact labelled with one district-year and
+        # measured on another, and the publication gate would approve it.
+        if args.slice and manifest_slice and args.slice != manifest_slice:
+            parser.error(
+                f"--slice {args.slice!r} contradicts the sample manifest in "
+                f"{args.documents_dir}, which records {manifest_slice!r}. "
+                "The manifest describes the draw these documents came from; "
+                "--slice can supply a label when there is no manifest, but it "
+                "cannot rename one. Drop --slice, or point --documents-dir at "
+                "the sample you meant."
+            )
+        sample_slice = args.slice or manifest_slice or "unspecified"
+        sample_digest = _document_sample_digest(args.documents_dir, sample_manifest)
+        # load_staged_documents has already refused a manifest that lists a
+        # document nobody staged. What is left is the other direction —
+        # staged files the manifest does not account for, and the no-manifest
+        # case — neither of which should stop the run, and neither of which
+        # may be published under a sample label they do not describe.
+        missing, unlisted = staged_sample_coverage(
+            sample_manifest, (doc["document_name"] for doc in loaded_docs)
+        )
+        # Rows that name no file are loadable -- that is the documented
+        # ticket-only exception -- but they are not coverage. Such a row is a
+        # manifest document tied to nothing measured, so a manifest with a
+        # valid row per staged file *plus* one ticket-only row described a
+        # larger draw than ran while `unlisted` stayed empty and completeness
+        # stayed true.
+        unkeyed = sum(
+            1
+            for entry in (sample_manifest or {}).get("documents", [])
+            if isinstance(entry, Mapping)
+            and not (isinstance(entry.get("file"), str) and entry["file"].strip())
+        )
+        # A manifest that does not enumerate its documents is no better than
+        # no manifest for this purpose. `{"slice": "Sambalpur/2024"}` — valid
+        # JSON, hand-written or truncated — makes staged_sample_coverage
+        # return nothing in either direction, which is indistinguishable from
+        # a perfect match unless the enumeration itself is required.
+        manifest_enumerates = isinstance(
+            (sample_manifest or {}).get("documents"), list
+        )
+        # `missing` is checked rather than assumed empty. load_staged_documents
+        # does refuse a manifest listing an unstaged file, but completeness is
+        # the claim that the manifest and the measurement describe the same
+        # set, and it should not rest on another function's invariant holding.
+        sample_manifest_complete = (
+            manifest_enumerates and not unlisted and not missing and not unkeyed
+        )
+        if sample_manifest is None:
+            logger.warning(
+                "no sample_manifest.json in {}; the run cannot say which draw "
+                "it measured, so it will not be marked publication_ready",
+                args.documents_dir,
+            )
+        elif not manifest_enumerates:
+            logger.warning(
+                "sample_manifest.json in {} has no 'documents' list, so "
+                "nothing ties these files to the draw it names; the run will "
+                "not be marked publication_ready",
+                args.documents_dir,
+            )
+        elif unkeyed:
+            logger.warning(
+                "sample_manifest.json in {} has {} row(s) naming no file, so "
+                "the manifest describes documents this run did not measure; "
+                "the run will not be marked publication_ready",
+                args.documents_dir,
+                unkeyed,
+            )
+        elif missing:
+            logger.warning(
+                "{} manifest-listed document(s) in {} were not staged; the "
+                "run will not be marked publication_ready",
+                len(missing),
+                args.documents_dir,
+            )
+        elif unlisted:
+            logger.warning(
+                "{} staged document(s) in {} are not accounted for by its "
+                "sample_manifest.json ({}...); the measured set is not the "
+                "drawn set, so the run will not be marked publication_ready",
+                len(unlisted),
+                args.documents_dir,
+                unlisted[:5],
+            )
+    else:
+        n_docs = DEFAULT_N_TEXT if args.n_docs is None else args.n_docs
+        n_image_docs = DEFAULT_N_IMAGE if args.n_image_docs is None else args.n_image_docs
+        if n_docs < 0 or n_image_docs < 0:
+            parser.error("--n-docs and --n-image-docs must be >= 0")
+        if n_docs + n_image_docs == 0:
+            parser.error("at least one of --n-docs or --n-image-docs must be > 0")
+        args.n_docs, args.n_image_docs = n_docs, n_image_docs
 
     discard_warm = not args.no_warm_discard
     if args.repeats == 1 and discard_warm:
@@ -921,8 +1516,9 @@ def main(argv: list[str] | None = None) -> int:
     for variant in variants:
         result = run_benchmark(
             variant=variant,
-            n_text=args.n_docs,
-            n_image=args.n_image_docs,
+            n_text=0 if loaded_docs is not None else args.n_docs,
+            n_image=0 if loaded_docs is not None else args.n_image_docs,
+            docs=loaded_docs,
             repeats=args.repeats,
             discard_warm=discard_warm,
             seed=args.seed,
@@ -931,12 +1527,34 @@ def main(argv: list[str] | None = None) -> int:
             is_fake=is_fake,
         )
         result["processor_startup_seconds"] = startup.get("seconds")
-        result["benchmark_context"] = {
-            "host_label": args.host_label,
-            "model_release_id": args.model_release_id,
-            "fixture": "deterministic synthetic grievances without citizen data",
-            "execution": "sequential single-process execution",
-        }
+        if loaded_docs is not None:
+            # Real-document path: this is the actual defect being fixed —
+            # an artifact that says what it ran on. Additive keys only; the
+            # synthetic-path dict below (host_label, model_release_id,
+            # fixture, execution) is unchanged so existing consumers of
+            # those keys and of the exact "fixture" string do not break.
+            result["benchmark_context"] = {
+                "host_label": args.host_label,
+                "model_release_id": args.model_release_id,
+                "fixture": (
+                    f"real staged document sample "
+                    f"({len(loaded_docs)} documents, slice {sample_slice})"
+                ),
+                "execution": "sequential single-process execution",
+                "sample_provenance": STAGED_PROVENANCE,
+                "sample_slice": sample_slice,
+                "sample_document_count": len(loaded_docs),
+                "sample_digest": sample_digest,
+                "sample_manifest_complete": sample_manifest_complete,
+            }
+        else:
+            result["benchmark_context"] = {
+                "host_label": args.host_label,
+                "model_release_id": args.model_release_id,
+                "fixture": "deterministic synthetic grievances without citizen data",
+                "sample_provenance": SYNTHETIC_PROVENANCE,
+                "execution": "sequential single-process execution",
+            }
         results[variant] = result
         e2e = result["stages"][E2E_KEY]
         print(

--- a/tests/test_benchmark_pipeline.py
+++ b/tests/test_benchmark_pipeline.py
@@ -11,7 +11,7 @@ import json
 import os
 import subprocess
 import sys
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 import pytest
 
@@ -20,13 +20,19 @@ from scripts.benchmark_pipeline import (
     ALL_KEYS,
     E2E_KEY,
     STAGES,
+    SUPPORTED_DOCUMENT_SUFFIXES,
     VALID_VARIANTS,
     _clustered_se,
+    _document_kind,
+    _document_sample_digest,
     _fake_process,
     _percentile,
+    _single_page_text_pdf,
     compute_stage_stats,
     latency_json_payload,
+    load_staged_documents,
     run_benchmark,
+    staged_sample_coverage,
     synthesize_documents,
     write_latency_json,
 )
@@ -148,6 +154,837 @@ def test_synthesize_documents_counts_and_deterministic():
     image_docs = [row for row in docs if row["document_bytes"] is not None]
     assert all(b"/Contents" in row["document_bytes"] for row in image_docs)
     assert all(b"District Collector" in row["document_bytes"] for row in image_docs)
+
+
+# ---------------------------------------------------------------------------
+# Real-document loader — load_staged_documents
+# ---------------------------------------------------------------------------
+
+
+def _stage_document(directory: Path, ticket: str, suffix: str = ".pdf", text: str | None = None) -> Path:
+    """Write one staged document under ``directory`` with the real naming
+    convention, using the stdlib PDF builder so no binary is committed."""
+    path = directory / f"{ticket}_complaint_20250715_234307{suffix}"
+    path.write_bytes(_single_page_text_pdf(text or f"Grievance document for {ticket}"))
+    return path
+
+
+def test_load_staged_documents_without_manifest(tmp_path):
+    _stage_document(tmp_path, "CMO20241020862")
+    _stage_document(tmp_path, "CMO2024483790", suffix=".jpeg")
+
+    docs = load_staged_documents(tmp_path)
+
+    assert len(docs) == 2
+    tickets = {d["ticket"] for d in docs}
+    assert tickets == {"CMO20241020862", "CMO2024483790"}
+    for doc in docs:
+        # Same shape as synthesize_documents(): ticket, text, document_name,
+        # document_bytes, district.
+        assert doc["text"] is None
+        assert doc["document_name"]
+        assert isinstance(doc["document_bytes"], bytes)
+        assert len(doc["document_bytes"]) > 0
+        # No manifest present, so district falls back to a stable label
+        # rather than crashing or silently using None.
+        assert doc["district"] == "unspecified"
+
+
+def test_load_staged_documents_with_manifest_sets_district_from_slice(tmp_path):
+    _stage_document(tmp_path, "CMO20241020862")
+    _stage_document(tmp_path, "CMO2024483790", suffix=".jpeg")
+    manifest = {
+        "slice": "Sambalpur/2024",
+        "seed": 20260809,
+        "target_pages": 2,
+        "tickets": 2,
+        "categories": 1,
+        "pages_by_category": {"Water Supply": 2},
+        "documents": [
+            {"ticket": "CMO20241020862", "gold_category": "Water Supply", "file": "CMO20241020862_complaint_20250715_234307.pdf"},
+            {"ticket": "CMO2024483790", "gold_category": "Water Supply", "file": "CMO2024483790_complaint_20250715_234307.jpeg"},
+        ],
+    }
+    (tmp_path / "sample_manifest.json").write_text(json.dumps(manifest))
+
+    docs = load_staged_documents(tmp_path)
+
+    assert len(docs) == 2
+    assert all(d["district"] == "Sambalpur" for d in docs)
+
+
+def test_load_staged_documents_manifest_can_be_passed_explicitly(tmp_path):
+    _stage_document(tmp_path, "CMO20241020862")
+    manifest = {"slice": "Khordha/2023", "documents": [{"ticket": "CMO20241020862"}]}
+
+    docs = load_staged_documents(tmp_path, manifest=manifest)
+
+    assert docs[0]["district"] == "Khordha"
+
+
+def test_load_staged_documents_reuses_ticket_module_parsing(tmp_path):
+    # Ticket ids matter because the stats code clusters repeats by ticket;
+    # this must match janasunani.pipeline.ticket.ticket_from_relpath exactly,
+    # not a second regex that could drift from it.
+    from janasunani.pipeline.ticket import ticket_from_relpath
+
+    path = _stage_document(tmp_path, "CMO20241020862")
+    docs = load_staged_documents(tmp_path)
+    assert docs[0]["ticket"] == ticket_from_relpath(path.name)
+    assert docs[0]["ticket"] == "CMO20241020862"
+
+
+def test_load_staged_documents_uses_manifest_for_hierarchical_tickets(tmp_path):
+    # Regression for P1-2 (PR #307 review): sarvam_sample_builder stages
+    # documents under Path(key).name, so two distinct complaints whose real
+    # tickets are "OR159/P/2021/00535" and "OR122/E/2021/00535" both land on
+    # disk with a filename that basename-parses to just "00535". Confirmed
+    # against the lake: 27,684 of 1,371,288 complaints (2.0%) have a
+    # hierarchical ticket like this. The manifest carries the real ticket
+    # per file and must be used to tell them apart.
+    from janasunani.pipeline.ticket import ticket_from_relpath
+
+    file1 = tmp_path / "00535_complaint_20250715_234307.pdf"
+    file1.write_bytes(_single_page_text_pdf("Grievance A"))
+    file2 = tmp_path / "00535_complaint_20250801_101010.pdf"
+    file2.write_bytes(_single_page_text_pdf("Grievance B"))
+
+    # Confirm the premise: basename-only parsing really does collide these.
+    assert ticket_from_relpath(file1.name) == ticket_from_relpath(file2.name) == "00535"
+
+    manifest = {
+        "slice": "State/2021",
+        "documents": [
+            {"ticket": "OR159/P/2021/00535", "gold_category": "Water Supply", "file": file1.name},
+            {"ticket": "OR122/E/2021/00535", "gold_category": "Water Supply", "file": file2.name},
+        ],
+    }
+
+    docs = load_staged_documents(tmp_path, manifest=manifest)
+
+    tickets = {d["ticket"] for d in docs}
+    assert tickets == {"OR159/P/2021/00535", "OR122/E/2021/00535"}
+
+
+def test_load_staged_documents_without_manifest_can_collapse_hierarchical_tickets(tmp_path):
+    # Documented limitation (see load_staged_documents docstring): without a
+    # manifest there is no way to recover the directory part of a
+    # hierarchical ticket that staging already discarded. This test records
+    # the gap honestly rather than claiming it is fixed in every case.
+    file1 = tmp_path / "00535_complaint_20250715_234307.pdf"
+    file1.write_bytes(_single_page_text_pdf("Grievance A"))
+    file2 = tmp_path / "00535_complaint_20250801_101010.pdf"
+    file2.write_bytes(_single_page_text_pdf("Grievance B"))
+
+    docs = load_staged_documents(tmp_path)  # no manifest
+
+    tickets = [d["ticket"] for d in docs]
+    assert tickets == ["00535", "00535"]
+
+
+def test_load_staged_documents_manifest_ticket_wins_per_file_not_all_or_nothing(tmp_path):
+    # A manifest entry is used per file it actually covers; a file the
+    # manifest omits still falls back to basename parsing rather than the
+    # whole load rejecting the manifest.
+    file1 = tmp_path / "OR159P202100535_complaint_20250715_234307.pdf"
+    file1.write_bytes(_single_page_text_pdf("Grievance A"))
+    file2 = _stage_document(tmp_path, "CMO2024483790", suffix=".jpeg")
+
+    manifest = {
+        "slice": "State/2021",
+        "documents": [
+            {"ticket": "OR159/P/2021/00535", "gold_category": "Water Supply", "file": file1.name},
+            # file2 intentionally absent from the manifest's documents list.
+        ],
+    }
+
+    docs = load_staged_documents(tmp_path, manifest=manifest)
+    by_name = {d["document_name"]: d["ticket"] for d in docs}
+    assert by_name[file1.name] == "OR159/P/2021/00535"
+    assert by_name[file2.name] == "CMO2024483790"
+
+
+def test_load_staged_documents_rejects_a_partially_staged_sample(tmp_path):
+    """A manifest document that is not on disk stops the run.
+
+    Codex P1 on #326: this used to log a warning and benchmark whatever had
+    been staged. The artifact then carried the manifest's slice, seed and
+    digest while describing a strict subset of the draw — an incomplete
+    Glacier restore silently became a publishable latency number for a
+    sample that was never measured.
+    """
+    staged = _stage_document(tmp_path, "CMO20241020862")
+    manifest = {
+        "slice": "Sambalpur/2024",
+        "documents": [
+            {"ticket": "CMO20241020862", "file": staged.name},
+            {"ticket": "CMO2024483790", "file": "CMO2024483790_complaint_20250715_234307.pdf"},
+        ],
+    }
+    (tmp_path / "sample_manifest.json").write_text(json.dumps(manifest))
+
+    with pytest.raises(ValueError, match="are not staged there"):
+        load_staged_documents(tmp_path)
+
+
+def test_staged_sample_coverage_reports_both_directions(tmp_path):
+    missing, unlisted = staged_sample_coverage(
+        {"documents": [{"file": "a.pdf", "ticket": "T1"},
+                       {"file": "b.pdf", "ticket": "T2"}]},
+        ["a.pdf", "c.pdf"],
+    )
+    assert missing == ["b.pdf"]
+    assert unlisted == ["c.pdf"]
+
+
+def test_staged_sample_coverage_does_not_count_entries_without_a_filename():
+    """Codex P1, round 3 on #326 — a count is not an identity.
+
+    An earlier version of this helper absorbed one unlisted file per manifest
+    entry that had no ``file`` key, reasoning that the count was the most that
+    could be claimed. That let a one-file staging beside
+    ``{"documents": [{"ticket": "CMO1"}]}`` report perfect coverage while
+    nothing tied the entry to the file on disk, and `main()` then marked the
+    run complete and publishable.
+
+    Such a manifest still loads — it supplies the slice — it just cannot
+    claim the staged files are the drawn ones.
+    """
+    missing, unlisted = staged_sample_coverage(
+        {"documents": [{"ticket": "CMO1"}]}, ["only.pdf"]
+    )
+    assert missing == []
+    assert unlisted == ["only.pdf"]
+
+
+def test_staged_sample_coverage_rejects_a_duplicated_filename():
+    """Codex P1, round 4 on #326 — the set hid it in the worst way.
+
+    A manifest claiming `one.pdf` for both T1 and T2, against a one-file
+    staging, collapsed to a single listed name and reported nothing missing
+    and nothing unlisted: a perfect match. `file_to_ticket` meanwhile kept
+    only the last entry, so the run measured one document, attributed it to
+    whichever entry came last, and published as complete under a manifest
+    claiming two.
+    """
+    with pytest.raises(ValueError, match="more than once"):
+        staged_sample_coverage(
+            {"documents": [{"file": "one.pdf", "ticket": "T1"},
+                           {"file": "one.pdf", "ticket": "T2"}]},
+            ["one.pdf"],
+        )
+
+
+def test_staged_sample_coverage_rejects_malformed_entries(tmp_path):
+    """Codex P1, round 5 on #326: a row that cannot be read is not coverage.
+
+    Skipping it let a manifest with valid rows for every staged file plus one
+    junk row still report a perfect match and publish. And a row naming a
+    file with no ticket counted as coverage while `load_staged_documents`
+    fell back to the basename parser — lossy for exactly the hierarchical
+    tickets the manifest exists to preserve.
+    """
+    with pytest.raises(ValueError, match="malformed"):
+        staged_sample_coverage(
+            {"documents": [{"file": "a.pdf", "ticket": "T1"}, "not-an-object"]},
+            ["a.pdf"],
+        )
+
+    with pytest.raises(ValueError, match="has no ticket"):
+        staged_sample_coverage({"documents": [{"file": "a.pdf"}]}, ["a.pdf"])
+
+    # The other half of the asymmetry is deliberate and stays: a ticket with
+    # no file cannot be matched by name, so it is simply not coverage.
+    missing, unlisted = staged_sample_coverage(
+        {"documents": [{"ticket": "T1"}]}, ["a.pdf"]
+    )
+    assert (missing, unlisted) == ([], ["a.pdf"])
+
+
+def test_load_staged_documents_rejects_a_ticket_its_key_contradicts(tmp_path):
+    """Codex P1, round 9 on #326: the row's own s3_key is the check.
+
+    `file_to_ticket` took the manifest's ticket as authoritative. A row
+    pairing a staged file with the wrong nonblank ticket still produced a
+    complete coverage match, so the run clustered under the wrong complaint
+    and could be published. The builder writes `file` as `Path(key).name` and
+    the key is `<ticket>_complaint_<timestamp>.<ext>`, so the key settles both.
+    """
+    ticket = "CMO20241020862"
+    name = _stage_document(tmp_path, ticket).name
+
+    def manifest(**row):
+        return {"slice": "Sambalpur/2024", "documents": [{"file": name, **row}]}
+
+    # The key names this ticket; the row claims another.
+    with pytest.raises(ValueError, match="contradicts"):
+        load_staged_documents(
+            tmp_path, manifest=manifest(ticket="CMO20241099999", s3_key=name)
+        )
+
+    # The other half: the key's basename is not the staged filename.
+    with pytest.raises(ValueError, match="contradicts"):
+        load_staged_documents(
+            tmp_path,
+            manifest=manifest(
+                ticket=ticket, s3_key=f"{ticket}/other_complaint_20250715_234307.pdf"
+            ),
+        )
+
+    # Agreeing rows load. The hierarchical case is the reason `file` exists at
+    # all: sarvam_sample_builder stages under Path(key).name, so the ticket
+    # OR159/P/2021/00535 reaches disk as 00535_complaint_..., and only the
+    # manifest can put the prefix back. The check has to compare the key's
+    # basename to `file` and the key's prefix to `ticket` -- not the two to
+    # each other -- or exactly this row would look contradictory.
+    nested_ticket = "OR159/P/2021/00535"
+    nested_key = f"{nested_ticket}_complaint_20250715_234307.pdf"
+    nested_name = _stage_document(tmp_path, "00535").name
+    assert nested_name == PurePosixPath(nested_key).name
+
+    docs = load_staged_documents(
+        tmp_path,
+        manifest={
+            "slice": "Sambalpur/2024",
+            "documents": [
+                {"file": name, "ticket": ticket, "s3_key": name},
+                {"file": nested_name, "ticket": nested_ticket, "s3_key": nested_key},
+            ],
+        },
+    )
+    assert sorted(d["ticket"] for d in docs) == sorted([ticket, nested_ticket])
+
+    # A key with no `_complaint_` marker names no ticket. Skipping the
+    # comparison there was the round-nine hole: the manifest mapping bypasses
+    # filename parsing, so this loaded under WRONG with complete coverage.
+    with pytest.raises(ValueError, match="no ticket|_complaint_"):
+        load_staged_documents(
+            tmp_path, manifest=manifest(ticket="WRONG", s3_key="one.pdf")
+        )
+
+    # A row without s3_key keeps the documented ticket-only behaviour.
+    ticket_only = load_staged_documents(
+        tmp_path,
+        manifest={
+            "slice": "Sambalpur/2024",
+            "documents": [
+                {"file": name, "ticket": ticket},
+                {"file": nested_name, "ticket": nested_ticket},
+            ],
+        },
+    )
+    assert sorted(d["ticket"] for d in ticket_only) == sorted([ticket, nested_ticket])
+
+
+def test_staged_sample_coverage_rejects_a_row_naming_neither_file_nor_ticket():
+    """Codex P1, round 6 on #326: `{}` is a Mapping, so it slipped through.
+
+    An empty object passed the non-mapping check, failed both identity
+    checks, and was then counted as nothing — so a manifest with valid rows
+    for every staged file plus one empty row still reported perfect coverage
+    and set `sample_manifest_complete`. Same junk-row class as a non-mapping,
+    one level in.
+
+    This supersedes an earlier assertion that blank and non-string filenames
+    were simply *ignored*: with no ticket either, such a row names nothing
+    and is the finding, not an exception to it.
+    """
+    with pytest.raises(ValueError, match="neither a file nor a ticket"):
+        staged_sample_coverage({"documents": [{}]}, ["only.pdf"])
+
+    with pytest.raises(ValueError, match="neither a file nor a ticket"):
+        staged_sample_coverage(
+            {"documents": [{"file": "  "}, {"file": None}, {"file": 7}]},
+            ["only.pdf"],
+        )
+
+    # The whole point: valid rows plus one empty row must not read as perfect.
+    with pytest.raises(ValueError, match="neither a file nor a ticket"):
+        staged_sample_coverage(
+            {"documents": [{"file": "only.pdf", "ticket": "T1"}, {}]},
+            ["only.pdf"],
+        )
+
+    # A blank filename *with* a ticket is still the documented ticket-only
+    # exception: it names an identity, it just cannot be matched by name.
+    missing, unlisted = staged_sample_coverage(
+        {"documents": [{"file": "  ", "ticket": "T1"}]}, ["only.pdf"]
+    )
+    assert (missing, unlisted) == ([], ["only.pdf"])
+
+
+def test_staged_sample_coverage_is_silent_without_a_documents_list():
+    assert staged_sample_coverage(None, ["a.pdf"]) == ([], [])
+    assert staged_sample_coverage({"slice": "X/2024"}, ["a.pdf"]) == ([], [])
+
+
+def test_load_staged_documents_empty_directory_raises_loudly(tmp_path):
+    # An empty doc list must never reach run_benchmark silently — its own
+    # "no documents" error talks about n_text + n_image, which would
+    # misdescribe a directory problem as a documents-count-flag problem.
+    with pytest.raises(ValueError, match="no supported documents"):
+        load_staged_documents(tmp_path)
+
+
+def test_load_staged_documents_ignores_manifest_json_itself(tmp_path):
+    # sample_manifest.json sits beside the documents; it must not be picked
+    # up as a document (it has no supported suffix, but guard it directly).
+    (tmp_path / "sample_manifest.json").write_text(json.dumps({"slice": "X/2024", "documents": []}))
+    with pytest.raises(ValueError, match="no supported documents"):
+        load_staged_documents(tmp_path)
+
+
+def test_load_staged_documents_missing_directory_raises_loudly():
+    with pytest.raises(FileNotFoundError):
+        load_staged_documents(Path("/nonexistent/staging/dir/for/janasunani/benchmark"))
+
+
+def test_load_staged_documents_unparseable_filename_raises(tmp_path):
+    # No "_complaint_" marker in the stem: ticket_from_relpath returns None.
+    (tmp_path / "not_a_staged_name.pdf").write_bytes(_single_page_text_pdf("hello"))
+    with pytest.raises(ValueError, match="staged naming convention"):
+        load_staged_documents(tmp_path)
+
+
+def test_load_staged_documents_supported_suffixes_include_pdf_and_images():
+    assert ".pdf" in SUPPORTED_DOCUMENT_SUFFIXES
+    for suffix in (".png", ".jpg", ".jpeg", ".tiff", ".tif", ".bmp", ".gif"):
+        assert suffix in SUPPORTED_DOCUMENT_SUFFIXES
+
+
+def test_document_sample_digest_prefers_manifest_and_is_stable(tmp_path):
+    _stage_document(tmp_path, "CMO20241020862")
+    manifest = {"slice": "Sambalpur/2024", "documents": [{"ticket": "CMO20241020862"}]}
+
+    d1 = _document_sample_digest(tmp_path, manifest)
+    d2 = _document_sample_digest(tmp_path, manifest)
+    assert d1 == d2
+    assert d1 != _document_sample_digest(tmp_path, {**manifest, "slice": "Khordha/2024"})
+
+
+def test_document_sample_digest_without_manifest_uses_filenames_and_content(tmp_path):
+    _stage_document(tmp_path, "CMO20241020862")
+    d1 = _document_sample_digest(tmp_path, None)
+    d2 = _document_sample_digest(tmp_path, None)
+    assert d1 == d2
+
+    _stage_document(tmp_path, "CMO2024483790", suffix=".jpeg")
+    d3 = _document_sample_digest(tmp_path, None)
+    assert d3 != d1
+
+
+def test_document_sample_digest_detects_content_change_with_manifest(tmp_path):
+    # Regression for P1-3 (PR #307 review): the original implementation
+    # hashed only the manifest JSON when a manifest was present, so
+    # replacing a staged scan's bytes (bad re-download, swapped page, a
+    # stale manifest beside different content) was invisible to the
+    # digest as long as the filename and document count still matched.
+    path = _stage_document(tmp_path, "CMO20241020862")
+    manifest = {
+        "slice": "Sambalpur/2024",
+        "documents": [{"ticket": "CMO20241020862", "file": path.name}],
+    }
+    d1 = _document_sample_digest(tmp_path, manifest)
+
+    path.write_bytes(_single_page_text_pdf("A completely different scan"))
+    d2 = _document_sample_digest(tmp_path, manifest)
+
+    assert d1 != d2
+
+
+def test_document_sample_digest_detects_content_change_without_manifest(tmp_path):
+    path = _stage_document(tmp_path, "CMO20241020862")
+    d1 = _document_sample_digest(tmp_path, None)
+
+    path.write_bytes(_single_page_text_pdf("A completely different scan"))
+    d2 = _document_sample_digest(tmp_path, None)
+
+    assert d1 != d2
+
+
+def test_document_sample_digest_stable_across_restage_to_new_path(tmp_path):
+    # The manifest-identity rationale claims stability across a re-stage to
+    # a different directory; hashing content must not break that, since the
+    # digest is keyed on filename + bytes, not the full path.
+    dir1 = tmp_path / "stageA"
+    dir1.mkdir()
+    dir2 = tmp_path / "stageB"
+    dir2.mkdir()
+    filename = "CMO20241020862_complaint_20250715_234307.pdf"
+    content = _single_page_text_pdf("Grievance for CMO20241020862")
+    (dir1 / filename).write_bytes(content)
+    (dir2 / filename).write_bytes(content)
+    manifest = {
+        "slice": "Sambalpur/2024",
+        "documents": [{"ticket": "CMO20241020862", "file": filename}],
+    }
+
+    assert _document_sample_digest(dir1, manifest) == _document_sample_digest(dir2, manifest)
+
+
+def test_run_benchmark_over_loaded_real_documents(tmp_path):
+    # The measurement loop needs no change: docs from load_staged_documents
+    # flow through run_benchmark exactly like any other custom doc list.
+    _stage_document(tmp_path, "CMO20241020862")
+    _stage_document(tmp_path, "CMO2024483790", suffix=".jpeg")
+    docs = load_staged_documents(tmp_path)
+
+    result = run_benchmark(variant="standard", docs=docs, repeats=2, discard_warm=False)
+    assert result["n_docs"] == 2
+    assert result["stages"]["e2e"]["n"] == 4
+    assert {"CMO20241020862", "CMO2024483790"} == set(result["_raw"]["tickets"]["e2e"])
+
+
+def test_document_kind_reads_the_doc_not_the_ticket_string():
+    # Regression for P1-1 (PR #307 review): input-path classification used
+    # to match on a "SYN-TXT-"/"SYN-IMG-" ticket prefix, so every real
+    # ticket (no such prefix) fell through to "unspecified". The doc's own
+    # fields settle it instead.
+    text_doc = {"ticket": "CMO20241020862", "text": "hello", "document_bytes": None}
+    document_doc = {"ticket": "CMO20241020862", "text": None, "document_bytes": b"%PDF-1.4"}
+    empty_doc = {"ticket": "CMO20241020862", "text": None, "document_bytes": None}
+    assert _document_kind(text_doc) == "text"
+    assert _document_kind(document_doc) == "document"
+    assert _document_kind(empty_doc) == "unspecified"
+
+
+def test_real_document_only_run_reaches_publication_ready(tmp_path):
+    # Regression for P1-1 (PR #307 review): --documents-dir stages real
+    # documents only (no text grievances mixed in), so a clean run has just
+    # the "document" input path. The gate used to hardcode requiring BOTH
+    # "text" and "document" paths with n > 0, which made every real-
+    # document run structurally unpublishable regardless of how clean the
+    # measurements were. This is the exact scenario the whole branch exists
+    # to make publishable, so it must reach publication_ready: true when
+    # everything else about the run is clean.
+    _stage_document(tmp_path, "CMO20241020862")
+    _stage_document(tmp_path, "CMO2024483790", suffix=".jpeg")
+    docs = load_staged_documents(tmp_path)
+
+    result = run_benchmark(
+        variant="standard",
+        docs=docs,
+        repeats=2,
+        discard_warm=False,
+        processor_factory=lambda _variant: type(
+            "Processor",
+            (),
+            {
+                "_timing_sink": None,
+                "process": lambda self, **kwargs: self._timing_sink(
+                    {"redact": 0.1, "e2e": 0.2, "ok": 1.0}
+                ),
+            },
+        )(),
+    )
+    result["benchmark_context"] = {
+        "host_label": "release-host",
+        "model_release_id": "model-release-1",
+        "sample_provenance": "staged-documents",
+        "sample_slice": "Sambalpur/2024",
+        "sample_manifest_complete": True,
+        "sample_digest": "a" * 64,
+    }
+
+    assert set(result["input_paths"]) == {"document"}
+    payload = latency_json_payload(result)
+    assert payload["publication_ready"] is True
+
+
+# ---------------------------------------------------------------------------
+# CLI wiring for --documents-dir / --slice
+# ---------------------------------------------------------------------------
+
+
+def test_cli_documents_dir_and_n_docs_are_mutually_exclusive(tmp_path, capsys):
+    _stage_document(tmp_path, "CMO20241020862")
+    out = tmp_path / "latency.json"
+    with pytest.raises(SystemExit) as exc:
+        bench_mod.main(
+            [
+                "--fake",
+                "--documents-dir",
+                str(tmp_path),
+                "--n-docs",
+                "2",
+                "--repeats",
+                "2",
+                "--output",
+                str(out),
+            ]
+        )
+    assert exc.value.code == 2
+    assert not out.exists()
+    err = capsys.readouterr().err
+    assert "mutually exclusive" in err
+
+
+def test_cli_documents_dir_runs_fake_and_records_provenance(tmp_path):
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    _stage_document(staging, "CMO20241020862")
+    _stage_document(staging, "CMO2024483790", suffix=".jpeg")
+    out = tmp_path / "latency.json"
+
+    rc = bench_mod.main(
+        [
+            "--fake",
+            "--documents-dir",
+            str(staging),
+            "--slice",
+            "Sambalpur/2024",
+            "--repeats",
+            "2",
+            "--output",
+            str(out),
+        ]
+    )
+    assert rc == 0
+    data = json.loads(out.read_text())
+    assert data["n_docs"] == 2
+    ctx = data["benchmark_context"]
+    assert ctx["sample_slice"] == "Sambalpur/2024"
+    assert ctx["sample_document_count"] == 2
+    assert ctx["sample_digest"]
+    assert "real staged document sample" in ctx["fixture"]
+    assert "synthetic" not in ctx["fixture"]
+    # Additive-only: synthetic-path keys are still present.
+    assert ctx["execution"] == "sequential single-process execution"
+    # No manifest, so --slice names a draw nothing ties these documents to.
+    # The run is fine; publishing it under that label is not.
+    assert ctx["sample_manifest_complete"] is False
+
+
+def test_cli_documents_dir_records_manifest_completeness(tmp_path):
+    """The recorded verdict follows the manifest, both ways.
+
+    A staged file the manifest does not cover is legal (its ticket falls back
+    to filename parsing) but means the measured set is larger than the drawn
+    set, which the gate has to see.
+    """
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    covered = _stage_document(staging, "CMO20241020862")
+    manifest = {
+        "slice": "Sambalpur/2024",
+        "documents": [{"ticket": "CMO20241020862", "file": covered.name}],
+    }
+    (staging / "sample_manifest.json").write_text(json.dumps(manifest))
+    out = tmp_path / "latency.json"
+
+    argv = [
+        "--fake",
+        "--documents-dir",
+        str(staging),
+        "--repeats",
+        "2",
+        "--no-warm-discard",
+        "--output",
+        str(out),
+    ]
+    assert bench_mod.main(argv) == 0
+    ctx = json.loads(out.read_text())["benchmark_context"]
+    assert ctx["sample_manifest_complete"] is True
+    assert ctx["sample_document_count"] == 1
+
+    # Drop a second document into the staging directory without touching the
+    # manifest: the same manifest now describes only part of what runs.
+    _stage_document(staging, "CMO2024483790", suffix=".jpeg")
+    assert bench_mod.main(argv) == 0
+    ctx = json.loads(out.read_text())["benchmark_context"]
+    assert ctx["sample_manifest_complete"] is False
+    assert ctx["sample_document_count"] == 2
+
+
+def test_cli_a_manifest_that_lists_no_documents_is_not_complete(tmp_path):
+    """Codex P1, round 2 on #326.
+
+    `{"slice": "Sambalpur/2024"}` is valid JSON and names a draw, but nothing
+    in it ties these files to that draw. `staged_sample_coverage` reports
+    nothing missing and nothing unlisted, which is byte-identical to a perfect
+    match — so the enumeration itself has to be required, or a truncated or
+    hand-written manifest publishes under a slice label it cannot support.
+    """
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    _stage_document(staging, "CMO20241020862")
+    (staging / "sample_manifest.json").write_text(json.dumps({"slice": "Sambalpur/2024"}))
+    out = tmp_path / "latency.json"
+
+    assert (
+        bench_mod.main(
+            [
+                "--fake",
+                "--documents-dir",
+                str(staging),
+                "--repeats",
+                "2",
+                "--no-warm-discard",
+                "--output",
+                str(out),
+            ]
+        )
+        == 0
+    )
+    ctx = json.loads(out.read_text())["benchmark_context"]
+    # The slice is still recorded — it is the only provenance there is.
+    assert ctx["sample_slice"] == "Sambalpur/2024"
+    assert ctx["sample_manifest_complete"] is False
+
+
+def test_cli_a_slice_override_that_contradicts_the_manifest_is_refused(tmp_path, capsys):
+    """Codex P1, round 3 on #326.
+
+    `--slice` used to win over the manifest while `sample_manifest_complete`
+    stayed true, so the gate would approve an artifact labelled with one
+    district-year and measured on another. The override exists to supply a
+    label where there is no manifest, not to rename a draw.
+    """
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    covered = _stage_document(staging, "CMO20241020862")
+    (staging / "sample_manifest.json").write_text(
+        json.dumps(
+            {
+                "slice": "Sambalpur/2024",
+                "documents": [{"ticket": "CMO20241020862", "file": covered.name}],
+            }
+        )
+    )
+    out = tmp_path / "latency.json"
+    argv = [
+        "--fake",
+        "--documents-dir",
+        str(staging),
+        "--repeats",
+        "2",
+        "--no-warm-discard",
+        "--output",
+        str(out),
+    ]
+
+    with pytest.raises(SystemExit):
+        bench_mod.main([*argv, "--slice", "Khordha/2023"])
+    assert "contradicts the sample manifest" in capsys.readouterr().err
+    assert not out.exists()
+
+    # The same value as the manifest is not a conflict.
+    assert bench_mod.main([*argv, "--slice", "Sambalpur/2024"]) == 0
+    ctx = json.loads(out.read_text())["benchmark_context"]
+    assert ctx["sample_slice"] == "Sambalpur/2024"
+    assert ctx["sample_manifest_complete"] is True
+
+
+def test_cli_documents_dir_rejects_a_partially_staged_manifest(tmp_path, capsys):
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    staged = _stage_document(staging, "CMO20241020862")
+    manifest = {
+        "slice": "Sambalpur/2024",
+        "documents": [
+            {"ticket": "CMO20241020862", "file": staged.name},
+            {"ticket": "CMO2024483790", "file": "CMO2024483790_complaint_20250715_234307.pdf"},
+        ],
+    }
+    (staging / "sample_manifest.json").write_text(json.dumps(manifest))
+    out = tmp_path / "latency.json"
+
+    with pytest.raises(SystemExit):
+        bench_mod.main(
+            [
+                "--fake",
+                "--documents-dir",
+                str(staging),
+                "--repeats",
+                "2",
+                "--output",
+                str(out),
+            ]
+        )
+    assert "are not staged there" in capsys.readouterr().err
+    assert not out.exists()
+
+
+def test_cli_documents_dir_uses_manifest_slice_when_no_override(tmp_path):
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    _stage_document(staging, "CMO20241020862")
+    manifest = {"slice": "Khordha/2023", "documents": [{"ticket": "CMO20241020862"}]}
+    (staging / "sample_manifest.json").write_text(json.dumps(manifest))
+    out = tmp_path / "latency.json"
+
+    rc = bench_mod.main(
+        [
+            "--fake",
+            "--documents-dir",
+            str(staging),
+            "--repeats",
+            "2",
+            "--no-warm-discard",
+            "--output",
+            str(out),
+        ]
+    )
+    assert rc == 0
+    data = json.loads(out.read_text())
+    assert data["benchmark_context"]["sample_slice"] == "Khordha/2023"
+
+
+def test_cli_documents_dir_empty_directory_fails_loudly(tmp_path, capsys):
+    empty = tmp_path / "empty_staging"
+    empty.mkdir()
+    out = tmp_path / "latency.json"
+    with pytest.raises(SystemExit) as exc:
+        bench_mod.main(
+            ["--fake", "--documents-dir", str(empty), "--repeats", "2", "--output", str(out)]
+        )
+    assert exc.value.code == 2
+    assert not out.exists()
+    err = capsys.readouterr().err
+    assert "no supported documents" in err
+
+
+def test_cli_synthetic_path_benchmark_context_fixture_is_unchanged(tmp_path):
+    # Regression guard for the actual defect: outputs/benchmark/latency.json
+    # today records "deterministic synthetic grievances without citizen
+    # data" for its fixture. Existing artifacts and any consumer of that
+    # exact string must not break when the real-document path is added.
+    out = tmp_path / "latency.json"
+    rc = bench_mod.main(
+        [
+            "--fake",
+            "--variant",
+            "standard",
+            "--n-docs",
+            "2",
+            "--n-image-docs",
+            "1",
+            "--repeats",
+            "2",
+            "--output",
+            str(out),
+            "--seed",
+            "42",
+        ]
+    )
+    assert rc == 0
+    data = json.loads(out.read_text())
+    ctx = data["benchmark_context"]
+    assert ctx["fixture"] == "deterministic synthetic grievances without citizen data"
+    assert ctx["execution"] == "sequential single-process execution"
+    # No document-sample keys leak onto the synthetic path. `sample_provenance`
+    # is the declaration that there is no sample, not a sample key: the gate
+    # requires it because a context that says nothing cannot be shown to be
+    # synthetic, and a real measurement must not inherit that benefit of the
+    # doubt.
+    assert ctx["sample_provenance"] == "synthetic"
+    assert set(ctx) == {
+        "host_label",
+        "model_release_id",
+        "fixture",
+        "execution",
+        "sample_provenance",
+    }
 
 
 def test_run_benchmark_standard_variant_basic():
@@ -316,6 +1153,149 @@ def test_latency_json_payload_multi_variant(tmp_path):
     assert payload["publication_ready"] is False
 
 
+def test_cli_ticket_only_row_blocks_completeness(tmp_path):
+    """Codex P1, round 13 on #326: a ticket-only row is not coverage.
+
+    Such a row loads — that is the documented exception — but it names a
+    manifest document tied to nothing measured. With a valid row per staged
+    file *plus* one ticket-only row, `unlisted` stayed empty and
+    `sample_manifest_complete` stayed true, so a run could publish while its
+    manifest described a larger draw than actually ran.
+    """
+    staged = _stage_document(tmp_path, "CMO20241020862")
+    manifest = {
+        "slice": "Sambalpur/2024",
+        "documents": [
+            {"file": staged.name, "ticket": "CMO20241020862", "s3_key": staged.name},
+            {"ticket": "CMO20249999999"},
+        ],
+    }
+    (tmp_path / "sample_manifest.json").write_text(json.dumps(manifest))
+
+    out = tmp_path / "latency.json"
+    rc = bench_mod.main(
+        ["--fake", "--variant", "standard", "--documents-dir", str(tmp_path),
+         "--repeats", "2", "--output", str(out), "--seed", "42"]
+    )
+    assert rc == 0
+    ctx = json.loads(out.read_text())["benchmark_context"]
+    assert ctx["sample_manifest_complete"] is False
+
+    # Drop the unkeyed row and the same sample is complete again.
+    manifest["documents"] = manifest["documents"][:1]
+    (tmp_path / "sample_manifest.json").write_text(json.dumps(manifest))
+    rc = bench_mod.main(
+        ["--fake", "--variant", "standard", "--documents-dir", str(tmp_path),
+         "--repeats", "2", "--output", str(out), "--seed", "42"]
+    )
+    assert rc == 0
+    assert json.loads(out.read_text())["benchmark_context"]["sample_manifest_complete"] is True
+
+
+def test_staged_verdict_without_a_digest_is_not_publication_ready():
+    """Codex P1, round 10 on #326: the slice names a population, not a draw.
+
+    A public-API caller could declare staged provenance, a real slice and a
+    complete manifest while omitting `sample_digest`, and still publish. Two
+    different staged sets from Sambalpur/2024 are indistinguishable by slice
+    alone — binding the manifest to the measured bytes is exactly what
+    `_document_sample_digest` was added for.
+    """
+    result = run_benchmark(
+        variant="standard",
+        n_text=1,
+        n_image=1,
+        repeats=2,
+        discard_warm=False,
+        processor_factory=lambda _variant: type(
+            "Processor",
+            (),
+            {
+                "_timing_sink": None,
+                "process": lambda self, **kwargs: self._timing_sink(
+                    {"redact": 0.1, "e2e": 0.2, "ok": 1.0}
+                ),
+            },
+        )(),
+    )
+    staged = {
+        "host_label": "release-host",
+        "model_release_id": "model-release-1",
+        "sample_provenance": "staged-documents",
+        "sample_slice": "Sambalpur/2024",
+        "sample_manifest_complete": True,
+        "sample_digest": "a" * 64,
+    }
+    result["benchmark_context"] = dict(staged)
+    assert latency_json_payload(result)["publication_ready"] is True
+
+    for missing in ({k: v for k, v in staged.items() if k != "sample_digest"},
+                    {**staged, "sample_digest": ""},
+                    {**staged, "sample_digest": "   "}):
+        result["benchmark_context"] = missing
+        assert latency_json_payload(result)["publication_ready"] is False
+
+
+def test_unspecified_sample_slice_is_not_publication_ready():
+    """Codex P1, round 8 on #326: a run must name the population it measured.
+
+    On the real-document path `sample_slice` falls back to "unspecified" when
+    neither --slice nor the manifest's own `slice` supplies one, while
+    `sample_manifest_complete` can still be true — a manifest can account for
+    every staged file without saying which draw those files are. The gate
+    only rejected an explicit False, so the run published an artifact that
+    could not identify its own population.
+    """
+    result = run_benchmark(
+        variant="standard",
+        n_text=1,
+        n_image=1,
+        repeats=2,
+        discard_warm=False,
+        processor_factory=lambda _variant: type(
+            "Processor",
+            (),
+            {
+                "_timing_sink": None,
+                "process": lambda self, **kwargs: self._timing_sink(
+                    {"redact": 0.1, "e2e": 0.2, "ok": 1.0}
+                ),
+            },
+        )(),
+    )
+    real_context = {
+        "host_label": "release-host",
+        "model_release_id": "model-release-1",
+        "sample_provenance": "staged-documents",
+        "sample_slice": "sambalpur-2024",
+        "sample_document_count": 2,
+        "sample_manifest_complete": True,
+        "sample_digest": "a" * 64,
+    }
+    result["benchmark_context"] = dict(real_context)
+    assert latency_json_payload(result)["publication_ready"] is True
+
+    for label in ("unspecified", "", "   "):
+        result["benchmark_context"] = {**real_context, "sample_slice": label}
+        assert latency_json_payload(result)["publication_ready"] is False, label
+
+    # The synthetic path publishes by declaring itself, not by staying silent.
+    result["benchmark_context"] = {
+        "host_label": "release-host",
+        "model_release_id": "model-release-1",
+        "sample_provenance": "synthetic",
+    }
+    assert latency_json_payload(result)["publication_ready"] is True
+
+    # And silence is now a refusal, which is the finding this supersedes:
+    # a staged run through the public API could omit both fields and pass.
+    result["benchmark_context"] = {
+        "host_label": "release-host",
+        "model_release_id": "model-release-1",
+    }
+    assert latency_json_payload(result)["publication_ready"] is False
+
+
 def test_identified_real_latency_run_is_publication_ready():
     result = run_benchmark(
         variant="standard",
@@ -337,6 +1317,7 @@ def test_identified_real_latency_run_is_publication_ready():
     result["benchmark_context"] = {
         "host_label": "release-host",
         "model_release_id": "model-release-1",
+        "sample_provenance": "synthetic",
     }
 
     payload = latency_json_payload(result)
@@ -350,6 +1331,64 @@ def test_identified_real_latency_run_is_publication_ready():
     result["git_sha"] = "abc1234"
     result["benchmark_context"]["host_label"] = "   "
     assert latency_json_payload(result)["publication_ready"] is False
+
+
+def test_an_incomplete_document_sample_is_not_publication_ready():
+    """The other half of Codex's P1 on #326.
+
+    ``load_staged_documents`` refuses a manifest listing documents nobody
+    staged. The reverse — staged documents the manifest does not account for,
+    or no manifest at all — is allowed to run (the ticket for an uncovered
+    file falls back to filename parsing, deliberately) but must not publish:
+    the artifact's ``sample_slice`` and ``sample_digest`` would name a draw
+    that is not the set measured.
+    """
+    result = run_benchmark(
+        variant="standard",
+        n_text=1,
+        n_image=1,
+        repeats=2,
+        discard_warm=False,
+        processor_factory=lambda _variant: type(
+            "Processor",
+            (),
+            {
+                "_timing_sink": None,
+                "process": lambda self, **kwargs: self._timing_sink(
+                    {"redact": 0.1, "e2e": 0.2, "ok": 1.0}
+                ),
+            },
+        )(),
+    )
+    result["benchmark_context"] = {
+        "host_label": "release-host",
+        "model_release_id": "model-release-1",
+        "sample_provenance": "staged-documents",
+        "sample_slice": "Sambalpur/2024",
+        "sample_manifest_complete": False,
+        "sample_digest": "a" * 64,
+    }
+    assert latency_json_payload(result)["publication_ready"] is False
+
+    result["benchmark_context"]["sample_manifest_complete"] = True
+    assert latency_json_payload(result)["publication_ready"] is True
+
+    # Supersedes an earlier assertion that a *missing* completeness key still
+    # published. It did, and that was the defect: a staged run assembled
+    # through the public API could omit the key entirely and inherit the
+    # synthetic path's benefit of the doubt. A run that declares staged
+    # documents must now say the manifest accounted for them.
+    del result["benchmark_context"]["sample_manifest_complete"]
+    assert latency_json_payload(result)["publication_ready"] is False
+
+    # The synthetic path is what the old exemption was protecting, and it
+    # still publishes -- by saying so.
+    result["benchmark_context"] = {
+        "host_label": "release-host",
+        "model_release_id": "model-release-1",
+        "sample_provenance": "synthetic",
+    }
+    assert latency_json_payload(result)["publication_ready"] is True
 
 
 def test_real_latency_with_failure_is_not_publication_ready():
@@ -382,7 +1421,17 @@ def test_real_latency_with_failure_is_not_publication_ready():
     assert latency_json_payload(result)["publication_ready"] is False
 
 
-def test_real_latency_without_document_path_is_not_publication_ready():
+def test_real_latency_single_kind_run_can_be_publication_ready():
+    # Regression for P1-1 (PR #307 review): this used to assert the
+    # opposite — that a text-only real run could never be
+    # publication_ready — because the gate hardcoded requiring BOTH "text"
+    # and "document" input_paths. That made every --documents-dir run
+    # (document-only, no synthetic text mixed in) structurally
+    # unpublishable no matter how clean the measurements were. The gate now
+    # requires clean coverage of whichever kinds a run actually exercised;
+    # a run that only ever saw text grievances is clean if its one path
+    # (text) is clean, symmetric with a document-only run (see
+    # test_real_document_only_run_reaches_publication_ready below).
     result = run_benchmark(
         variant="standard",
         n_text=1,
@@ -403,8 +1452,49 @@ def test_real_latency_without_document_path_is_not_publication_ready():
     result["benchmark_context"] = {
         "host_label": "release-host",
         "model_release_id": "model-release-1",
+        "sample_provenance": "synthetic",
     }
 
+    assert set(result["input_paths"]) == {"text"}
+    assert latency_json_payload(result)["publication_ready"] is True
+
+
+def test_real_latency_with_unspecified_input_kind_is_not_publication_ready():
+    # A doc with neither text nor document_bytes can't be classified by
+    # _document_kind, and "unspecified" must never satisfy the coverage
+    # gate: it means the provenance of at least one measurement is unknown,
+    # which is exactly what this gate exists to catch.
+    docs = [
+        {
+            "ticket": "T1",
+            "text": None,
+            "document_name": None,
+            "document_bytes": None,
+            "district": "Sambalpur",
+        },
+    ]
+    result = run_benchmark(
+        variant="standard",
+        docs=docs,
+        repeats=2,
+        discard_warm=False,
+        processor_factory=lambda _variant: type(
+            "Processor",
+            (),
+            {
+                "_timing_sink": None,
+                "process": lambda self, **kwargs: self._timing_sink(
+                    {"redact": 0.1, "e2e": 0.2, "ok": 1.0}
+                ),
+            },
+        )(),
+    )
+    result["benchmark_context"] = {
+        "host_label": "release-host",
+        "model_release_id": "model-release-1",
+    }
+
+    assert set(result["input_paths"]) == {"unspecified"}
     assert latency_json_payload(result)["publication_ready"] is False
 
 

--- a/tests/test_dsi_sample.py
+++ b/tests/test_dsi_sample.py
@@ -1,0 +1,606 @@
+"""Tests for the nested DSI corpus draw.
+
+Fixtures are synthetic files written into tmp_path. Nothing here touches the
+real corpus or anything under data/.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from janasunani.evaluation.dsi_sample import (
+    DEFAULT_FLOOR,
+    UNCATEGORISED,
+    DocumentRecord,
+    assert_nested,
+    draw_nested,
+    load_corpus,
+    manifest_digest,
+    summarise,
+    write_manifest,
+)
+
+
+def _corpus(spec: dict[str, int]) -> list[DocumentRecord]:
+    """Build records from {category: n_documents}."""
+    out: list[DocumentRecord] = []
+    for category, n in sorted(spec.items()):
+        for i in range(n):
+            ticket = f"{category[:3].upper()}{i:05d}"
+            out.append(
+                DocumentRecord(
+                    ticket=ticket,
+                    filename=f"{ticket}_complaint_2025_{i:05d}.pdf",
+                    category=category,
+                    size_bytes=1000 + i,
+                )
+            )
+    return out
+
+
+def test_module_documents_the_pinned_corpus_not_the_short_copy():
+    """Codex P1, round 10 on #326: the docstring taught the wrong number.
+
+    It described the corpus as 69,844 documents — the known-short Box copy —
+    while the pinned registry holds 70,029. A caller following it would pass
+    69,844 as the largest tier's budget, so `_draw` would sample rather than
+    return the population whole, and every nested tier would descend from a
+    corpus 185 documents short. Same wrong-population failure the manifest
+    comparison exists to catch, reached through the budget instead of the disk.
+
+    Pinned against the registry so the two cannot drift apart again.
+    """
+    import janasunani.evaluation.dsi_sample as dsi
+    from janasunani.samples import REGISTRY
+
+    doc = dsi.__doc__ or ""
+    assert "70,029 documents across 69,977 tickets" in REGISTRY["dsi_large"].what
+    assert "70,029 documents across 69,977 tickets" in doc
+
+    # 69,844 may appear, but only as the short copy it is — never as the corpus.
+    for line in doc.splitlines():
+        if "69,844" in line:
+            assert "not this number" in line or "Box" in line, line
+
+
+def test_tiers_nest_by_construction():
+    """The smaller tier must be a strict subset of the larger one.
+
+    This is the property the module exists to guarantee. If it ever fails,
+    latency and quality stop describing the same documents.
+    """
+    corpus = _corpus({"Housing": 400, "Social Welfare": 220, "Traffic": 12, "Sports": 30})
+    tiers = draw_nested(corpus, {"quality": 200, "latency": 40}, seed=7, floor=3)
+
+    assert len(tiers["quality"]) == 200
+    assert len(tiers["latency"]) == 40
+    assert_nested(tiers)
+
+    quality = {r.filename for r in tiers["quality"]}
+    latency = {r.filename for r in tiers["latency"]}
+    assert latency < quality
+    assert quality < {r.filename for r in corpus}
+
+
+def test_drawing_from_the_corpus_differs_from_drawing_from_the_tier_above():
+    """Why `draw_nested` chains pools instead of redrawing from the corpus.
+
+    The two are not the same operation. Drawing the small tier from the full
+    corpus samples a different population than drawing it from the larger
+    tier, so the results differ and nesting is not implied. `draw_nested`
+    therefore feeds each tier the previous tier as its pool; nesting is a
+    property of that construction, never of the seed.
+    """
+    corpus = _corpus({"Housing": 400, "Social Welfare": 220, "Traffic": 12, "Sports": 30})
+
+    chained = draw_nested(corpus, {"quality": 200, "latency": 40}, seed=7, floor=3)
+    independent = draw_nested(corpus, {"latency": 40}, seed=7, floor=3)["latency"]
+
+    assert {r.filename for r in chained["latency"]} != {r.filename for r in independent}
+    # The chained one is nested by construction; the independent one is not
+    # required to be, which is exactly the risk.
+    assert_nested(chained)
+
+
+def test_rare_categories_survive_the_floor():
+    """Without a floor the long tail vanishes and per-category accuracy dies."""
+    corpus = _corpus({"Housing": 5000, "Traffic": 4, "Sports": 6})
+    drawn = draw_nested(corpus, {"q": 100}, seed=1, floor=DEFAULT_FLOOR)["q"]
+    per_category = summarise(drawn)["per_category"]
+    assert per_category["Traffic"] >= 3
+    assert per_category["Sports"] >= 3
+    # Housing must not have eaten the budget.
+    assert per_category["Housing"] == 100 - per_category["Traffic"] - per_category["Sports"]
+
+
+def test_infeasible_floor_raises_rather_than_overshooting():
+    """A budget smaller than the floors is a caller error, not a silent trim."""
+    corpus = _corpus({"A": 10, "B": 10, "C": 10})
+    with pytest.raises(ValueError, match="exceeds the budget"):
+        draw_nested(corpus, {"q": 2}, seed=1, floor=3)
+
+
+def test_draw_is_deterministic_for_a_seed():
+    corpus = _corpus({"Housing": 300, "Legal": 80})
+    a = draw_nested(corpus, {"q": 60, "l": 15}, seed=99, floor=3)
+    b = draw_nested(corpus, {"q": 60, "l": 15}, seed=99, floor=3)
+    assert manifest_digest(a["q"]) == manifest_digest(b["q"])
+    assert manifest_digest(a["l"]) == manifest_digest(b["l"])
+
+    c = draw_nested(corpus, {"q": 60, "l": 15}, seed=100, floor=3)
+    assert manifest_digest(c["q"]) != manifest_digest(a["q"])
+
+
+def test_budget_at_or_above_pool_returns_everything():
+    corpus = _corpus({"A": 5, "B": 5})
+    drawn = draw_nested(corpus, {"q": 50}, seed=1, floor=3)["q"]
+    assert len(drawn) == 10
+
+
+def test_assert_nested_catches_a_broken_chain():
+    outer = _corpus({"A": 10})
+    inner = _corpus({"B": 2})
+    with pytest.raises(ValueError, match="not a subset"):
+        assert_nested({"outer": outer, "inner": inner})
+
+
+def test_load_corpus_joins_categories_and_keeps_uncategorised(tmp_path):
+    """Real code path: files on disk joined to a real parquet."""
+    polars = pytest.importorskip("polars")
+
+    docs = tmp_path / "documents"
+    docs.mkdir()
+    for name in (
+        "DM2024001_complaint_20250101_000000.pdf",
+        "DM2024002_complaint_20250101_000001.jpg",
+        "DM2024002_complaint_20250101_000002.jpg",  # same ticket, two documents
+        "DM2024003_complaint_20250101_000003.pdf",  # in complaints, null category
+        "DM2024999_complaint_20250101_000004.pdf",  # not in complaints at all
+    ):
+        (docs / name).write_bytes(b"%PDF-1.3 stub")
+    (docs / ".DS_Store").write_bytes(b"junk")
+
+    parquet = tmp_path / "complaints.parquet"
+    polars.DataFrame(
+        {
+            "ticket_no": ["DM2024001", "DM2024002", "DM2024003"],
+            "category": ["Housing", "Agriculture & Farming", None],
+        }
+    ).write_parquet(parquet)
+
+    records = load_corpus(docs, parquet)
+
+    assert len(records) == 5  # .DS_Store skipped, both docs for DM2024002 kept
+    by_name = {r.filename: r for r in records}
+    assert by_name["DM2024001_complaint_20250101_000000.pdf"].category == "Housing"
+    # A literal ampersand is a real category name and must survive untouched.
+    assert by_name["DM2024002_complaint_20250101_000001.jpg"].category == "Agriculture & Farming"
+    # Present in complaints but with no category: bucketed, not dropped.
+    assert by_name["DM2024003_complaint_20250101_000003.pdf"].category == UNCATEGORISED
+    # Absent from complaints entirely: also bucketed, not dropped.
+    assert by_name["DM2024999_complaint_20250101_000004.pdf"].category == UNCATEGORISED
+
+    summary = summarise(records)
+    assert summary["documents"] == 5
+    assert summary["tickets"] == 4
+    assert summary["categorised_documents"] == 3
+    assert summary["distinct_categories"] == 2
+
+
+def test_load_corpus_preserves_hierarchical_tickets(tmp_path):
+    """1,446 of the 70,029 corpus documents (2.06%) have a ticket with slashes.
+
+    Codex P1 on #326. The reference bucket stores those under the full key, so
+    a synced copy has them one directory down. The old flat `iterdir()` did
+    not mis-parse them, it never reached them — they were silently absent from
+    the corpus and therefore from every tier drawn out of it. Taking the
+    basename instead is the other failure: `00535_complaint_...` parses to
+    `00535`, which matches no complaint and collapses distinct tickets sharing
+    a trailing segment.
+    """
+    polars = pytest.importorskip("polars")
+
+    docs = tmp_path / "documents"
+    (docs / "OR159" / "P" / "2021").mkdir(parents=True)
+    (docs / "OR160" / "P" / "2021").mkdir(parents=True)
+    (docs / "OR159/P/2021/00535_complaint_20250101_000000.pdf").write_bytes(b"a")
+    # Same trailing segment, different ticket. A basename parse merges these.
+    (docs / "OR160/P/2021/00535_complaint_20250101_000001.pdf").write_bytes(b"bb")
+    (docs / "CMO2024001_complaint_20250101_000002.pdf").write_bytes(b"ccc")
+    # Hidden directories anywhere in the path are not documents.
+    (docs / ".dvc" / "cache").mkdir(parents=True)
+    (docs / ".dvc" / "cache" / "x_complaint_20250101_000009.pdf").write_bytes(b"no")
+
+    parquet = tmp_path / "complaints.parquet"
+    polars.DataFrame(
+        {
+            "ticket_no": ["OR159/P/2021/00535", "OR160/P/2021/00535", "CMO2024001"],
+            "category": ["Housing", "Traffic", "Housing"],
+        }
+    ).write_parquet(parquet)
+
+    records = load_corpus(docs, parquet)
+
+    assert len(records) == 3
+    by_ticket = {r.ticket: r for r in records}
+    assert set(by_ticket) == {
+        "OR159/P/2021/00535",
+        "OR160/P/2021/00535",
+        "CMO2024001",
+    }
+    # Both nested documents are found, categorised, and kept distinct.
+    assert by_ticket["OR159/P/2021/00535"].category == "Housing"
+    assert by_ticket["OR160/P/2021/00535"].category == "Traffic"
+    assert all(r.is_categorised for r in records)
+    # filename is the key relative to the corpus root, not the basename —
+    # a basename is not unique across subdirectories.
+    assert (
+        by_ticket["OR159/P/2021/00535"].filename
+        == "OR159/P/2021/00535_complaint_20250101_000000.pdf"
+    )
+
+
+def test_load_corpus_refuses_a_file_that_is_not_a_document(tmp_path):
+    """A stray manifest kept as a document becomes its own stratum.
+
+    Silently, and with a floor allocation taken from a real category.
+    """
+    polars = pytest.importorskip("polars")
+
+    docs = tmp_path / "documents"
+    docs.mkdir()
+    (docs / "CMO2024001_complaint_20250101_000000.pdf").write_bytes(b"a")
+    (docs / "manifest.tsv").write_text("ticket\ts3_key\n")
+
+    parquet = tmp_path / "complaints.parquet"
+    polars.DataFrame(
+        {"ticket_no": ["CMO2024001"], "category": ["Housing"]}
+    ).write_parquet(parquet)
+
+    with pytest.raises(ValueError, match="no '_complaint_' marker"):
+        load_corpus(docs, parquet)
+
+
+def test_write_manifest_round_trips(tmp_path):
+    corpus = _corpus({"Housing": 40, "Legal": 20})
+    drawn = draw_nested(corpus, {"q": 20}, seed=5, floor=3)["q"]
+    path = write_manifest(
+        drawn, tmp_path / "m.json", name="quality", seed=5, floor=3, source="unit-test"
+    )
+    body = json.loads(path.read_text(encoding="utf-8"))
+    assert body["name"] == "quality"
+    assert body["seed"] == 5
+    assert body["documents"] == 20
+    assert body["digest"] == manifest_digest(drawn)
+    assert len(body["documents_list"]) == 20
+    # A manifest must not carry document text.
+    assert "text" not in json.dumps(body)
+
+
+def test_escaped_category_raises_rather_than_splitting_a_stratum(tmp_path):
+    """The DSI corpus is clean; our lake is not. Fail loudly on a corpus swap.
+
+    `Scheme & Benefits` is stored double-escaped in the lake. If this module
+    were ever pointed at that corpus, keying strata on the raw string would
+    split one category in two and quietly halve its floor. Raising is the
+    point: the alternative is a second copy of the scoring-side unescaper
+    drifting away from the original.
+    """
+    polars = pytest.importorskip("polars")
+
+    docs = tmp_path / "documents"
+    docs.mkdir()
+    (docs / "DM2024001_complaint_20250101_000000.pdf").write_bytes(b"%PDF-1.3 stub")
+
+    parquet = tmp_path / "complaints.parquet"
+    polars.DataFrame(
+        {"ticket_no": ["DM2024001"], "category": ["Scheme &amp;amp; Benefits"]}
+    ).write_parquet(parquet)
+
+    with pytest.raises(ValueError, match="HTML entity"):
+        load_corpus(docs, parquet)
+
+
+def test_load_corpus_verifies_against_the_pinned_manifest(tmp_path):
+    """Codex P1 on #326: without this the corpus is whatever is on disk.
+
+    `draw_nested` then emits valid-looking tier manifests for a different
+    population. That is not hypothetical — the Box copy holds 69,844 files
+    against S3's 70,029, and the registry caveat in `janasunani.samples`
+    already warns to source from the manifest rather than from Box.
+    """
+    polars = pytest.importorskip("polars")
+
+    docs = tmp_path / "documents"
+    docs.mkdir()
+    (docs / "CMO2024001_complaint_20250101_000000.pdf").write_bytes(b"a")
+    (docs / "CMO2024002_complaint_20250101_000001.pdf").write_bytes(b"bb")
+
+    parquet = tmp_path / "complaints.parquet"
+    polars.DataFrame(
+        {"ticket_no": ["CMO2024001", "CMO2024002"], "category": ["Housing", "Traffic"]}
+    ).write_parquet(parquet)
+
+    from janasunani.evaluation.dsi_sample import ManifestEntry
+
+    complete = {
+        "CMO2024001_complaint_20250101_000000.pdf": ManifestEntry("CMO2024001", 1, None),
+        "CMO2024002_complaint_20250101_000001.pdf": ManifestEntry("CMO2024002", 2, None),
+    }
+    records = load_corpus(docs, parquet, manifest=complete)
+    assert {r.ticket for r in records} == {"CMO2024001", "CMO2024002"}
+
+    # A manifest listing a document nobody synced: the Box-copy failure.
+    short = dict(complete)
+    short["CMO2024003_complaint_20250101_000002.pdf"] = ManifestEntry("CMO2024003", 3, None)
+    with pytest.raises(ValueError, match="does not match the pinned"):
+        load_corpus(docs, parquet, manifest=short)
+
+    # A document on disk the manifest does not list: the other direction.
+    (docs / "CMO2024999_complaint_20250101_000003.pdf").write_bytes(b"ccc")
+    with pytest.raises(ValueError, match="does not match the pinned"):
+        load_corpus(docs, parquet, manifest=complete)
+
+
+def test_load_corpus_takes_the_ticket_from_the_manifest_not_the_path(tmp_path):
+    """The key and the ticket agree by construction, but the manifest is the
+    pinned record and the parser is a derivation. Where both exist, the
+    record wins — which is what makes hierarchical tickets exact rather than
+    reconstructed."""
+    polars = pytest.importorskip("polars")
+
+    docs = tmp_path / "documents"
+    (docs / "OR159" / "P" / "2021").mkdir(parents=True)
+    key = "OR159/P/2021/00535_complaint_20250101_000000.pdf"
+    (docs / key).write_bytes(b"a")
+
+    parquet = tmp_path / "complaints.parquet"
+    polars.DataFrame(
+        {"ticket_no": ["OR159/P/2021/00535"], "category": ["Housing"]}
+    ).write_parquet(parquet)
+
+    from janasunani.evaluation.dsi_sample import ManifestEntry
+
+    records = load_corpus(
+        docs, parquet, manifest={key: ManifestEntry("OR159/P/2021/00535", 1, None)}
+    )
+    assert records[0].ticket == "OR159/P/2021/00535"
+    assert records[0].is_categorised
+
+
+def test_load_reference_manifest_reads_the_tsv_and_rejects_a_wrong_one(tmp_path):
+    from janasunani.evaluation.dsi_sample import load_reference_manifest
+
+    good = tmp_path / "manifest.tsv"
+    good.write_text(
+        "ticket\ts3_key\tsize_bytes\tmd5\n"
+        "CMO2024001\tCMO2024001_complaint_20250101_000000.pdf\t100\tabc\n"
+        "OR159/P/2021/00535\tOR159/P/2021/00535_complaint_20250101_000001.pdf\t200\tdef\n"
+    )
+    got = load_reference_manifest(good)
+    first = got["CMO2024001_complaint_20250101_000000.pdf"]
+    assert (first.ticket, first.size_bytes, first.md5) == ("CMO2024001", 100, "abc")
+    # The hierarchical key keeps its directory prefix, which is the whole point.
+    assert got["OR159/P/2021/00535_complaint_20250101_000001.pdf"].ticket == "OR159/P/2021/00535"
+
+    wrong = tmp_path / "other.tsv"
+    wrong.write_text("a\tb\n1\t2\n")
+    with pytest.raises(ValueError, match="not a reference manifest"):
+        load_reference_manifest(wrong)
+
+
+def test_a_manifest_and_corpus_can_agree_and_both_be_wrong(tmp_path):
+    """Codex P1, round 14 on #326: the set comparison is symmetric.
+
+    A header-only manifest beside an empty directory, or the same strict
+    subset listed and staged, passes verification vacuously — and
+    `draw_nested` then emits well-formed tier manifests for a fraction of the
+    population. Only a count known independently of both can catch it.
+    """
+    polars = pytest.importorskip("polars")
+
+    from janasunani.evaluation.dsi_sample import (
+        ManifestEntry,
+        load_reference_manifest,
+    )
+
+    # Zero rows is refused outright: it would verify against anything.
+    header_only = tmp_path / "empty.tsv"
+    header_only.write_text("ticket\ts3_key\tsize_bytes\tmd5\n")
+    with pytest.raises(ValueError, match="zero rows"):
+        load_reference_manifest(header_only)
+
+    # A consistent strict subset needs the independent count.
+    docs = tmp_path / "documents"
+    docs.mkdir()
+    name = "CMO2024001_complaint_20250101_000000.pdf"
+    (docs / name).write_bytes(b"the real document")
+
+    parquet = tmp_path / "complaints.parquet"
+    polars.DataFrame(
+        {"ticket_no": ["CMO2024001"], "category": ["Housing"]}
+    ).write_parquet(parquet)
+
+    subset = {name: ManifestEntry("CMO2024001", len(b"the real document"), "abc")}
+    # Manifest and disk agree, so verification alone is satisfied.
+    assert load_corpus(docs, parquet, manifest=subset)
+    # The pinned population is larger, and that is only visible from outside.
+    with pytest.raises(ValueError, match="not the expected"):
+        load_corpus(docs, parquet, manifest=subset, expected_documents=70_029)
+    # The right count still passes.
+    assert load_corpus(docs, parquet, manifest=subset, expected_documents=1)
+
+
+def test_load_reference_manifest_rejects_a_blank_identity(tmp_path):
+    """Codex P1, round 7 on #326: a blank column is not a valid row.
+
+    A blank `s3_key` silently left the expected-key set, so a document that
+    was also absent on disk still compared equal and certified a smaller
+    corpus — the known-short-copy failure the manifest exists to catch,
+    caused by the manifest. A blank `ticket` was emitted in place of the path
+    parse, because `load_corpus` prefers the record over the derivation, and
+    the document landed in the uncategorised stratum under an empty ticket.
+    """
+    from janasunani.evaluation.dsi_sample import load_reference_manifest
+
+    header = "ticket\ts3_key\tsize_bytes\tmd5\n"
+    good = "CMO2024001\tCMO2024001_complaint_20250101_000000.pdf\t100\tabc\n"
+
+    no_key = tmp_path / "no_key.tsv"
+    no_key.write_text(header + good + "CMO2024002\t\t100\tabc\n")
+    with pytest.raises(ValueError, match="blank identity"):
+        load_reference_manifest(no_key)
+
+    no_ticket = tmp_path / "no_ticket.tsv"
+    no_ticket.write_text(
+        header + good + "\tCMO2024002_complaint_20250101_000001.pdf\t100\tabc\n"
+    )
+    with pytest.raises(ValueError, match="blank identity"):
+        load_reference_manifest(no_ticket)
+
+    # Whitespace is blank, not an identity.
+    spaces = tmp_path / "spaces.tsv"
+    spaces.write_text(header + good + "   \t   \t100\tabc\n")
+    with pytest.raises(ValueError, match="blank identity"):
+        load_reference_manifest(spaces)
+
+    # And the well-formed manifest still loads, with the ticket stripped.
+    ok = tmp_path / "ok.tsv"
+    ok.write_text(header + good)
+    got = load_reference_manifest(ok)
+    assert got["CMO2024001_complaint_20250101_000000.pdf"].ticket == "CMO2024001"
+
+
+def test_load_reference_manifest_rejects_a_ticket_that_contradicts_its_key(tmp_path):
+    """Codex P1, round 8 on #326: a valid key with the wrong ticket.
+
+    Every key, size and hash check passes, and `load_corpus` prefers the
+    manifest's ticket over the path parse, so the document is filed under the
+    wrong ticket and inherits that ticket's category and provenance.
+    """
+    from janasunani.evaluation.dsi_sample import load_reference_manifest
+
+    header = "ticket\ts3_key\tsize_bytes\tmd5\n"
+
+    wrong = tmp_path / "wrong.tsv"
+    wrong.write_text(
+        header + "CMO2024002\tCMO2024001_complaint_20250101_000000.pdf\t100\tabc\n"
+    )
+    with pytest.raises(ValueError, match="contradicts"):
+        load_reference_manifest(wrong)
+
+    # Hierarchical tickets keep their slashes and must still round-trip.
+    nested = tmp_path / "nested.tsv"
+    key = "OR159/P/2021/00535_complaint_20250101_000001.pdf"
+    nested.write_text(header + f"OR159/P/2021/00535\t{key}\t200\tdef\n")
+    assert load_reference_manifest(nested)[key].ticket == "OR159/P/2021/00535"
+
+
+def test_load_reference_manifest_rejects_a_repeated_key(tmp_path):
+    """Codex P1 on #326: a duplicate s3_key silently picked the last row.
+
+    The disk-versus-manifest set comparison in `load_corpus` still passes on
+    a duplicate, so nothing downstream noticed; but the surviving row is what
+    supplies the ticket used for category lookup and emitted provenance, so
+    two rows for one key made stratification depend on manifest order.
+    """
+    from janasunani.evaluation.dsi_sample import load_reference_manifest
+
+    key = "CMO2024001_complaint_20250101_000000.pdf"
+    duped = tmp_path / "manifest.tsv"
+    # Both rows must carry the key's own ticket, or the mismatch check below
+    # would catch them first and this would stop testing duplication.
+    duped.write_text(
+        "ticket\ts3_key\tsize_bytes\tmd5\n"
+        f"CMO2024001\t{key}\t100\tabc\n"
+        f"CMO2024001\t{key}\t999\tdef\n"
+    )
+    with pytest.raises(ValueError, match="more than once"):
+        load_reference_manifest(duped)
+
+
+def test_load_corpus_requires_the_metadata_for_the_tier_it_was_asked_for(tmp_path):
+    """Codex P1 on #326: a blank column silently downgraded the check.
+
+    Both byte comparisons were written as "compare it if we have it", so a
+    manifest with a blank `size_bytes` or `md5` degraded verify="size" and
+    verify="md5" to the key comparison while the caller believed they had
+    asked for bytes — certifying altered documents on their names alone.
+    """
+    polars = pytest.importorskip("polars")
+
+    from janasunani.evaluation.dsi_sample import ManifestEntry
+
+    docs = tmp_path / "documents"
+    docs.mkdir()
+    name = "CMO2024001_complaint_20250101_000000.pdf"
+    (docs / name).write_bytes(b"the real document")
+
+    parquet = tmp_path / "complaints.parquet"
+    polars.DataFrame(
+        {"ticket_no": ["CMO2024001"], "category": ["Housing"]}
+    ).write_parquet(parquet)
+
+    no_size = {name: ManifestEntry("CMO2024001", None, "abc")}
+    with pytest.raises(ValueError, match="needs a size_bytes"):
+        load_corpus(docs, parquet, manifest=no_size)
+    # The escape hatch still says so deliberately.
+    assert load_corpus(docs, parquet, manifest=no_size, verify="keys")
+
+    no_md5 = {name: ManifestEntry("CMO2024001", len(b"the real document"), None)}
+    with pytest.raises(ValueError, match="needs a md5"):
+        load_corpus(docs, parquet, manifest=no_md5, verify="md5")
+    # size is what this manifest can support, and it still works.
+    assert load_corpus(docs, parquet, manifest=no_md5)
+
+
+def test_load_corpus_catches_altered_bytes_under_the_right_key(tmp_path):
+    """Codex P1 on #326: matching keys is not matching content.
+
+    A truncated, stale or replaced document stored under the expected key
+    passes the key comparison, and `draw_nested` then emits well-formed tier
+    manifests for altered bytes — the same silent-wrong-population failure
+    the key check exists to stop, one level down.
+    """
+    polars = pytest.importorskip("polars")
+
+    from janasunani.evaluation.dsi_sample import ManifestEntry
+
+    docs = tmp_path / "documents"
+    docs.mkdir()
+    name = "CMO2024001_complaint_20250101_000000.pdf"
+    (docs / name).write_bytes(b"the real document")
+
+    parquet = tmp_path / "complaints.parquet"
+    polars.DataFrame(
+        {"ticket_no": ["CMO2024001"], "category": ["Housing"]}
+    ).write_parquet(parquet)
+
+    import hashlib
+
+    good_md5 = hashlib.md5(b"the real document").hexdigest()  # noqa: S324
+    good = {name: ManifestEntry("CMO2024001", len(b"the real document"), good_md5)}
+
+    assert load_corpus(docs, parquet, manifest=good)  # size and md5 both agree
+    assert load_corpus(docs, parquet, manifest=good, verify="md5")
+
+    # Truncated in place: right key, wrong bytes. Caught by size alone,
+    # which is why size is the default — a stat() per file, free at 70,029.
+    (docs / name).write_bytes(b"trunc")
+    with pytest.raises(ValueError, match="recorded bytes"):
+        load_corpus(docs, parquet, manifest=good)
+
+    # Replaced with something the same length: size cannot see it, md5 can.
+    (docs / name).write_bytes(b"THE FAKE DOCUMENT")
+    assert len(b"THE FAKE DOCUMENT") == len(b"the real document")
+    load_corpus(docs, parquet, manifest=good)  # size check passes
+    with pytest.raises(ValueError, match="md5 mismatch"):
+        load_corpus(docs, parquet, manifest=good, verify="md5")
+
+    # And the escape hatch for a manifest without those columns.
+    load_corpus(docs, parquet, manifest=good, verify="keys")
+
+    with pytest.raises(ValueError, match="verify must be"):
+        load_corpus(docs, parquet, manifest=good, verify="checksum")

--- a/tests/test_sarvam_evaluate.py
+++ b/tests/test_sarvam_evaluate.py
@@ -6,6 +6,7 @@ Recorded / dry-run only; no live Sarvam call.
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -834,3 +835,364 @@ def test_every_supported_extract_field_type_is_accepted():
             # a separate, already-covered rule, not part of this guard.
             field["properties"] = {"child": {"type": "string", "description": "child field"}}
         _validate_extract_schema({"type": "object", "properties": {"field": field}})
+
+
+def test_unwrap_extract_result_reads_the_live_result_envelope():
+    """GET /doc-ai/v1/job/{id}/results nests the schema fields under `result`.
+
+    Regression for the 2026-08-25 Sambalpur/2024 run: the unwrapper knew
+    `results` (plural list) and `data` but not `result` (singular), so it fell
+    through to returning the envelope. The caller's
+    `payload.get("grievance_category")` then read one level too high, every
+    `sarvam_category` recorded as null, and the scorecard reported 0.000
+    accuracy for a measurement that had never been taken.
+    """
+    from janasunani.evaluation.sarvam_evaluate import _unwrap_extract_result
+
+    envelope = {
+        "job_id": "01a036cc",
+        "type": "extract",
+        "status": "completed",
+        "usage": {"pages": 1},
+        "version": "1",
+        "annotations": {"grievance_category": {"confidence": 0.9}},
+        "source_map": {},
+        "result": {
+            "grievance_category": "Social Welfare",
+            "summary": "Pension not disbursed.",
+            "district": "Sambalpur",
+            "grievance_text": "...",
+        },
+    }
+
+    unwrapped = _unwrap_extract_result(envelope)
+
+    assert unwrapped["grievance_category"] == "Social Welfare"
+    assert unwrapped["district"] == "Sambalpur"
+    # The envelope's own keys must not leak through as if they were fields.
+    assert "annotations" not in unwrapped
+    assert "job_id" not in unwrapped
+
+
+def test_unwrap_extract_result_keeps_the_other_known_shapes():
+    from janasunani.evaluation.sarvam_evaluate import _unwrap_extract_result
+
+    assert _unwrap_extract_result({"results": [{"district": "Sambalpur"}]}) == {
+        "district": "Sambalpur"
+    }
+    assert _unwrap_extract_result({"data": {"district": "Sambalpur"}}) == {
+        "district": "Sambalpur"
+    }
+    assert _unwrap_extract_result([{"district": "Sambalpur"}]) == {"district": "Sambalpur"}
+    assert _unwrap_extract_result({"district": "Sambalpur"}) == {"district": "Sambalpur"}
+    assert _unwrap_extract_result(None) == {}
+
+
+def test_unwrap_extract_result_prefers_result_over_a_stale_sibling():
+    """`result` wins: a response carrying both must not silently pick the other."""
+    from janasunani.evaluation.sarvam_evaluate import _unwrap_extract_result
+
+    both = {
+        "result": {"grievance_category": "Housing"},
+        "data": {"grievance_category": "WRONG"},
+    }
+    assert _unwrap_extract_result(both)["grievance_category"] == "Housing"
+
+
+def test_save_records_destination_must_be_inside_the_data_tree(tmp_path):
+    """The dump is unredacted citizen text, so the destination is not free-form.
+
+    Codex P1 on #309: an operator passing `--save-records records.jsonl` or a
+    path under `docs/` got the file created without complaint, leaving
+    unredacted grievance text somewhere git was watching.
+    """
+    import pytest
+
+    from janasunani.config import DATA_DIR
+    from janasunani.evaluation.sarvam_evaluate import _checked_record_destination
+
+    inside = DATA_DIR / "external" / "run" / "records.jsonl"
+    assert _checked_record_destination(inside) == inside.resolve()
+
+    for bad in (
+        Path("records.jsonl"),
+        Path("docs/records.jsonl"),
+        DATA_DIR / ".." / "docs" / "records.jsonl",
+        tmp_path / "records.jsonl",
+    ):
+        with pytest.raises(ValueError, match="governed data tree"):
+            _checked_record_destination(bad)
+
+
+def test_save_records_is_validated_before_any_page_is_processed(tmp_path, monkeypatch):
+    """Codex P2 on #326: a knowable path error must not cost a paid run.
+
+    The check used to run at the write, after every page had been rendered,
+    submitted to Sarvam and scored — and the command then returned before
+    writing the aggregate outputs, so the spend bought nothing at all.
+
+    `discover_pages` is the first thing that touches the input, so asserting
+    it is never reached is what pins "before any page is processed".
+    """
+    from janasunani.evaluation import sarvam_evaluate
+
+    input_dir = tmp_path / "pages"
+    input_dir.mkdir()
+    (input_dir / "CMO1_complaint_20250101_000000.pdf").write_bytes(b"%PDF-1.3 stub")
+
+    def _explode(*args, **kwargs):  # pragma: no cover - must not be called
+        raise AssertionError("discover_pages reached despite an invalid --save-records")
+
+    monkeypatch.setattr(sarvam_evaluate, "discover_pages", _explode)
+
+    rc = sarvam_evaluate.main(
+        [
+            "--input-dir",
+            str(input_dir),
+            "--out",
+            str(tmp_path / "out"),
+            "--dry-run",
+            "--save-records",
+            str(tmp_path / "records.jsonl"),  # outside data/
+        ]
+    )
+    assert rc == 1
+
+
+def test_save_records_unwritable_destination_fails_before_the_run(tmp_path, monkeypatch):
+    """Codex P2, round 4 on #326: being inside data/ is not being writable.
+
+    A parent that is an existing file passes the location check and then
+    raises inside `_write_record_dump` — after every page has been rendered,
+    sent to a paid provider and scored.
+    """
+    from janasunani.config import DATA_DIR
+    from janasunani.evaluation import sarvam_evaluate
+
+    input_dir = tmp_path / "pages"
+    input_dir.mkdir()
+    (input_dir / "CMO1_complaint_20250101_000000.pdf").write_bytes(b"%PDF-1.3 stub")
+
+    # Inside the governed tree, but its parent is a regular file.
+    blocker = DATA_DIR / "external" / "not_a_dir_probe"
+    blocker.parent.mkdir(parents=True, exist_ok=True)
+    blocker.write_text("i am a file\n")
+
+    def _explode(*a, **k):  # pragma: no cover - must not be reached
+        raise AssertionError("discover_pages reached despite an unusable destination")
+
+    monkeypatch.setattr(sarvam_evaluate, "discover_pages", _explode)
+    try:
+        rc = sarvam_evaluate.main(
+            ["--input-dir", str(input_dir), "--out", str(tmp_path / "out"),
+             "--dry-run", "--save-records", str(blocker / "records.jsonl")]
+        )
+    finally:
+        blocker.unlink()
+    assert rc == 1
+
+
+def test_record_dump_is_0600_from_creation_not_after_the_write(tmp_path):
+    """The dump must never be readable by other local users, not even briefly.
+
+    Codex P1 on #326: `destination.open("w")` under the usual 022 umask
+    creates the file 0644 and the old code narrowed it only after the last
+    record was written, so unredacted citizen text sat world-readable for the
+    length of the write -- and permanently if the run was interrupted.
+
+    Asserted mid-write, via a records iterable that checks the mode on its
+    way past. Checking only the finished file would pass against the old
+    chmod-afterwards code too, which is the bug.
+    """
+    from dataclasses import dataclass
+
+    from janasunani.evaluation.sarvam_evaluate import _write_record_dump
+
+    @dataclass
+    class _Rec:
+        page: int
+
+    destination = tmp_path / "records.jsonl"
+    seen_modes: list[int] = []
+
+    def _partial() -> Path:
+        # The write now lands on a temporary sibling and is renamed into place
+        # only once every record is on disk, so mid-write the bytes are there
+        # and `destination` is not. The mode still has to be right from
+        # creation: the partial holds the same unredacted citizen text.
+        partials = list(tmp_path.glob(".records.jsonl.*partial"))
+        assert len(partials) == 1, partials
+        return partials[0]
+
+    def _records():
+        for page in range(3):
+            seen_modes.append(_partial().stat().st_mode & 0o777)
+            yield _Rec(page=page)
+
+    original_umask = os.umask(0o022)
+    try:
+        _write_record_dump(destination, _records())
+    finally:
+        os.umask(original_umask)
+
+    assert seen_modes == [0o600, 0o600, 0o600]
+    assert destination.stat().st_mode & 0o777 == 0o600
+    assert len(destination.read_text().splitlines()) == 3
+
+
+def test_record_dump_temp_file_cannot_be_hijacked_by_a_symlink(tmp_path):
+    """Codex P1, round 13 on #326: my atomic write used a predictable path.
+
+    `.<name>.<pid>.partial` is guessable, and the open used O_TRUNC. A local
+    process able to pre-create that path as a symlink would have had the dump
+    follow it — writing unredacted citizen text outside the tree
+    `_checked_record_destination` validates — and `os.replace` would then have
+    installed the symlink as the final dump.
+
+    `mkstemp` creates with O_CREAT|O_EXCL and an unguessable suffix, so a
+    pre-planted path is neither predictable nor reusable.
+    """
+    from dataclasses import dataclass
+
+    from janasunani.evaluation.sarvam_evaluate import _write_record_dump
+
+    @dataclass
+    class _Rec:
+        page: int
+
+    outside = tmp_path / "outside.txt"
+    outside.write_text("must not be touched\n")
+
+    destination = tmp_path / "dump" / "records.jsonl"
+    destination.parent.mkdir()
+
+    # Plant every partial path the old scheme could have produced.
+    for pid in {os.getpid(), os.getpid() + 1, 1}:
+        os.symlink(outside, destination.parent / f".records.jsonl.{pid}.partial")
+
+    _write_record_dump(destination, [_Rec(page=1)])
+
+    # The dump landed at the validated destination and is a real file.
+    assert destination.is_file() and not destination.is_symlink()
+    assert len(destination.read_text().splitlines()) == 1
+    # Nothing was written through any planted link.
+    assert outside.read_text() == "must not be touched\n"
+
+
+def test_probe_rejects_a_writable_dump_in_a_read_only_directory(tmp_path):
+    """Codex P2, round 12 on #326: my own atomic-write fix broke this probe.
+
+    `_write_record_dump` no longer opens the destination — it writes a
+    sibling and renames it — so the write needs the *directory* writable even
+    when the existing file is. The probe returned early for an existing
+    destination, so this combination passed validation, ran every paid page,
+    and then failed creating the sibling: exactly what the probe exists to
+    prevent.
+    """
+    import pytest as _pytest
+
+    from janasunani.evaluation.sarvam_evaluate import _probe_record_destination
+
+    if os.getuid() == 0:
+        _pytest.skip("root ignores directory permissions")
+
+    holder = tmp_path / "locked"
+    holder.mkdir()
+    destination = holder / "records.jsonl"
+    destination.write_text("prior evidence\n")
+    os.chmod(destination, 0o600)
+    os.chmod(holder, 0o500)  # r-x: the file is writable, the directory is not
+    try:
+        with _pytest.raises(OSError):
+            _probe_record_destination(destination)
+    finally:
+        os.chmod(holder, 0o700)
+
+    # And it still passes when the directory is writable, leaving the
+    # existing evidence untouched.
+    _probe_record_destination(destination)
+    assert destination.read_text() == "prior evidence\n"
+    assert list(holder.glob(".records.jsonl.probe-*")) == []
+
+
+def test_a_failed_record_dump_leaves_the_previous_evidence_intact(tmp_path):
+    """Codex P2, round 11 on #326: O_TRUNC destroyed the old dump on open.
+
+    A serialisation error or an interrupt mid-write left a truncated file
+    where a complete one had been. This is unredacted per-page output from a
+    paid run, so it is not something a retry reconstructs for free — and the
+    startup probe is deliberately non-destructive for exactly that reason.
+    """
+    from dataclasses import dataclass
+
+    from janasunani.evaluation.sarvam_evaluate import _write_record_dump
+
+    @dataclass
+    class _Rec:
+        page: int
+
+    destination = tmp_path / "records.jsonl"
+    _write_record_dump(destination, [_Rec(page=1), _Rec(page=2)])
+    prior = destination.read_text()
+    assert len(prior.splitlines()) == 2
+
+    def _explodes():
+        yield _Rec(page=1)
+        raise RuntimeError("serialisation blew up halfway")
+
+    with pytest.raises(RuntimeError, match="blew up"):
+        _write_record_dump(destination, _explodes())
+
+    # The previous dump is untouched, not truncated to the one record that
+    # had been written when the generator raised.
+    assert destination.read_text() == prior
+    # And nothing unredacted is stranded in a partial sibling.
+    assert list(tmp_path.glob(".records.jsonl.*partial")) == []
+
+    # A KeyboardInterrupt is the interrupt this exists to survive, and it is
+    # a BaseException — the cleanup has to catch it too.
+    def _interrupted():
+        yield _Rec(page=1)
+        raise KeyboardInterrupt
+
+    with pytest.raises(KeyboardInterrupt):
+        _write_record_dump(destination, _interrupted())
+    assert destination.read_text() == prior
+    assert list(tmp_path.glob(".records.jsonl.*partial")) == []
+
+    # A successful write still replaces it.
+    _write_record_dump(destination, [_Rec(page=9)])
+    assert len(destination.read_text().splitlines()) == 1
+    assert destination.stat().st_mode & 0o777 == 0o600
+
+
+def test_record_dump_narrows_a_pre_existing_world_readable_file(tmp_path):
+    """O_CREAT's mode is ignored when the path already exists, so fchmod does it."""
+    from dataclasses import dataclass
+
+    from janasunani.evaluation.sarvam_evaluate import _write_record_dump
+
+    @dataclass
+    class _Rec:
+        page: int
+
+    destination = tmp_path / "records.jsonl"
+    destination.write_text("stale\n")
+    destination.chmod(0o644)
+
+    _write_record_dump(destination, [_Rec(page=1)])
+
+    assert destination.stat().st_mode & 0o777 == 0o600
+    assert "stale" not in destination.read_text()
+
+
+def test_save_records_destination_rejects_traversal_after_resolution():
+    """`data/../docs/x` must not pass on the strength of its prefix."""
+    import pytest
+
+    from janasunani.config import DATA_DIR
+    from janasunani.evaluation.sarvam_evaluate import _checked_record_destination
+
+    escaped = DATA_DIR / "external" / ".." / ".." / "docs" / "leak.jsonl"
+    with pytest.raises(ValueError, match="governed data tree"):
+        _checked_record_destination(escaped)


### PR DESCRIPTION
Splits #326. This is the half where **every** one of its fourteen review rounds landed. The inert half is #338, which this is stacked on.

## Why this is its own pull request

Fourteen rounds, and five of them were caused by the fix from the round before — a marker guard that left the manifest mapping unchecked, a publication gate keyed off the wrong signal, an atomic write that introduced a symlink-planting path, a probe that no longer matched the write it validates. Each fix was correct and each changed an assumption elsewhere. That pattern is going to continue for at least another round or two, and the blast radius of it should be these six files rather than a 4,900-line PR with two others queued behind it.

## What is here

**`janasunani/evaluation/dsi_sample.py`** — nested stratified draws over the DSI reference corpus, with the manifest verification that makes a draw *verified* rather than *whatever happens to be on disk*. It rejects duplicate `s3_key`s, blank identities, a ticket that contradicts its key, a manifest with no rows, and — via `expected_documents` — a manifest and a corpus that agree with each other while both being a strict subset of the pinned population. That last one is the failure mode the whole module exists to prevent, and the set comparison alone cannot see it because it is symmetric.

**`scripts/benchmark_pipeline.py`** — real staged documents as a benchmark input, with a publication gate that requires an *explicit* sample verdict. Silence is a refusal: a run declares `synthetic` or `staged-documents` provenance, and a staged run must name a slice that is not `"unspecified"`, carry a digest, and account for every manifest row. Rows are validated against their own `s3_key`, prefix against `ticket` and basename against `file` — never the two against each other, because a hierarchical ticket stages under `Path(key).name` and a naive check would reject exactly the ~2% of complaints the manifest exists to protect.

**`janasunani/evaluation/sarvam_evaluate.py`** — the record dump is written to an unguessable, exclusively created temporary and replaced atomically, so a failed or interrupted write cannot destroy paid-run evidence and a planted symlink cannot divert unredacted citizen text out of the governed tree.

## Dependency on #338

One edge: `tests/test_dsi_sample.py` pins the module docstring's corpus count against `REGISTRY["dsi_large"]`. That guard exists because the docstring had drifted to the known-short Box copy's 69,844, which would have made a caller draw from a population 185 documents short. Retarget to `main` once #338 lands.

## Known, filed rather than fixed

#335 — hold a descriptor on the validated directory so an ancestor swap mid-run cannot redirect the record dump. Real, deferred deliberately; reasoning is in the issue and in the #326 thread.

## Validation

- `uv run ruff check .` — clean
- `uv run --extra serving --extra pipeline-core pytest` — **2102 passed, 19 skipped**

Every file is byte-identical to its state on #326 at `08aad9e`, so the review history there carries over.