### PR TITLE
Key masked mobiles on surviving fragments instead of on the mask

### DIFF
--- a/janasunani/analytics/findings/spike.py
+++ b/janasunani/analytics/findings/spike.py
@@ -124,7 +124,7 @@ def _read_lake_source_records(lake_dir: Optional[Path], district: str, year: int
     try:
         sql = """
             SELECT c.ticket_no, c.district, c.created_year, c.created_on,
-                   c.petitioner_mobile, c.petitioner_email,
+                   c.petitioner_mobile, c.petitioner_email, c.petitioner_name,
                    g.grievance_redacted
             FROM complaints c
             JOIN grievance_redactions g USING (ticket_no)
@@ -142,6 +142,7 @@ def _read_lake_source_records(lake_dir: Optional[Path], district: str, year: int
                     "created_on": row["created_on"],
                     "petitioner_mobile": row["petitioner_mobile"],
                     "petitioner_email": row["petitioner_email"],
+                    "petitioner_name": row["petitioner_name"],
                     "grievance_redacted": row["grievance_redacted"],
                 }
             )

--- a/janasunani/analytics/findings/workload.py
+++ b/janasunani/analytics/findings/workload.py
@@ -49,7 +49,7 @@ def _read_lake_source_records(
     try:
         sql = """
             SELECT c.ticket_no, c.district, c.created_year, c.created_on,
-                   c.petitioner_mobile, c.petitioner_email,
+                   c.petitioner_mobile, c.petitioner_email, c.petitioner_name,
                    g.grievance_redacted
             FROM complaints c
             JOIN grievance_redactions g USING (ticket_no)
@@ -67,6 +67,7 @@ def _read_lake_source_records(
                     "created_on": row["created_on"],
                     "petitioner_mobile": row["petitioner_mobile"],
                     "petitioner_email": row["petitioner_email"],
+                    "petitioner_name": row["petitioner_name"],
                     "grievance_redacted": row["grievance_redacted"],
                 }
             )

--- a/janasunani/pipeline/dedup.py
+++ b/janasunani/pipeline/dedup.py
@@ -182,6 +182,11 @@ def _canonical_source_record(record: Mapping[str, object]) -> tuple[str, bytes]:
         "created_on",
         "petitioner_mobile",
         "petitioner_email",
+        # Feeds the masked-mobile composite in `mobile_identity_key` (#341),
+        # so a name change changes the identity key and must read as
+        # staleness. Omitting it would let `_source_digest_mismatches` certify
+        # a row whose key was derived from a name the record no longer has.
+        "petitioner_name",
         "grievance_redacted",
     )
     try:

--- a/janasunani/pipeline/dedup.py
+++ b/janasunani/pipeline/dedup.py
@@ -818,3 +818,112 @@ def identity_key(value: str, salt: str) -> str | None:
         f"{salt}\x00{normalized}".encode("utf-8"), digest_size=32
     )
     return digest.hexdigest()
+
+
+# --- identity under masking (#341) -----------------------------------------
+
+#: Marker for the identity-key derivation, stamped into the index version so
+#: a change here is visible as staleness rather than as silently mixed keys.
+IDENTITY_ALGORITHM = "mobile-tail4-name-v1"
+
+#: Digits kept from a masked mobile. The portal masks `petitioner_mobile` as
+#: a `******`-style prefix plus the last four digits, and those four are
+#: genuine: they spread across all 10,000 values at a mean of ~108 rows each
+#: over the 1.37M-row corpus, which is what real last-four digits look like.
+MASKED_MOBILE_TAIL = 4
+
+#: Characters kept from the petitioner name. `petitioner_name` is effectively
+#: unmasked (6 of 1,371,285 rows carry a mask), so this is real signal.
+NAME_TAIL = 4
+
+
+def _tail_digits(value: str | None, n: int) -> str | None:
+    digits = [ch for ch in (value or "") if ch.isdigit()]
+    return "".join(digits[-n:]) if len(digits) >= n else None
+
+
+def _tail_alpha(value: str | None, n: int) -> str | None:
+    alpha = [ch.lower() for ch in (value or "") if ch.isalpha()]
+    return "".join(alpha[-n:]) if len(alpha) >= n else None
+
+
+def mobile_identity_key(
+    mobile: str | None, name: str | None, salt: str
+) -> str | None:
+    """Same-citizen key for a mobile column that arrives masked (#341).
+
+    :func:`identity_key` assumes it is handed an identifier. On this corpus
+    it is not: **zero** of 1,359,804 identity-keyed signatures had a
+    phone-shaped `petitioner_mobile`. Every value was a mask or a sentinel,
+    and `identity_key`'s trim-and-lowercase fallback -- correct for email --
+    turned each of them into a valid-looking identity. The single value
+    ``'~::~'`` alone accounted for 201,965 signatures spanning 136,779
+    distinct petitioner names, i.e. "no mobile recorded" was being treated
+    as one citizen.
+
+    Two paths, namespaced so they can never collide:
+
+    **A real number, if one is ever present.** Canonicalised exactly as
+    :func:`identity_key` does, and keyed on the full subscriber number. This
+    is unreachable on the current corpus but is the strongest key available
+    and must not be weakened for data that may yet arrive unmasked.
+
+    **Otherwise the surviving fragments.** The last four digits of the mask,
+    plus the last four letters of the petitioner name. Neither is sufficient
+    alone: four digits is ~10^4 values over 1.37M rows, about 108 rows each,
+    which would rebuild the very buckets this exists to remove. Together they
+    yield ~658k keys of which most are singletons.
+
+    Abstains -- ``None``, the module's "nothing meaningful here" contract --
+    when the mobile carries fewer than four digits, which is what removes
+    ``'~::~'``, or when the name carries fewer than four letters. An
+    abstention is the honest answer: a record with no usable fragment has no
+    identity, and inventing one merges strangers.
+
+    **A composite is weaker than a phone number, and deliberately so.** It
+    says "plausibly the same person", not "provably". That is sound here only
+    because identity buckets are *candidates*: every pair still has to clear
+    Jaccard verification on the grievance text before anything is grouped
+    (module docstring point 6). A wrong composite match therefore cannot
+    merge two citizens unless their filings are also near-duplicate in
+    content, which is a duplicate on its own terms.
+
+    ``name`` is read only to derive four lowercase letters. It is never
+    stored, and the return value is a salted hash exactly as elsewhere in
+    this module.
+    """
+    canonical = _canonical_phone_digits(mobile or "")
+    if canonical is not None:
+        # Unnamespaced on purpose: this is the key `identity_key` already
+        # produces for a phone-shaped value, and keeping it byte-identical
+        # means unmasked records keep linking across this change.
+        return identity_key(canonical, salt)
+
+    tail = _tail_digits(mobile, MASKED_MOBILE_TAIL)
+    if tail is None:
+        return None
+    name_tail = _tail_alpha(name, NAME_TAIL)
+    if name_tail is None:
+        return None
+    return identity_key(f"mobile{MASKED_MOBILE_TAIL}:{tail}:{name_tail}", salt)
+
+
+def email_identity_key(email: str | None, salt: str) -> str | None:
+    """Same-citizen key for the email column.
+
+    Unlike the mobile column, this one is healthy: 261,161 of 262,159
+    identity-keyed signatures carry an email-shaped value, across 4,580
+    distinct addresses. So the derivation is unchanged from
+    :func:`identity_key` -- trim and lowercase, which is the right
+    canonicalisation for an address.
+
+    The only addition is a shape requirement. 56 distinct non-address values
+    covering 998 signatures were being keyed as identities by the same
+    fallback that broke the mobile column. An address needs a non-empty local
+    part and a dotted domain; anything else abstains.
+    """
+    value = (email or "").strip()
+    local, _, domain = value.partition("@")
+    if not local or "." not in domain:
+        return None
+    return identity_key(value, salt)

--- a/janasunani/pipeline/dedup_index.py
+++ b/janasunani/pipeline/dedup_index.py
@@ -20,7 +20,8 @@ answer depends on which *other* records are in scope.
 directly would put raw citizen PII into signatures and identity keys instead
 of the typed placeholders the redaction pass exists to produce. The pending
 query below joins `complaints` only for structured columns (district,
-created_on, petitioner_mobile/email); it never selects `complaints.grievance`.
+created_on, petitioner_mobile/email, and petitioner_name for the masked-mobile
+composite of #341); it never selects `complaints.grievance`.
 
 **Two stages, two persistence shapes.**
 
@@ -34,7 +35,10 @@ created_on, petitioner_mobile/email); it never selects `complaints.grievance`.
    key, and separately compute salted identity keys from
    `petitioner_mobile`/`petitioner_email` — a path that never touches the
    redacted text and never feeds `shingles()` (dedup.py module docstring
-   point 3; see `identity_key()`'s contract). Writes `dedup_signatures`.
+   point 3). The mobile column arrives masked on this corpus, so its key is
+   a composite of the surviving fragments plus `petitioner_name`; see
+   `mobile_identity_key()` and `email_identity_key()` for both contracts.
+   Writes `dedup_signatures`.
 2. `_group_duplicates()` — not batched. It loads every signature already
    written for the scope (tens of thousands of rows for a district-year,
    comfortably in memory; 1.37M for `--all`, where that claim has not been
@@ -190,11 +194,13 @@ from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 from janasunani.config import settings
 from janasunani.db.models import Complaint, DedupGroup, DedupSignature, GrievanceRedaction
 from janasunani.pipeline.dedup import (
+    IDENTITY_ALGORITHM,
+    email_identity_key,
+    mobile_identity_key,
     DEDUP_SOURCE_NAME,
     DEFAULT_NUM_BANDS,
     DEFAULT_NUM_HASHES,
     DEFAULT_SHINGLE_SIZE,
-    identity_key,
     jaccard_similarity,
     lsh_bands,
     minhash_signature,
@@ -372,7 +378,8 @@ def _index_version(
         f"shingle_size={DEFAULT_SHINGLE_SIZE} num_hashes={DEFAULT_NUM_HASHES} "
         f"num_bands={DEFAULT_NUM_BANDS} window_days={window_days} "
         f"epoch={DEDUP_WINDOW_EPOCH.isoformat()} "
-        f"threshold={threshold} salt={_salt_marker(salt)}"
+        f"threshold={threshold} salt={_salt_marker(salt)} "
+        f"identity_algorithm={IDENTITY_ALGORITHM}"
     )
     grouping_values = (grouping_algorithm, representative_cap, anchor_count)
     if all(value is None for value in grouping_values):
@@ -489,8 +496,8 @@ async def _load_pending_signature_batch(
 
     Selects `GrievanceRedaction.grievance_redacted` — never
     `Complaint.grievance` — joined to `complaints` only for the structured
-    columns (district, created_on, petitioner_mobile/email) the signature
-    row and the identity keys need. The pending predicate is the resume
+    columns (district, created_on, petitioner_mobile/email, petitioner_name)
+    the signature row and the identity keys need. The pending predicate is the resume
     mechanism (same reasoning as `redact_grievance._load_pending_batch`): it
     must stay a NOT EXISTS against the output table, not an offset.
     """
@@ -516,6 +523,7 @@ async def _load_pending_signature_batch(
             Complaint.created_on,
             Complaint.petitioner_mobile,
             Complaint.petitioner_email,
+            Complaint.petitioner_name,
         )
         .join(Complaint, Complaint.ticket_no == GrievanceRedaction.ticket_no)
         .where(
@@ -539,6 +547,7 @@ def _source_record(
     created_on: datetime | None,
     mobile: str | None,
     email: str | None,
+    name: str | None,
 ) -> dict[str, object]:
     """The exact source fields captured by a signature provenance digest."""
     return {
@@ -548,6 +557,10 @@ def _source_record(
         "created_on": created_on,
         "petitioner_mobile": mobile,
         "petitioner_email": email,
+        # Read only to derive four lowercase letters for the masked-mobile
+        # composite (#341). In the digest because it feeds the identity key:
+        # if the name changes, the key changes, and the row is stale.
+        "petitioner_name": name,
         "grievance_redacted": redacted_text,
     }
 
@@ -571,6 +584,7 @@ def _signature_rows_for_source_batch(
         created_on,
         mobile,
         email,
+        name,
     ) in batch:
         text = redacted_text or ""
         shingle_set = shingles(text)
@@ -578,7 +592,7 @@ def _signature_rows_for_source_batch(
         script = _script_of(text)
         window_index = _window_index(created_on, epoch, window_days)
         source = _source_record(
-            ticket_no, redacted_text, row_district, row_year, created_on, mobile, email
+            ticket_no, redacted_text, row_district, row_year, created_on, mobile, email, name
         )
         rows.append(
             {
@@ -593,8 +607,8 @@ def _signature_rows_for_source_batch(
                 # A separate path from text above: computed from the complaints
                 # columns directly, never from redacted_text (dedup.py module
                 # docstring point 3).
-                "identity_key_mobile": identity_key(mobile, salt) if mobile else None,
-                "identity_key_email": identity_key(email, salt) if email else None,
+                "identity_key_mobile": mobile_identity_key(mobile, name, salt),
+                "identity_key_email": email_identity_key(email, salt),
                 "source_record_digest": source_record_digest(source),
                 "index_version": version,
                 "indexed_at": now,
@@ -634,6 +648,7 @@ async def _source_digest_mismatches(conn, district: Optional[str], year: Optiona
             Complaint.created_on,
             Complaint.petitioner_mobile,
             Complaint.petitioner_email,
+            Complaint.petitioner_name,
             GrievanceRedaction.grievance_redacted,
         )
         .select_from(DedupSignature)
@@ -653,6 +668,7 @@ async def _source_digest_mismatches(conn, district: Optional[str], year: Optiona
         created_on,
         mobile,
         email,
+        name,
         redacted_text,
     ) in result:
         if row_district is None or row_year is None or redacted_text is None:
@@ -660,7 +676,7 @@ async def _source_digest_mismatches(conn, district: Optional[str], year: Optiona
             continue
         current = source_record_digest(
             _source_record(
-                ticket_no, redacted_text, row_district, row_year, created_on, mobile, email
+                ticket_no, redacted_text, row_district, row_year, created_on, mobile, email, name
             )
         )
         if stored_digest is not None and stored_digest != current:
@@ -685,6 +701,7 @@ async def _load_source_rows_for_tickets(conn, ticket_nos: list[str]):
             Complaint.created_on,
             Complaint.petitioner_mobile,
             Complaint.petitioner_email,
+            Complaint.petitioner_name,
         )
         .select_from(DedupSignature)
         .outerjoin(Complaint, Complaint.ticket_no == DedupSignature.ticket_no)

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -712,3 +712,143 @@ class TestGroupingScopeId:
     def test_a_blank_grouping_version_is_refused(self):
         with pytest.raises(ValueError, match="non-blank grouping version"):
             self._scope(version="   ")
+
+
+class TestMobileIdentityKeyUnderMasking:
+    """#341. `petitioner_mobile` arrives masked: zero of 1,359,804
+    identity-keyed signatures in the corpus had a phone-shaped value, and
+    `identity_key`'s trim-and-lowercase fallback turned every mask into a
+    valid-looking identity. The value ``'~::~'`` alone covered 201,965
+    signatures across 136,779 distinct petitioner names.
+    """
+
+    SALT = "a-real-salt"
+
+    def test_a_real_number_keys_exactly_as_before(self):
+        """Unmasked records must keep linking across this change, so the
+        canonical path stays byte-identical to `identity_key`."""
+        from janasunani.pipeline.dedup import identity_key, mobile_identity_key
+
+        assert mobile_identity_key(MOBILE_ASCII, "Ranjan Kumar", self.SALT) == identity_key(
+            MOBILE_ASCII, self.SALT
+        )
+
+    def test_a_real_number_ignores_the_name(self):
+        """The full subscriber number is the identity; the name is only ever
+        a fallback fragment."""
+        from janasunani.pipeline.dedup import mobile_identity_key
+
+        assert mobile_identity_key(MOBILE_ASCII, "Ranjan Kumar", self.SALT) == (
+            mobile_identity_key(MOBILE_ASCII, "Someone Else", self.SALT)
+        )
+
+    def test_the_null_sentinel_abstains(self):
+        """`'~::~'` carries no digits. It is not an identity -- its 201,965
+        signatures span 136,779 distinct names, i.e. 'no mobile recorded'."""
+        from janasunani.pipeline.dedup import mobile_identity_key
+
+        assert mobile_identity_key("~::~", "Ranjan Kumar", self.SALT) is None
+
+    def test_too_few_digits_abstains(self):
+        from janasunani.pipeline.dedup import mobile_identity_key
+
+        assert mobile_identity_key("***", "Ranjan Kumar", self.SALT) is None
+        assert mobile_identity_key("******123", "Ranjan Kumar", self.SALT) is None
+
+    def test_a_missing_name_abstains_rather_than_keying_on_four_digits(self):
+        """Four digits alone is ~10^4 values over 1.37M rows -- about 108 rows
+        each, which rebuilds the buckets this exists to remove."""
+        from janasunani.pipeline.dedup import mobile_identity_key
+
+        assert mobile_identity_key("******1234", None, self.SALT) is None
+        assert mobile_identity_key("******1234", "  ", self.SALT) is None
+        assert mobile_identity_key("******1234", "Li", self.SALT) is None
+
+    def test_the_same_masked_citizen_links(self):
+        from janasunani.pipeline.dedup import mobile_identity_key
+
+        first = mobile_identity_key("******1234", "Ranjan Kumar", self.SALT)
+        second = mobile_identity_key("******1234", "Ranjan Kumar", self.SALT)
+        assert first is not None
+        assert first == second
+
+    def test_the_name_is_case_and_punctuation_insensitive(self):
+        """The corpus carries the same name as '******anja' and '******ANJA'."""
+        from janasunani.pipeline.dedup import mobile_identity_key
+
+        assert mobile_identity_key("******1234", "Ranjan KUMAR", self.SALT) == (
+            mobile_identity_key("******1234", "ranjan kumar", self.SALT)
+        )
+
+    def test_a_different_tail_is_a_different_citizen(self):
+        from janasunani.pipeline.dedup import mobile_identity_key
+
+        assert mobile_identity_key("******1234", "Ranjan Kumar", self.SALT) != (
+            mobile_identity_key("******5678", "Ranjan Kumar", self.SALT)
+        )
+
+    def test_a_different_name_is_a_different_citizen(self):
+        """Two people sharing a last-four must not merge -- that is the whole
+        reason the tail is not used alone."""
+        from janasunani.pipeline.dedup import mobile_identity_key
+
+        assert mobile_identity_key("******1234", "Ranjan Kumar", self.SALT) != (
+            mobile_identity_key("******1234", "Sunita Devi", self.SALT)
+        )
+
+    def test_the_composite_is_salted(self):
+        from janasunani.pipeline.dedup import mobile_identity_key
+
+        assert mobile_identity_key("******1234", "Ranjan Kumar", "salt-1") != (
+            mobile_identity_key("******1234", "Ranjan Kumar", "salt-2")
+        )
+
+    def test_a_blank_salt_still_fails_loudly(self):
+        """A blank value is one citizen's record; a blank salt is the whole
+        deployment. Same stance as `identity_key`."""
+        from janasunani.pipeline.dedup import mobile_identity_key
+
+        with pytest.raises(ValueError, match="non-blank salt"):
+            mobile_identity_key("******1234", "Ranjan Kumar", "")
+
+    def test_a_composite_never_collides_with_a_real_number(self):
+        from janasunani.pipeline.dedup import identity_key, mobile_identity_key
+
+        composite = mobile_identity_key("******4567", "Ranjan Kumar", self.SALT)
+        assert composite != identity_key(MOBILE_ASCII, self.SALT)
+
+
+class TestEmailIdentityKey:
+    """#341. The email column is healthy -- 261,161 of 262,159 keyed
+    signatures carry an address -- so the derivation is unchanged. Only the
+    56 non-address values covering 998 signatures are now refused.
+    """
+
+    SALT = "a-real-salt"
+
+    def test_an_address_keys_exactly_as_before(self):
+        from janasunani.pipeline.dedup import email_identity_key, identity_key
+
+        assert email_identity_key("citizen@example.com", self.SALT) == identity_key(
+            "citizen@example.com", self.SALT
+        )
+
+    def test_case_and_whitespace_still_normalize(self):
+        from janasunani.pipeline.dedup import email_identity_key
+
+        assert email_identity_key(" Citizen@Example.com ", self.SALT) == (
+            email_identity_key("citizen@example.com", self.SALT)
+        )
+
+    def test_a_non_address_abstains(self):
+        """These were being keyed as identities by the same fallback that
+        broke the mobile column."""
+        from janasunani.pipeline.dedup import email_identity_key
+
+        for value in ("751001", "~::~", "not-an-email", "@example.com", "a@b", ""):
+            assert email_identity_key(value, self.SALT) is None, value
+
+    def test_none_abstains(self):
+        from janasunani.pipeline.dedup import email_identity_key
+
+        assert email_identity_key(None, self.SALT) is None

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -852,3 +852,54 @@ class TestEmailIdentityKey:
         from janasunani.pipeline.dedup import email_identity_key
 
         assert email_identity_key(None, self.SALT) is None
+
+
+class TestSourceDigestCoversTheIdentityInputs:
+    """Codex P1 on #346. `petitioner_name` feeds the masked-mobile composite,
+    so a digest that ignores it certifies a row whose identity key was
+    derived from a name the record no longer has -- and
+    `_source_digest_mismatches` never asks for the rebuild, even under
+    --refresh-stale once the index version already matches.
+    """
+
+    @staticmethod
+    def _record(**overrides):
+        from datetime import datetime
+
+        base = {
+            "ticket_no": "T1",
+            "district": "Sambalpur",
+            "created_year": 2024,
+            "created_on": datetime(2024, 1, 1),
+            "petitioner_mobile": "******1234",
+            "petitioner_email": None,
+            "petitioner_name": "Ranjan Kumar",
+            "grievance_redacted": "text",
+        }
+        base.update(overrides)
+        return base
+
+    def test_a_changed_name_changes_the_digest(self):
+        from janasunani.pipeline.dedup import source_record_digest
+
+        assert source_record_digest(self._record()) != source_record_digest(
+            self._record(petitioner_name="Sunita Devi")
+        )
+
+    def test_an_unchanged_record_is_stable(self):
+        from janasunani.pipeline.dedup import source_record_digest
+
+        assert source_record_digest(self._record()) == source_record_digest(
+            self._record()
+        )
+
+    def test_a_record_without_the_name_is_refused(self):
+        """The lake-side builders in analytics/findings share this contract,
+        so a producer that forgets the column fails loudly rather than
+        digesting a partial row."""
+        from janasunani.pipeline.dedup import source_record_digest
+
+        partial = self._record()
+        del partial["petitioner_name"]
+        with pytest.raises(ValueError, match="missing 'petitioner_name'"):
+            source_record_digest(partial)

--- a/tests/test_dedup_index.py
+++ b/tests/test_dedup_index.py
@@ -2512,3 +2512,106 @@ class TestLargeBucketShingleRetention:
         warm = di._verify_bucket(members, text, warm_cache, {}, 0.9, 200, 8)
 
         assert cold == warm
+
+
+@pytest.fixture
+def masked_oltp(tmp_path):
+    """The corpus as it actually arrives: `petitioner_mobile` masked to a
+    `******`-plus-last-four form, `petitioner_name` in the clear, and the
+    `'~::~'` sentinel standing in for "no mobile recorded" (#341)."""
+    complaints = [
+        # Same citizen, same complaint, two windows apart. Only the identity
+        # path can join these -- different windows means different blocks.
+        {
+            "ticket_no": "M1", "district": "Sambalpur", "created_year": 2024,
+            "created_on": datetime(2024, 1, 5), "petitioner_mobile": "******1234",
+            "petitioner_email": None, "petitioner_name": "Ranjan Kumar",
+            "grievance": "raw m1",
+        },
+        {
+            "ticket_no": "M2", "district": "Sambalpur", "created_year": 2024,
+            "created_on": datetime(2024, 7, 20), "petitioner_mobile": "******1234",
+            "petitioner_email": None, "petitioner_name": "RANJAN KUMAR",
+            "grievance": "raw m2",
+        },
+        # Same last four, different citizen. Must not link.
+        {
+            "ticket_no": "M3", "district": "Sambalpur", "created_year": 2024,
+            "created_on": datetime(2024, 10, 1), "petitioner_mobile": "******1234",
+            "petitioner_email": None, "petitioner_name": "Sunita Devi",
+            "grievance": "raw m3",
+        },
+        # The sentinel. Carries no digits, so it is not an identity at all.
+        {
+            "ticket_no": "M4", "district": "Sambalpur", "created_year": 2024,
+            "created_on": datetime(2024, 11, 1), "petitioner_mobile": "~::~",
+            "petitioner_email": None, "petitioner_name": "Ranjan Kumar",
+            "grievance": "raw m4",
+        },
+        {
+            "ticket_no": "M5", "district": "Sambalpur", "created_year": 2024,
+            "created_on": datetime(2024, 12, 1), "petitioner_mobile": "~::~",
+            "petitioner_email": None, "petitioner_name": "Ranjan Kumar",
+            "grievance": "raw m5",
+        },
+    ]
+    redactions = [
+        {"ticket_no": t, "grievance_redacted": text}
+        for t, text in (
+            ("M1", CAMPAIGN_A), ("M2", CAMPAIGN_A), ("M3", CAMPAIGN_A),
+            ("M4", CAMPAIGN_A), ("M5", CAMPAIGN_A),
+        )
+    ]
+    return _make_oltp(tmp_path, complaints, redactions)
+
+
+class TestMaskedMobileIdentityEndToEnd:
+    """#341, through the real backfill rather than the pure function."""
+
+    def test_the_sentinel_produces_no_identity_key(self, masked_oltp):
+        async_url, sync_url = masked_oltp
+        build_dedup_index("Sambalpur", 2024, oltp_url=async_url, salt=_SALT)
+        sigs = _signature_rows(sync_url)
+
+        assert sigs["M4"].identity_key_mobile is None
+        assert sigs["M5"].identity_key_mobile is None
+
+    def test_the_same_masked_citizen_shares_one_key_across_windows(self, masked_oltp):
+        async_url, sync_url = masked_oltp
+        build_dedup_index("Sambalpur", 2024, oltp_url=async_url, salt=_SALT)
+        sigs = _signature_rows(sync_url)
+
+        assert sigs["M1"].identity_key_mobile is not None
+        assert sigs["M1"].identity_key_mobile == sigs["M2"].identity_key_mobile
+        # Different windows, so the text path alone could never join them.
+        assert sigs["M1"].block_key != sigs["M2"].block_key
+
+    def test_a_shared_last_four_is_not_a_shared_citizen(self, masked_oltp):
+        async_url, sync_url = masked_oltp
+        build_dedup_index("Sambalpur", 2024, oltp_url=async_url, salt=_SALT)
+        sigs = _signature_rows(sync_url)
+
+        assert sigs["M3"].identity_key_mobile is not None
+        assert sigs["M3"].identity_key_mobile != sigs["M1"].identity_key_mobile
+
+    def test_identity_widens_the_search_and_text_still_decides(self, masked_oltp):
+        """M1 and M2 are the same citizen in different windows with matching
+        text, so they group. That join exists only because the identity key
+        crosses the block boundary."""
+        async_url, sync_url = masked_oltp
+        build_dedup_index("Sambalpur", 2024, oltp_url=async_url, salt=_SALT)
+        groups = _group_rows(sync_url)
+
+        assert groups["M1"].duplicate_group_id == groups["M2"].duplicate_group_id
+
+
+class TestIdentityAlgorithmProvenance:
+    def test_the_index_version_names_the_identity_derivation(self):
+        """#341 changes what goes into the identity key, so a row produced
+        under the old derivation must read as stale rather than be silently
+        mixed with new ones."""
+        from janasunani.pipeline.dedup import IDENTITY_ALGORITHM
+        from janasunani.pipeline.dedup_index import _index_version
+
+        version = _index_version(30, 0.5, "a-salt")
+        assert f"identity_algorithm={IDENTITY_ALGORITHM}" in version

--- a/tests/test_dedup_index.py
+++ b/tests/test_dedup_index.py
@@ -240,6 +240,7 @@ class TestGroupSourceSnapshotProvenance:
                 "created_on": created_on,
                 "petitioner_mobile": mobile,
                 "petitioner_email": None,
+                "petitioner_name": None,
                 "grievance_redacted": redacted,
             }
             for ticket_no, district, year, created_on, mobile, redacted in _SMALL_ROWS
@@ -1438,6 +1439,7 @@ class TestHeldOutRecall:
                 "created_on": created_on,
                 "petitioner_mobile": mobile,
                 "petitioner_email": None,
+                "petitioner_name": None,
                 "grievance_redacted": redacted,
             }
             for ticket_no, district, year, created_on, mobile, redacted in _SMALL_ROWS
@@ -1979,6 +1981,7 @@ class TestGroupingScopeProvenance:
                 "created_on": datetime(2024, 1, 5),
                 "petitioner_mobile": None,
                 "petitioner_email": None,
+                "petitioner_name": None,
                 "grievance_redacted": text_,
             }
             for ticket, text_ in (("A1", UNRELATED_A), ("A2", UNRELATED_B))
@@ -2021,6 +2024,7 @@ class TestGroupingScopeProvenance:
                 "created_on": datetime(2024, 1, 5),
                 "petitioner_mobile": None,
                 "petitioner_email": None,
+                "petitioner_name": None,
                 "grievance_redacted": UNRELATED_A,
             }
         ]


### PR DESCRIPTION
`identity_key` assumes it is handed an identifier. On this corpus it is not.

```
keyed_signatures     1,359,804
phone-shaped                 0
not phone-shaped     1,359,804   (100.0%), over 18,034 distinct values
```

`petitioner_mobile` arrives masked. Every value is a `******`-plus-last-four mask, a name fragment that landed in the wrong column, or the sentinel `~::~`. The trim-and-lowercase fallback in `identity_key` — correct for an email address — turned each of them into a valid-looking identity.

## Why `~::~` is not a citizen

It covers 201,965 signatures. Sampling 3,000 pairs inside it, using the pipeline's own `shingles`/`jaccard_similarity`:

| bucket | mean | median | pairs >= 0.5 | distinct names |
|---|---|---|---|---|
| control, random corpus pairs | 0.009 | 0.000 | 0.10% | - |
| `~::~`, n=201,965 | 0.011 | 0.000 | 0.27% | 136,779 |

Statistically indistinguishable from random pairs, across 430 blocks and 1,469 days. It means "no mobile recorded".

Note this is **not** true of every large bucket, which is why this PR adds no size cap and no similarity filter. The n=31,360 bucket has median similarity 0.697 with 90.6% of pairs over threshold, and 99.6% of its filings carry one name — a single filer repeating, which is a true duplicate cluster and exactly what the index should find. An earlier draft of this fix would have discarded it.

## What changed

`identity_key` itself is untouched, so its contract and its existing tests stand. Two derivations are added.

**`mobile_identity_key(mobile, name, salt)`** keys a real number exactly as before — unmasked records must keep linking across this change — and otherwise composes the last four digits of the mask with the last four letters of `petitioner_name`.

Both fragments are real. The mask preserves genuine last-four digits: they spread across all 10,000 values at a mean of ~108 rows each over 1.37M rows, which is what real last-four digits look like. And `petitioner_name` is effectively unmasked, 6 masked rows out of 1,371,285.

Neither is sufficient alone — four digits is ~108 rows per key, which rebuilds the buckets this exists to remove — so it abstains unless both are present. That abstention is what drops `~::~`.

**`email_identity_key(email, salt)`** changes nothing about the derivation, because that column is healthy: 261,161 of 262,159 keyed signatures carry an address across 4,580 distinct values. It only refuses the 56 non-address values, covering 998 signatures, that the same fallback was keying.

## On composites being weaker than a phone number

A composite says "plausibly the same person", not "provably". That is sound here only because identity buckets are *candidates*: every pair still clears Jaccard verification on the grievance text before anything is grouped. A wrong composite match cannot merge two citizens unless their filings are also near-duplicate in content, which is a duplicate on its own terms.

Deliberately **not** in the key: `block_id` and `gender_id`. Both fragment a single filer — block splits one across 73 blocks, and gender varies within one name, splitting n=31,360 down to 18,711.

`petitioner_name` is read only to derive four lowercase letters. It is never stored; the output is a salted hash as before. It does join the source provenance digest, because it now feeds the key and a change to it must read as staleness.

## Operational consequence

`IDENTITY_ALGORITHM` is stamped into the index version, so **this requires a full re-index**: every signature is stale and must be rebuilt with `--refresh-stale`. That is the ~5 hour indexing pass, not the ~40 minute grouping. Existing identity keys are invalidated by design — they were keyed on masks.

Grouping memory is unaffected; #340 already bounds that at 692 MB on the largest slice.

## Verification

- `uv run --extra serving --extra pipeline-core pytest` — 2,268 passed, 8 skipped. Not against production Postgres.
- `uv run ruff check .` — clean.
- New coverage: 15 unit tests over both derivations, plus an end-to-end class on a masked fixture proving the sentinel yields no key, that the same masked citizen shares one key across window boundaries, that a shared last-four alone does not merge two people, and that the cross-block join only happens because identity widens the search.
- All pre-existing `identity_key` tests pass unchanged, which is the check that the unmasked path did not move.

Refs #341
