### PR TITLE
Bound corpus-wide grouping memory: per-block verification and a bounded identity path

### DIFF
--- a/janasunani/pipeline/dedup_index.py
+++ b/janasunani/pipeline/dedup_index.py
@@ -180,6 +180,7 @@ from dataclasses import dataclass
 from datetime import date, datetime, timezone
 import hashlib
 from itertools import combinations
+from collections.abc import Iterator
 from typing import Optional
 
 from loguru import logger
@@ -274,6 +275,15 @@ LARGE_BUCKET_ANCHOR_COUNT = 32
 # Stable provenance marker for the bounded grouping policy. Increment this
 # when the algorithm changes even if the cap/anchor defaults do not.
 GROUPING_ALGORITHM = "fixed-anchor-v1"
+
+# Identity buckets carry no block key, so they cannot be scoped to a block
+# the way band buckets are (#336). They are bounded by batching instead: each
+# bucket is one citizen's filings, so this many of them is a small working
+# set even though their members can come from anywhere in the scope. Not a
+# tuning knob -- it trades round trips against peak memory, and only the
+# memory side has a hard limit.
+IDENTITY_BUCKET_BATCH = 2_000
+
 
 # Odia Unicode block. Presence, not majority: any real Odia content in a
 # filing is enough to route it to the Odia-script partition rather than the
@@ -1201,62 +1211,55 @@ def _identity_candidate_pairs(rows) -> set[tuple[str, str]]:
     return pairs
 
 
-def _candidate_buckets(rows, num_bands: int) -> list[tuple[Optional[str], list[str]]]:
-    """Candidate buckets as ``(block_key, members)``, band and identity
-    together.
+def _band_buckets(rows, num_bands: int) -> Iterator[tuple[str, list[str]]]:
+    """Yield non-singleton band buckets as ``(block_key, members)``, one band
+    at a time.
 
-    Returns buckets rather than the pairs inside them. A bucket is quadratic
-    in its membership, so materialising its pairs is what exhausted memory on
-    the Sambalpur slice; the caller streams each bucket and unions as it goes.
+    One band at a time, not all sixteen at once.
 
-    Band buckets are keyed by block, so they respect district/script/time
-    blocking, and carry that block's key in the returned tuple. `_group_duplicates`
-    uses the key to organize overlapping bands before fetching all candidate
-    text once (#158), rather than once per bucket. Identity
-    buckets deliberately are not blocked: a resubmission can land months
-    later and a phone number carries no script (module docstring). They come
-    back with ``None`` in place of a block key -- there is no single block to
-    cache text against, since one identity bucket's members can span the
-    whole slice.
+    Building the full map first and filtering singletons afterwards costs
+    16N dictionary entries at peak -- about 21.9M for the corpus, measured
+    at ~5.2 GiB, which dwarfs the 1.05 GiB the banded rows themselves take
+    and was enough to exhaust an 8 GiB box on its own. Almost all of those
+    entries are singletons that are then thrown away: a signature that
+    collides with nothing still occupies sixteen of them.
 
-    Singleton buckets are dropped -- no pairs, and they would only cost a
-    round trip.
+    Banding is independent per band index, so a bucket can never span two
+    of them. Handling one band per pass therefore yields exactly the same
+    buckets while holding only N entries at a time -- a sixteenth of the
+    peak -- and the singletons are discarded at the end of each pass
+    instead of at the end of everything. The extra passes are over a list
+    already in memory and cost no I/O.
 
-    ``_text_candidate_pairs`` and ``_identity_candidate_pairs`` are retained
-    as the pure, directly-testable statement of what a bucket means, including
-    the all-pairs invariant from #101. This function is the streaming path
-    that production uses.
+    A generator, not a list: `_group_duplicates` consumes one block's buckets
+    and discards them before starting the next, so nothing ever holds every
+    bucket in the scope. Returning a list is what made the corpus run need
+    the buckets twice over -- once here and once in the caller's own
+    per-block index (#336).
     """
-    # One band at a time, not all sixteen at once.
-    #
-    # Building the full map first and filtering singletons afterwards costs
-    # 16N dictionary entries at peak -- about 21.9M for the corpus, measured
-    # at ~5.2 GiB, which dwarfs the 1.05 GiB the banded rows themselves take
-    # and was enough to exhaust an 8 GiB box on its own. Almost all of those
-    # entries are singletons that are then thrown away: a signature that
-    # collides with nothing still occupies sixteen of them.
-    #
-    # Banding is independent per band index, so a bucket can never span two
-    # of them. Handling one band per pass therefore yields exactly the same
-    # buckets while holding only N entries at a time -- a sixteenth of the
-    # peak -- and the singletons are discarded at the end of each pass
-    # instead of at the end of everything. The extra passes are over a list
-    # already in memory and cost no I/O.
-    out: list[tuple[Optional[str], list[str]]] = []
     for band_index in range(num_bands):
         band_buckets: dict[tuple[str, int], list[str]] = defaultdict(list)
         for row, bands in _banded(rows, num_bands):
             band_buckets[(row.block_key, bands[band_index])].append(row.ticket_no)
-        out.extend(
-            (block_key, members)
-            for (block_key, _band_hash), members in band_buckets.items()
-            if len(set(members)) > 1
-        )
+        for (block_key, _band_hash), members in band_buckets.items():
+            if len(set(members)) > 1:
+                yield block_key, members
         del band_buckets
 
-    # Identity buckets are keyed by the citizen, not by a band, so there is
-    # no equivalent split: two dicts over the rows that carry a key at all,
-    # measured at ~0.38 GiB for the corpus.
+
+def _identity_buckets(rows) -> Iterator[list[str]]:
+    """Yield non-singleton identity buckets -- the mobile/email path.
+
+    Identity buckets are keyed by the citizen, not by a band, so there is
+    no per-band split to make: two dicts over the rows that carry a key at
+    all, measured at ~0.38 GiB for the corpus.
+
+    They are deliberately *not* blocked: a resubmission can land months
+    later and a phone number carries no script (module docstring). One
+    identity bucket's members can therefore span the whole scope, which is
+    why `_group_duplicates` verifies them in batches rather than per block,
+    and why they carry no block key.
+    """
     identity_buckets: dict[tuple[str, str], list[str]] = defaultdict(list)
     for row in rows:
         for kind, key in (
@@ -1266,10 +1269,37 @@ def _candidate_buckets(rows, num_bands: int) -> list[tuple[Optional[str], list[s
             if key is not None:
                 identity_buckets[(kind, key)].append(row.ticket_no)
 
-    out.extend(
-        (None, members) for members in identity_buckets.values() if len(set(members)) > 1
-    )
-    return out
+    for members in identity_buckets.values():
+        if len(set(members)) > 1:
+            yield members
+
+
+def _candidate_buckets(rows, num_bands: int) -> list[tuple[Optional[str], list[str]]]:
+    """Candidate buckets as ``(block_key, members)``, band and identity
+    together.
+
+    Returns buckets rather than the pairs inside them. A bucket is quadratic
+    in its membership, so materialising its pairs is what exhausted memory on
+    the Sambalpur slice; the caller streams each bucket and unions as it goes.
+
+    Band buckets carry the key of the block they came from; identity buckets
+    come back with ``None`` in its place, because there is no single block to
+    key them on.
+
+    Singleton buckets are dropped -- no pairs, and they would only cost a
+    round trip.
+
+    This is the whole-scope statement of what a bucket means, including the
+    all-pairs invariant from #101, and is what the bucket tests assert
+    against. **Production does not call it**: `_group_duplicates` streams
+    `_band_buckets` per block and `_identity_buckets` in batches, so that no
+    structure in the grouping pass is sized by the corpus (#336). Keep the
+    two paths agreeing -- `TestBandBucketsAreBuiltOneBandAtATime` is what
+    catches them drifting.
+    """
+    return [(block_key, members) for block_key, members in _band_buckets(rows, num_bands)] + [
+        (None, members) for members in _identity_buckets(rows)
+    ]
 
 
 def _find(parent: dict[str, str], item: str) -> str:
@@ -1428,44 +1458,55 @@ async def _group_duplicates(
     # pairs. Grievance subjects are a couple of hundred characters, so every
     # text in the slice together is only megabytes.
     #
-    # That fixed memory; it left runtime quadratic (#158). Two changes here:
-    # `_verify_bucket` (above) stops generating every pair once a bucket
-    # crosses `representative_cap`, and this loop fetches each candidate
-    # ticket once for all its overlapping LSH and identity buckets. Text and
-    # shingle memory are linear in candidate tickets, not candidate pairs.
+    # That fixed memory; it left runtime quadratic (#158). `_verify_bucket`
+    # (above) stops generating every pair once a bucket crosses
+    # `representative_cap`, and candidate text is fetched once per block
+    # rather than once per bucket.
+    #
+    # Fetching it once for the whole *run* was the next ceiling (#336): text
+    # and shingle memory were linear in the scope's candidate tickets, which
+    # is fine for a district-year and is ~27 GiB for the corpus. Both are now
+    # scoped to a block, which does not grow with the corpus.
     parent: dict[str, str] = {}
-
-    band_buckets_by_block: dict[str, list[list[str]]] = defaultdict(list)
-    identity_buckets: list[list[str]] = []
-    for block_key, members in _candidate_buckets(rows, DEFAULT_NUM_BANDS):
-        unique = sorted(set(members))
-        if block_key is None:
-            identity_buckets.append(unique)
-        else:
-            band_buckets_by_block[block_key].append(unique)
-
-    # Text is small relative to the former pair set. Fetch each candidate
-    # ticket once, in BATCH_SIZE chunks, then reuse it across overlapping LSH
-    # bands *and* identity buckets. This makes database reads linear in unique
-    # candidate tickets rather than one query sequence per candidate bucket.
-    candidate_tickets = sorted(
-        {
-            ticket
-            for buckets in band_buckets_by_block.values()
-            for members in buckets
-            for ticket in members
-        }
-        | {ticket for members in identity_buckets for ticket in members}
-    )
-    async with engine.begin() as conn:
-        text_by_ticket = await _load_redacted_text(conn, candidate_tickets)
-
     verified = 0
     comparisons = 0
     large_buckets = 0
-    shingle_cache: dict[str, set[str]] = {}
-    for buckets_in_block in band_buckets_by_block.values():
-        for members in buckets_in_block:
+
+    # One block at a time, so that nothing here is sized by the corpus (#336).
+    #
+    # `_band_buckets` keys every bucket on `(block_key, band_hash)`, so a band
+    # bucket can never span two blocks. Finishing a block before starting the
+    # next therefore loses nothing -- it is the same set of buckets, verified
+    # in a different order, and union-find connectivity does not depend on the
+    # order pairs arrive in.
+    #
+    # What it buys is that candidate text and the shingle memo live for one
+    # block instead of for the run. `block_key` is district:script:window, so
+    # a block does not grow as the corpus does: measured over all 1,361,842
+    # signatures there are 3,227 blocks, mean 422 rows, p99 3,268, largest
+    # 8,691. Holding the largest of those is ~0.2 GiB against the ~27 GiB a
+    # corpus-wide shingle cache extrapolated to.
+    #
+    # The cost is re-reading text for a ticket that also appears in an
+    # identity bucket, and one round trip per block instead of one for the
+    # run. Both are cheap next to the alternative, which does not fit in RAM.
+    rows_by_block: dict[str, list] = defaultdict(list)
+    for row in rows:
+        rows_by_block[row.block_key].append(row)
+
+    for block_rows in rows_by_block.values():
+        block_buckets = [
+            sorted(set(members))
+            for _block_key, members in _band_buckets(block_rows, DEFAULT_NUM_BANDS)
+        ]
+        if not block_buckets:
+            continue
+        block_tickets = sorted({t for members in block_buckets for t in members})
+        async with engine.begin() as conn:
+            text_by_ticket = await _load_redacted_text(conn, block_tickets)
+        # Fresh per block, as `_verify_bucket`'s docstring has always said.
+        shingle_cache: dict[str, set[str]] = {}
+        for members in block_buckets:
             matches, checked, used_large_policy = _verify_bucket(
                 members,
                 text_by_ticket,
@@ -1478,22 +1519,57 @@ async def _group_duplicates(
             verified += matches
             comparisons += checked
             large_buckets += used_large_policy
+        del block_buckets, block_tickets, text_by_ticket, shingle_cache
 
-    # Identity buckets are unblocked by construction (module docstring), but
-    # share the same candidate-text/shingle cache as LSH buckets above.
-    for members in identity_buckets:
-        matches, checked, used_large_policy = _verify_bucket(
-            members,
-            text_by_ticket,
-            shingle_cache,
-            parent,
-            threshold,
-            representative_cap,
-            anchor_count,
-        )
-        verified += matches
-        comparisons += checked
-        large_buckets += used_large_policy
+    del rows_by_block
+
+    # Identity buckets are unblocked by construction (module docstring), so
+    # there is no block to scope them to. They are bounded a different way:
+    # each one is a single citizen's filings, so a batch of them is small
+    # even though the batch's members can come from anywhere in the scope.
+    identity_batch: list[list[str]] = []
+
+    async def _verify_identity_batch(batch: list[list[str]]) -> tuple[int, int, int]:
+        if not batch:
+            return 0, 0, 0
+        tickets = sorted({t for members in batch for t in members})
+        async with engine.begin() as conn:
+            text_by_ticket = await _load_redacted_text(conn, tickets)
+        shingle_cache: dict[str, set[str]] = {}
+        batch_verified = batch_comparisons = batch_large = 0
+        for members in batch:
+            matches, checked, used_large_policy = _verify_bucket(
+                members,
+                text_by_ticket,
+                shingle_cache,
+                parent,
+                threshold,
+                representative_cap,
+                anchor_count,
+            )
+            batch_verified += matches
+            batch_comparisons += checked
+            batch_large += used_large_policy
+        return batch_verified, batch_comparisons, batch_large
+
+    for members in _identity_buckets(rows):
+        identity_batch.append(sorted(set(members)))
+        if len(identity_batch) >= IDENTITY_BUCKET_BATCH:
+            batch_verified, batch_comparisons, batch_large = await _verify_identity_batch(
+                identity_batch
+            )
+            verified += batch_verified
+            comparisons += batch_comparisons
+            large_buckets += batch_large
+            identity_batch = []
+
+    batch_verified, batch_comparisons, batch_large = await _verify_identity_batch(
+        identity_batch
+    )
+    verified += batch_verified
+    comparisons += batch_comparisons
+    large_buckets += batch_large
+    del identity_batch
 
     all_tickets = [row.ticket_no for row in rows]
     # Singletons still need a group id, so every ticket is seeded through find().

--- a/janasunani/pipeline/dedup_index.py
+++ b/janasunani/pipeline/dedup_index.py
@@ -178,9 +178,9 @@ import math
 from collections import Counter, defaultdict
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
+from collections.abc import Iterator
 import hashlib
 from itertools import combinations
-from collections.abc import Iterator
 from typing import Optional
 
 from loguru import logger
@@ -277,13 +277,19 @@ LARGE_BUCKET_ANCHOR_COUNT = 32
 GROUPING_ALGORITHM = "fixed-anchor-v1"
 
 # Identity buckets carry no block key, so they cannot be scoped to a block
-# the way band buckets are (#336). They are bounded by batching instead: each
-# bucket is one citizen's filings, so this many of them is a small working
-# set even though their members can come from anywhere in the scope. Not a
-# tuning knob -- it trades round trips against peak memory, and only the
-# memory side has a hard limit.
-IDENTITY_BUCKET_BATCH = 2_000
-
+# the way band buckets are (#336). They are bounded by batching instead --
+# by member count, not by bucket count.
+#
+# Bucket count is the wrong unit because identity buckets are wildly uneven.
+# Measured over the corpus: 13,428 non-singleton buckets covering 1,355,855
+# of 1,361,842 signatures, the largest holding 201,965 of them. A batch of
+# "2,000 buckets" is a few hundred tickets or a quarter of the corpus
+# depending on which buckets it gets.
+#
+# A single bucket larger than this still forms its own batch -- nothing can
+# split one bucket, since every member is compared against the anchors. What
+# keeps that bounded is `_verify_bucket` not retaining non-anchor shingles.
+IDENTITY_BATCH_TICKETS = 25_000
 
 # Odia Unicode block. Presence, not majority: any real Odia content in a
 # filing is enough to route it to the Odia-script partition rather than the
@@ -1354,8 +1360,11 @@ def _verify_bucket(
     merely the final connectivity.
 
     At ``cap`` members or more: fixed-anchor comparison (#158; see the module
-    docstring for the full rationale and the accepted recall trade). The first
-    ``anchor_count`` sorted tickets are deterministic anchors. Every unordered
+    docstring for the full rationale and the accepted recall trade). Only the
+    anchors are memoised on this path -- a non-anchor is read once, against
+    every anchor, and caching it would make ``shingle_cache`` as large as the
+    bucket (#336). The first ``anchor_count`` sorted tickets are deterministic
+    anchors. Every unordered
     anchor pair is scored once, then every remaining member is scored against
     every anchor, including when it already matched another anchor. Exact work
     is ``C(anchor_count, 2) + anchor_count * (members - anchor_count)``, at most
@@ -1392,9 +1401,19 @@ def _verify_bucket(
             _union(parent, a, b)
             verified += 1
     for member in members[len(anchors) :]:
+        # Deliberately not `shingles_for`: a non-anchor is compared against
+        # the anchors and then never looked at again in this bucket, so
+        # memoising it only grows the caller's cache (#336). Reuse an entry
+        # another bucket already put there, but never add one. The largest
+        # identity bucket in the corpus has 201,965 members; caching those
+        # is ~4 GiB of shingle sets that are each read once.
+        cached = shingle_cache.get(member)
+        member_shingles = (
+            cached if cached is not None else shingles(text_by_ticket.get(member, ""))
+        )
         for anchor in anchors:
             comparisons += 1
-            if jaccard_similarity(shingles_for(anchor), shingles_for(member)) >= threshold:
+            if jaccard_similarity(shingles_for(anchor), member_shingles) >= threshold:
                 _union(parent, anchor, member)
                 verified += 1
     return verified, comparisons, True
@@ -1552,9 +1571,12 @@ async def _group_duplicates(
             batch_large += used_large_policy
         return batch_verified, batch_comparisons, batch_large
 
+    identity_batch_tickets = 0
     for members in _identity_buckets(rows):
-        identity_batch.append(sorted(set(members)))
-        if len(identity_batch) >= IDENTITY_BUCKET_BATCH:
+        unique = sorted(set(members))
+        identity_batch.append(unique)
+        identity_batch_tickets += len(unique)
+        if identity_batch_tickets >= IDENTITY_BATCH_TICKETS:
             batch_verified, batch_comparisons, batch_large = await _verify_identity_batch(
                 identity_batch
             )
@@ -1562,6 +1584,7 @@ async def _group_duplicates(
             comparisons += batch_comparisons
             large_buckets += batch_large
             identity_batch = []
+            identity_batch_tickets = 0
 
     batch_verified, batch_comparisons, batch_large = await _verify_identity_batch(
         identity_batch

--- a/tests/test_dedup_index.py
+++ b/tests/test_dedup_index.py
@@ -834,7 +834,19 @@ class TestBucketVerificationPolicy:
         assert matches == 1
         assert di._find(parent, "a") == di._find(parent, "b")
 
-    def test_overlapping_bands_fetch_each_candidate_text_once(self, dup_oltp, monkeypatch):
+    def test_overlapping_bands_in_a_block_fetch_each_candidate_text_once(
+        self, dup_oltp, monkeypatch
+    ):
+        """#158: a ticket sitting in several overlapping band buckets is
+        fetched once, not once per bucket.
+
+        #336 rescoped that guarantee from the run to the block. One fetch for
+        every candidate ticket in the scope is what did not fit corpus-wide,
+        so the promise is now "once per block, plus once per identity batch".
+        On this fixture that is three block fetches -- the January window, the
+        September window, and the Odia-script window all produce buckets --
+        and one identity batch.
+        """
         import janasunani.pipeline.dedup_index as di
 
         original = di._load_redacted_text
@@ -848,8 +860,12 @@ class TestBucketVerificationPolicy:
         async_url, _ = dup_oltp
         counts = build_dedup_index("Sambalpur", 2024, oltp_url=async_url, salt=_SALT)
 
-        assert len(fetches) == 1
-        assert fetches[0] == tuple(sorted(set(fetches[0])))
+        assert len(fetches) == 4
+        # The #158 property itself: T1, T2 and T3 share the January block and
+        # collide on more than one band. One fetch has to cover all three.
+        assert any({"T1", "T2", "T3"} <= set(fetch) for fetch in fetches)
+        for fetch in fetches:
+            assert fetch == tuple(sorted(set(fetch)))
         assert counts["comparison_pairs"] >= counts["verified_pairs"]
         assert counts["large_buckets"] == 0
 
@@ -1166,10 +1182,14 @@ class TestGroupingStreamsBucketsInsteadOfMaterialisingPairs:
         import janasunani.pipeline.dedup_index as di
 
         source = inspect.getsource(di._group_duplicates)
-        assert "_candidate_buckets" in source
+        assert "_band_buckets" in source
+        assert "_identity_buckets" in source
         # Assignment, not any mention: a comment referring to the old helpers
         # is fine, a variable holding every pair is the thing being guarded.
         assert not re.search(r"^\s*candidate_pairs\s*=", source, re.M)
+        # #336: production must not call the whole-scope helper. It builds
+        # every bucket in the scope at once, which is the thing being avoided.
+        assert not re.search(r"_candidate_buckets\s*\(", source)
 
     def test_singleton_buckets_are_dropped(self):
         """No pairs in them, and they would each cost a database round trip."""
@@ -2273,9 +2293,12 @@ class TestBandBucketsAreBuiltOneBandAtATime:
 
         def peak(fn):
             tracemalloc.start()
-            fn(rows, 16)
+            # Materialise, so a generator is measured on the same footing as
+            # the list the old build returned.
+            held = list(fn(rows, 16))
             _, pk = tracemalloc.get_traced_memory()
             tracemalloc.stop()
+            assert held
             return pk
 
         before = peak(self._all_at_once)
@@ -2286,3 +2309,138 @@ class TestBandBucketsAreBuiltOneBandAtATime:
             f"peak {after / 2**20:.1f} MiB vs {before / 2**20:.1f} MiB — "
             "band buckets are being retained across bands again"
         )
+
+
+class TestGroupingIsScopedPerBlock:
+    """#336. Corpus-wide grouping needed ~59 GB because every structure in the
+    pass was sized by the scope: buckets for the whole run held twice, then
+    candidate text and a shingle memo for every candidate ticket at once.
+
+    Measured on Sambalpur/2024 (55,544 of 1,361,842 signatures) the grouping
+    pass peaked at 3,169 MB against a 788 MB baseline, which extrapolates to
+    ~59 GB on a 15.7 GB box. `block_key` is district:script:window, so a block
+    does not grow with the corpus -- 3,227 blocks, mean 422 rows, largest
+    8,691 -- and scoping the caches to a block makes the peak flat in corpus
+    size.
+    """
+
+    @staticmethod
+    def _rows(n, num_bands, blocks=4, seed=17):
+        import random
+
+        from janasunani.pipeline.dedup_index import _BandedSignature
+
+        rng = random.Random(seed)
+        return [
+            _BandedSignature(
+                ticket_no=f"CMO2024{i:07d}",
+                district="Sambalpur",
+                created_year=2024,
+                block_key=f"Sambalpur:latin:{i % blocks}",
+                identity_key_mobile=(f"m{i // 3}" if i % 3 == 0 else None),
+                identity_key_email=None,
+                bands=tuple(
+                    rng.getrandbits(63) if rng.random() > 0.05 else rng.randrange(30)
+                    for _ in range(num_bands)
+                ),
+            )
+            for i in range(n)
+        ]
+
+    def test_band_buckets_is_a_generator(self):
+        """A list is what made the corpus run hold every bucket twice: once
+        in the helper's return value and once in the caller's own index."""
+        import inspect
+
+        from janasunani.pipeline import dedup_index as di
+
+        rows = self._rows(200, 8)
+        assert inspect.isgenerator(di._band_buckets(rows, 8))
+        assert inspect.isgenerator(di._identity_buckets(rows))
+
+    def test_verifying_block_by_block_finds_exactly_the_same_band_buckets(self):
+        """The correctness core of the change. `_band_buckets` keys on
+        ``(block_key, band_hash)``, so a band bucket can never span two
+        blocks -- which is why a block can be finished before the next one
+        starts. Asserted rather than argued: a bucket that went missing here
+        would silently drop duplicates."""
+        from collections import defaultdict
+
+        from janasunani.pipeline import dedup_index as di
+
+        rows = self._rows(2000, 8, blocks=5)
+
+        whole_scope = sorted(
+            (block_key, tuple(sorted(set(members))))
+            for block_key, members in di._band_buckets(rows, 8)
+        )
+
+        rows_by_block = defaultdict(list)
+        for row in rows:
+            rows_by_block[row.block_key].append(row)
+        per_block = sorted(
+            (block_key, tuple(sorted(set(members))))
+            for block_rows in rows_by_block.values()
+            for block_key, members in di._band_buckets(block_rows, 8)
+        )
+
+        assert per_block == whole_scope
+        assert whole_scope, "fixture must produce real (non-singleton) buckets"
+
+    def test_candidate_text_is_never_fetched_for_the_whole_scope_at_once(
+        self, dup_oltp, monkeypatch
+    ):
+        """The memory property, over the real fixture and the real code path.
+
+        One fetch for every candidate ticket in the scope is exactly what did
+        not fit. The fixture spans several windows and both scripts, so a
+        block-scoped fetch is necessarily smaller than the scope."""
+        from janasunani.pipeline import dedup_index as di
+
+        async_url, _ = dup_oltp
+        calls: list[list[str]] = []
+        real = di._load_redacted_text
+
+        async def recording(conn, ticket_nos):
+            calls.append(list(ticket_nos))
+            return await real(conn, ticket_nos)
+
+        monkeypatch.setattr(di, "_load_redacted_text", recording)
+        counts = build_dedup_index("Sambalpur", 2024, oltp_url=async_url, salt="s")
+
+        assert counts["groups"] > 0
+        assert len(calls) > 1, "text was still fetched in a single pass"
+        every_candidate = {t for call in calls for t in call}
+        assert max(len(call) for call in calls) < len(every_candidate), (
+            "one fetch covered every candidate ticket in the scope -- the "
+            "caches are scope-sized again"
+        )
+
+    def test_identity_buckets_are_verified_in_batches(self, dup_oltp, monkeypatch):
+        """Identity buckets carry no block key, so batching is the only thing
+        bounding them. With a batch size of one, each identity bucket must
+        cost its own fetch."""
+        from janasunani.pipeline import dedup_index as di
+
+        async_url, _ = dup_oltp
+        calls: list[list[str]] = []
+        real = di._load_redacted_text
+
+        async def recording(conn, ticket_nos):
+            calls.append(list(ticket_nos))
+            return await real(conn, ticket_nos)
+
+        monkeypatch.setattr(di, "_load_redacted_text", recording)
+        monkeypatch.setattr(di, "IDENTITY_BUCKET_BATCH", 1)
+        batched = build_dedup_index("Sambalpur", 2024, oltp_url=async_url, salt="s")
+        batched_calls = len(calls)
+
+        calls.clear()
+        monkeypatch.setattr(di, "IDENTITY_BUCKET_BATCH", 10_000)
+        unbatched = build_dedup_index("Sambalpur", 2024, oltp_url=async_url, salt="s")
+
+        assert batched_calls > len(calls), "batch size did not change the fetches"
+        # Batching is a memory knob, never an answer knob.
+        assert batched["groups"] == unbatched["groups"]
+        assert batched["verified_pairs"] == unbatched["verified_pairs"]
+        assert batched["comparison_pairs"] == unbatched["comparison_pairs"]

--- a/tests/test_dedup_index.py
+++ b/tests/test_dedup_index.py
@@ -2418,7 +2418,7 @@ class TestGroupingIsScopedPerBlock:
 
     def test_identity_buckets_are_verified_in_batches(self, dup_oltp, monkeypatch):
         """Identity buckets carry no block key, so batching is the only thing
-        bounding them. With a batch size of one, each identity bucket must
+        bounding them. With a one-ticket budget, each identity bucket must
         cost its own fetch."""
         from janasunani.pipeline import dedup_index as di
 
@@ -2431,12 +2431,12 @@ class TestGroupingIsScopedPerBlock:
             return await real(conn, ticket_nos)
 
         monkeypatch.setattr(di, "_load_redacted_text", recording)
-        monkeypatch.setattr(di, "IDENTITY_BUCKET_BATCH", 1)
+        monkeypatch.setattr(di, "IDENTITY_BATCH_TICKETS", 1)
         batched = build_dedup_index("Sambalpur", 2024, oltp_url=async_url, salt="s")
         batched_calls = len(calls)
 
         calls.clear()
-        monkeypatch.setattr(di, "IDENTITY_BUCKET_BATCH", 10_000)
+        monkeypatch.setattr(di, "IDENTITY_BATCH_TICKETS", 10_000_000)
         unbatched = build_dedup_index("Sambalpur", 2024, oltp_url=async_url, salt="s")
 
         assert batched_calls > len(calls), "batch size did not change the fetches"
@@ -2444,3 +2444,71 @@ class TestGroupingIsScopedPerBlock:
         assert batched["groups"] == unbatched["groups"]
         assert batched["verified_pairs"] == unbatched["verified_pairs"]
         assert batched["comparison_pairs"] == unbatched["comparison_pairs"]
+
+
+class TestLargeBucketShingleRetention:
+    """#336. Identity buckets are wildly uneven: measured over the corpus,
+    13,428 non-singleton buckets cover 1,355,855 of 1,361,842 signatures and
+    the largest holds 201,965 of them. Nothing can split one bucket, since
+    every member is compared against the anchors -- so the bucket has to be
+    survivable, which means not keeping a shingle set per member.
+    """
+
+    @staticmethod
+    def _bucket(n):
+        members = [f"T{i:04d}" for i in range(n)]
+        text = {t: f"grievance about the road near ward {t}" for t in members}
+        return members, text
+
+    def test_large_bucket_memoises_only_its_anchors(self):
+        from janasunani.pipeline import dedup_index as di
+
+        members, text = self._bucket(300)
+        shingle_cache: dict[str, set[str]] = {}
+        _matches, _checked, used_large_policy = di._verify_bucket(
+            members, text, shingle_cache, {}, 0.9, 200, 8
+        )
+
+        assert used_large_policy is True
+        assert set(shingle_cache) == set(members[:8]), (
+            "non-anchors are read once and must not be memoised"
+        )
+
+    def test_small_bucket_still_memoises_every_member(self):
+        """#158's reuse is on the exhaustive path and must survive #336."""
+        from janasunani.pipeline import dedup_index as di
+
+        members, text = self._bucket(10)
+        shingle_cache: dict[str, set[str]] = {}
+        _matches, _checked, used_large_policy = di._verify_bucket(
+            members, text, shingle_cache, {}, 0.9, 200, 8
+        )
+
+        assert used_large_policy is False
+        assert set(shingle_cache) == set(members)
+
+    def test_a_cached_non_anchor_is_reused_rather_than_recomputed(self):
+        """Not adding to the cache is not the same as ignoring it. A member
+        another bucket already paid for is still read from the memo."""
+        from janasunani.pipeline import dedup_index as di
+
+        members, text = self._bucket(300)
+        seeded = members[100]
+        shingle_cache = {seeded: shingles(text[seeded])}
+        before = shingle_cache[seeded]
+
+        di._verify_bucket(members, text, shingle_cache, {}, 0.9, 200, 8)
+
+        assert shingle_cache[seeded] is before
+
+    def test_the_answer_does_not_depend_on_what_was_cached(self):
+        """The cache is a memo, never an input to the decision."""
+        from janasunani.pipeline import dedup_index as di
+
+        members, text = self._bucket(300)
+
+        cold = di._verify_bucket(members, text, {}, {}, 0.9, 200, 8)
+        warm_cache = {t: shingles(text[t]) for t in members}
+        warm = di._verify_bucket(members, text, warm_cache, {}, 0.9, 200, 8)
+
+        assert cold == warm


### PR DESCRIPTION
Corpus-wide grouping needed about 59 GB and could not run. It now peaks at 692 MB on the largest district-year, with bit-identical results.

## Measured on the box, same slice, same sampler

Sambalpur/2024, the largest district-year (55,544 of 1,361,842 signatures). Signatures were already indexed, so each run timed grouping alone.

| | `fe0d105` before | `09bed95` per-block | `c667604` + identity |
|---|---|---|---|
| **peak RSS** | 3,169 MB | 2,405 MB | **692 MB** |
| min free | 11,814 MB | 12,587 MB | 14,291 MB |
| duplicate groups | 10,874 | 10,874 | 10,874 |
| comparison pairs | 16,638,274 | 16,638,274 | 16,638,274 |
| large buckets | 322 | 322 | 322 |
| wall time | 44m 47s | 41m 41s | 41m 21s |

**The answer never moves.** Groups, comparisons and large-bucket counts are identical across all three, which is the property that matters: this is a memory change, not an algorithm change.

The measured run was `179d325`; `c667604` is that tree plus an import reorder and one blank line, amended before review.

## Two commits

**`09bed95` — verify one block at a time.** `_band_buckets` keys every bucket on `(block_key, band_hash)`, so a band bucket can never span two blocks. Finishing a block before starting the next is the same set of buckets in a different order, and union-find connectivity does not depend on arrival order. Candidate text and the shingle cache now live for one block instead of for the run, which is what `_verify_bucket`'s docstring already claimed ("see `_group_duplicates`'s per-block cache") — the cache was created outside the block loop and never was per-block.

This bounds the peak because a block does not grow with the corpus. `block_key` is district:script:window, and over all 1,361,842 signatures there are 3,227 blocks, mean 422, p99 3,268, largest 8,691.

`_candidate_buckets` becomes a generator pair and stays as the whole-scope statement the bucket tests assert against. Production no longer calls it, and a guard asserts that.

**`c667604` — bound the identity path.** The per-block split fixed the band phase and left identity verification as the ceiling: the band phase peaked at 779 MB, and a `py-spy` dump caught the rest inside `_verify_identity_batch` at 2,053 MB.

Identity buckets are far more uneven than "one citizen's filings" suggests:

| | buckets | members | largest |
|---|---|---|---|
| slice | 5,840 | 52,824 | 27,641 |
| corpus | 13,428 | 1,355,855 | 201,965 |

So `_verify_bucket` no longer memoises non-anchors on the large-bucket path — a non-anchor is read once, against every anchor, and caching it grows the cache by the size of the bucket (~4 GiB for the 201,965-member one). An entry another bucket already paid for is still reused; this only stops new ones being added. The exhaustive path below `cap` is unchanged, so #158's reuse survives where it pays. And identity batching became a member budget rather than a bucket count.

## Projection for `--all`

banded rows ~1.05 GB, union-find ~0.2 GB, largest block ~0.2 GB, identity batch ~0.5 GB, interpreter ~0.4 GB. **About 2.2 GB, flat in corpus size**, against 15.7 GB on the box.

Runtime is untouched. The corpus is still an ~18 hour job. Parallelising across now-independent blocks is a separate question and not attempted here.

## Costs, both accepted

One round trip per block instead of one per run, and re-shingling a ticket that appears in both a band and an identity bucket.

## Base branch

Cut from `main`, not from `docs/timing-quality-briefing` or the current working branch. Those are 22 commits behind `main` and do not contain `d11a8aa`, so their `dedup_index.py` is the pre-fix version and the diff would not have been reviewable against the real code.

## Verification

- `uv run --extra serving --extra pipeline-core pytest` — 2,120 passed, 8 skipped. Not against production Postgres.
- `uv run ruff check .` — clean.
- Two full box runs on the real slice, above.
- No `dvc pull`; no gold-metric gate is touched by this change.

## Not fixed here

One hashed mobile accounts for 201,965 signatures, and non-singleton identity buckets cover 1,355,855 of 1,361,842. A citizen did not file 201,965 grievances — that is a placeholder number being treated as an identity, and the identity path is doing large amounts of work on pairs that are not same-citizen. This change makes that survivable, not correct. Filed separately.

Closes #336
