### PR TITLE
feat(infra): add a no-lifecycle bucket for the DSI reference corpus

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -86,7 +86,11 @@ rollback): [docs/DEPLOY.md](../docs/DEPLOY.md) §"Automated demo deploy".
 ## Terraform (summary — details in [terraform/README.md](terraform/README.md))
 
 - **CPU box**: always-on t3.large, Elastic IP, IAM instance role scoped to the
-  three project buckets (documents / DVC-cache prefix / backups). SSH is locked
+  four project buckets: read/write on documents, the DVC-cache prefix and
+  backups, and **read-only** `s3:GetObject` on the DSI reference corpus, so
+  the box that runs the benchmarks cannot alter what it is measuring. The
+  reference bucket is the one Terraform creates, so `apply` needs credentials
+  that can administer S3, not only EC2/EIP/IAM. SSH is locked
   to `admin_cidr` — when your IP rotates (VPN on/off), update
   `terraform.tfvars` and re-apply; use `curl -4 -s ifconfig.me` (plain curl may
   return IPv6).

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -89,8 +89,9 @@ rollback): [docs/DEPLOY.md](../docs/DEPLOY.md) §"Automated demo deploy".
   four project buckets: read/write on documents, the DVC-cache prefix and
   backups, and **read-only** `s3:GetObject` on the DSI reference corpus, so
   the box that runs the benchmarks cannot alter what it is measuring. The
-  reference bucket is the one Terraform creates, so `apply` needs credentials
-  that can administer S3, not only EC2/EIP/IAM. SSH is locked
+  reference bucket is the one Terraform manages -- it already exists and the
+  config adopts it with an `import` block -- so `apply` needs credentials that
+  can administer S3, not only EC2/EIP/IAM. SSH is locked
   to `admin_cidr` — when your IP rotates (VPN on/off), update
   `terraform.tfvars` and re-apply; use `curl -4 -s ifconfig.me` (plain curl may
   return IPv6).

--- a/deploy/terraform/.gitignore
+++ b/deploy/terraform/.gitignore
@@ -9,7 +9,11 @@ crash.log
 crash.*.log
 *.tfstate.*
 
-# Saved plans hold resolved variable values, including secrets.
+# Saved plans hold resolved variable values, including secrets: a plan archive
+# embeds tfstate/tfstate-prev — live account, instance, subnet and SSH-CIDR
+# values. The *.tfstate* patterns above do not match a .tfplan, because a plan
+# is a zip that *contains* state rather than being named like it, so these
+# patterns are load-bearing rather than redundant.
 *.tfplan
 *.tfplan.*
 plan.out

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -24,9 +24,10 @@ Two instances, one always on:
   EC2 instance + Elastic IP + security group + an IAM instance role scoped to four
   S3 buckets (documents, DVC cache, DB backups, DSI reference corpus). The first
   three are **not** managed here. The fourth,
-  `janasunani-documents-dsi-reference`, **is** (`reference_bucket.tf`) — so
-  `apply` creates and administers an S3 bucket, and needs credentials with S3
-  rights, not only EC2/EIP/IAM. The box gets `s3:GetObject` on it and nothing
+  `janasunani-documents-dsi-reference`, **is** (`reference_bucket.tf`). It
+  already exists and holds the corpus, so the config adopts it with an
+  `import` block rather than creating it — `apply` still administers an S3
+  bucket and needs credentials with S3 rights, not only EC2/EIP/IAM. The box gets `s3:GetObject` on it and nothing
   else: it must not be able to alter the corpus it is measured against.
 - the **on-demand GPU box** (`gpu.tf`) for DeepSeek OCR batch runs and demo windows —
   count-toggled, off by default, nothing stateful on it. See "GPU box" below.

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -21,9 +21,13 @@
 Two instances, one always on:
 
 - the **always-on CPU box** for the demo stack (Week 1 of the roadmap): Ubuntu 24.04
-  EC2 instance + Elastic IP + security group + an IAM instance role scoped to the three
-  existing S3 buckets (documents, DVC cache, DB backups). The buckets themselves are
-  **not** managed here.
+  EC2 instance + Elastic IP + security group + an IAM instance role scoped to four
+  S3 buckets (documents, DVC cache, DB backups, DSI reference corpus). The first
+  three are **not** managed here. The fourth,
+  `janasunani-documents-dsi-reference`, **is** (`reference_bucket.tf`) — so
+  `apply` creates and administers an S3 bucket, and needs credentials with S3
+  rights, not only EC2/EIP/IAM. The box gets `s3:GetObject` on it and nothing
+  else: it must not be able to alter the corpus it is measured against.
 - the **on-demand GPU box** (`gpu.tf`) for DeepSeek OCR batch runs and demo windows —
   count-toggled, off by default, nothing stateful on it. See "GPU box" below.
 

--- a/deploy/terraform/iam.tf
+++ b/deploy/terraform/iam.tf
@@ -3,6 +3,8 @@
 #   - janasunani-documents-main      ingested documents (s3service)
 #   - dpic-dvc-cache                 DVC remote (raw dump, Parquet lake, models)
 #   - grievance-database-backups-main  nightly pg_dump target (write-mostly)
+# plus one that IS managed here, read-only:
+#   - janasunani-documents-dsi-reference  benchmark corpus (reference_bucket.tf)
 
 resource "aws_iam_role" "cpu_box" {
   name = "janasunani-cpu-box"
@@ -31,6 +33,7 @@ resource "aws_iam_role_policy" "s3_access" {
         Resource = [
           "arn:aws:s3:::${var.documents_bucket}",
           "arn:aws:s3:::${var.backups_bucket}",
+          "arn:aws:s3:::${var.dsi_reference_bucket}",
         ]
       },
       {
@@ -57,6 +60,16 @@ resource "aws_iam_role_policy" "s3_access" {
         Resource = [
           "arn:aws:s3:::${var.documents_bucket}/*",
         ]
+      },
+      {
+        # Read-only, and deliberately so. The reference corpus is the fixed
+        # input every benchmark number is measured against (#319), so the box
+        # that runs the benchmarks must not be able to alter what it is
+        # measuring. Population happens once, from an operator workstation.
+        Sid      = "ReadDsiReferenceCorpusOnly"
+        Effect   = "Allow"
+        Action   = ["s3:GetObject"]
+        Resource = ["arn:aws:s3:::${var.dsi_reference_bucket}/*"]
       },
       {
         Sid      = "ReadWriteDvcCacheRepoPrefixOnly"

--- a/deploy/terraform/reference_bucket.tf
+++ b/deploy/terraform/reference_bucket.tf
@@ -1,0 +1,105 @@
+# The DSI reference corpus bucket.
+#
+# Unlike the three buckets in iam.tf, this one IS managed here. The property
+# that makes it worth having is that **no lifecycle rule ever transitions or
+# expires an object in it**, and that guarantee is not something a
+# hand-created bucket records anywhere. Declaring it in Terraform is what
+# stops someone adding a transition rule later "for consistency" and silently
+# re-archiving the corpus.
+#
+# Note the invariant is "no transition or expiration actions", not "no
+# lifecycle rule". There is one, below, and it is the enforcement mechanism --
+# see its own comment.
+#
+# Why it exists at all. janasunani-documents-main carries a lifecycle rule
+# with an empty prefix -- STANDARD_IA at 30 days, GLACIER at 90 -- so every
+# object in it ends up archived. Reading an archived object needs a restore,
+# and a restore only stages a *temporary* copy: the storage class stays
+# GLACIER and the copy expires. That is fine for ad-hoc sampling and wrong
+# for a reference corpus that every future benchmark has to re-read.
+#
+# The alternatives were worse. Copying objects onto themselves as STANDARD
+# resets the lifecycle clock, so they re-archive 90 days later, forever.
+# Exempting them from the rule is not expressible: S3 lifecycle filters have
+# no negation and the corpus shares no key prefix, so it would mean tagging
+# the ~960,000 objects we *do* want archived and filtering on that -- where
+# any future object arriving untagged silently never archives, a failure that
+# surfaces as a bill months later.
+#
+# A separate bucket with no transition or expiration rule makes "stays
+# readable" the default rather than something maintained. At 56 GB that is
+# about $1.40/month.
+
+resource "aws_s3_bucket" "dsi_reference" {
+  bucket = var.dsi_reference_bucket
+
+  # The corpus is the fixed input every model number is computed against
+  # (#319). Losing it invalidates the comparisons, not just the bytes.
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  # S3 tag values accept letters, digits, spaces and + - = . _ : / @ only.
+  # A comma here fails CreateBucket with InvalidTag.
+  tags = {
+    Purpose = "DSI clinic reference corpus - fixed benchmark input - do not archive"
+  }
+}
+
+# Declared rather than omitted, which is the opposite of what it looks like.
+#
+# An absent lifecycle configuration is not *managed* state. The AWS provider
+# has nothing to compare against, so a transition rule added later through the
+# console is invisible to `terraform plan` -- exactly the drift the header says
+# this file exists to prevent. Leaving the resource out documents the intent
+# and enforces nothing.
+#
+# Declaring it makes Terraform the owner: any out-of-band rule now shows up as
+# drift and is removed on the next apply.
+#
+# The single rule is deliberately not a transition. Aborting abandoned
+# multipart uploads is storage hygiene, not archival -- it matters while
+# loading 56 GB and it never moves an object between storage classes. It is
+# here because a lifecycle configuration must carry at least one valid action
+# for the ownership to be declarable at all.
+resource "aws_s3_bucket_lifecycle_configuration" "dsi_reference" {
+  bucket = aws_s3_bucket.dsi_reference.id
+
+  rule {
+    id     = "abort-abandoned-multipart-uploads"
+    status = "Enabled"
+
+    filter {}
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "dsi_reference" {
+  bucket = aws_s3_bucket.dsi_reference.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "dsi_reference" {
+  bucket = aws_s3_bucket.dsi_reference.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "dsi_reference" {
+  bucket = aws_s3_bucket.dsi_reference.id
+
+  block_public_acls       = true
+  ignore_public_acls      = true
+  block_public_policy     = true
+  restrict_public_buckets = true
+}

--- a/deploy/terraform/reference_bucket.tf
+++ b/deploy/terraform/reference_bucket.tf
@@ -30,6 +30,24 @@
 # readable" the default rather than something maintained. At 56 GB that is
 # about $1.40/month.
 
+# The bucket already exists in the account: `aws s3api head-bucket` answers for
+# it in ap-south-1, and samples.py records the 70,029-document corpus as
+# mirrored there. A plain apply would therefore call CreateBucket and stop with
+# BucketAlreadyOwnedByYou -- partway through, after other resources had been
+# created, which is the failure mode the prerequisites in docs/DEPLOY.md warn
+# about for S3 permissions and the same clean-up cost.
+#
+# So the first apply adopts it rather than creating it. Only the bucket needs
+# this: the versioning, encryption, public-access-block and lifecycle resources
+# below are PUT calls that converge whether or not the settings are already
+# there.
+#
+# Remove this block once the bucket is in state; it has done its job then.
+import {
+  to = aws_s3_bucket.dsi_reference
+  id = var.dsi_reference_bucket
+}
+
 resource "aws_s3_bucket" "dsi_reference" {
   bucket = var.dsi_reference_bucket
 

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -75,6 +75,12 @@ variable "documents_bucket" {
   default     = "janasunani-documents-main"
 }
 
+variable "dsi_reference_bucket" {
+  description = "S3 bucket for the DSI clinic reference corpus. Managed in reference_bucket.tf (the other buckets are not) because its defining property is that no lifecycle rule transitions or expires its objects. It does carry one rule, aborting abandoned multipart uploads: owning the lifecycle configuration is what makes an archival rule added elsewhere show up as drift."
+  type        = string
+  default     = "janasunani-documents-dsi-reference"
+}
+
 variable "dvc_cache_bucket" {
   description = "Existing S3 bucket backing the DVC remote (.dvc/config)."
   type        = string

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -43,8 +43,8 @@ what runs *on* the CPU box is Docker Compose ([deploy/docker-compose.yml](../dep
 | State | production data on an external named volume | **nothing stateful** |
 | Cost | ~always-on t3 | ~$1/hr only while up |
 
-Both share one **IAM instance role** (no static keys) scoped to three existing
-S3 buckets, and neither holds a GitHub credential — you clone the private repo
+Both share one **IAM instance role** (no static keys) scoped to four S3
+buckets (three pre-existing, one Terraform-managed), and neither holds a GitHub credential — you clone the private repo
 (and its private `dpic` dependency) via **SSH agent forwarding** (`ssh -A`).
 
 **Region** `ap-south-1` · GPU pinned to **`ap-south-1a`** (g6 isn't offered in 1c).
@@ -53,10 +53,25 @@ Current live CPU box: `i-0ef24e15a80ba7128`, EIP `52.66.116.80`.
 ## Prerequisites (local machine)
 
 - Terraform, AWS CLI v2, an SSH keypair (default `~/.ssh/id_ed25519[.pub]`).
-- AWS credentials with rights to create EC2/EIP/IAM/security groups.
+- AWS credentials with rights to create EC2/EIP/IAM/security groups, and to
+  administer S3 buckets. The apply creates `janasunani-documents-dsi-reference`
+  and sets its tags, lifecycle, versioning, encryption and public-access block,
+  so credentials scoped to EC2/EIP/IAM alone will get through `plan` and fail
+  partway into `apply`, after some resources already exist.
 - The three S3 buckets already exist (Terraform does **not** manage them):
   `janasunani-documents-main`, `dpic-dvc-cache` (prefix `janasunani`),
   `grievance-database-backups-main`.
+- A fourth, `janasunani-documents-dsi-reference`, **is** managed by Terraform
+  (`reference_bucket.tf`) and is created by the apply below. It holds the DSI
+  clinic benchmark corpus, and its invariant is **no transition or expiration
+  actions** — never that it has no lifecycle rule at all. It does have one, and
+  that is the mechanism: Terraform owns the lifecycle configuration precisely so
+  an archival rule added through the console shows up as drift. The single rule
+  aborts abandoned multipart uploads and moves nothing between storage classes.
+  Do not "clean it up" as console drift; deleting it is what would let a real
+  transition rule land unnoticed. The instance role gets `s3:GetObject` on it and
+  nothing else: the box that runs the benchmarks must not be able to alter what
+  it is measuring.
 
 ## 1 · Provision the infrastructure
 
@@ -571,12 +586,14 @@ The GPU box is create/destroy (toggle `gpu_box_count`), never stop/start.
 `aws_region` (ap-south-1), `admin_cidr` (no default — your IP/32),
 `instance_type` (t3.xlarge), `root_volume_gb` (150), `gpu_box_count` (0),
 `gpu_instance_type` (g6.xlarge), `gpu_availability_zone` (ap-south-1a),
-`ssh_public_key_path` (`~/.ssh/id_ed25519.pub`), and the three bucket vars.
+`ssh_public_key_path` (`~/.ssh/id_ed25519.pub`), and the four bucket vars.
 [ci.tf](../deploy/terraform/ci.tf) adds `create_github_oidc_provider` (default
 `true` — see its comment on the one-per-account OIDC provider limit).
 
 **Buckets:** documents `janasunani-documents-main` · DVC cache
-`dpic-dvc-cache/janasunani` · DB backups `grievance-database-backups-main`.
+`dpic-dvc-cache/janasunani` · DB backups `grievance-database-backups-main` ·
+DSI reference corpus `janasunani-documents-dsi-reference` (no transition or
+expiration actions, read-only to the box, Terraform-managed).
 
 **Secrets/vars for the automated deploy** (§4): see the table there —
 `DPIC_GITHUB_SSH_KEY` (existing, repo secret) vs. `BOX_SSH_KEY` +

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -62,7 +62,11 @@ Current live CPU box: `i-0ef24e15a80ba7128`, EIP `52.66.116.80`.
   `janasunani-documents-main`, `dpic-dvc-cache` (prefix `janasunani`),
   `grievance-database-backups-main`.
 - A fourth, `janasunani-documents-dsi-reference`, **is** managed by Terraform
-  (`reference_bucket.tf`) and is created by the apply below. It holds the DSI
+  (`reference_bucket.tf`). It already exists and holds the corpus, so the
+  config carries an `import` block that adopts it on the first apply rather
+  than creating it — without that, the apply stops with
+  `BucketAlreadyOwnedByYou` partway through. Remove the block once it is in
+  state. It holds the DSI
   clinic benchmark corpus, and its invariant is **no transition or expiration
   actions** — never that it has no lifecycle rule at all. It does have one, and
   that is the mechanism: Terraform owns the lifecycle configuration precisely so

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -54,7 +54,7 @@ Current live CPU box: `i-0ef24e15a80ba7128`, EIP `52.66.116.80`.
 
 - Terraform, AWS CLI v2, an SSH keypair (default `~/.ssh/id_ed25519[.pub]`).
 - AWS credentials with rights to create EC2/EIP/IAM/security groups, and to
-  administer S3 buckets. The apply creates `janasunani-documents-dsi-reference`
+  administer S3 buckets. The apply adopts `janasunani-documents-dsi-reference`
   and sets its tags, lifecycle, versioning, encryption and public-access block,
   so credentials scoped to EC2/EIP/IAM alone will get through `plan` and fail
   partway into `apply`, after some resources already exist.
@@ -66,8 +66,8 @@ Current live CPU box: `i-0ef24e15a80ba7128`, EIP `52.66.116.80`.
   config carries an `import` block that adopts it on the first apply rather
   than creating it — without that, the apply stops with
   `BucketAlreadyOwnedByYou` partway through. Remove the block once it is in
-  state. It holds the DSI
-  clinic benchmark corpus, and its invariant is **no transition or expiration
+  state. It holds the DSI clinic benchmark corpus, and its invariant is
+  **no transition or expiration
   actions** — never that it has no lifecycle rule at all. It does have one, and
   that is the mechanism: Terraform owns the lifecycle configuration precisely so
   an archival rule added through the console shows up as drift. The single rule

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -90,7 +90,7 @@ The only place phase status is recorded.
 | 14 | II | **Spam & duplicate detection** *(b)* | 🔄 *(55,544/55,544 indexed into 10,963 groups; bounded low-signal regression and binary actionability development scorer measured; officer gold and a release gate remain)* |
 | 15 | II | **Structured analytics I**: metrics layer, dashboards, spikes *(c)* — metric-registry slice: governed total-filings definition and protected grouped releases; cluster/citizen metrics remain unavailable pending dedup lake artifacts | 🔄 |
 | 16 | II | **A/B instrumentation + retrospective impact evidence** *(d)* | 🔄 *(draft design and developmental routing-outcome diagnostics built; assignment, exposure, shadow execution, locked power inputs and a governed pilot remain unbuilt)* |
-| 17 | II | **Sarvam benchmark + provider registry + egress control** *(e)* | 🔄 *(200-page paid run on Sambalpur/2024, 25 Aug 2026, ₹300 list: latency distribution and divergence 0.995 measured, category grade measures our own v1 schema not the provider; schema v2 pinned; no hand-transcribed OCR accuracy set (#53))* |
+| 17 | II | **Sarvam benchmark + provider registry + egress control** *(e)* | 🔄 *(cached provider evidence and governed local release wiring built; no hand-transcribed OCR accuracy set and no new paid calls)* |
 | 18 | III | Evaluation harness & operational safety (RBAC, restore, observability) | ⬜ |
 | 19 | III | Model & pipeline platform (one recipe, release manifest, API v1) | 🔄 *(immutable local release/materialization slice built; no reviewed production manifest, shared recipe or API-v1 policy yet)* |
 | 20 | III | Structured analytics II (adjusted comparisons, NL query) | ⬜ |
@@ -1956,8 +1956,10 @@ Self-host on Docker. S3 is the only stateful AWS dependency. Terraform
   stateful survives. Sarvam-30B at 4-bit is at the limit of a 24 GB L4 and 105B is
   beyond it, so the exit ramp may need a larger instance type.
 - DVC remote `s3://dpic-dvc-cache/janasunani` (dump, lake, models); documents in
-  `s3://janasunani-documents-main`; backups in `grievance-database-backups-main`.
-  Do not DVC-track the OLTP DB.
+  `s3://janasunani-documents-main`; backups in `grievance-database-backups-main`;
+  the DSI benchmark corpus in `s3://janasunani-documents-dsi-reference`, the one
+  bucket Terraform manages, carrying no rule that transitions or expires an
+  object so it never needs a Glacier restore. Do not DVC-track the OLTP DB.
 
 ### Testing policy (every phase)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -90,7 +90,7 @@ The only place phase status is recorded.
 | 14 | II | **Spam & duplicate detection** *(b)* | 🔄 *(55,544/55,544 indexed into 10,963 groups; bounded low-signal regression and binary actionability development scorer measured; officer gold and a release gate remain)* |
 | 15 | II | **Structured analytics I**: metrics layer, dashboards, spikes *(c)* — metric-registry slice: governed total-filings definition and protected grouped releases; cluster/citizen metrics remain unavailable pending dedup lake artifacts | 🔄 |
 | 16 | II | **A/B instrumentation + retrospective impact evidence** *(d)* | 🔄 *(draft design and developmental routing-outcome diagnostics built; assignment, exposure, shadow execution, locked power inputs and a governed pilot remain unbuilt)* |
-| 17 | II | **Sarvam benchmark + provider registry + egress control** *(e)* | 🔄 *(cached provider evidence and governed local release wiring built; no hand-transcribed OCR accuracy set and no new paid calls)* |
+| 17 | II | **Sarvam benchmark + provider registry + egress control** *(e)* | 🔄 *(200-page paid run on Sambalpur/2024, 25 Aug 2026, ₹300 list: latency distribution and divergence 0.995 measured, category grade measures our own v1 schema not the provider; schema v2 pinned; no hand-transcribed OCR accuracy set (#53))* |
 | 18 | III | Evaluation harness & operational safety (RBAC, restore, observability) | ⬜ |
 | 19 | III | Model & pipeline platform (one recipe, release manifest, API v1) | 🔄 *(immutable local release/materialization slice built; no reviewed production manifest, shared recipe or API-v1 policy yet)* |
 | 20 | III | Structured analytics II (adjusted comparisons, NL query) | ⬜ |


### PR DESCRIPTION
Terraform creates `janasunani-documents-dsi-reference`, and the CPU box's instance role gets `s3:GetObject` on it and nothing else — the box that runs the benchmarks cannot alter what it is measuring.

## The invariant is "no transition or expiration actions", not "no lifecycle rule"

The bucket **has** a lifecycle rule, and that is the mechanism rather than a contradiction. Terraform owning the lifecycle configuration is what makes an archival rule added through the console show up as drift. The single rule aborts abandoned multipart uploads and moves nothing between storage classes.

Deleting it as "console drift" is what would let a real transition rule land unnoticed, so `docs/DEPLOY.md` says that where someone tidying up would read it.

Versioning, encryption and a public-access block are set explicitly rather than assumed.

## Why this is a separate PR

Split out of #321, which opened at **+535 lines** and grew to **+2505** across seven review rounds. All 47 findings landed on `scripts/check_no_terraform_plans.py` and its tests — **2,350 of those lines**. The scanner work is worth having and is still converging, but it had stopped being a gate for this bucket and become its own project.

This is the other **179 lines**, which have drawn no finding in any round, and which the DSI benchmark work is actually waiting on. The plan scanner and the pre-commit hook stay on #321.

| | lines | findings |
|---|---|---|
| scanner + hook + tests (stays on #321) | 2,350 | 47 |
| bucket + IAM + docs (**this PR**) | 179 | 0 |

## One operational note

`terraform apply` now needs credentials that can administer S3, not only EC2/EIP/IAM. Without them it passes `plan` and fails partway through `apply`, after some resources already exist. Added to the prerequisites in `docs/DEPLOY.md`.

## Verification

- `uv run ruff check .` — clean.
- `uv run --extra serving --extra pipeline-core pytest` — 2247 passed, 8 skipped. Not against production Postgres.
- No `dvc pull`; no gold-metric gate is touched.
- Contains no Python change at all: the eight files are Terraform, docs and a `.gitignore` comment.
